### PR TITLE
chore: minor refactor split secret

### DIFF
--- a/ironfish-rust-nodejs/index.d.ts
+++ b/ironfish-rust-nodejs/index.d.ts
@@ -9,6 +9,7 @@ export interface SigningCommitments {
 }
 export function roundOne(keyPackage: string, seed: number): SigningCommitments
 export function roundTwo(signingPackage: string, keyPackage: string, publicKeyRandomness: string, seed: number): string
+export function splitSecret(coordinatorSaplingKey: string, minSigners: number, maxSigners: number, identifiers: Array<string>): TrustedDealerKeyPackages
 export function contribute(inputPath: string, outputPath: string, seed?: string | undefined | null): Promise<string>
 export function verifyTransform(paramsPath: string, newParamsPath: string): Promise<string>
 export const KEY_LENGTH: number
@@ -55,6 +56,10 @@ export const TRANSACTION_EXPIRATION_LENGTH: number
 export const TRANSACTION_FEE_LENGTH: number
 export const LATEST_TRANSACTION_VERSION: number
 export function verifyTransactions(serializedTransactions: Array<Buffer>): boolean
+export interface IdentiferKeyPackage {
+  identifier: string
+  keyPackage: string
+}
 export interface TrustedDealerKeyPackages {
   verifyingKey: string
   proofGenerationKey: string
@@ -62,7 +67,7 @@ export interface TrustedDealerKeyPackages {
   incomingViewKey: string
   outgoingViewKey: string
   publicAddress: string
-  keyPackages: Record<string, string>
+  keyPackages: Array<IdentiferKeyPackage>
   publicKeyPackage: string
 }
 export const enum LanguageCode {
@@ -83,7 +88,6 @@ export interface Key {
   publicAddress: string
   proofGenerationKey: string
 }
-export function splitSecret(coordinatorSaplingKey: string, minSigners: number, maxSigners: number, identifiers: Array<string>): TrustedDealerKeyPackages
 export function generateKey(): Key
 export function spendingKeyToWords(privateKey: string, languageCode: LanguageCode): string
 export function wordsToSpendingKey(words: string, languageCode: LanguageCode): string

--- a/ironfish-rust-nodejs/index.js
+++ b/ironfish-rust-nodejs/index.js
@@ -252,13 +252,14 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { FishHashContext, roundOne, roundTwo, ParticipantSecret, ParticipantIdentity, contribute, verifyTransform, KEY_LENGTH, NONCE_LENGTH, BoxKeyPair, randomBytes, boxMessage, unboxMessage, RollingFilter, initSignalHandler, triggerSegfault, ASSET_ID_LENGTH, ASSET_METADATA_LENGTH, ASSET_NAME_LENGTH, ASSET_LENGTH, Asset, NOTE_ENCRYPTION_KEY_LENGTH, MAC_LENGTH, ENCRYPTED_NOTE_PLAINTEXT_LENGTH, ENCRYPTED_NOTE_LENGTH, NoteEncrypted, PUBLIC_ADDRESS_LENGTH, RANDOMNESS_LENGTH, MEMO_LENGTH, AMOUNT_VALUE_LENGTH, DECRYPTED_NOTE_LENGTH, Note, PROOF_LENGTH, TRANSACTION_SIGNATURE_LENGTH, TRANSACTION_PUBLIC_KEY_RANDOMNESS_LENGTH, TRANSACTION_EXPIRATION_LENGTH, TRANSACTION_FEE_LENGTH, LATEST_TRANSACTION_VERSION, TransactionPosted, Transaction, verifyTransactions, UnsignedTransaction, LanguageCode, splitSecret, generateKey, spendingKeyToWords, wordsToSpendingKey, generateKeyFromPrivateKey, initializeSapling, FoundBlockResult, ThreadPoolHandler, isValidPublicAddress } = nativeBinding
+const { FishHashContext, roundOne, roundTwo, ParticipantSecret, ParticipantIdentity, splitSecret, contribute, verifyTransform, KEY_LENGTH, NONCE_LENGTH, BoxKeyPair, randomBytes, boxMessage, unboxMessage, RollingFilter, initSignalHandler, triggerSegfault, ASSET_ID_LENGTH, ASSET_METADATA_LENGTH, ASSET_NAME_LENGTH, ASSET_LENGTH, Asset, NOTE_ENCRYPTION_KEY_LENGTH, MAC_LENGTH, ENCRYPTED_NOTE_PLAINTEXT_LENGTH, ENCRYPTED_NOTE_LENGTH, NoteEncrypted, PUBLIC_ADDRESS_LENGTH, RANDOMNESS_LENGTH, MEMO_LENGTH, AMOUNT_VALUE_LENGTH, DECRYPTED_NOTE_LENGTH, Note, PROOF_LENGTH, TRANSACTION_SIGNATURE_LENGTH, TRANSACTION_PUBLIC_KEY_RANDOMNESS_LENGTH, TRANSACTION_EXPIRATION_LENGTH, TRANSACTION_FEE_LENGTH, LATEST_TRANSACTION_VERSION, TransactionPosted, Transaction, verifyTransactions, UnsignedTransaction, LanguageCode, generateKey, spendingKeyToWords, wordsToSpendingKey, generateKeyFromPrivateKey, initializeSapling, FoundBlockResult, ThreadPoolHandler, isValidPublicAddress } = nativeBinding
 
 module.exports.FishHashContext = FishHashContext
 module.exports.roundOne = roundOne
 module.exports.roundTwo = roundTwo
 module.exports.ParticipantSecret = ParticipantSecret
 module.exports.ParticipantIdentity = ParticipantIdentity
+module.exports.splitSecret = splitSecret
 module.exports.contribute = contribute
 module.exports.verifyTransform = verifyTransform
 module.exports.KEY_LENGTH = KEY_LENGTH
@@ -297,7 +298,6 @@ module.exports.Transaction = Transaction
 module.exports.verifyTransactions = verifyTransactions
 module.exports.UnsignedTransaction = UnsignedTransaction
 module.exports.LanguageCode = LanguageCode
-module.exports.splitSecret = splitSecret
 module.exports.generateKey = generateKey
 module.exports.spendingKeyToWords = spendingKeyToWords
 module.exports.wordsToSpendingKey = wordsToSpendingKey

--- a/ironfish-rust-nodejs/src/frost.rs
+++ b/ironfish-rust-nodejs/src/frost.rs
@@ -2,17 +2,22 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use crate::{
+    structs::{IdentiferKeyPackage, TrustedDealerKeyPackages},
+    to_napi_err,
+};
+use ironfish::keys::ProofGenerationKeySerializable;
 use ironfish::{
     frost::{keys::KeyPackage, round2::Randomizer, Identifier, SigningPackage},
+    frost_utils::split_spender_key::split_spender_key,
     frost_utils::{round_one::round_one as round_one_rust, round_two::round_two as round_two_rust},
     participant::{Identity, Secret},
     serializing::{bytes_to_hex, hex_to_bytes, hex_to_vec_bytes},
+    SaplingKey,
 };
 use napi::{bindgen_prelude::*, JsBuffer};
 use napi_derive::napi;
 use rand::thread_rng;
-
-use crate::to_napi_err;
 
 #[napi(object, js_name = "SigningCommitments")]
 pub struct NativeSigningCommitments {
@@ -110,4 +115,48 @@ impl ParticipantIdentity {
 
         bytes_to_hex(&identifier.serialize())
     }
+}
+
+#[napi]
+pub fn split_secret(
+    coordinator_sapling_key: String,
+    min_signers: u16,
+    max_signers: u16,
+    identifiers: Vec<String>,
+) -> Result<TrustedDealerKeyPackages> {
+    let coordinator_key =
+        SaplingKey::new(hex_to_bytes(&coordinator_sapling_key).map_err(to_napi_err)?)
+            .map_err(to_napi_err)?;
+
+    let mut converted = Vec::new();
+
+    for identifier in &identifiers {
+        let bytes = hex_to_bytes(identifier).map_err(to_napi_err)?;
+        let deserialized = Identifier::deserialize(&bytes).map_err(to_napi_err)?;
+        converted.push(deserialized);
+    }
+
+    let t = split_spender_key(&coordinator_key, min_signers, max_signers, converted)
+        .map_err(to_napi_err)?;
+
+    let mut key_packages_serialized = Vec::new();
+    for (k, v) in t.key_packages.iter() {
+        key_packages_serialized.push(IdentiferKeyPackage {
+            identifier: bytes_to_hex(&k.serialize()),
+            key_package: bytes_to_hex(&v.serialize().map_err(to_napi_err)?),
+        });
+    }
+
+    let public_key_package = t.public_key_package.serialize().map_err(to_napi_err)?;
+
+    Ok(TrustedDealerKeyPackages {
+        verifying_key: bytes_to_hex(&t.verifying_key),
+        proof_generation_key: t.proof_generation_key.hex_key(),
+        view_key: t.view_key.hex_key(),
+        incoming_view_key: t.incoming_view_key.hex_key(),
+        outgoing_view_key: t.outgoing_view_key.hex_key(),
+        public_address: t.public_address.hex_public_address(),
+        key_packages: key_packages_serialized,
+        public_key_package: bytes_to_hex(&public_key_package),
+    })
 }

--- a/ironfish-rust-nodejs/src/structs/key_packages.rs
+++ b/ironfish-rust-nodejs/src/structs/key_packages.rs
@@ -3,8 +3,12 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use napi_derive::napi;
-use std::collections::HashMap;
 
+#[napi(object)]
+pub struct IdentiferKeyPackage {
+    pub identifier: String,
+    pub key_package: String,
+}
 #[napi(object)]
 
 pub struct TrustedDealerKeyPackages {
@@ -14,6 +18,6 @@ pub struct TrustedDealerKeyPackages {
     pub incoming_view_key: String,
     pub outgoing_view_key: String,
     pub public_address: String,
-    pub key_packages: HashMap<String, String>,
+    pub key_packages: Vec<IdentiferKeyPackage>,
     pub public_key_package: String,
 }

--- a/ironfish/src/wallet/wallet.test.slow.ts
+++ b/ironfish/src/wallet/wallet.test.slow.ts
@@ -1169,12 +1169,10 @@ describe('Wallet', () => {
         identifiers,
       )
 
-      const keyPackages = Object.entries(trustedDealerPackage.keyPackages)
-
       const getMultiSigKeys = (index: number) => {
         return {
-          identifier: keyPackages[index][0],
-          keyPackage: keyPackages[index][1],
+          identifier: trustedDealerPackage.keyPackages[index].identifier,
+          keyPackage: trustedDealerPackage.keyPackages[index].keyPackage,
           proofGenerationKey: trustedDealerPackage.proofGenerationKey,
         }
       }
@@ -1182,7 +1180,7 @@ describe('Wallet', () => {
       const participantA = await node.wallet.importAccount({
         version: 2,
         id: uuid(),
-        name: keyPackages[0][0],
+        name: trustedDealerPackage.keyPackages[0].identifier,
         spendingKey: null,
         createdAt: null,
         multiSigKeys: getMultiSigKeys(0),
@@ -1191,7 +1189,7 @@ describe('Wallet', () => {
       const participantB = await node.wallet.importAccount({
         version: 2,
         id: uuid(),
-        name: keyPackages[1][0],
+        name: trustedDealerPackage.keyPackages[1].identifier,
         spendingKey: null,
         createdAt: null,
         multiSigKeys: getMultiSigKeys(1),
@@ -1200,7 +1198,7 @@ describe('Wallet', () => {
       const participantC = await node.wallet.importAccount({
         version: 2,
         id: uuid(),
-        name: keyPackages[2][0],
+        name: trustedDealerPackage.keyPackages[2].identifier,
         spendingKey: null,
         createdAt: null,
         multiSigKeys: getMultiSigKeys(2),


### PR DESCRIPTION
## Summary
This makes the `key_packages` part of the struct forward compatible with additional fields, also moves the split key to `frost.rs` since this is frost specific code.
## Testing Plan
N/A
## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
