### PR TITLE
adds build method to rawTransaction

### DIFF
--- a/ironfish/src/primitives/rawTransaction.ts
+++ b/ironfish/src/primitives/rawTransaction.ts
@@ -12,6 +12,7 @@ import {
   TRANSACTION_FEE_LENGTH,
   TRANSACTION_PUBLIC_KEY_RANDOMNESS_LENGTH,
   TRANSACTION_SIGNATURE_LENGTH,
+  UnsignedTransaction,
 } from '@ironfish/rust-nodejs'
 import { Asset, ASSET_ID_LENGTH } from '@ironfish/rust-nodejs'
 import bufio from 'bufio'
@@ -116,7 +117,7 @@ export class RawTransaction {
     return size
   }
 
-  post(spendingKey: string): Transaction {
+  _build(): NativeTransaction {
     const builder = new NativeTransaction(this.version)
     for (const spend of this.spends) {
       builder.spend(spend.note.takeReference(), spend.witness)
@@ -157,6 +158,31 @@ export class RawTransaction {
       builder.setExpiration(this.expiration)
     }
 
+    return builder
+  }
+
+  build(
+    proofGenerationKey: string,
+    viewKey: string,
+    outgoingViewKey: string,
+    publicAddress: string,
+  ): UnsignedTransaction {
+    const builder = this._build()
+
+    const serialized = builder.build(
+      proofGenerationKey,
+      viewKey,
+      outgoingViewKey,
+      publicAddress,
+      this.fee,
+      null,
+    )
+
+    return new UnsignedTransaction(serialized)
+  }
+
+  post(spendingKey: string): Transaction {
+    const builder = this._build()
     const serialized = builder.post(spendingKey, null, this.fee)
     const posted = new Transaction(serialized)
 


### PR DESCRIPTION
## Summary

refactors logic for adding spends, outputs, mints, and burns into '_build' to produce a 'NativeTransaction'

'build' uses '_build' to produce a NativeTransaction then calls 'build' on the NativeTransaction to produce a serialized UnsignedTransaction

the multisig signing flow will require an UnsignedTransaction for generating a signing package

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
