### PR TITLE
adds napi binding for signing package

### DIFF
--- a/ironfish-rust-nodejs/index.d.ts
+++ b/ironfish-rust-nodejs/index.d.ts
@@ -228,6 +228,7 @@ export type NativeUnsignedTransaction = UnsignedTransaction
 export class UnsignedTransaction {
   constructor(jsBytes: Buffer)
   serialize(): Buffer
+  signingPackage(nativeCommitments: Record<string, SigningCommitments>): string
 }
 export class FoundBlockResult {
   randomness: string

--- a/ironfish-rust-nodejs/src/frost.rs
+++ b/ironfish-rust-nodejs/src/frost.rs
@@ -16,19 +16,19 @@ use napi_derive::napi;
 
 use crate::to_napi_err;
 
-#[napi(object)]
-pub struct SigningCommitments {
+#[napi(object, js_name = "SigningCommitments")]
+pub struct NativeSigningCommitments {
     pub hiding: String,
     pub binding: String,
 }
 
 #[napi]
-pub fn round_one(key_package: String, seed: u32) -> Result<SigningCommitments> {
+pub fn round_one(key_package: String, seed: u32) -> Result<NativeSigningCommitments> {
     let key_package =
         KeyPackage::deserialize(&hex_to_vec_bytes(&key_package).map_err(to_napi_err)?)
             .map_err(to_napi_err)?;
     let (_, commitment) = round_one_rust(&key_package, seed as u64);
-    Ok(SigningCommitments {
+    Ok(NativeSigningCommitments {
         hiding: bytes_to_hex(&commitment.hiding().serialize()),
         binding: bytes_to_hex(&commitment.binding().serialize()),
     })


### PR DESCRIPTION
## Summary

adds binding for 'UnsignedTransaction::signing_package' to create a siging package from participant signing commitments

returns the SigningPackage serialized as a hex string

the signing package is created from the signing commitments that each participant generates in round 1. the signing package is then used as an input for generating signature shares in round 2 and for aggregating signature shares

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
