### PR TITLE
fixes flaky filestore test

### DIFF
--- a/ironfish/src/fileStores/fileStore.test.ts
+++ b/ironfish/src/fileStores/fileStore.test.ts
@@ -39,11 +39,14 @@ describe('FileStore', () => {
     await flushTimeout()
     await flushTimeout()
     await flushTimeout()
+    await flushTimeout()
     expect(writeFileSpy).toHaveBeenCalledTimes(1)
 
     resolve1()
     // Resolve the first promise, freeing the mutex and allowing save2 to
     // execute
+    await flushTimeout()
+    await flushTimeout()
     await flushTimeout()
     await flushTimeout()
     expect(writeFileSpy).toHaveBeenCalledTimes(2)


### PR DESCRIPTION
## Summary

I think what is happening here is that the node js event loop needs to run 1 more time to confirm promises are settled

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
