### PR TITLE
Add RpcHttpClient

### DIFF
--- a/ironfish/src/rpc/adapters/httpAdapter.test.ts
+++ b/ironfish/src/rpc/adapters/httpAdapter.test.ts
@@ -1,0 +1,117 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+/* eslint-disable jest/no-conditional-expect */
+import Mitm from 'mitm'
+import * as yup from 'yup'
+import { Assert } from '../../assert'
+import { createNodeTest } from '../../testUtilities'
+import { RpcHttpClient, RpcRequestError } from '../clients'
+import { ALL_API_NAMESPACES } from '../routes'
+import { RPC_ERROR_CODES, RpcValidationError } from './errors'
+import { RpcHttpAdapter } from './httpAdapter'
+
+describe('HttpAdapter', () => {
+  let httpAdapter: RpcHttpAdapter | undefined
+  let mitm: ReturnType<typeof Mitm>
+
+  const nodeTest = createNodeTest(false, {
+    config: {
+      enableRpc: false,
+      enableRpcIpc: false,
+      enableRpcTcp: false,
+      enableRpcTls: false,
+      rpcHttpPort: 0,
+    },
+  })
+
+  beforeEach(async () => {
+    httpAdapter = new RpcHttpAdapter('localhost', 0, undefined, ALL_API_NAMESPACES)
+
+    mitm = Mitm()
+    mitm.on('request', (req, res) => httpAdapter?.onRequest(req, res))
+
+    await nodeTest.node.rpc.mount(httpAdapter)
+  }, 20000)
+
+  afterEach(() => {
+    mitm.disable()
+  })
+
+  it('should send and receive message', async () => {
+    Assert.isNotUndefined(httpAdapter)
+    Assert.isNotNull(httpAdapter.router)
+
+    httpAdapter.router.routes.register('foo/bar', yup.string(), (request) => {
+      request.end(request.data)
+    })
+
+    const client = new RpcHttpClient('http://localhost')
+
+    const response = await client.request('foo/bar', 'hello world').waitForEnd()
+    expect(response.content).toBe('hello world')
+  }, 20000)
+
+  it('should stream message', async () => {
+    Assert.isNotUndefined(httpAdapter)
+    Assert.isNotNull(httpAdapter?.router)
+
+    httpAdapter.router.routes.register('foo/bar', yup.object({}), (request) => {
+      request.stream('hello 1')
+      request.stream('hello 2')
+      request.end()
+    })
+
+    const client = new RpcHttpClient('http://localhost')
+
+    const response = client.request('foo/bar')
+    expect((await response.contentStream().next()).value).toBe('hello 1')
+    expect((await response.contentStream().next()).value).toBe('hello 2')
+
+    await response.waitForEnd()
+    expect(response.content).toBe(undefined)
+  }, 20000)
+
+  it('should handle errors', async () => {
+    Assert.isNotUndefined(httpAdapter)
+    Assert.isNotNull(httpAdapter?.router)
+
+    httpAdapter.router.routes.register('foo/bar', yup.object({}), () => {
+      throw new RpcValidationError('hello error', 402, 'hello-error' as RPC_ERROR_CODES)
+    })
+
+    const client = new RpcHttpClient('http://localhost')
+
+    const response = client.request('foo/bar')
+
+    await expect(response.waitForEnd()).rejects.toThrow(RpcRequestError)
+    await expect(response.waitForEnd()).rejects.toMatchObject({
+      status: 402,
+      code: 'hello-error',
+      codeMessage: 'hello error',
+    })
+  }, 20000)
+
+  it('should handle request errors', async () => {
+    Assert.isNotUndefined(httpAdapter)
+    Assert.isNotNull(httpAdapter?.router)
+
+    // Requires this
+    const schema = yup.string().defined()
+    // But send this instead
+    const body = undefined
+
+    httpAdapter.router.routes.register('foo/bar', schema, (res) => res.end())
+
+    const client = new RpcHttpClient('http://localhost')
+
+    const response = client.request('foo/bar', body)
+
+    await expect(response.waitForEnd()).rejects.toThrow(RpcRequestError)
+    await expect(response.waitForEnd()).rejects.toMatchObject({
+      status: 400,
+      code: RPC_ERROR_CODES.VALIDATION,
+      codeMessage: expect.stringContaining('this must be defined'),
+    })
+  }, 20000)
+})

