### PR TITLE
Require Node.js 20 for tests in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ See https://ironfish.network
 
 The following steps should only be used to install if you are planning on contributing to the Iron Fish codebase. Otherwise, we **strongly** recommend using the installation methods here: https://ironfish.network/use/get-started/installation
 
-1. Install [Node.js LTS](https://nodejs.org/en/download/)
+1. Install [Node.js 20 LTS (or greater)](https://nodejs.org/en/download/).
 1. Install [Rust](https://www.rust-lang.org/learn/get-started).
 1. Install [Yarn](https://classic.yarnpkg.com/en/docs/install).
 1. Windows:
@@ -51,6 +51,8 @@ The following steps should only be used to install if you are planning on contri
 Once your environment is set up - you can run the CLI by following [these directions](https://github.com/iron-fish/ironfish/tree/master/ironfish-cli).
 
 ## Running Tests
+
+> **Note:** Running tests requires Node.js 20 or greater.
 
 1. To test the entire monorepo:
    1. Run `yarn test` at the root of the repository


### PR DESCRIPTION
## Summary

Tests will segfault if you're not using Node.js 20, but I'm not sure that's documented anywhere clearly. I'll add this to the README for now, but it might be interesting to see if we could add something to the jest setup script that prints an error instead if you're using an older version of Node.js.

## Testing Plan

None needed for a README change.

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

Our developer docs don't reference this, that I've seen

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
