### PR TITLE
Make config networkDefinitionPath static

### DIFF
--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -276,8 +276,6 @@ export type ConfigOptions = {
    */
   memPoolRecentlyEvictedCacheSize: number
 
-  networkDefinitionPath: string
-
   /**
    * Always allow incoming connections from these IPs even if the node is at maxPeers
    */
@@ -376,7 +374,6 @@ export const ConfigOptionsSchema: yup.ObjectSchema<Partial<ConfigOptions>> = yup
       .integer()
       .min(20 * MEGABYTES),
     memPoolRecentlyEvictedCacheSize: yup.number().integer(),
-    networkDefinitionPath: yup.string().trim(),
     incomingWebSocketWhitelist: yup.array(yup.string().trim().defined()),
     walletGossipTransactionsMaxQueueSize: yup.number(),
     walletSyncingMaxQueueSize: yup.number(),
@@ -389,6 +386,7 @@ export class Config<
 > extends KeyStore<ConfigOptions & TExtend> {
   readonly chainDatabasePath: string
   readonly walletDatabasePath: string
+  readonly networkDefinitionPath: string
   readonly tempDir: string
 
   constructor(
@@ -412,6 +410,7 @@ export class Config<
 
     this.chainDatabasePath = this.files.join(this.storage.dataDir, 'databases', 'chain')
     this.walletDatabasePath = this.files.join(this.storage.dataDir, 'databases', 'wallet')
+    this.networkDefinitionPath = this.files.join(this.storage.dataDir, 'network.json')
     this.tempDir = this.files.join(this.storage.dataDir, 'temp')
   }
 
@@ -483,7 +482,6 @@ export class Config<
       maxSyncedAgeBlocks: 60,
       memPoolMaxSizeBytes: 60 * MEGABYTES,
       memPoolRecentlyEvictedCacheSize: 60000,
-      networkDefinitionPath: files.resolve(files.join(dataDir, 'network.json')),
       incomingWebSocketWhitelist: [],
       walletGossipTransactionsMaxQueueSize: 1000,
       walletSyncingMaxQueueSize: 100,

--- a/ironfish/src/networkDefinition.ts
+++ b/ironfish/src/networkDefinition.ts
@@ -86,7 +86,7 @@ export async function getNetworkDefinition(
     } else if (networkId === 2) {
       networkDefinitionJSON = DEVNET
     } else {
-      networkDefinitionJSON = await files.readFile(config.get('networkDefinitionPath'))
+      networkDefinitionJSON = await files.readFile(config.networkDefinitionPath)
     }
   }
 
@@ -104,7 +104,7 @@ export async function getNetworkDefinition(
     }
 
     // Copy custom network definition to data directory for future use
-    await files.writeFile(config.get('networkDefinitionPath'), networkDefinitionJSON)
+    await files.writeFile(config.networkDefinitionPath, networkDefinitionJSON)
   }
 
   internal.set('networkId', networkDefinition.id)


### PR DESCRIPTION
## Summary
The `networkDefinitionPath` value is used for storing custom network definitions in the node's data directory. There doesn't seem to be any good reason to make the path to this file customizable. Quite the opposite, it seems like it could add complexity if different dataDirs store their network definitions in different files. Making this static relative to the dataDir

## Testing Plan
Starting a new node with a customNetwork locally

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[X] Yes
```
https://github.com/iron-fish/website/pull/593

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[X] Yes
```
Removes the `networkDefinitionPath` config value
