### PR TITLE
Make consensus properties on chain and wallet readonly

### DIFF
--- a/ironfish/src/blockchain/blockchain.test.ts
+++ b/ironfish/src/blockchain/blockchain.test.ts
@@ -4,7 +4,7 @@
 
 import { Asset, generateKey, Note as NativeNote } from '@ironfish/rust-nodejs'
 import { Assert } from '../assert'
-import { VerificationResultReason } from '../consensus'
+import { Consensus, VerificationResultReason } from '../consensus'
 import { FullNode } from '../node'
 import { Block, Note } from '../primitives'
 import { NoteEncrypted } from '../primitives/noteEncrypted'
@@ -1758,7 +1758,10 @@ describe('Blockchain', () => {
         fee: 0,
       })
 
-      node.chain.consensus.parameters.minFee = 1
+      node.chain.consensus = new Consensus({
+        ...node.chain.consensus.parameters,
+        minFee: 1,
+      })
 
       const added = await chain.addBlock(block)
 

--- a/ironfish/src/consensus/consensus.ts
+++ b/ironfish/src/consensus/consensus.ts
@@ -58,7 +58,7 @@ export type ConsensusParameters = {
 }
 
 export class Consensus {
-  readonly parameters: ConsensusParameters
+  readonly parameters: Readonly<ConsensusParameters>
 
   constructor(parameters: ConsensusParameters) {
     this.parameters = parameters

--- a/ironfish/src/memPool/memPool.test.ts
+++ b/ironfish/src/memPool/memPool.test.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Asset } from '@ironfish/rust-nodejs'
 import { Assert } from '../assert'
+import { Consensus } from '../consensus'
 import * as ConsensusUtils from '../consensus/utils'
 import { getTransactionSize } from '../network/utils/serializers'
 import { FullNode } from '../node'
@@ -523,7 +524,10 @@ describe('MemPool', () => {
       const account = await useAccountFixture(wallet)
 
       // Enable V1 transactions to setup the test transactions
-      chain.consensus.parameters.enableAssetOwnership = 999999
+      chain.consensus = new Consensus({
+        ...chain.consensus.parameters,
+        enableAssetOwnership: 999999,
+      })
 
       const block1 = await useMinerBlockFixture(chain, undefined, account)
       await expect(chain).toAddBlock(block1)
@@ -537,7 +541,10 @@ describe('MemPool', () => {
       expect(memPool.acceptTransaction(transaction1)).toBe(true)
 
       // Re-enable V2 transactions
-      chain.consensus.parameters.enableAssetOwnership = 1
+      chain.consensus = new Consensus({
+        ...chain.consensus.parameters,
+        enableAssetOwnership: 1,
+      })
 
       const transaction2 = await useTxFixture(wallet, account, account)
       expect(memPool.acceptTransaction(transaction2)).toBe(true)

--- a/ironfish/src/mining/manager.test.slow.ts
+++ b/ironfish/src/mining/manager.test.slow.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Assert } from '../assert'
-import { VerificationResultReason } from '../consensus'
+import { Consensus, VerificationResultReason } from '../consensus'
 import { getBlockWithMinersFeeSize, getTransactionSize } from '../network/utils/serializers'
 import { Target, Transaction } from '../primitives'
 import { TransactionVersion } from '../primitives/transaction'
@@ -289,7 +289,10 @@ describe('Mining manager', () => {
       const { node, chain, wallet } = nodeTest
 
       // Enable V1 transactions
-      chain.consensus.parameters.enableAssetOwnership = 999999
+      chain.consensus = new Consensus({
+        ...chain.consensus.parameters,
+        enableAssetOwnership: 999999,
+      })
 
       const account = await useAccountFixture(wallet, 'account')
       await wallet.setDefaultAccount(account.name)
@@ -318,7 +321,10 @@ describe('Mining manager', () => {
       expect(node.memPool.acceptTransaction(mintTx1)).toEqual(true)
 
       // Enable V2 transactions
-      chain.consensus.parameters.enableAssetOwnership = 1
+      chain.consensus = new Consensus({
+        ...chain.consensus.parameters,
+        enableAssetOwnership: 1,
+      })
 
       const mintTx2 = await usePostTxFixture({
         node,
@@ -367,7 +373,10 @@ describe('Mining manager', () => {
       )
 
       node.memPool.acceptTransaction(transaction)
-      chain.consensus.parameters.maxBlockSizeBytes = getBlockWithMinersFeeSize()
+      chain.consensus = new Consensus({
+        ...chain.consensus.parameters,
+        maxBlockSizeBytes: getBlockWithMinersFeeSize(),
+      })
 
       const templates = await collectTemplates(node.miningManager, 2)
       const fullTemplate = templates.find((t) => t.transactions.length > 1)
@@ -375,8 +384,10 @@ describe('Mining manager', () => {
       expect(fullTemplate).toBeUndefined()
 
       // Expand max block size, should allow transaction to be added to block
-      chain.consensus.parameters.maxBlockSizeBytes =
-        getBlockWithMinersFeeSize() + getTransactionSize(transaction)
+      chain.consensus = new Consensus({
+        ...chain.consensus.parameters,
+        maxBlockSizeBytes: getBlockWithMinersFeeSize() + getTransactionSize(transaction),
+      })
 
       const templates2 = await collectTemplates(node.miningManager, 2)
       const fullTemplate2 = templates2.find((t) => t.transactions.length > 1)

--- a/ironfish/src/strategy.ts
+++ b/ironfish/src/strategy.ts
@@ -15,7 +15,7 @@ import { WorkerPool } from './workerPool'
  */
 export class Strategy {
   readonly workerPool: WorkerPool
-  readonly consensus: Consensus
+  readonly consensus: Readonly<Consensus>
   readonly blockHasher: BlockHasher
 
   private miningRewardCachedByYear: Map<number, number>

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -94,7 +94,7 @@ export class Wallet {
   readonly chainProcessor: RemoteChainProcessor
   readonly nodeClient: RpcClient | null
   private readonly config: Config
-  private readonly consensus: Consensus
+  readonly consensus: Readonly<Consensus>
 
   protected rebroadcastAfter: number
   protected defaultAccount: string | null = null


### PR DESCRIPTION
## Summary
Once initialized, consensus parameters should not be modifiable. This is partially enforced by making the consensus property itself readonly but the individual parameters are not readonly. Using the typescript Readonly<> type to fix this

## Testing Plan
Unit tests + only making type changes in production code

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[X] Yes
```

This changes the consensus property on the Chain, Wallet and Strategy