--- a/ironfish/src/rpc/clients/httpClient.ts
+++ b/ironfish/src/rpc/clients/httpClient.ts
@@ -1,0 +1,146 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import Axios, { AxiosInstance } from 'axios'
+import http from 'http'
+import * as yup from 'yup'
+import { ErrorUtils, PromiseUtils, YupUtils } from '../../utils'
+import { RpcHttpErrorSchema, RpcHttpResponseSchema } from '../adapters/httpAdapter'
+import { RpcClient } from '../clients/client'
+import { MessageBuffer } from '../messageBuffer'
+import { isRpcResponseError, RpcResponse } from '../response'
+import { Stream } from '../stream'
+import { RpcConnectionRefusedError, RpcRequestError, RpcRequestTimeoutError } from './errors'
+
+export const RpcHttpMessageSchema = yup
+  .object({
+    status: yup.number().optional(),
+  })
+  .required()
+
+export class RpcHttpClient extends RpcClient {
+  protected readonly axios: AxiosInstance
+
+  constructor(baseURL: string) {
+    super()
+    this.axios = Axios.create({ baseURL })
+  }
+
+  request<TEnd = unknown, TStream = unknown>(
+    route: string,
+    data?: unknown,
+    options: {
+      timeoutMs?: number | null
+    } = {},
+  ): RpcResponse<TEnd, TStream> {
+    const timeoutMs = options.timeoutMs ?? 0
+    const messageBuffer = new MessageBuffer('\f')
+    const [promise, resolve, reject] = PromiseUtils.split<TEnd>()
+    const stream = new Stream<TStream>()
+    const rpcResponse = new RpcResponse<TEnd, TStream>(promise, stream)
+
+    const onData = async (data: Buffer): Promise<void> => {
+      messageBuffer.write(data)
+
+      for (const message of messageBuffer.readMessages()) {
+        const parsed: unknown = JSON.parse(message)
+
+        const { result, error } = await YupUtils.tryValidate(RpcHttpMessageSchema, parsed)
+
+        if (!result) {
+          throw error
+        }
+
+        if (result.status) {
+          rpcResponse.status = result.status
+        }
+
+        if (isRpcResponseError(rpcResponse as RpcResponse<unknown, unknown>)) {
+          const { result: errorBody, error: errorError } = await YupUtils.tryValidate(
+            RpcHttpErrorSchema,
+            parsed,
+          )
+
+          if (errorBody) {
+            const err = new RpcRequestError(
+              rpcResponse,
+              errorBody.code,
+              errorBody.message,
+              errorBody.stack,
+            )
+            stream.close(err)
+            reject(err)
+          } else if (errorError) {
+            stream.close(errorError)
+            reject(errorError)
+          } else {
+            stream.close(data)
+            reject(data)
+          }
+          return
+        }
+
+        const { result: messageBody, error: messageError } = await YupUtils.tryValidate(
+          RpcHttpResponseSchema,
+          parsed,
+        )
+
+        if (messageError) {
+          throw messageError
+        }
+
+        if (result.status !== undefined) {
+          stream.close()
+          resolve(messageBody.data as TEnd)
+          return
+        }
+
+        stream.write(messageBody.data as TStream)
+      }
+    }
+
+    const body = JSON.stringify(data)
+
+    void this.axios
+      .post<http.IncomingMessage>(route, body, {
+        responseType: 'stream',
+        timeout: timeoutMs,
+        validateStatus: () => true,
+        transitional: {
+          clarifyTimeoutError: true,
+          forcedJSONParsing: true,
+          silentJSONParsing: true,
+        },
+      })
+      .then((response) => {
+        response.data.on('data', (data: Buffer) => {
+          void onData(data)
+        })
+
+        response.data.on('end', () => {
+          void onData(Buffer.from('\f'))
+        })
+      })
+      .catch((error) => {
+        if (ErrorUtils.isConnectTimeOutError(error)) {
+          const errorTimeout = new RpcRequestTimeoutError(rpcResponse, timeoutMs, route)
+          stream.close(errorTimeout)
+          reject(errorTimeout)
+          return
+        }
+
+        if (ErrorUtils.isConnectRefusedError(error)) {
+          const errorRefused = new RpcConnectionRefusedError(`Failed to connect to ${route}`)
+          stream.close(errorRefused)
+          reject(errorRefused)
+          return
+        }
+
+        stream.close(error)
+        reject(error)
+      })
+
+    return rpcResponse
+  }
+}

--- a/ironfish/src/rpc/clients/index.ts
+++ b/ironfish/src/rpc/clients/index.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 export * from './errors'
 export * from './client'
+export * from './httpClient'
 export * from './memoryClient'
 export * from './socketClient'
 export * from './tcpClient'


### PR DESCRIPTION
## Summary

This adds a new RpcHttpClient to the SDK which allows you to make HTTP requests against the RpcHttpAdapter.

**HttpAdapter Bugs**
- Crash if you send a chunk and then send a response because headers try to send twice
- Crash if you send an RpcValidationError after a chunk was sent because headers try to send twice
- Fixed not sending delimter before rendering an error to the client which would cause client to crash when parsing 2 messages as 1 JSON payload.

## Testing Plan

Still need to add tests and check on postman that some of the requests still work.

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
