### PR TITLE
allow import an account with the same view key

### DIFF
--- a/ironfish/src/wallet/wallet.test.ts
+++ b/ironfish/src/wallet/wallet.test.ts
@@ -674,7 +674,7 @@ describe('Wallet', () => {
       expect(viewonlyAccount.publicAddress).toEqual(key.publicAddress)
     })
 
-    it('should be unable to import a viewonly account if it is a dupe', async () => {
+    it('should be able to import a viewonly account if it is a dupe', async () => {
       const { node } = nodeTest
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { spendingKey, ...key } = generateKey()
@@ -686,13 +686,14 @@ describe('Wallet', () => {
         createdAt: null,
         ...key,
       }
-      await node.wallet.importAccount(accountValue)
+      const accountImport1 = await node.wallet.importAccount(accountValue)
       const clone = { ...accountValue }
       clone.name = 'Different name'
 
-      await expect(node.wallet.importAccount(clone)).rejects.toThrow(
-        'Account already exists with provided view key(s)',
-      )
+      const accountImport2 = await node.wallet.importAccount(clone)
+
+      expect(accountImport2.createdAt).toBeDefined()
+      expect(accountImport1.viewKey).toEqual(accountImport2.viewKey)
     })
 
     it('should set createdAt if that block is in the chain', async () => {

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -1495,9 +1495,6 @@ export class Wallet {
     ) {
       throw new Error(`Account already exists with provided spending key`)
     }
-    if (accounts.find((a) => accountValue.viewKey === a.viewKey)) {
-      throw new Error(`Account already exists with provided view key(s)`)
-    }
 
     validateAccount(accountValue)
 


### PR DESCRIPTION
Removes the check to prevent importing another account with the same view key. This allows the user to be multiple participants in a frost signing group. 

## Summary

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
