### PR TITLE
updates ParticipantSecret napi with serde

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1542,7 +1542,7 @@ dependencies = [
 [[package]]
 name = "ironfish-frost"
 version = "0.1.0"
-source = "git+https://github.com/iron-fish/ironfish-frost.git#a52338e0d2de8f6854f485011bc7003a60be0e28"
+source = "git+https://github.com/iron-fish/ironfish-frost.git?branch=main#f6699a938bdcf7da6c335acc77dd4dbfd7466b45"
 dependencies = [
  "blake3",
  "ed25519-dalek",

--- a/ironfish-rust-nodejs/index.d.ts
+++ b/ironfish-rust-nodejs/index.d.ts
@@ -96,7 +96,9 @@ export class FishHashContext {
   hash(header: Buffer): Buffer
 }
 export class ParticipantSecret {
-  constructor()
+  constructor(jsBytes: Buffer)
+  serialize(): Buffer
+  static random(): ParticipantSecret
   toIdentity(): ParticipantIdentity
 }
 export class ParticipantIdentity {

--- a/ironfish-rust-nodejs/src/frost.rs
+++ b/ironfish-rust-nodejs/src/frost.rs
@@ -62,8 +62,24 @@ pub struct ParticipantSecret {
 
 #[napi]
 impl ParticipantSecret {
-    // TODO(hughy): implement Secret ser/de
     #[napi(constructor)]
+    pub fn new(js_bytes: JsBuffer) -> Result<ParticipantSecret> {
+        let bytes = js_bytes.into_value()?;
+
+        let secret = Secret::deserialize_from(bytes.as_ref()).map_err(to_napi_err)?;
+
+        Ok(ParticipantSecret { secret })
+    }
+
+    #[napi]
+    pub fn serialize(&self) -> Result<Buffer> {
+        let mut vec: Vec<u8> = vec![];
+        self.secret.serialize_into(&mut vec).map_err(to_napi_err)?;
+
+        Ok(Buffer::from(vec))
+    }
+
+    #[napi]
     pub fn random() -> ParticipantSecret {
         let secret = Secret::random(thread_rng());
 

--- a/ironfish-rust-nodejs/tests/frost.test.slow.ts
+++ b/ironfish-rust-nodejs/tests/frost.test.slow.ts
@@ -7,7 +7,7 @@ import { ParticipantIdentity, ParticipantSecret } from "..";
 describe('ParticipantIdentity', () => {
   describe('ser/de', () => {
     it('serializes and deserializes as a buffer', () => {
-      const secret = new ParticipantSecret()
+      const secret = ParticipantSecret.random()
 
       const identity = secret.toIdentity()
 

--- a/ironfish-rust/Cargo.toml
+++ b/ironfish-rust/Cargo.toml
@@ -42,7 +42,7 @@ chacha20poly1305 = "0.9.0"
 crypto_box = { version = "0.8", features = ["std"] }
 ff = "0.12.0"
 group = "0.12.0"
-ironfish-frost = { git = "https://github.com/iron-fish/ironfish-frost.git" }
+ironfish-frost = { git = "https://github.com/iron-fish/ironfish-frost.git", branch = "main" }
 ironfish_zkp = { version = "0.2.0", path = "../ironfish-zkp" }
 jubjub = { git = "https://github.com/iron-fish/jubjub.git", branch = "blstrs" }
 lazy_static = "1.4.0"

--- a/ironfish/src/wallet/wallet.test.slow.ts
+++ b/ironfish/src/wallet/wallet.test.slow.ts
@@ -1156,7 +1156,7 @@ describe('Wallet', () => {
       const identifiers: string[] = []
 
       for (let i = 0; i < maxSigners; i++) {
-        identifiers.push(new ParticipantSecret().toIdentity().toFrostIdentifier())
+        identifiers.push(ParticipantSecret.random().toIdentity().toFrostIdentifier())
       }
 
       // construct 3 separate secrets for the participants


### PR DESCRIPTION
## Summary

implements 'serialize' and changes constructor to deserialize from buffer

adds separate static 'random' method to generate random secret

pins ironfish-frost dependency to 'main' branch from git repo in order to pick up latest changes

## Testing Plan

updates tests to use 'random' instead of constructor

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
