### PR TITLE
Renamed many RPC types for consistency

### DIFF
--- a/ironfish/src/rpc/adapters/errors.ts
+++ b/ironfish/src/rpc/adapters/errors.ts
@@ -22,7 +22,7 @@ export enum ERROR_CODES {
  *
  * @note Look at the {@link IPCAdapter} implementation for an example
  */
-export class ResponseError extends Error {
+export class RpcResponseError extends Error {
   name = this.constructor.name
   status: number
   code: string
@@ -47,7 +47,7 @@ export class ResponseError extends Error {
  * A convenience error to throw inside of routes when you want to indicate
  * a 400 error to the user based on validation
  */
-export class ValidationError extends ResponseError {
+export class RpcValidationError extends RpcResponseError {
   constructor(message: string, status = 400, code = ERROR_CODES.VALIDATION) {
     super(message, code, status)
   }
@@ -56,7 +56,7 @@ export class ValidationError extends ResponseError {
 /**
  * A convenience error to throw inside of routes when a resource is not found
  */
-export class NotFoundError extends ResponseError {
+export class RpcNotFoundError extends RpcResponseError {
   constructor(message: string, status = 404, code = ERROR_CODES.NOT_FOUND) {
     super(message, code, status)
   }

--- a/ironfish/src/rpc/adapters/ipcAdapter.test.ts
+++ b/ironfish/src/rpc/adapters/ipcAdapter.test.ts
@@ -9,7 +9,7 @@ import { PromiseUtils } from '../../utils/promise'
 import { RpcRequestError } from '../clients'
 import { RpcIpcClient } from '../clients/ipcClient'
 import { ALL_API_NAMESPACES } from '../routes/router'
-import { ERROR_CODES, ValidationError } from './errors'
+import { ERROR_CODES, RpcValidationError } from './errors'
 import { RpcIpcAdapter } from './ipcAdapter'
 
 describe('IpcAdapter', () => {
@@ -102,7 +102,7 @@ describe('IpcAdapter', () => {
 
   it('should handle errors', async () => {
     ipc.router?.routes.register('foo/bar', yup.object({}), () => {
-      throw new ValidationError('hello error', 402, 'hello-error' as ERROR_CODES)
+      throw new RpcValidationError('hello error', 402, 'hello-error' as ERROR_CODES)
     })
 
     await ipc.start()

--- a/ironfish/src/rpc/adapters/memoryAdapter.ts
+++ b/ironfish/src/rpc/adapters/memoryAdapter.ts
@@ -8,7 +8,7 @@ import { RpcRequest } from '../request'
 import { RpcResponse } from '../response'
 import { Router } from '../routes'
 import { Stream } from '../stream'
-import { ResponseError } from './errors'
+import { RpcResponseError } from './errors'
 
 /**
  * This class provides a way to route requests directly against the routing layer
@@ -48,7 +48,7 @@ export class RpcMemoryAdapter {
     response.routePromise = router.route(route, request).catch((e) => {
       stream.close()
 
-      if (e instanceof ResponseError) {
+      if (e instanceof RpcResponseError) {
         // Set the response status to the errors status because RequsetError takes it from the response
         response.status = e.status
 

--- a/ironfish/src/rpc/adapters/socketAdapter/protocol.ts
+++ b/ironfish/src/rpc/adapters/socketAdapter/protocol.ts
@@ -5,41 +5,41 @@ import * as yup from 'yup'
 
 export const MESSAGE_DELIMITER = '\f'
 
-export type ClientSocketRpc = {
+export type RpcSocketClientMessage = {
   type: 'message'
-  data: SocketRpcRequest
+  data: RpcSocketRequest
 }
 
-export type ServerSocketRpc = {
+export type RpcSocketServerMessage = {
   type: 'message' | 'malformedRequest' | 'error' | 'stream'
-  data: SocketRpcResponse | SocketRpcError | SocketRpcStream
+  data: RpcSocketResponse | RpcSocketError | RpcSocketStream
 }
 
-export type SocketRpcRequest = {
+export type RpcSocketRequest = {
   mid: number
   type: string
   auth: string | null | undefined
   data: unknown
 }
 
-export type SocketRpcResponse = {
+export type RpcSocketResponse = {
   id: number
   status: number
   data: unknown
 }
 
-export type SocketRpcStream = {
+export type RpcSocketStream = {
   id: number
   data: unknown
 }
 
-export type SocketRpcError = {
+export type RpcSocketError = {
   code: string
   message: string
   stack?: string
 }
 
-export const ClientSocketRpcSchema: yup.ObjectSchema<ClientSocketRpc> = yup
+export const RpcSocketClientMessageSchema: yup.ObjectSchema<RpcSocketClientMessage> = yup
   .object({
     type: yup.string().oneOf(['message']).required(),
     data: yup
@@ -53,14 +53,14 @@ export const ClientSocketRpcSchema: yup.ObjectSchema<ClientSocketRpc> = yup
   })
   .required()
 
-export const ServerSocketRpcSchema: yup.ObjectSchema<ServerSocketRpc> = yup
+export const RpcSocketServerMessageSchema: yup.ObjectSchema<RpcSocketServerMessage> = yup
   .object({
     type: yup.string().oneOf(['message', 'malformedRequest', 'error', 'stream']).required(),
-    data: yup.mixed<SocketRpcResponse | SocketRpcError | SocketRpcStream>().required(),
+    data: yup.mixed<RpcSocketResponse | RpcSocketError | RpcSocketStream>().required(),
   })
   .required()
 
-export const SocketRpcErrorSchema: yup.ObjectSchema<SocketRpcError> = yup
+export const RpcSocketErrorSchema: yup.ObjectSchema<RpcSocketError> = yup
   .object({
     code: yup.string().defined(),
     message: yup.string().defined(),
@@ -68,7 +68,7 @@ export const SocketRpcErrorSchema: yup.ObjectSchema<SocketRpcError> = yup
   })
   .defined()
 
-export const SocketRpcRequestSchema: yup.ObjectSchema<SocketRpcRequest> = yup
+export const RpcSocketRequestSchema: yup.ObjectSchema<RpcSocketRequest> = yup
   .object({
     mid: yup.number().required(),
     type: yup.string().required(),
@@ -77,7 +77,7 @@ export const SocketRpcRequestSchema: yup.ObjectSchema<SocketRpcRequest> = yup
   })
   .required()
 
-export const SocketRpcResponseSchema: yup.ObjectSchema<SocketRpcResponse> = yup
+export const RpcSocketResponseSchema: yup.ObjectSchema<RpcSocketResponse> = yup
   .object({
     id: yup.number().defined(),
     status: yup.number().defined(),
@@ -85,7 +85,7 @@ export const SocketRpcResponseSchema: yup.ObjectSchema<SocketRpcResponse> = yup
   })
   .defined()
 
-export const SocketRpcStreamSchema: yup.ObjectSchema<SocketRpcStream> = yup
+export const RpcSocketStreamSchema: yup.ObjectSchema<RpcSocketStream> = yup
   .object({
     id: yup.number().defined(),
     data: yup.mixed().notRequired(),

--- a/ironfish/src/rpc/adapters/tcpAdapter.test.ts
+++ b/ironfish/src/rpc/adapters/tcpAdapter.test.ts
@@ -13,7 +13,7 @@ import { getUniqueTestDataDir } from '../../testUtilities'
 import { RpcRequestError } from '../clients'
 import { RpcTcpClient } from '../clients/tcpClient'
 import { ALL_API_NAMESPACES } from '../routes'
-import { ERROR_CODES, ValidationError } from './errors'
+import { ERROR_CODES, RpcValidationError } from './errors'
 import { RpcTcpAdapter } from './tcpAdapter'
 
 describe('TcpAdapter', () => {
@@ -97,7 +97,7 @@ describe('TcpAdapter', () => {
     Assert.isNotNull(tcp?.router)
 
     tcp.router.routes.register('foo/bar', yup.object({}), () => {
-      throw new ValidationError('hello error', 402, 'hello-error' as ERROR_CODES)
+      throw new RpcValidationError('hello error', 402, 'hello-error' as ERROR_CODES)
     })
 
     client = new RpcTcpClient('localhost', 0)

--- a/ironfish/src/rpc/clients/errors.ts
+++ b/ironfish/src/rpc/clients/errors.ts
@@ -58,7 +58,7 @@ export class RpcRequestError<TEnd = unknown, TStream = unknown> extends Error {
 }
 
 /** Thrown when the request timeout has been exceeded and the request has been aborted */
-export class RequestTimeoutError<TEnd, TStream> extends RpcRequestError<TEnd, TStream> {
+export class RpcRequestTimeoutError<TEnd, TStream> extends RpcRequestError<TEnd, TStream> {
   constructor(response: RpcResponse<TEnd, TStream>, timeoutMs: number, route: string) {
     super(response, 'request-timeout', `Timeout of ${timeoutMs} exceeded to ${route}`)
   }

--- a/ironfish/src/rpc/routes/chain/broadcastTransaction.ts
+++ b/ironfish/src/rpc/routes/chain/broadcastTransaction.ts
@@ -6,7 +6,7 @@ import * as yup from 'yup'
 import { Assert } from '../../../assert'
 import { FullNode } from '../../../node'
 import { Transaction } from '../../../primitives'
-import { ValidationError } from '../../adapters'
+import { RpcValidationError } from '../../adapters'
 import { ApiNamespace } from '../namespaces'
 import { routes } from '../router'
 
@@ -47,7 +47,7 @@ routes.register<typeof BroadcastTransactionRequestSchema, BroadcastTransactionRe
 
     const verify = await context.chain.verifier.verifyNewTransaction(transaction)
     if (!verify.valid) {
-      throw new ValidationError(`Invalid transaction, reason: ${String(verify.reason)}`)
+      throw new RpcValidationError(`Invalid transaction, reason: ${String(verify.reason)}`)
     }
 
     const accepted = context.memPool.acceptTransaction(transaction)

--- a/ironfish/src/rpc/routes/chain/getAsset.ts
+++ b/ironfish/src/rpc/routes/chain/getAsset.ts
@@ -8,7 +8,7 @@ import { AssetValue } from '../../../blockchain/database/assetValue'
 import { FullNode } from '../../../node'
 import { CurrencyUtils } from '../../../utils'
 import { AssetStatus } from '../../../wallet'
-import { NotFoundError, ValidationError } from '../../adapters'
+import { RpcNotFoundError, RpcValidationError } from '../../adapters'
 import { ApiNamespace } from '../namespaces'
 import { routes } from '../router'
 import { RpcAsset, RpcAssetSchema } from '../types'
@@ -63,14 +63,14 @@ routes.register<typeof GetAssetRequestSchema, GetAssetResponse>(
     const id = Buffer.from(request.data.id, 'hex')
 
     if (id.byteLength !== ASSET_ID_LENGTH) {
-      throw new ValidationError(
+      throw new RpcValidationError(
         `Asset identifier is invalid length, expected ${ASSET_ID_LENGTH} but got ${id.byteLength}`,
       )
     }
 
     const asset = await node.chain.getAssetById(id)
     if (!asset) {
-      throw new NotFoundError(`No asset found with identifier ${request.data.id}`)
+      throw new RpcNotFoundError(`No asset found with identifier ${request.data.id}`)
     }
 
     request.end({

--- a/ironfish/src/rpc/routes/chain/getBlock.ts
+++ b/ironfish/src/rpc/routes/chain/getBlock.ts
@@ -8,7 +8,7 @@ import { FullNode } from '../../../node'
 import { BlockHeader } from '../../../primitives'
 import { GENESIS_BLOCK_SEQUENCE } from '../../../primitives/block'
 import { BufferUtils } from '../../../utils'
-import { NotFoundError, ValidationError } from '../../adapters'
+import { RpcNotFoundError, RpcValidationError } from '../../adapters'
 import { ApiNamespace } from '../namespaces'
 import { routes } from '../router'
 import { RpcBlock, RpcBlockSchema, serializeRpcBlockHeader } from '../types'
@@ -94,16 +94,16 @@ routes.register<typeof GetBlockRequestSchema, GetBlockResponse>(
     }
 
     if (!header) {
-      throw new NotFoundError(error)
+      throw new RpcNotFoundError(error)
     }
 
     if (header.noteSize === null) {
-      throw new ValidationError('Block header was saved to database without a note size')
+      throw new RpcValidationError('Block header was saved to database without a note size')
     }
 
     const block = await context.chain.getBlock(header)
     if (!block) {
-      throw new NotFoundError(`No block with header ${header.hash.toString('hex')}`)
+      throw new RpcNotFoundError(`No block with header ${header.hash.toString('hex')}`)
     }
 
     const transactions: GetBlockResponse['block']['transactions'] = []

--- a/ironfish/src/rpc/routes/chain/getDifficulty.ts
+++ b/ironfish/src/rpc/routes/chain/getDifficulty.ts
@@ -4,7 +4,7 @@
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
 import { FullNode } from '../../../node'
-import { ValidationError } from '../../adapters'
+import { RpcValidationError } from '../../adapters'
 import { ApiNamespace } from '../namespaces'
 import { routes } from '../router'
 
@@ -46,7 +46,7 @@ routes.register<typeof GetDifficultyRequestSchema, GetDifficultyResponse>(
     if (request.data?.sequence) {
       const sequenceBlock = await node.chain.getHeaderAtSequence(request.data.sequence)
       if (!sequenceBlock) {
-        throw new ValidationError(`No block found at sequence ${request.data.sequence}`)
+        throw new RpcValidationError(`No block found at sequence ${request.data.sequence}`)
       }
       sequence = sequenceBlock.sequence
       block = sequenceBlock

--- a/ironfish/src/rpc/routes/chain/getNetworkHashPower.ts
+++ b/ironfish/src/rpc/routes/chain/getNetworkHashPower.ts
@@ -5,7 +5,7 @@ import * as yup from 'yup'
 import { Assert } from '../../../assert'
 import { FullNode } from '../../../node'
 import { BigIntUtils } from '../../../utils'
-import { ValidationError } from '../../adapters'
+import { RpcValidationError } from '../../adapters'
 import { ApiNamespace } from '../namespaces'
 import { routes } from '../router'
 
@@ -47,7 +47,7 @@ routes.register<typeof GetNetworkHashPowerRequestSchema, GetNetworkHashPowerResp
     let sequence = request.data?.sequence ?? -1
 
     if (blocks < 0) {
-      throw new ValidationError('[blocks] value must be greater than 0')
+      throw new RpcValidationError('[blocks] value must be greater than 0')
     }
 
     let endBlock = context.chain.head

--- a/ironfish/src/rpc/routes/chain/getNoteWitness.ts
+++ b/ironfish/src/rpc/routes/chain/getNoteWitness.ts
@@ -5,7 +5,7 @@ import * as yup from 'yup'
 import { Assert } from '../../../assert'
 import { FullNode } from '../../../node'
 import { GENESIS_BLOCK_SEQUENCE } from '../../../primitives'
-import { ValidationError } from '../../adapters'
+import { RpcValidationError } from '../../adapters'
 import { ApiNamespace } from '../namespaces'
 import { routes } from '../router'
 
@@ -68,7 +68,7 @@ routes.register<typeof GetNoteWitnessRequestSchema, GetNoteWitnessResponse>(
     const witness = await chain.notes.witness(request.data.index, maxConfirmedHeader.noteSize)
 
     if (witness === null) {
-      throw new ValidationError(
+      throw new RpcValidationError(
         `No confirmed notes exist with index ${request.data.index} in tree of size ${maxConfirmedHeader.noteSize}`,
       )
     }

--- a/ironfish/src/rpc/routes/chain/getTransaction.ts
+++ b/ironfish/src/rpc/routes/chain/getTransaction.ts
@@ -7,7 +7,7 @@ import { getTransactionSize } from '../../../network/utils/serializers'
 import { FullNode } from '../../../node'
 import { BlockHashSerdeInstance } from '../../../serde'
 import { CurrencyUtils } from '../../../utils'
-import { NotFoundError, ValidationError } from '../../adapters'
+import { RpcNotFoundError, RpcValidationError } from '../../adapters'
 import { ApiNamespace } from '../namespaces'
 import { routes } from '../router'
 import { RpcTransaction, RpcTransactionSchema } from './types'
@@ -58,7 +58,7 @@ routes.register<typeof GetTransactionRequestSchema, GetTransactionResponse>(
     Assert.isInstanceOf(context, FullNode)
 
     if (!request.data.transactionHash) {
-      throw new ValidationError(`Missing transaction hash`)
+      throw new RpcValidationError(`Missing transaction hash`)
     }
 
     const transactionHashBuffer = Buffer.from(request.data.transactionHash, 'hex')
@@ -68,14 +68,14 @@ routes.register<typeof GetTransactionRequestSchema, GetTransactionResponse>(
       : await context.chain.getBlockHashByTransactionHash(transactionHashBuffer)
 
     if (!blockHashBuffer) {
-      throw new NotFoundError(
+      throw new RpcNotFoundError(
         `No block hash found for transaction hash ${request.data.transactionHash}`,
       )
     }
 
     const blockHeader = await context.chain.getHeader(blockHashBuffer)
     if (!blockHeader) {
-      throw new NotFoundError(
+      throw new RpcNotFoundError(
         `No block found for block hash ${blockHashBuffer.toString('hex')}`,
       )
     }
@@ -87,7 +87,7 @@ routes.register<typeof GetTransactionRequestSchema, GetTransactionResponse>(
     )
 
     if (!foundTransaction) {
-      throw new NotFoundError(
+      throw new RpcNotFoundError(
         `Transaction not found on block ${blockHashBuffer.toString('hex')}`,
       )
     }

--- a/ironfish/src/rpc/routes/chain/getTransactionStream.ts
+++ b/ironfish/src/rpc/routes/chain/getTransactionStream.ts
@@ -10,7 +10,7 @@ import { BlockHeader } from '../../../primitives/blockheader'
 import { BufferUtils, CurrencyUtils } from '../../../utils'
 import { PromiseUtils } from '../../../utils/promise'
 import { isValidIncomingViewKey, isValidOutgoingViewKey } from '../../../wallet/validator'
-import { ValidationError } from '../../adapters/errors'
+import { RpcValidationError } from '../../adapters/errors'
 import { ApiNamespace } from '../namespaces'
 import { routes } from '../router'
 import {
@@ -112,17 +112,17 @@ routes.register<typeof GetTransactionStreamRequestSchema, GetTransactionStreamRe
     Assert.isInstanceOf(node, FullNode)
 
     if (!isValidIncomingViewKey(request.data.incomingViewKey)) {
-      throw new ValidationError(`incomingViewKey is not valid`)
+      throw new RpcValidationError(`incomingViewKey is not valid`)
     }
 
     if (request.data.outgoingViewKey && !isValidOutgoingViewKey(request.data.outgoingViewKey)) {
-      throw new ValidationError(`outgoingViewKey is not valid`)
+      throw new RpcValidationError(`outgoingViewKey is not valid`)
     }
 
     const head = request.data.head ? Buffer.from(request.data.head, 'hex') : null
 
     if (head && !(await node.chain.hasBlock(head))) {
-      throw new ValidationError(
+      throw new RpcValidationError(
         `Block with hash ${String(request.data.head)} was not found in the chain`,
       )
     }

--- a/ironfish/src/rpc/routes/config/getConfig.ts
+++ b/ironfish/src/rpc/routes/config/getConfig.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
 import { ConfigOptions, ConfigOptionsSchema } from '../../../fileStores/config'
-import { ValidationError } from '../../adapters/errors'
+import { RpcValidationError } from '../../adapters/errors'
 import { ApiNamespace } from '../namespaces'
 import { routes } from '../router'
 import { AssertHasRpcContext } from '../rpcContext'
@@ -27,7 +27,7 @@ routes.register<typeof GetConfigRequestSchema, GetConfigResponse>(
     AssertHasRpcContext(request, context, 'config')
 
     if (request.data?.name && !(request.data.name in context.config.defaults)) {
-      throw new ValidationError(`No config option ${String(request.data.name)}`)
+      throw new RpcValidationError(`No config option ${String(request.data.name)}`)
     }
 
     let pickKeys: string[] | undefined = undefined

--- a/ironfish/src/rpc/routes/config/uploadConfig.ts
+++ b/ironfish/src/rpc/routes/config/uploadConfig.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
 import { Config, ConfigOptions, ConfigOptionsSchema } from '../../../fileStores/config'
-import { ValidationError } from '../../adapters/errors'
+import { RpcValidationError } from '../../adapters/errors'
 import { ApiNamespace } from '../namespaces'
 import { routes } from '../router'
 import { AssertHasRpcContext } from '../rpcContext'
@@ -52,7 +52,7 @@ export function setUnknownConfigValue(
 ): void {
   if (unknownKey && !(unknownKey in config.defaults)) {
     if (!ignoreUnknownKey) {
-      throw new ValidationError(`No config option ${String(unknownKey)}`)
+      throw new RpcValidationError(`No config option ${String(unknownKey)}`)
     }
   }
 
@@ -99,7 +99,7 @@ function stringToStringArray(value: string): string[] | null {
 
 function convertValue(sourceKey: string, sourceValue: unknown, targetValue: unknown): unknown {
   if (typeof sourceValue !== 'string') {
-    throw new ValidationError(
+    throw new RpcValidationError(
       `${sourceKey} has an invalid value: Cannot convert ${JSON.stringify(
         sourceValue,
       )} from ${typeof sourceValue} to ${String(typeof targetValue)}`,
@@ -139,7 +139,7 @@ function convertValue(sourceKey: string, sourceValue: unknown, targetValue: unkn
     targetType = 'array'
   }
 
-  throw new ValidationError(
+  throw new RpcValidationError(
     `${sourceKey} has an invalid value: Could not convert ${JSON.stringify(
       sourceValue,
     )} from ${typeof sourceValue} to ${String(targetType)}`,

--- a/ironfish/src/rpc/routes/faucet/getFunds.ts
+++ b/ironfish/src/rpc/routes/faucet/getFunds.ts
@@ -4,7 +4,7 @@
 import axios, { AxiosError } from 'axios'
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
-import { ERROR_CODES, ResponseError } from '../../adapters'
+import { ERROR_CODES, RpcResponseError } from '../../adapters'
 import { ApiNamespace } from '../namespaces'
 import { routes } from '../router'
 import { AssertHasRpcContext } from '../rpcContext'
@@ -37,7 +37,10 @@ routes.register<typeof GetFundsRequestSchema, GetFundsResponse>(
 
     if (networkId !== 0) {
       // not testnet
-      throw new ResponseError('This endpoint is only available for testnet.', ERROR_CODES.ERROR)
+      throw new RpcResponseError(
+        'This endpoint is only available for testnet.',
+        ERROR_CODES.ERROR,
+      )
     }
 
     const account = getAccount(context.wallet, request.data.account)
@@ -54,20 +57,20 @@ routes.register<typeof GetFundsRequestSchema, GetFundsResponse>(
         if (status === 422) {
           if (data.code === 'faucet_max_requests_reached') {
             Assert.isNotUndefined(data.message)
-            throw new ResponseError(data.message, ERROR_CODES.VALIDATION, status)
+            throw new RpcResponseError(data.message, ERROR_CODES.VALIDATION, status)
           }
 
-          throw new ResponseError(
+          throw new RpcResponseError(
             'You entered an invalid email.',
             ERROR_CODES.VALIDATION,
             status,
           )
         } else if (data.message) {
-          throw new ResponseError(data.message, ERROR_CODES.ERROR, status)
+          throw new RpcResponseError(data.message, ERROR_CODES.ERROR, status)
         }
       }
 
-      throw new ResponseError(error.message, ERROR_CODES.ERROR, Number(error.code))
+      throw new RpcResponseError(error.message, ERROR_CODES.ERROR, Number(error.code))
     })
 
     request.end({

--- a/ironfish/src/rpc/routes/router.ts
+++ b/ironfish/src/rpc/routes/router.ts
@@ -5,7 +5,7 @@ import { Assert } from '../../assert'
 import { YupSchema, YupSchemaResult, YupUtils } from '../../utils'
 import { StrEnumUtils } from '../../utils/enums'
 import { ERROR_CODES } from '../adapters'
-import { ResponseError, ValidationError } from '../adapters/errors'
+import { RpcResponseError, RpcValidationError } from '../adapters/errors'
 import { RpcRequest } from '../request'
 import { RpcServer } from '../server'
 import { ApiNamespace } from './namespaces'
@@ -18,7 +18,7 @@ export type RouteHandler<TRequest = unknown, TResponse = unknown> = (
   context: RpcContext,
 ) => Promise<void> | void
 
-export class RouteNotFoundError extends ResponseError {
+export class RouteNotFoundError extends RpcResponseError {
   constructor(route: string, namespace: string, method: string) {
     super(
       `No route found ${route} in namespace ${namespace} for method ${method}`,
@@ -56,18 +56,18 @@ export class Router {
 
     const { result, error } = await YupUtils.tryValidate(schema, request.data)
     if (error) {
-      throw new ValidationError(error.message, 400)
+      throw new RpcValidationError(error.message, 400)
     }
     request.data = result
 
     try {
       await handler(request, this.server.context)
     } catch (e: unknown) {
-      if (e instanceof ResponseError) {
+      if (e instanceof RpcResponseError) {
         throw e
       }
       if (e instanceof Error) {
-        throw new ResponseError(e)
+        throw new RpcResponseError(e)
       }
       throw e
     }

--- a/ironfish/src/rpc/routes/wallet/addTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/addTransaction.ts
@@ -5,7 +5,7 @@ import * as yup from 'yup'
 import { Verifier } from '../../../consensus'
 import { Transaction } from '../../../primitives'
 import { AsyncUtils } from '../../../utils'
-import { ValidationError } from '../../adapters'
+import { RpcValidationError } from '../../adapters'
 import { ApiNamespace } from '../namespaces'
 import { routes } from '../router'
 import { AssertHasRpcContext } from '../rpcContext'
@@ -48,7 +48,7 @@ routes.register<typeof AddTransactionRequestSchema, AddTransactionResponse>(
     const verify = Verifier.verifyCreatedTransaction(transaction, context.strategy.consensus)
 
     if (!verify.valid) {
-      throw new ValidationError(`Invalid transaction, reason: ${String(verify.reason)}`, 400)
+      throw new RpcValidationError(`Invalid transaction, reason: ${String(verify.reason)}`, 400)
     }
 
     await context.wallet.addPendingTransaction(transaction)
@@ -58,7 +58,7 @@ routes.register<typeof AddTransactionRequestSchema, AddTransactionResponse>(
     )
 
     if (accounts.length === 0) {
-      throw new ValidationError(
+      throw new RpcValidationError(
         `Transaction ${transaction.hash().toString('hex')} is not related to any account`,
       )
     }

--- a/ironfish/src/rpc/routes/wallet/create.ts
+++ b/ironfish/src/rpc/routes/wallet/create.ts
@@ -8,7 +8,7 @@
  * is the verbObject naming convention. For example, `POST /wallet/burnAsset` burns an asset.
  */
 
-import { ERROR_CODES, ValidationError } from '../../adapters'
+import { ERROR_CODES, RpcValidationError } from '../../adapters'
 import { ApiNamespace } from '../namespaces'
 import { routes } from '../router'
 import { AssertHasRpcContext } from '../rpcContext'
@@ -23,7 +23,7 @@ routes.register<typeof CreateAccountRequestSchema, CreateAccountResponse>(
     const name = request.data.name
 
     if (context.wallet.accountExists(name)) {
-      throw new ValidationError(
+      throw new RpcValidationError(
         `There is already an account with the name ${name}`,
         400,
         ERROR_CODES.ACCOUNT_EXISTS,

--- a/ironfish/src/rpc/routes/wallet/createAccount.ts
+++ b/ironfish/src/rpc/routes/wallet/createAccount.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
-import { ERROR_CODES, ValidationError } from '../../adapters'
+import { ERROR_CODES, RpcValidationError } from '../../adapters'
 import { ApiNamespace } from '../namespaces'
 import { routes } from '../router'
 import { AssertHasRpcContext } from '../rpcContext'
@@ -48,7 +48,7 @@ routes.register<typeof CreateAccountRequestSchema, CreateAccountResponse>(
     const name = request.data.name
 
     if (context.wallet.accountExists(name)) {
-      throw new ValidationError(
+      throw new RpcValidationError(
         `There is already an account with the name ${name}`,
         400,
         ERROR_CODES.ACCOUNT_EXISTS,

--- a/ironfish/src/rpc/routes/wallet/createTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/createTransaction.ts
@@ -13,7 +13,7 @@ import { RawTransactionSerde } from '../../../primitives/rawTransaction'
 import { CurrencyUtils, YupUtils } from '../../../utils'
 import { Wallet } from '../../../wallet'
 import { NotEnoughFundsError } from '../../../wallet/errors'
-import { ERROR_CODES, ValidationError } from '../../adapters/errors'
+import { ERROR_CODES, RpcValidationError } from '../../adapters/errors'
 import { ApiNamespace } from '../namespaces'
 import { routes } from '../router'
 import { AssertHasRpcContext } from '../rpcContext'
@@ -136,7 +136,7 @@ routes.register<typeof CreateTransactionRequestSchema, CreateTransactionResponse
 
       for (const mint of request.data.mints) {
         if (mint.assetId == null && mint.name == null) {
-          throw new ValidationError('Must provide name or identifier to mint')
+          throw new RpcValidationError('Must provide name or identifier to mint')
         }
 
         let creator = account.publicAddress
@@ -148,7 +148,7 @@ routes.register<typeof CreateTransactionRequestSchema, CreateTransactionResponse
           const asset = await account.getAsset(assetId)
 
           if (!asset) {
-            throw new ValidationError(`Error minting: Asset ${mint.assetId} not found.`)
+            throw new RpcValidationError(`Error minting: Asset ${mint.assetId} not found.`)
           }
 
           creator = asset.creator.toString('hex')
@@ -209,7 +209,7 @@ routes.register<typeof CreateTransactionRequestSchema, CreateTransactionResponse
       })
     } catch (e) {
       if (e instanceof NotEnoughFundsError) {
-        throw new ValidationError(e.message, 400, ERROR_CODES.INSUFFICIENT_BALANCE)
+        throw new RpcValidationError(e.message, 400, ERROR_CODES.INSUFFICIENT_BALANCE)
       }
       throw e
     }

--- a/ironfish/src/rpc/routes/wallet/getAsset.ts
+++ b/ironfish/src/rpc/routes/wallet/getAsset.ts
@@ -4,7 +4,7 @@
 import { ASSET_ID_LENGTH } from '@ironfish/rust-nodejs'
 import * as yup from 'yup'
 import { CurrencyUtils } from '../../../utils'
-import { NotFoundError, ValidationError } from '../../adapters'
+import { RpcNotFoundError, RpcValidationError } from '../../adapters'
 import { ApiNamespace } from '../namespaces'
 import { routes } from '../router'
 import { AssertHasRpcContext } from '../rpcContext'
@@ -41,14 +41,14 @@ routes.register<typeof GetWalletAssetRequestSchema, GetWalletAssetResponse>(
 
     const id = Buffer.from(request.data.id, 'hex')
     if (id.byteLength !== ASSET_ID_LENGTH) {
-      throw new ValidationError(
+      throw new RpcValidationError(
         `Asset identifier is invalid length, expected ${ASSET_ID_LENGTH} but got ${id.byteLength}`,
       )
     }
 
     const asset = await account.getAsset(id)
     if (!asset) {
-      throw new NotFoundError(`No asset found with identifier ${request.data.id}`)
+      throw new RpcNotFoundError(`No asset found with identifier ${request.data.id}`)
     }
 
     request.end({

--- a/ironfish/src/rpc/routes/wallet/getNodeStatus.ts
+++ b/ironfish/src/rpc/routes/wallet/getNodeStatus.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Assert } from '../../../assert'
-import { ValidationError } from '../../adapters'
+import { RpcValidationError } from '../../adapters'
 import { RpcSocketClient } from '../../clients'
 import { ApiNamespace } from '../namespaces'
 import { GetNodeStatusResponse, GetStatusRequestSchema } from '../node/getStatus'
@@ -16,7 +16,7 @@ routes.register<typeof GetStatusRequestSchema, GetNodeStatusResponse>(
     Assert.isNotNull(wallet.nodeClient)
 
     if (wallet.nodeClient instanceof RpcSocketClient && !wallet.nodeClient.isConnected) {
-      throw new ValidationError('Wallet node client is disconnected')
+      throw new RpcValidationError('Wallet node client is disconnected')
     }
 
     if (!request.data?.stream) {

--- a/ironfish/src/rpc/routes/wallet/mintAsset.ts
+++ b/ironfish/src/rpc/routes/wallet/mintAsset.ts
@@ -10,7 +10,7 @@ import * as yup from 'yup'
 import { Assert } from '../../../assert'
 import { CurrencyUtils, YupUtils } from '../../../utils'
 import { MintAssetOptions } from '../../../wallet/interfaces/mintAssetOptions'
-import { ValidationError } from '../../adapters'
+import { RpcValidationError } from '../../adapters'
 import { ApiNamespace } from '../namespaces'
 import { routes } from '../router'
 import { AssertHasRpcContext } from '../rpcContext'
@@ -92,7 +92,7 @@ routes.register<typeof MintAssetRequestSchema, MintAssetResponse>(
       request.data.transferOwnershipTo &&
       !isValidPublicAddress(request.data.transferOwnershipTo)
     ) {
-      throw new ValidationError('transferOwnershipTo must be a valid public address')
+      throw new RpcValidationError('transferOwnershipTo must be a valid public address')
     }
 
     let options: MintAssetOptions

--- a/ironfish/src/rpc/routes/wallet/rescanAccount.ts
+++ b/ironfish/src/rpc/routes/wallet/rescanAccount.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
 import { GENESIS_BLOCK_SEQUENCE } from '../../../primitives'
-import { ValidationError } from '../../adapters/errors'
+import { RpcValidationError } from '../../adapters/errors'
 import { ApiNamespace } from '../namespaces'
 import { routes } from '../router'
 import { AssertHasRpcContext } from '../rpcContext'
@@ -35,7 +35,7 @@ routes.register<typeof RescanAccountRequestSchema, RescanAccountResponse>(
     let scan = context.wallet.scan
 
     if (scan && !request.data.follow) {
-      throw new ValidationError(`A transaction rescan is already running`)
+      throw new RpcValidationError(`A transaction rescan is already running`)
     }
 
     if (!scan) {
@@ -50,7 +50,7 @@ routes.register<typeof RescanAccountRequestSchema, RescanAccountResponse>(
         const response = await context.wallet.chainGetBlock({ sequence: request.data.from })
 
         if (response === null) {
-          throw new ValidationError(
+          throw new RpcValidationError(
             `No block header found in the chain at sequence ${request.data.from}`,
           )
         }

--- a/ironfish/src/rpc/routes/wallet/sendTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/sendTransaction.ts
@@ -8,7 +8,7 @@ import { Assert } from '../../../assert'
 import { CurrencyUtils, YupUtils } from '../../../utils'
 import { Wallet } from '../../../wallet'
 import { NotEnoughFundsError } from '../../../wallet/errors'
-import { ERROR_CODES, ValidationError } from '../../adapters/errors'
+import { ERROR_CODES, RpcValidationError } from '../../adapters/errors'
 import { ApiNamespace } from '../namespaces'
 import { routes } from '../router'
 import { AssertHasRpcContext } from '../rpcContext'
@@ -80,7 +80,7 @@ routes.register<typeof SendTransactionRequestSchema, SendTransactionResponse>(
     const status = await context.wallet.nodeClient.node.getStatus()
 
     if (!status.content.blockchain.synced) {
-      throw new ValidationError(
+      throw new RpcValidationError(
         `Your node must be synced with the Iron Fish network to send a transaction. Please try again later`,
       )
     }
@@ -123,7 +123,7 @@ routes.register<typeof SendTransactionRequestSchema, SendTransactionResponse>(
       })
 
       if (balance.available < sum) {
-        throw new ValidationError(
+        throw new RpcValidationError(
           `Your balance is too low. Add funds to your account first`,
           undefined,
           ERROR_CODES.INSUFFICIENT_BALANCE,
@@ -145,7 +145,7 @@ routes.register<typeof SendTransactionRequestSchema, SendTransactionResponse>(
       })
     } catch (e) {
       if (e instanceof NotEnoughFundsError) {
-        throw new ValidationError(e.message, 400, ERROR_CODES.INSUFFICIENT_BALANCE)
+        throw new RpcValidationError(e.message, 400, ERROR_CODES.INSUFFICIENT_BALANCE)
       }
       throw e
     }

--- a/ironfish/src/rpc/routes/wallet/utils.ts
+++ b/ironfish/src/rpc/routes/wallet/utils.ts
@@ -10,7 +10,7 @@ import { AssetValue } from '../../../wallet/walletdb/assetValue'
 import { DecryptedNoteValue } from '../../../wallet/walletdb/decryptedNoteValue'
 import { TransactionValue } from '../../../wallet/walletdb/transactionValue'
 import { WorkerPool } from '../../../workerPool'
-import { ValidationError } from '../../adapters'
+import { RpcValidationError } from '../../adapters'
 import {
   RpcAccountAssetBalanceDelta,
   RpcAccountImport,
@@ -25,7 +25,7 @@ export function getAccount(wallet: Wallet, name?: string): Account {
     if (account) {
       return account
     }
-    throw new ValidationError(`No account with name ${name}`)
+    throw new RpcValidationError(`No account with name ${name}`)
   }
 
   const defaultAccount = wallet.getDefaultAccount()
@@ -33,7 +33,7 @@ export function getAccount(wallet: Wallet, name?: string): Account {
     return defaultAccount
   }
 
-  throw new ValidationError(
+  throw new RpcValidationError(
     `No account is currently active.\n\n` +
       `Use ironfish wallet:create <name> to first create an account`,
   )


### PR DESCRIPTION
## Summary

All RPC types now have an "Rpc" prefix. This is useful so you don't mix Rpc types unknowingly in other systems. Names now generally follow this protocol

**Pattern**
1. Rpc
2. Adapter (ex Socket, Ipc, Http) (Optional if applies to all protocols)
3. Server | Client (Optional if applies to both)
4. Thing (Ex Response, Error, etc)
5. Schema (Optional if this is a schema for that thing)

**Examples**
- RpcSocketClientMessage
- RpcSocketClientMessageSchema
- RpcSocketError

## Testing Plan

This only renames types so the existing tests and building the project should be sufficient.

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[X] Yes
```

I'll document this in the latest release.
