### PR TITLE
Rename ERROR_CODES TO RPC_ERROR_CODES

### DIFF
--- a/ironfish-cli/src/utils/fees.ts
+++ b/ironfish-cli/src/utils/fees.ts
@@ -7,10 +7,10 @@ import {
   Assert,
   CreateTransactionRequest,
   CurrencyUtils,
-  ERROR_CODES,
   Logger,
   RawTransaction,
   RawTransactionSerde,
+  RPC_ERROR_CODES,
   RpcClient,
   RpcRequestError,
 } from '@ironfish/sdk'
@@ -109,7 +109,10 @@ async function getTxWithFee(
   })
 
   const response = await promise.catch((e) => {
-    if (e instanceof RpcRequestError && e.code === ERROR_CODES.INSUFFICIENT_BALANCE.valueOf()) {
+    if (
+      e instanceof RpcRequestError &&
+      e.code === RPC_ERROR_CODES.INSUFFICIENT_BALANCE.valueOf()
+    ) {
       return null
     } else {
       throw e

--- a/ironfish/src/rpc/adapters/errors.ts
+++ b/ironfish/src/rpc/adapters/errors.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /** All the known error codes for APIs that can be sent back from all APIs */
-export enum ERROR_CODES {
+export enum RPC_ERROR_CODES {
   ACCOUNT_EXISTS = 'account-exists',
   ERROR = 'error',
   ROUTE_NOT_FOUND = 'route-not-found',
@@ -30,7 +30,7 @@ export class RpcResponseError extends Error {
 
   constructor(message: string, code?: string, status?: number)
   constructor(error: Error, code?: string, status?: number)
-  constructor(messageOrError: string | Error, code = ERROR_CODES.ERROR, status = 400) {
+  constructor(messageOrError: string | Error, code = RPC_ERROR_CODES.ERROR, status = 400) {
     super(messageOrError instanceof Error ? messageOrError.message : messageOrError)
 
     if (messageOrError instanceof Error) {
@@ -48,7 +48,7 @@ export class RpcResponseError extends Error {
  * a 400 error to the user based on validation
  */
 export class RpcValidationError extends RpcResponseError {
-  constructor(message: string, status = 400, code = ERROR_CODES.VALIDATION) {
+  constructor(message: string, status = 400, code = RPC_ERROR_CODES.VALIDATION) {
     super(message, code, status)
   }
 }
@@ -57,7 +57,7 @@ export class RpcValidationError extends RpcResponseError {
  * A convenience error to throw inside of routes when a resource is not found
  */
 export class RpcNotFoundError extends RpcResponseError {
-  constructor(message: string, status = 404, code = ERROR_CODES.NOT_FOUND) {
+  constructor(message: string, status = 404, code = RPC_ERROR_CODES.NOT_FOUND) {
     super(message, code, status)
   }
 }

--- a/ironfish/src/rpc/adapters/httpAdapter.ts
+++ b/ironfish/src/rpc/adapters/httpAdapter.ts
@@ -11,7 +11,7 @@ import { RpcRequest } from '../request'
 import { ApiNamespace, Router } from '../routes'
 import { RpcServer } from '../server'
 import { IRpcAdapter } from './adapter'
-import { ERROR_CODES, RpcResponseError } from './errors'
+import { RPC_ERROR_CODES, RpcResponseError } from './errors'
 import { MESSAGE_DELIMITER } from './socketAdapter'
 
 const MEGABYTES = 1000 * 1000
@@ -102,7 +102,7 @@ export class RpcHttpAdapter implements IRpcAdapter {
             const error = ErrorUtils.renderError(e)
             this.logger.debug(`Error in HTTP adapter: ${error}`)
             let errorResponse: RpcHttpError = {
-              code: ERROR_CODES.ERROR,
+              code: RPC_ERROR_CODES.ERROR,
               status: 500,
               message: error,
             }

--- a/ironfish/src/rpc/adapters/ipcAdapter.test.ts
+++ b/ironfish/src/rpc/adapters/ipcAdapter.test.ts
@@ -9,7 +9,7 @@ import { PromiseUtils } from '../../utils/promise'
 import { RpcRequestError } from '../clients'
 import { RpcIpcClient } from '../clients/ipcClient'
 import { ALL_API_NAMESPACES } from '../routes/router'
-import { ERROR_CODES, RpcValidationError } from './errors'
+import { RPC_ERROR_CODES, RpcValidationError } from './errors'
 import { RpcIpcAdapter } from './ipcAdapter'
 
 describe('IpcAdapter', () => {
@@ -102,7 +102,7 @@ describe('IpcAdapter', () => {
 
   it('should handle errors', async () => {
     ipc.router?.routes.register('foo/bar', yup.object({}), () => {
-      throw new RpcValidationError('hello error', 402, 'hello-error' as ERROR_CODES)
+      throw new RpcValidationError('hello error', 402, 'hello-error' as RPC_ERROR_CODES)
     })
 
     await ipc.start()
@@ -134,7 +134,7 @@ describe('IpcAdapter', () => {
     await expect(response.waitForEnd()).rejects.toThrow(RpcRequestError)
     await expect(response.waitForEnd()).rejects.toMatchObject({
       status: 400,
-      code: ERROR_CODES.VALIDATION,
+      code: RPC_ERROR_CODES.VALIDATION,
       codeMessage: expect.stringContaining('this must be defined'),
     })
   })

--- a/ironfish/src/rpc/adapters/socketAdapter/socketAdapter.ts
+++ b/ironfish/src/rpc/adapters/socketAdapter/socketAdapter.ts
@@ -14,7 +14,7 @@ import { RpcRequest } from '../../request'
 import { ApiNamespace, Router } from '../../routes'
 import { RpcServer } from '../../server'
 import { IRpcAdapter } from '../adapter'
-import { ERROR_CODES, RpcResponseError } from '../errors'
+import { RPC_ERROR_CODES, RpcResponseError } from '../errors'
 import {
   MESSAGE_DELIMITER,
   RpcSocketClientMessageSchema,
@@ -239,7 +239,7 @@ export abstract class RpcSocketAdapter implements IRpcAdapter {
             const error = message.auth
               ? 'Failed authentication'
               : 'Missing authentication token'
-            throw new RpcResponseError(error, ERROR_CODES.UNAUTHENTICATED, 401)
+            throw new RpcResponseError(error, RPC_ERROR_CODES.UNAUTHENTICATED, 401)
           }
         }
 
@@ -311,7 +311,7 @@ export abstract class RpcSocketAdapter implements IRpcAdapter {
     const error = new Error(`Malformed request rejected`)
 
     const data: RpcSocketError = {
-      code: ERROR_CODES.ERROR,
+      code: RPC_ERROR_CODES.ERROR,
       message: error.message,
       stack: error.stack,
     }

--- a/ironfish/src/rpc/adapters/tcpAdapter.test.ts
+++ b/ironfish/src/rpc/adapters/tcpAdapter.test.ts
@@ -13,7 +13,7 @@ import { getUniqueTestDataDir } from '../../testUtilities'
 import { RpcRequestError } from '../clients'
 import { RpcTcpClient } from '../clients/tcpClient'
 import { ALL_API_NAMESPACES } from '../routes'
-import { ERROR_CODES, RpcValidationError } from './errors'
+import { RPC_ERROR_CODES, RpcValidationError } from './errors'
 import { RpcTcpAdapter } from './tcpAdapter'
 
 describe('TcpAdapter', () => {
@@ -97,7 +97,7 @@ describe('TcpAdapter', () => {
     Assert.isNotNull(tcp?.router)
 
     tcp.router.routes.register('foo/bar', yup.object({}), () => {
-      throw new RpcValidationError('hello error', 402, 'hello-error' as ERROR_CODES)
+      throw new RpcValidationError('hello error', 402, 'hello-error' as RPC_ERROR_CODES)
     })
 
     client = new RpcTcpClient('localhost', 0)
@@ -132,7 +132,7 @@ describe('TcpAdapter', () => {
     await expect(response.waitForEnd()).rejects.toThrow(RpcRequestError)
     await expect(response.waitForEnd()).rejects.toMatchObject({
       status: 400,
-      code: ERROR_CODES.VALIDATION,
+      code: RPC_ERROR_CODES.VALIDATION,
       codeMessage: expect.stringContaining('this must be defined'),
     })
   }, 20000)
@@ -173,7 +173,7 @@ describe('TcpAdapter', () => {
 
     await expect(response.waitForEnd()).rejects.toMatchObject({
       status: 401,
-      code: ERROR_CODES.UNAUTHENTICATED,
+      code: RPC_ERROR_CODES.UNAUTHENTICATED,
       codeMessage: expect.stringContaining('Failed authentication'),
     })
   }, 20000)
@@ -197,7 +197,7 @@ describe('TcpAdapter', () => {
 
     await expect(response.waitForEnd()).rejects.toMatchObject({
       status: 401,
-      code: ERROR_CODES.UNAUTHENTICATED,
+      code: RPC_ERROR_CODES.UNAUTHENTICATED,
       codeMessage: expect.stringContaining('Missing authentication token'),
     })
   }, 20000)

--- a/ironfish/src/rpc/routes/chain/getBlock.test.ts
+++ b/ironfish/src/rpc/routes/chain/getBlock.test.ts
@@ -4,7 +4,7 @@
 import { Assert } from '../../../assert'
 import { useBlockWithTx, useMinerBlockFixture } from '../../../testUtilities'
 import { createRouteTest } from '../../../testUtilities/routeTest'
-import { ERROR_CODES } from '../../adapters'
+import { RPC_ERROR_CODES } from '../../adapters'
 import { RpcRequestError } from '../../clients/errors'
 import { GetBlockResponse } from './getBlock'
 
@@ -50,7 +50,7 @@ describe('Route chain/getBlock', () => {
         throw e
       }
       expect(e.status).toBe(404)
-      expect(e.code).toBe(ERROR_CODES.NOT_FOUND)
+      expect(e.code).toBe(RPC_ERROR_CODES.NOT_FOUND)
       expect(e.message).toContain('No block found with hash')
     }
 
@@ -88,7 +88,7 @@ describe('Route chain/getBlock', () => {
         throw e
       }
       expect(e.status).toBe(404)
-      expect(e.code).toBe(ERROR_CODES.NOT_FOUND)
+      expect(e.code).toBe(RPC_ERROR_CODES.NOT_FOUND)
       expect(e.message).toContain('No block found with sequence')
     }
 
@@ -104,7 +104,7 @@ describe('Route chain/getBlock', () => {
         throw e
       }
       expect(e.status).toBe(404)
-      expect(e.code).toBe(ERROR_CODES.NOT_FOUND)
+      expect(e.code).toBe(RPC_ERROR_CODES.NOT_FOUND)
       expect(e.message).toContain('No block with header')
     }
   })

--- a/ironfish/src/rpc/routes/chain/getNetworkHashPower.test.ts
+++ b/ironfish/src/rpc/routes/chain/getNetworkHashPower.test.ts
@@ -4,7 +4,7 @@
 import { useAccountFixture, useMinerBlockFixture } from '../../../testUtilities/fixtures'
 import { createRouteTest } from '../../../testUtilities/routeTest'
 import { Account } from '../../../wallet'
-import { ERROR_CODES } from '../../adapters'
+import { RPC_ERROR_CODES } from '../../adapters'
 
 describe('Route chain/getNetworkHashPower', () => {
   const routeTest = createRouteTest(true)
@@ -76,7 +76,7 @@ describe('Route chain/getNetworkHashPower', () => {
       expect.objectContaining({
         message: expect.stringContaining('[blocks] value must be greater than 0'),
         status: 400,
-        code: ERROR_CODES.VALIDATION,
+        code: RPC_ERROR_CODES.VALIDATION,
       }),
     )
   })

--- a/ironfish/src/rpc/routes/faucet/getFunds.ts
+++ b/ironfish/src/rpc/routes/faucet/getFunds.ts
@@ -4,7 +4,7 @@
 import axios, { AxiosError } from 'axios'
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
-import { ERROR_CODES, RpcResponseError } from '../../adapters'
+import { RPC_ERROR_CODES, RpcResponseError } from '../../adapters'
 import { ApiNamespace } from '../namespaces'
 import { routes } from '../router'
 import { AssertHasRpcContext } from '../rpcContext'
@@ -39,7 +39,7 @@ routes.register<typeof GetFundsRequestSchema, GetFundsResponse>(
       // not testnet
       throw new RpcResponseError(
         'This endpoint is only available for testnet.',
-        ERROR_CODES.ERROR,
+        RPC_ERROR_CODES.ERROR,
       )
     }
 
@@ -57,20 +57,20 @@ routes.register<typeof GetFundsRequestSchema, GetFundsResponse>(
         if (status === 422) {
           if (data.code === 'faucet_max_requests_reached') {
             Assert.isNotUndefined(data.message)
-            throw new RpcResponseError(data.message, ERROR_CODES.VALIDATION, status)
+            throw new RpcResponseError(data.message, RPC_ERROR_CODES.VALIDATION, status)
           }
 
           throw new RpcResponseError(
             'You entered an invalid email.',
-            ERROR_CODES.VALIDATION,
+            RPC_ERROR_CODES.VALIDATION,
             status,
           )
         } else if (data.message) {
-          throw new RpcResponseError(data.message, ERROR_CODES.ERROR, status)
+          throw new RpcResponseError(data.message, RPC_ERROR_CODES.ERROR, status)
         }
       }
 
-      throw new RpcResponseError(error.message, ERROR_CODES.ERROR, Number(error.code))
+      throw new RpcResponseError(error.message, RPC_ERROR_CODES.ERROR, Number(error.code))
     })
 
     request.end({

--- a/ironfish/src/rpc/routes/router.ts
+++ b/ironfish/src/rpc/routes/router.ts
@@ -4,7 +4,7 @@
 import { Assert } from '../../assert'
 import { YupSchema, YupSchemaResult, YupUtils } from '../../utils'
 import { StrEnumUtils } from '../../utils/enums'
-import { ERROR_CODES } from '../adapters'
+import { RPC_ERROR_CODES } from '../adapters'
 import { RpcResponseError, RpcValidationError } from '../adapters/errors'
 import { RpcRequest } from '../request'
 import { RpcServer } from '../server'
@@ -22,7 +22,7 @@ export class RouteNotFoundError extends RpcResponseError {
   constructor(route: string, namespace: string, method: string) {
     super(
       `No route found ${route} in namespace ${namespace} for method ${method}`,
-      ERROR_CODES.ROUTE_NOT_FOUND,
+      RPC_ERROR_CODES.ROUTE_NOT_FOUND,
       404,
     )
   }

--- a/ironfish/src/rpc/routes/wallet/create.test.slow.ts
+++ b/ironfish/src/rpc/routes/wallet/create.test.slow.ts
@@ -7,7 +7,7 @@
 
 import { v4 as uuid } from 'uuid'
 import { createRouteTest } from '../../../testUtilities/routeTest'
-import { ERROR_CODES } from '../../adapters'
+import { RPC_ERROR_CODES } from '../../adapters'
 import { RpcRequestError } from '../../clients/errors'
 
 describe('Route wallet/create', () => {
@@ -65,7 +65,7 @@ describe('Route wallet/create', () => {
         throw e
       }
       expect(e.status).toBe(400)
-      expect(e.code).toBe(ERROR_CODES.ACCOUNT_EXISTS)
+      expect(e.code).toBe(RPC_ERROR_CODES.ACCOUNT_EXISTS)
     }
   })
 

--- a/ironfish/src/rpc/routes/wallet/create.ts
+++ b/ironfish/src/rpc/routes/wallet/create.ts
@@ -8,7 +8,7 @@
  * is the verbObject naming convention. For example, `POST /wallet/burnAsset` burns an asset.
  */
 
-import { ERROR_CODES, RpcValidationError } from '../../adapters'
+import { RPC_ERROR_CODES, RpcValidationError } from '../../adapters'
 import { ApiNamespace } from '../namespaces'
 import { routes } from '../router'
 import { AssertHasRpcContext } from '../rpcContext'
@@ -26,7 +26,7 @@ routes.register<typeof CreateAccountRequestSchema, CreateAccountResponse>(
       throw new RpcValidationError(
         `There is already an account with the name ${name}`,
         400,
-        ERROR_CODES.ACCOUNT_EXISTS,
+        RPC_ERROR_CODES.ACCOUNT_EXISTS,
       )
     }
 

--- a/ironfish/src/rpc/routes/wallet/createAccount.ts
+++ b/ironfish/src/rpc/routes/wallet/createAccount.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
-import { ERROR_CODES, RpcValidationError } from '../../adapters'
+import { RPC_ERROR_CODES, RpcValidationError } from '../../adapters'
 import { ApiNamespace } from '../namespaces'
 import { routes } from '../router'
 import { AssertHasRpcContext } from '../rpcContext'
@@ -51,7 +51,7 @@ routes.register<typeof CreateAccountRequestSchema, CreateAccountResponse>(
       throw new RpcValidationError(
         `There is already an account with the name ${name}`,
         400,
-        ERROR_CODES.ACCOUNT_EXISTS,
+        RPC_ERROR_CODES.ACCOUNT_EXISTS,
       )
     }
 

--- a/ironfish/src/rpc/routes/wallet/createTransaction.test.ts
+++ b/ironfish/src/rpc/routes/wallet/createTransaction.test.ts
@@ -7,7 +7,7 @@ import { RawTransactionSerde } from '../../../primitives/rawTransaction'
 import { useAccountFixture, useMinerBlockFixture } from '../../../testUtilities'
 import { createRouteTest } from '../../../testUtilities/routeTest'
 import { AsyncUtils } from '../../../utils'
-import { ERROR_CODES } from '../../adapters/errors'
+import { RPC_ERROR_CODES } from '../../adapters/errors'
 
 const REQUEST_PARAMS = {
   account: 'existingAccount',
@@ -51,7 +51,7 @@ describe('Route wallet/createTransaction', () => {
       expect.objectContaining({
         message: expect.any(String),
         status: 400,
-        code: ERROR_CODES.INSUFFICIENT_BALANCE,
+        code: RPC_ERROR_CODES.INSUFFICIENT_BALANCE,
       }),
     )
   })
@@ -380,7 +380,7 @@ describe('Route wallet/createTransaction', () => {
       expect.objectContaining({
         message: expect.any(String),
         status: 400,
-        code: ERROR_CODES.INSUFFICIENT_BALANCE,
+        code: RPC_ERROR_CODES.INSUFFICIENT_BALANCE,
       }),
     )
   })

--- a/ironfish/src/rpc/routes/wallet/createTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/createTransaction.ts
@@ -13,7 +13,7 @@ import { RawTransactionSerde } from '../../../primitives/rawTransaction'
 import { CurrencyUtils, YupUtils } from '../../../utils'
 import { Wallet } from '../../../wallet'
 import { NotEnoughFundsError } from '../../../wallet/errors'
-import { ERROR_CODES, RpcValidationError } from '../../adapters/errors'
+import { RPC_ERROR_CODES, RpcValidationError } from '../../adapters/errors'
 import { ApiNamespace } from '../namespaces'
 import { routes } from '../router'
 import { AssertHasRpcContext } from '../rpcContext'
@@ -209,7 +209,7 @@ routes.register<typeof CreateTransactionRequestSchema, CreateTransactionResponse
       })
     } catch (e) {
       if (e instanceof NotEnoughFundsError) {
-        throw new RpcValidationError(e.message, 400, ERROR_CODES.INSUFFICIENT_BALANCE)
+        throw new RpcValidationError(e.message, 400, RPC_ERROR_CODES.INSUFFICIENT_BALANCE)
       }
       throw e
     }

--- a/ironfish/src/rpc/routes/wallet/rename.test.ts
+++ b/ironfish/src/rpc/routes/wallet/rename.test.ts
@@ -4,7 +4,7 @@
 
 import { useAccountFixture } from '../../../testUtilities'
 import { createRouteTest } from '../../../testUtilities/routeTest'
-import { ERROR_CODES } from '../../adapters/errors'
+import { RPC_ERROR_CODES } from '../../adapters/errors'
 
 const REQUEST_PARAMS = {
   account: 'existingAccount',
@@ -19,7 +19,7 @@ describe('Route wallet/rename', () => {
       expect.objectContaining({
         message: expect.any(String),
         status: 400,
-        code: ERROR_CODES.VALIDATION,
+        code: RPC_ERROR_CODES.VALIDATION,
       }),
     )
   })

--- a/ironfish/src/rpc/routes/wallet/renameAccount.test.ts
+++ b/ironfish/src/rpc/routes/wallet/renameAccount.test.ts
@@ -4,7 +4,7 @@
 
 import { useAccountFixture } from '../../../testUtilities'
 import { createRouteTest } from '../../../testUtilities/routeTest'
-import { ERROR_CODES } from '../../adapters/errors'
+import { RPC_ERROR_CODES } from '../../adapters/errors'
 
 const REQUEST_PARAMS = {
   account: 'existingAccount',
@@ -19,7 +19,7 @@ describe('Route wallet/renameAccount', () => {
       expect.objectContaining({
         message: expect.any(String),
         status: 400,
-        code: ERROR_CODES.VALIDATION,
+        code: RPC_ERROR_CODES.VALIDATION,
       }),
     )
   })

--- a/ironfish/src/rpc/routes/wallet/sendTransaction.test.ts
+++ b/ironfish/src/rpc/routes/wallet/sendTransaction.test.ts
@@ -7,7 +7,7 @@ import { Assert } from '../../../assert'
 import { useAccountFixture, useMinersTxFixture } from '../../../testUtilities/fixtures'
 import { createRouteTest } from '../../../testUtilities/routeTest'
 import { NotEnoughFundsError } from '../../../wallet/errors'
-import { ERROR_CODES } from '../../adapters'
+import { RPC_ERROR_CODES } from '../../adapters'
 
 const TEST_PARAMS = {
   account: 'existingAccount',
@@ -74,7 +74,7 @@ describe('Route wallet/sendTransaction', () => {
           `Your balance is too low. Add funds to your account first`,
         ),
         status: 400,
-        code: ERROR_CODES.INSUFFICIENT_BALANCE,
+        code: RPC_ERROR_CODES.INSUFFICIENT_BALANCE,
       }),
     )
 
@@ -84,7 +84,7 @@ describe('Route wallet/sendTransaction', () => {
           `Your balance is too low. Add funds to your account first`,
         ),
         status: 400,
-        code: ERROR_CODES.INSUFFICIENT_BALANCE,
+        code: RPC_ERROR_CODES.INSUFFICIENT_BALANCE,
       }),
     )
   })
@@ -109,7 +109,7 @@ describe('Route wallet/sendTransaction', () => {
           `Your balance is too low. Add funds to your account first`,
         ),
         status: 400,
-        code: ERROR_CODES.INSUFFICIENT_BALANCE,
+        code: RPC_ERROR_CODES.INSUFFICIENT_BALANCE,
       }),
     )
 
@@ -130,7 +130,7 @@ describe('Route wallet/sendTransaction', () => {
           `Your balance is too low. Add funds to your account first`,
         ),
         status: 400,
-        code: ERROR_CODES.INSUFFICIENT_BALANCE,
+        code: RPC_ERROR_CODES.INSUFFICIENT_BALANCE,
       }),
     )
   })
@@ -157,7 +157,7 @@ describe('Route wallet/sendTransaction', () => {
     await expect(routeTest.client.wallet.sendTransaction(TEST_PARAMS)).rejects.toThrow(
       expect.objectContaining({
         status: 400,
-        code: ERROR_CODES.INSUFFICIENT_BALANCE,
+        code: RPC_ERROR_CODES.INSUFFICIENT_BALANCE,
       }),
     )
   })

--- a/ironfish/src/rpc/routes/wallet/sendTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/sendTransaction.ts
@@ -8,7 +8,7 @@ import { Assert } from '../../../assert'
 import { CurrencyUtils, YupUtils } from '../../../utils'
 import { Wallet } from '../../../wallet'
 import { NotEnoughFundsError } from '../../../wallet/errors'
-import { ERROR_CODES, RpcValidationError } from '../../adapters/errors'
+import { RPC_ERROR_CODES, RpcValidationError } from '../../adapters/errors'
 import { ApiNamespace } from '../namespaces'
 import { routes } from '../router'
 import { AssertHasRpcContext } from '../rpcContext'
@@ -126,7 +126,7 @@ routes.register<typeof SendTransactionRequestSchema, SendTransactionResponse>(
         throw new RpcValidationError(
           `Your balance is too low. Add funds to your account first`,
           undefined,
-          ERROR_CODES.INSUFFICIENT_BALANCE,
+          RPC_ERROR_CODES.INSUFFICIENT_BALANCE,
         )
       }
     }
@@ -145,7 +145,7 @@ routes.register<typeof SendTransactionRequestSchema, SendTransactionResponse>(
       })
     } catch (e) {
       if (e instanceof NotEnoughFundsError) {
-        throw new RpcValidationError(e.message, 400, ERROR_CODES.INSUFFICIENT_BALANCE)
+        throw new RpcValidationError(e.message, 400, RPC_ERROR_CODES.INSUFFICIENT_BALANCE)
       }
       throw e
     }


### PR DESCRIPTION
## Summary

To keep this consistent with other RPC types.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
