### PR TITLE
chore: Ironfish rust refactor add change

### DIFF
--- a/ironfish-rust-nodejs/index.d.ts
+++ b/ironfish-rust-nodejs/index.d.ts
@@ -223,7 +223,7 @@ export class Transaction {
    * aka: self.value_balance - intended_transaction_fee - change = 0
    */
   post(spenderHexKey: string, changeGoesTo: string | undefined | null, intendedTransactionFee: bigint): Buffer
-  build(proofGenerationKeyStr: string, viewKeyStr: string, outgoingViewKeyStr: string, publicAddressStr: string, intendedTransactionFee: bigint): Buffer
+  build(proofGenerationKeyStr: string, viewKeyStr: string, outgoingViewKeyStr: string, publicAddressStr: string, intendedTransactionFee: bigint, changeGoesTo?: string | undefined | null): Buffer
   setExpiration(sequence: number): void
 }
 export class FoundBlockResult {

--- a/ironfish-rust-nodejs/src/structs/transaction.rs
+++ b/ironfish-rust-nodejs/src/structs/transaction.rs
@@ -321,6 +321,7 @@ impl NativeTransaction {
         outgoing_view_key_str: String,
         public_address_str: String,
         intended_transaction_fee: BigInt,
+        change_goes_to: Option<String>,
     ) -> Result<Buffer> {
         let view_key = ViewKey::from_hex(&view_key_str).map_err(to_napi_err)?;
         let outgoing_view_key =
@@ -328,6 +329,10 @@ impl NativeTransaction {
         let public_address = PublicAddress::from_hex(&public_address_str).map_err(to_napi_err)?;
         let proof_generation_key = ProofGenerationKey::from_hex(&proof_generation_key_str)
             .map_err(|_| to_napi_err("PublicKeyPackage hex to bytes failed"))?;
+        let change_address = match change_goes_to {
+            Some(address) => Some(PublicAddress::from_hex(&address).map_err(to_napi_err)?),
+            None => None,
+        };
         let unsigned_transaction = self
             .transaction
             .build(
@@ -336,6 +341,7 @@ impl NativeTransaction {
                 outgoing_view_key,
                 public_address,
                 intended_transaction_fee.get_i64().0,
+                change_address,
             )
             .map_err(to_napi_err)?;
 

--- a/ironfish-rust/src/transaction/outputs.rs
+++ b/ironfish-rust/src/transaction/outputs.rs
@@ -60,6 +60,10 @@ impl OutputBuilder {
         self.is_miners_fee = true;
     }
 
+    pub(crate) fn get_is_miners_fee(&self) -> bool {
+        self.is_miners_fee
+    }
+
     /// Get the value_commitment from this proof as an edwards Point.
     ///
     /// This integrates the value and randomness into a single point, using an

--- a/ironfish-rust/src/transaction/tests.rs
+++ b/ironfish-rust/src/transaction/tests.rs
@@ -227,11 +227,8 @@ fn test_proposed_transaction_build() {
     transaction.add_output(out_note).unwrap();
     assert_eq!(transaction.outputs.len(), 1);
 
-    let public_address = spender_key.public_address();
+    let public_address: crate::PublicAddress = spender_key.public_address();
     let intended_fee = 1;
-    transaction
-        .add_change_notes(Some(public_address), public_address, intended_fee)
-        .expect("should be able to add change notes");
 
     let unsigned_transaction = transaction
         .build(
@@ -240,6 +237,7 @@ fn test_proposed_transaction_build() {
             spender_key.outgoing_view_key().clone(),
             spender_key.public_address(),
             intended_fee,
+            Some(public_address),
         )
         .expect("should be able to build unsigned transaction");
 


### PR DESCRIPTION
## Summary
Adds change notes as a method that is executed if the transaction is a miners fee (only special type of transaction that doesn't balance). The only reason this method exists is so that no change notes are added for miner fee transactions, otherwise it would always be run inside the `build()` method.

## Testing Plan
tests pass

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
