### PR TITLE
Remove networkId from config

### DIFF
--- a/ironfish-cli/src/commands/start.ts
+++ b/ironfish-cli/src/commands/start.ts
@@ -201,16 +201,16 @@ export default class Start extends IronfishCommand {
         'Cannot specify both the networkId and customNetwork flags at the same time',
       )
     }
-    if (networkId !== undefined && networkId !== this.sdk.config.get('networkId')) {
-      this.sdk.config.setOverride('networkId', networkId)
-    }
 
     if (!this.sdk.internal.get('telemetryNodeId')) {
       this.sdk.internal.set('telemetryNodeId', uuid())
       await this.sdk.internal.save()
     }
 
-    const node = await this.sdk.node({ customNetworkPath: customNetwork })
+    const node = await this.sdk.node({
+      customNetworkPath: customNetwork,
+      networkId,
+    })
 
     const nodeName = this.sdk.config.get('nodeName').trim() || null
     const blockGraffiti = this.sdk.config.get('blockGraffiti').trim() || null

--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -255,11 +255,6 @@ export type ConfigOptions = {
   feeEstimatorPercentileFast: number
 
   /**
-   * Network ID of an official Iron Fish network
-   */
-  networkId: number
-
-  /**
    * The oldest the tip should be before we consider the chain synced
    */
   maxSyncedAgeBlocks: number
@@ -367,7 +362,6 @@ export const ConfigOptionsSchema: yup.ObjectSchema<Partial<ConfigOptions>> = yup
     feeEstimatorPercentileSlow: YupUtils.isPositiveInteger,
     feeEstimatorPercentileAverage: YupUtils.isPositiveInteger,
     feeEstimatorPercentileFast: YupUtils.isPositiveInteger,
-    networkId: yup.number().integer().min(0),
     maxSyncedAgeBlocks: yup.number().integer().min(0),
     mempoolMaxSizeBytes: yup
       .number()
@@ -478,7 +472,6 @@ export class Config<
       feeEstimatorPercentileSlow: DEFAULT_FEE_ESTIMATOR_PERCENTILE_SLOW,
       feeEstimatorPercentileAverage: DEFAULT_FEE_ESTIMATOR_PERCENTILE_AVERAGE,
       feeEstimatorPercentileFast: DEFAULT_FEE_ESTIMATOR_PERCENTILE_FAST,
-      networkId: DEFAULT_NETWORK_ID,
       maxSyncedAgeBlocks: 60,
       memPoolMaxSizeBytes: 60 * MEGABYTES,
       memPoolRecentlyEvictedCacheSize: 60000,

--- a/ironfish/src/networkDefinition.ts
+++ b/ironfish/src/networkDefinition.ts
@@ -60,6 +60,7 @@ export async function getNetworkDefinition(
   internal: InternalStore,
   files: FileSystem,
   customNetworkPath?: string,
+  networkIdOverride?: number,
 ): Promise<NetworkDefinition> {
   let networkDefinitionJSON = ''
 
@@ -69,15 +70,14 @@ export async function getNetworkDefinition(
   } else {
     if (
       internal.isSet('networkId') &&
-      config.isSet('networkId') &&
-      internal.get('networkId') !== config.get('networkId')
+      networkIdOverride !== undefined &&
+      internal.get('networkId') !== networkIdOverride
     ) {
       throw Error('Network ID flag does not match network ID stored in datadir')
     }
 
-    const networkId = config.isSet('networkId')
-      ? config.get('networkId')
-      : internal.get('networkId')
+    const networkId =
+      networkIdOverride !== undefined ? networkIdOverride : internal.get('networkId')
 
     if (networkId === 0) {
       networkDefinitionJSON = TESTNET

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -197,6 +197,7 @@ export class FullNode {
     privateIdentity,
     fishHashContext,
     customNetworkPath,
+    networkId,
   }: {
     pkg: Package
     dataDir?: string
@@ -211,6 +212,7 @@ export class FullNode {
     privateIdentity?: PrivateIdentity
     fishHashContext?: FishHashContext
     customNetworkPath?: string
+    networkId?: number
   }): Promise<FullNode> {
     logger = logger.withTag('ironfishnode')
     dataDir = dataDir || DEFAULT_DATA_DIR
@@ -248,6 +250,7 @@ export class FullNode {
       internal,
       files,
       customNetworkPath,
+      networkId,
     )
 
     if (!config.isSet('bootstrapNodes')) {

--- a/ironfish/src/sdk.ts
+++ b/ironfish/src/sdk.ts
@@ -182,11 +182,13 @@ export class IronfishSdk {
     autoSeed,
     privateIdentity,
     customNetworkPath,
+    networkId,
   }: {
     autoSeed?: boolean
     privateIdentity?: PrivateIdentity
     fishHashContext?: FishHashContext
     customNetworkPath?: string
+    networkId?: number
   } = {}): Promise<FullNode> {
     const webSocket = WebSocketClient as IsomorphicWebSocketConstructor
 
@@ -203,6 +205,7 @@ export class IronfishSdk {
       privateIdentity: privateIdentity,
       dataDir: this.dataDir,
       customNetworkPath,
+      networkId,
     })
 
     if (this.config.get('enableRpcIpc')) {

--- a/ironfish/src/testUtilities/nodeTest.ts
+++ b/ironfish/src/testUtilities/nodeTest.ts
@@ -79,7 +79,6 @@ export class NodeTest {
     const sdk = await IronfishSdk.init({ dataDir, strategyClass })
 
     sdk.config.setOverride('bootstrapNodes', [''])
-    sdk.config.setOverride('networkId', 2)
     sdk.config.setOverride('enableListenP2P', false)
     sdk.config.setOverride('enableTelemetry', false)
     sdk.config.setOverride('enableAssetVerification', false)
@@ -97,7 +96,9 @@ export class NodeTest {
     const node = await sdk.node({
       autoSeed: this.options?.autoSeed,
       fishHashContext: FISH_HASH_CONTEXT,
+      networkId: 2,
     })
+
     const strategy = node.strategy as TestStrategy
     const chain = node.chain
     const wallet = node.wallet


### PR DESCRIPTION
## Summary
The `networkId` config value is used to pass an id from the CLI to the node. After the `networkId` is set in a data directory though (on first startup) there is no need to change this config value. So it's essentially only used on the first run. It's better to not store this in the config if its unable to be set later on. 

## Testing Plan
Starting up a local node with the networkId flag and starting up a node with no flag to make sure it sets to mainnet

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[X] Yes
```
https://github.com/iron-fish/website/pull/594
## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[X] Yes
```
Removes the `networkId` field in config
