### PR TITLE
public key randomness napi binding

### DIFF
--- a/ironfish-rust-nodejs/index.d.ts
+++ b/ironfish-rust-nodejs/index.d.ts
@@ -230,6 +230,7 @@ export type NativeUnsignedTransaction = UnsignedTransaction
 export class UnsignedTransaction {
   constructor(jsBytes: Buffer)
   serialize(): Buffer
+  publicKeyRandomness(): string
   signingPackage(nativeCommitments: Record<string, SigningCommitments>): string
   signFrost(publicKeyPackageStr: string, signingPackageStr: string, signatureSharesMap: Record<string, string>): Buffer
 }

--- a/ironfish-rust-nodejs/src/structs/transaction.rs
+++ b/ironfish-rust-nodejs/src/structs/transaction.rs
@@ -407,6 +407,12 @@ impl NativeUnsignedTransaction {
     }
 
     #[napi]
+    pub fn public_key_randomness(&self) -> String {
+        let bytes = self.transaction.public_key_randomness().to_bytes();
+        bytes_to_hex(&bytes)
+    }
+
+    #[napi]
     pub fn signing_package(
         &self,
         native_commitments: HashMap<String, NativeSigningCommitments>,

--- a/ironfish-rust/src/transaction/unsigned.rs
+++ b/ironfish-rust/src/transaction/unsigned.rs
@@ -294,4 +294,9 @@ impl UnsignedTransaction {
         let data_to_sign = self.transaction_signature_hash()?;
         Ok(SigningPackage::new(commitments, &data_to_sign))
     }
+
+    // Exposes the public key package for use in round two of FROST multisig protocol
+    pub fn public_key_randomness(&self) -> jubjub::Fr {
+        self.public_key_randomness
+    }
 }


### PR DESCRIPTION
## Summary

1. adds a method to retrieve the public key randomness from the unsigned transaction
2. adds a napi binding and generates the ts code

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
