### PR TITLE
Support TRM Stratum in testnet pool

### DIFF
--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -228,6 +228,16 @@ export type ConfigOptions = {
   poolLarkWebhook: string
 
   /**
+   * Extranonce size in bytes for v2 protocol.
+   */
+  poolXnSize: number
+
+  /**
+   * Versions of the ironfish stratum protocol that the pool supports.
+   */
+  poolSupportedVersions: number[]
+
+  /**
    * Whether we want the logs to the console to be in JSON format or not. This can be used to log to
    * more easily process logs on a remote server using a log service like Datadog
    */
@@ -357,6 +367,8 @@ export const ConfigOptionsSchema: yup.ObjectSchema<Partial<ConfigOptions>> = yup
     poolDiscordWebhook: yup.string(),
     poolMaxConnectionsPerIp: YupUtils.isPositiveInteger,
     poolLarkWebhook: yup.string(),
+    poolXnSize: yup.number(),
+    poolSupportedVersions: yup.array().of(yup.number().defined().integer().min(1).max(5)),
     jsonLogs: yup.boolean(),
     feeEstimatorMaxBlockHistory: YupUtils.isPositiveInteger,
     feeEstimatorPercentileSlow: YupUtils.isPositiveInteger,
@@ -467,6 +479,8 @@ export class Config<
       poolDiscordWebhook: '',
       poolMaxConnectionsPerIp: 0,
       poolLarkWebhook: '',
+      poolXnSize: 2,
+      poolSupportedVersions: [1, 2],
       jsonLogs: false,
       feeEstimatorMaxBlockHistory: DEFAULT_FEE_ESTIMATOR_MAX_BLOCK_HISTORY,
       feeEstimatorPercentileSlow: DEFAULT_FEE_ESTIMATOR_PERCENTILE_SLOW,

--- a/ironfish/src/mining/pool.ts
+++ b/ironfish/src/mining/pool.ts
@@ -170,7 +170,7 @@ export class MiningPool {
     this.stopPromise = new Promise((r) => (this.stopResolve = r))
     this.started = true
 
-    this.logger.info(`Starting stratum server v${String(this.stratum.version)}`)
+    this.logger.info(`Starting stratum server`)
     await this.stratum.start()
 
     this.logger.info('Connecting to node...')
@@ -257,42 +257,47 @@ export class MiningPool {
     client: StratumServerClient,
     miningRequestId: number,
     randomness: string,
-  ): Promise<void> {
-    Assert.isNotNull(client.publicAddress)
-    Assert.isNotNull(client.graffiti)
+    graffiti: string,
+  ): Promise<{ error: string | null }> {
+    Assert.isNotNull(client.subscription)
     Assert.isNotNull(this.blockHasher)
 
+    if (graffiti.length !== 64) {
+      const msg = `Client ${client.id} work with invalid custom graffiti length: ${graffiti.length}`
+      this.logger.warn(msg)
+      return { error: msg }
+    } else {
+      // TODO verify hex parse?
+    }
+
     if (miningRequestId !== this.nextMiningRequestId - 1) {
-      this.logger.debug(
-        `Client ${client.id} submitted work for stale mining request: ${miningRequestId}`,
-      )
-      return
+      const msg = `Client ${client.id} submitted work for stale mining request: ${miningRequestId}`
+      this.logger.debug(msg)
+      return { error: msg }
     }
 
     const originalBlockTemplate = this.miningRequestBlocks.get(miningRequestId)
 
     if (!originalBlockTemplate) {
-      this.logger.warn(
-        `Client ${client.id} work for invalid mining request: ${miningRequestId}`,
-      )
-      return
+      const msg = `Client ${client.id} work for invalid mining request: ${miningRequestId}`
+      this.logger.warn(msg)
+      return { error: msg }
     }
 
     const blockTemplate = Object.assign({}, originalBlockTemplate)
     blockTemplate.header = Object.assign({}, originalBlockTemplate.header)
 
-    const isDuplicate = this.isDuplicateSubmission(client.id, randomness)
+    const isDuplicate = this.isDuplicateSubmission(client.id, randomness, graffiti)
 
     if (isDuplicate) {
-      this.logger.warn(
-        `Client ${client.id} submitted a duplicate mining request: ${miningRequestId}, ${randomness}`,
-      )
-      return
+      const msg = `Client ${client.id} submitted a duplicate share: ${miningRequestId}, ${randomness}, ${graffiti}`
+      this.logger.warn(msg)
+      return { error: msg }
     }
 
-    this.addWorkSubmission(client.id, randomness)
+    this.addWorkSubmission(client.id, randomness, graffiti)
 
-    blockTemplate.header.graffiti = client.graffiti.toString('hex')
+    blockTemplate.header.graffiti = graffiti
     blockTemplate.header.randomness = randomness
 
     let hashedHeader: Buffer
@@ -300,8 +305,9 @@ export class MiningPool {
       const rawBlock = RawBlockTemplateSerde.deserialize(blockTemplate)
       hashedHeader = this.blockHasher.hashHeader(rawBlock.header)
     } catch (error) {
-      this.stratum.peers.punish(client, `${client.id} sent malformed work.`)
-      return
+      const msg = `${client.id} sent malformed work.`
+      this.stratum.peers.punish(client, msg)
+      return { error: msg }
     }
 
     if (hashedHeader.compare(Buffer.from(blockTemplate.header.target, 'hex')) !== 1) {
@@ -333,8 +339,10 @@ export class MiningPool {
     }
 
     if (hashedHeader.compare(this.target) !== 1) {
-      this.logger.debug('Valid pool share submitted')
-      await this.shares.submitShare(client.publicAddress)
+      await this.shares.submitShare(client.subscription.publicAddress)
+      return { error: null }
+    } else {
+      return { error: 'low difficulty' }
     }
   }
 
@@ -482,20 +490,26 @@ export class MiningPool {
     }, RECALCULATE_TARGET_TIMEOUT)
   }
 
-  private isDuplicateSubmission(clientId: number, randomness: string): boolean {
+  private isDuplicateSubmission(
+    clientId: number,
+    randomness: string,
+    graffiti: string,
+  ): boolean {
     const submissions = this.recentSubmissions.get(clientId)
     if (submissions == null) {
       return false
     }
-    return submissions.includes(randomness)
+    const k = randomness + '|' + graffiti
+    return submissions.includes(k)
   }
 
-  private addWorkSubmission(clientId: number, randomness: string): void {
+  private addWorkSubmission(clientId: number, randomness: string, graffiti: string): void {
     const submissions = this.recentSubmissions.get(clientId)
+    const k = randomness + '|' + graffiti
     if (submissions == null) {
-      this.recentSubmissions.set(clientId, [randomness])
+      this.recentSubmissions.set(clientId, [k])
     } else {
-      submissions.push(randomness)
+      submissions.push(k)
       this.recentSubmissions.set(clientId, submissions)
     }
   }
@@ -542,9 +556,9 @@ export class MiningPool {
       const addressConnectedMiners: string[] = []
 
       for (const client of this.stratum.clients.values()) {
-        if (client.subscribed && client.publicAddress === publicAddress) {
+        if (client.subscription?.publicAddress === publicAddress) {
           addressMinerCount++
-          addressConnectedMiners.push(client.name || `Miner ${client.id}`)
+          addressConnectedMiners.push(client.subscription.name || `Miner ${client.id}`)
         }
       }
 

--- a/ironfish/src/mining/stratum/clients/client.ts
+++ b/ironfish/src/mining/stratum/clients/client.ts
@@ -18,16 +18,15 @@ import {
   MiningSetTargetSchema,
   MiningStatusMessage,
   MiningStatusSchema,
-  MiningSubmitMessage,
-  MiningSubscribedMessage,
-  MiningSubscribedMessageSchema,
+  MiningSubmitMessageV1,
+  MiningSubscribedMessageSchemaV1,
+  MiningSubscribedMessageV1,
   MiningSubscribeMessage,
   MiningWaitForWorkMessage,
   MiningWaitForWorkSchema,
   StratumMessage,
   StratumMessageSchema,
 } from '../messages'
-import { VERSION_PROTOCOL_STRATUM } from '../version'
 
 export abstract class StratumClient {
   readonly logger: Logger
@@ -47,7 +46,7 @@ export abstract class StratumClient {
   private disconnectMessage: string | null = null
 
   readonly onConnected = new Event<[]>()
-  readonly onSubscribed = new Event<[MiningSubscribedMessage]>()
+  readonly onSubscribed = new Event<[MiningSubscribedMessageV1]>()
   readonly onSetTarget = new Event<[MiningSetTargetMessage]>()
   readonly onNotify = new Event<[MiningNotifyMessage]>()
   readonly onWaitForWork = new Event<[MiningWaitForWorkMessage]>()
@@ -55,7 +54,8 @@ export abstract class StratumClient {
 
   constructor(options: { logger: Logger }) {
     this.logger = options.logger
-    this.version = VERSION_PROTOCOL_STRATUM
+    // TODO: upgrade this client to FishHash version when ready
+    this.version = 1
 
     this.started = false
     this.id = null
@@ -141,7 +141,7 @@ export abstract class StratumClient {
     return this.connected
   }
 
-  private send(method: 'mining.submit', body: MiningSubmitMessage): void
+  private send(method: 'mining.submit', body: MiningSubmitMessageV1): void
   private send(method: 'mining.subscribe', body: MiningSubscribeMessage): void
   private send(method: 'mining.get_status', body: MiningGetStatusMessage): void
   private send(method: string, body?: unknown): void {
@@ -229,7 +229,7 @@ export abstract class StratumClient {
 
         case 'mining.subscribed': {
           const body = await YupUtils.tryValidate(
-            MiningSubscribedMessageSchema,
+            MiningSubscribedMessageSchemaV1,
             header.result.body,
           )
 

--- a/ironfish/src/mining/stratum/messages.ts
+++ b/ironfish/src/mining/stratum/messages.ts
@@ -9,6 +9,13 @@ export type StratumMessage = {
   body?: unknown
 }
 
+export interface StratumMessageWithError extends Omit<StratumMessage, 'method' | 'body'> {
+  error: {
+    id: number
+    message: string
+  }
+}
+
 export type MiningDisconnectMessage =
   | {
       reason?: string
@@ -22,16 +29,34 @@ export type MiningSubscribeMessage = {
   version: number
   name?: string
   publicAddress: string
+  agent?: string
 }
 
-export type MiningSubmitMessage = {
+export type MiningSubmitMessageV1 = {
   miningRequestId: number
   randomness: string
 }
 
-export type MiningSubscribedMessage = {
+export type MiningSubmitMessageV2 = {
+  miningRequestId: number
+  randomness: string
+  graffiti: string
+}
+
+export type MiningSubscribedMessageV1 = {
   clientId: number
   graffiti: string
+}
+
+export type MiningSubscribedMessageV2 = {
+  clientId: number
+  xn: string
+}
+
+export type MiningSubmittedMessageV2 = {
+  id: number
+  result: boolean
+  message?: string
 }
 
 export type MiningSetTargetMessage = {
@@ -75,6 +100,18 @@ export const StratumMessageSchema: yup.ObjectSchema<StratumMessage> = yup
   })
   .required()
 
+export const StratumMessageWithErrorSchema: yup.ObjectSchema<StratumMessageWithError> = yup
+  .object({
+    id: yup.number().required(),
+    error: yup
+      .object({
+        id: yup.number().required(),
+        message: yup.string().required(),
+      })
+      .required(),
+  })
+  .required()
+
 export const MiningDisconnectMessageSchema: yup.ObjectSchema<MiningDisconnectMessage> = yup
   .object({
     reason: yup.string().optional(),
@@ -84,16 +121,31 @@ export const MiningDisconnectMessageSchema: yup.ObjectSchema<MiningDisconnectMes
   })
   .optional()
 
-export const MiningSubscribedMessageSchema: yup.ObjectSchema<MiningSubscribedMessage> = yup
+export const MiningSubscribedMessageSchemaV1: yup.ObjectSchema<MiningSubscribedMessageV1> = yup
   .object({
     clientId: yup.number().required(),
     graffiti: yup.string().required(),
   })
   .required()
 
+export const MiningSubscribedMessageV2Schema: yup.ObjectSchema<MiningSubscribedMessageV2> = yup
+  .object({
+    clientId: yup.number().required(),
+    xn: yup.string().required(),
+  })
+  .required()
+
 export const MiningSetTargetSchema: yup.ObjectSchema<MiningSetTargetMessage> = yup
   .object({
     target: yup.string().required(),
+  })
+  .required()
+
+export const MiningSubmittedSchemaV2: yup.ObjectSchema<MiningSubmittedMessageV2> = yup
+  .object({
+    id: yup.number().required(),
+    result: yup.bool().required(),
+    message: yup.string().optional(),
   })
   .required()
 
@@ -113,13 +165,22 @@ export const MiningSubscribeSchema: yup.ObjectSchema<MiningSubscribeMessage> = y
     version: yup.number().required(),
     name: yup.string().optional(),
     publicAddress: yup.string().required(),
+    agent: yup.string().optional(),
   })
   .required()
 
-export const MiningSubmitSchema: yup.ObjectSchema<MiningSubmitMessage> = yup
+export const MiningSubmitSchemaV1: yup.ObjectSchema<MiningSubmitMessageV1> = yup
   .object({
     miningRequestId: yup.number().required(),
     randomness: yup.string().required(),
+  })
+  .required()
+
+export const MiningSubmitSchemaV2: yup.ObjectSchema<MiningSubmitMessageV2> = yup
+  .object({
+    miningRequestId: yup.number().required(),
+    randomness: yup.string().required(),
+    graffiti: yup.string().required(),
   })
   .required()
 

--- a/ironfish/src/mining/stratum/stratumServer.ts
+++ b/ironfish/src/mining/stratum/stratumServer.ts
@@ -247,7 +247,7 @@ export class StratumServer {
       return
     }
 
-    if (![1, 2].includes(body.result.version)) {
+    if (!this.supportedVersions.includes(body.result.version)) {
       const msg = `Client version ${body.result.version} is not handled by this server`
       this.sendStratumError(client, message.id, msg)
       this.peers.ban(client, {

--- a/ironfish/src/mining/stratum/stratumServer.ts
+++ b/ironfish/src/mining/stratum/stratumServer.ts
@@ -20,17 +20,20 @@ import {
   MiningNotifyMessage,
   MiningSetTargetMessage,
   MiningStatusMessage,
-  MiningSubmitSchema,
-  MiningSubscribedMessage,
+  MiningSubmitSchemaV1,
+  MiningSubmitSchemaV2,
+  MiningSubmittedMessageV2,
+  MiningSubscribedMessageV1,
+  MiningSubscribedMessageV2,
   MiningSubscribeSchema,
   StratumMessage,
   StratumMessageSchema,
+  StratumMessageWithError,
 } from './messages'
 import { StratumPeers } from './stratumPeers'
 import { StratumServerClient } from './stratumServerClient'
-import { VERSION_PROTOCOL_STRATUM, VERSION_PROTOCOL_STRATUM_MIN } from './version'
 
-const FIVE_MINUTES_MS = 5 * 60 * 1000
+const SUPPORTED_VERSIONS = [1, 2]
 
 export class StratumServer {
   readonly pool: MiningPool
@@ -46,8 +49,7 @@ export class StratumServer {
 
   currentWork: Buffer | null = null
   currentMiningRequestId: number | null = null
-  readonly version: number
-  readonly versionMin: number
+  readonly supportedVersions: number[]
 
   private _isRunning = false
   private _startPromise: Promise<unknown> | null = null
@@ -62,8 +64,7 @@ export class StratumServer {
     this.config = options.config
     this.logger = options.logger
 
-    this.version = VERSION_PROTOCOL_STRATUM
-    this.versionMin = VERSION_PROTOCOL_STRATUM_MIN
+    this.supportedVersions = SUPPORTED_VERSIONS
 
     this.clients = new Map()
     this.nextMinerId = 1
@@ -92,6 +93,9 @@ export class StratumServer {
     this._startPromise = Promise.all(this.adapters.map((a) => a.start()))
     this._isRunning = true
     await this._startPromise
+    this.logger.info(
+      `Stratum server started with versions ${this.supportedVersions.join(', ')}`,
+    )
   }
 
   /** Stops the Stratum server and tells any attached adapters to stop serving requests */
@@ -175,7 +179,7 @@ export class StratumServer {
   private onDisconnect(client: StratumServerClient): void {
     this.logger.debug(`Client ${client.id} disconnected  (${this.clients.size - 1} total)`)
 
-    if (client.subscribed) {
+    if (client.subscription) {
       this.subscribed--
     }
 
@@ -191,126 +195,206 @@ export class StratumServer {
       return
     }
 
-    client.messageBuffer += data.toString('utf-8')
-    const lastDelimiterIndex = client.messageBuffer.lastIndexOf('\n')
-    const splits = client.messageBuffer.substring(0, lastDelimiterIndex).trim().split('\n')
-    client.messageBuffer = client.messageBuffer.substring(lastDelimiterIndex + 1)
+    client.messageBuffer.write(data)
 
-    for (const split of splits) {
+    for (const split of client.messageBuffer.readMessages()) {
       const payload: unknown = JSON.parse(split)
+      const { error: parseError, result: message } = await YupUtils.tryValidate(
+        StratumMessageSchema,
+        payload,
+      )
 
-      const header = await YupUtils.tryValidate(StratumMessageSchema, payload)
-
-      if (header.error) {
+      if (parseError) {
         this.peers.ban(client, {
-          message: header.error.message,
+          message: parseError.message,
         })
         return
       }
 
-      this.logger.debug(`Client ${client.id} sent ${header.result.method} message`)
+      this.logger.debug(`Client ${client.id} sent ${message.method} message`)
 
-      switch (header.result.method) {
-        case 'mining.subscribe': {
-          const body = await YupUtils.tryValidate(MiningSubscribeSchema, header.result.body)
-
-          if (body.error) {
-            this.peers.ban(client, {
-              message: body.error.message,
-            })
-            return
-          }
-
-          if (body.result.version < this.versionMin) {
-            this.peers.ban(client, {
-              message: `Client version ${body.result.version} does not meet minimum version ${this.versionMin}`,
-              reason: DisconnectReason.BAD_VERSION,
-              until: Date.now() + FIVE_MINUTES_MS,
-              versionExpected: this.version,
-            })
-            return
-          }
-
-          if (!isValidPublicAddress(body.result.publicAddress)) {
-            this.peers.ban(client, {
-              message: `Invalid public address: ${body.result.publicAddress}`,
-            })
-            return
-          }
-
-          client.publicAddress = body.result.publicAddress
-          client.name = body.result.name
-          client.subscribed = true
-          this.subscribed++
-
-          const idHex = client.id.toString(16)
-          const graffiti = `${this.pool.name}.${idHex}`
-          Assert.isTrue(StringUtils.getByteLength(graffiti) <= GRAFFITI_SIZE)
-          client.graffiti = GraffitiUtils.fromString(graffiti)
-
-          this.logger.info(`Miner ${idHex} connected (${this.subscribed} total)`)
-
-          this.send(client.socket, 'mining.subscribed', {
-            clientId: client.id,
-            graffiti: graffiti,
-          })
-
-          this.send(client.socket, 'mining.set_target', this.getSetTargetMessage())
-
-          if (this.hasWork()) {
-            this.send(client.socket, 'mining.notify', this.getNotifyMessage())
-          }
-
-          break
-        }
-
-        case 'mining.submit': {
-          const body = await YupUtils.tryValidate(MiningSubmitSchema, header.result.body)
-
-          if (body.error) {
-            this.peers.ban(client, {
-              message: body.error.message,
-            })
-            return
-          }
-
-          const submittedRequestId = body.result.miningRequestId
-          const submittedRandomness = body.result.randomness
-
-          void this.pool.submitWork(client, submittedRequestId, submittedRandomness)
-          break
-        }
-
-        case 'mining.get_status': {
-          const body = await YupUtils.tryValidate(MiningGetStatusSchema, header.result.body)
-
-          if (body.error) {
-            this.peers.ban(client, {
-              message: body.error.message,
-            })
-            return
-          }
-
-          const publicAddress = body.result?.publicAddress
-
-          if (publicAddress && !isValidPublicAddress(publicAddress)) {
-            this.peers.ban(client, {
-              message: `Invalid public address: ${publicAddress}`,
-            })
-            return
-          }
-
-          this.send(client.socket, 'mining.status', await this.pool.getStatus(publicAddress))
-          break
-        }
-
-        default:
-          throw new ClientMessageMalformedError(
-            client,
-            `Invalid message ${header.result.method}`,
-          )
+      if (message.method === 'mining.subscribe') {
+        await this.handleMiningSubscribeMessage(client, message)
+      } else if (message.method === 'mining.submit') {
+        await this.handleMiningSubmitMessage(client, message)
+      } else if (message.method === 'mining.get_status') {
+        await this.handleMiningGetStatusMessage(client, message)
+      } else {
+        throw new ClientMessageMalformedError(client, `Invalid message ${message.method}`)
       }
     }
+  }
+
+  private async handleMiningSubscribeMessage(
+    client: StratumServerClient,
+    message: StratumMessage,
+  ) {
+    const body = await YupUtils.tryValidate(MiningSubscribeSchema, message.body)
+
+    if (body.error) {
+      this.peers.ban(client, {
+        message: body.error.message,
+      })
+      return
+    }
+
+    if (!isValidPublicAddress(body.result.publicAddress)) {
+      const msg = `Invalid public address: ${body.result.publicAddress}`
+      this.sendStratumError(client, message.id, msg)
+      this.peers.ban(client, {
+        message: msg,
+      })
+      return
+    }
+
+    if (![1, 2].includes(body.result.version)) {
+      const msg = `Client version ${body.result.version} is not handled by this server`
+      this.sendStratumError(client, message.id, msg)
+      this.peers.ban(client, {
+        message: msg,
+        reason: DisconnectReason.BAD_VERSION,
+      })
+      return
+    }
+
+    const idHex = client.id.toString(16)
+
+    if (body.result.version === 1) {
+      const graffiti = `${this.pool.name}.${idHex}`
+      Assert.isTrue(StringUtils.getByteLength(graffiti) <= GRAFFITI_SIZE)
+
+      client.subscription = {
+        version: 1,
+        publicAddress: body.result.publicAddress,
+        graffiti: GraffitiUtils.fromString(graffiti),
+        name: body.result.name,
+        agent: body.result.agent,
+      }
+
+      this.send(client.socket, 'mining.subscribed', {
+        clientId: client.id,
+        graffiti: graffiti,
+      })
+    } else if (body.result.version === 2) {
+      const xnHexSize = 2 * this.config.get('poolXnSize')
+      const xn = idHex.slice(-xnHexSize).padStart(xnHexSize, '0')
+
+      client.subscription = {
+        version: 2,
+        publicAddress: body.result.publicAddress,
+        xn,
+        name: body.result.name,
+        agent: body.result.agent,
+      }
+
+      this.send(client.socket, 'mining.subscribed', {
+        clientId: client.id,
+        xn,
+      })
+    }
+
+    this.subscribed++
+
+    this.logger.info(`Miner ${idHex} connected (${this.subscribed} total)`)
+
+    this.send(client.socket, 'mining.set_target', this.getSetTargetMessage())
+
+    if (this.hasWork()) {
+      this.send(client.socket, 'mining.notify', this.getNotifyMessage())
+    }
+  }
+
+  private async handleMiningSubmitMessage(
+    client: StratumServerClient,
+    message: StratumMessage,
+  ) {
+    if (client.subscription?.version === 1) {
+      const body = await YupUtils.tryValidate(MiningSubmitSchemaV1, message.body)
+
+      if (body.error) {
+        this.peers.ban(client, {
+          message: body.error.message,
+        })
+        return
+      }
+
+      const { miningRequestId, randomness } = body.result
+
+      await this.pool.submitWork(
+        client,
+        miningRequestId,
+        randomness,
+        client.subscription.graffiti.toString('hex'),
+      )
+    } else if (client.subscription?.version === 2) {
+      const body = await YupUtils.tryValidate(MiningSubmitSchemaV2, message.body)
+
+      if (body.error) {
+        this.peers.ban(client, {
+          message: body.error.message,
+        })
+        return
+      }
+
+      const { randomness, graffiti, miningRequestId } = body.result
+
+      if (!randomness.startsWith(client.subscription.xn)) {
+        this.send(client.socket, 'mining.submitted', {
+          id: message.id,
+          result: false,
+          message: 'invalid leading xnonce in randomness',
+        })
+        return
+      }
+
+      const { error } = await this.pool.submitWork(
+        client,
+        miningRequestId,
+        randomness,
+        graffiti,
+      )
+
+      if (error) {
+        this.send(client.socket, 'mining.submitted', {
+          id: message.id,
+          result: false,
+          message: error,
+        })
+      } else {
+        this.send(client.socket, 'mining.submitted', {
+          id: message.id,
+          result: true,
+        })
+      }
+    } else {
+      this.peers.ban(client, { message: 'Client was not subscribed' })
+      return
+    }
+  }
+
+  private async handleMiningGetStatusMessage(
+    client: StratumServerClient,
+    message: StratumMessage,
+  ) {
+    const body = await YupUtils.tryValidate(MiningGetStatusSchema, message.body)
+
+    if (body.error) {
+      this.peers.ban(client, {
+        message: body.error.message,
+      })
+      return
+    }
+
+    const publicAddress = body.result?.publicAddress
+
+    if (publicAddress && !isValidPublicAddress(publicAddress)) {
+      this.peers.ban(client, {
+        message: `Invalid public address: ${publicAddress}`,
+      })
+      return
+    }
+
+    this.send(client.socket, 'mining.status', await this.pool.getStatus(publicAddress))
   }
 
   private onError(client: StratumServerClient, error: unknown): void {
@@ -324,7 +408,7 @@ export class StratumServer {
     client.socket.removeAllListeners()
     client.close()
 
-    if (client.subscribed) {
+    if (client.subscription) {
       this.subscribed--
     }
 
@@ -332,7 +416,7 @@ export class StratumServer {
     this.peers.removeConnectionCount(client)
   }
 
-  private getNotifyMessage(): MiningNotifyMessage {
+  getNotifyMessage(): MiningNotifyMessage {
     Assert.isNotNull(this.currentMiningRequestId)
     Assert.isNotNull(this.currentWork)
 
@@ -342,7 +426,7 @@ export class StratumServer {
     }
   }
 
-  private getSetTargetMessage(): MiningSetTargetMessage {
+  getSetTargetMessage(): MiningSetTargetMessage {
     return {
       target: this.pool.getTarget(),
     }
@@ -369,7 +453,7 @@ export class StratumServer {
     let broadcasted = 0
 
     for (const client of this.clients.values()) {
-      if (!client.subscribed) {
+      if (!client.subscription) {
         continue
       }
 
@@ -395,7 +479,9 @@ export class StratumServer {
   send(socket: net.Socket, method: 'mining.notify', body: MiningNotifyMessage): void
   send(socket: net.Socket, method: 'mining.disconnect', body: MiningDisconnectMessage): void
   send(socket: net.Socket, method: 'mining.set_target', body: MiningSetTargetMessage): void
-  send(socket: net.Socket, method: 'mining.subscribed', body: MiningSubscribedMessage): void
+  send(socket: net.Socket, method: 'mining.subscribed', body: MiningSubscribedMessageV1): void
+  send(socket: net.Socket, method: 'mining.subscribed', body: MiningSubscribedMessageV2): void
+  send(socket: net.Socket, method: 'mining.submitted', body: MiningSubmittedMessageV2): void
   send(socket: net.Socket, method: 'mining.wait_for_work'): void
   send(socket: net.Socket, method: 'mining.status', body: MiningStatusMessage): void
   send(socket: net.Socket, method: string, body?: unknown): void {
@@ -407,5 +493,17 @@ export class StratumServer {
 
     const serialized = JSON.stringify(message) + '\n'
     socket.write(serialized)
+  }
+
+  sendStratumError(client: StratumServerClient, id: number, message: string): void {
+    const msg: StratumMessageWithError = {
+      id: this.nextMessageId++,
+      error: {
+        id: id,
+        message: message,
+      },
+    }
+    const serialized = JSON.stringify(msg) + '\n'
+    client.socket.write(serialized)
   }
 }

--- a/ironfish/src/mining/stratum/stratumServerClient.ts
+++ b/ironfish/src/mining/stratum/stratumServerClient.ts
@@ -3,24 +3,37 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import net from 'net'
 import { Assert } from '../../assert'
+import { MessageBuffer } from '../../rpc/messageBuffer'
+
+type V1Subscription = {
+  version: 1
+  publicAddress: string
+  name?: string
+  agent?: string
+  graffiti: Buffer
+}
+
+type V2Subscription = {
+  version: 2
+  publicAddress: string
+  name?: string
+  agent?: string
+  xn: string
+}
 
 export class StratumServerClient {
   id: number
   socket: net.Socket
   connected: boolean
-  subscribed: boolean
-  publicAddress: string | null = null
-  name: string | undefined
   remoteAddress: string
-  graffiti: Buffer | null = null
-  messageBuffer: string
+  subscription: V1Subscription | V2Subscription | null = null
+  messageBuffer: MessageBuffer
 
   private constructor(options: { socket: net.Socket; id: number }) {
     this.id = options.id
     this.socket = options.socket
     this.connected = true
-    this.subscribed = false
-    this.messageBuffer = ''
+    this.messageBuffer = new MessageBuffer('\n')
 
     Assert.isNotUndefined(this.socket.remoteAddress)
     this.remoteAddress = this.socket.remoteAddress
@@ -35,7 +48,7 @@ export class StratumServerClient {
       return
     }
 
-    this.messageBuffer = ''
+    this.messageBuffer.clear()
     this.connected = false
     this.socket.destroy(error)
   }

--- a/ironfish/src/mining/stratum/version.ts
+++ b/ironfish/src/mining/stratum/version.ts
@@ -1,6 +1,0 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-
-export const VERSION_PROTOCOL_STRATUM = 1
-export const VERSION_PROTOCOL_STRATUM_MIN = 1


### PR DESCRIPTION
## Summary
To help test FishHash and to allow users to solo-mine before the FishHash hardfork. All Ironfish miniers currently support TRM Stratum. Most of this code was taken from https://github.com/Kerney666/ironfish/blob/trm_stratum/TRM_STRATUM.md
 
## Testing Plan
Running pool against miner locally

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
