### PR TITLE
Query the full consensus parameters in the pool and solo miners

### DIFF
--- a/ironfish/src/mining/pool.ts
+++ b/ironfish/src/mining/pool.ts
@@ -354,7 +354,7 @@ export class MiningPool {
       return
     }
 
-    // Get block explorer URLs based on netowrk ID
+    // Get block explorer URLs based on network ID
     const networkResponse = await this.rpc.chain.getNetworkInfo()
     const explorer = this.getExplorer(networkResponse.content.networkId)
     this.webhooks.map((w) => w.poolConnected(explorer ?? undefined))


### PR DESCRIPTION
## Summary
Add the consensus parameters to pool and solo miner to be able to switch at the FishHash activation sequence.

## Testing Plan
Unit test + running pool miner / solo miner on devnet

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
