### PR TITLE
Rahul/ifl 2052 add multisig/createsigningcommitment

### DIFF
--- a/ironfish/src/rpc/routes/multisig/createSigningCommitment.test.ts
+++ b/ironfish/src/rpc/routes/multisig/createSigningCommitment.test.ts
@@ -1,6 +1,10 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { ParticipantSecret, TrustedDealerKeyPackages } from '@ironfish/rust-nodejs'
+import { v4 as uuid } from 'uuid'
+import { Assert } from '../../../assert'
+import { createNodeTest } from '../../../testUtilities'
 import { createRouteTest } from '../../../testUtilities/routeTest'
 
 describe('Route multisig/createSigningCommitment', () => {
@@ -14,5 +18,77 @@ describe('Route multisig/createSigningCommitment', () => {
     await expect(
       routeTest.client.request('multisig/createSigningCommitment', request).waitForEnd(),
     ).rejects.toThrow('InvalidData')
+  })
+
+  it('should create signing commitment', async () => {
+    const seed = 420
+    const nodeTest = createNodeTest()
+    const { node } = await nodeTest.createSetup()
+
+    const participants: { identifier: string }[] = []
+    for (let i = 0; i < 3; i++) {
+      const identifier = ParticipantSecret.random().toIdentity().toFrostIdentifier()
+      participants.push({
+        identifier: identifier,
+      })
+    }
+    const request = { minSigners: 2, maxSigners: 3, participants }
+    const response = await routeTest.client
+      .request('multisig/createTrustedDealerKeyPackage', request)
+      .waitForEnd()
+
+    const trustedDealerPackage = response.content as TrustedDealerKeyPackages
+
+    const getMultiSigKeys = (index: number) => {
+      return {
+        identifier: trustedDealerPackage.keyPackages[index].identifier,
+        keyPackage: trustedDealerPackage.keyPackages[index].keyPackage,
+        proofGenerationKey: trustedDealerPackage.proofGenerationKey,
+      }
+    }
+
+    const participantA = await node.wallet.importAccount({
+      version: 2,
+      id: uuid(),
+      name: trustedDealerPackage.keyPackages[0].identifier,
+      spendingKey: null,
+      createdAt: null,
+      multiSigKeys: getMultiSigKeys(0),
+      ...trustedDealerPackage,
+    })
+    const participantB = await node.wallet.importAccount({
+      version: 2,
+      id: uuid(),
+      name: trustedDealerPackage.keyPackages[1].identifier,
+      spendingKey: null,
+      createdAt: null,
+      multiSigKeys: getMultiSigKeys(1),
+      ...trustedDealerPackage,
+    })
+    const participantC = await node.wallet.importAccount({
+      version: 2,
+      id: uuid(),
+      name: trustedDealerPackage.keyPackages[2].identifier,
+      spendingKey: null,
+      createdAt: null,
+      multiSigKeys: getMultiSigKeys(2),
+      ...trustedDealerPackage,
+    })
+
+    Assert.isNotUndefined(participantA.multiSigKeys)
+    Assert.isNotUndefined(participantB.multiSigKeys)
+    Assert.isNotUndefined(participantC.multiSigKeys)
+
+    const signingCommitment = await routeTest.client
+      .request('multisig/createSigningCommitment', {
+        keyPackage: participantA.multiSigKeys.keyPackage,
+        seed,
+      })
+      .waitForEnd()
+
+    expect(signingCommitment.content).toMatchObject({
+      hiding: expect.any(String),
+      binding: expect.any(String),
+    })
   })
 })

--- a/ironfish/src/rpc/routes/multisig/createSigningCommitment.test.ts
+++ b/ironfish/src/rpc/routes/multisig/createSigningCommitment.test.ts
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { createRouteTest } from '../../../testUtilities/routeTest'
+
+describe('Route multisig/createSigningCommitment', () => {
+  const routeTest = createRouteTest()
+
+  it('should error on invalid keypackage', async () => {
+    const keyPackage = 'invalid key package'
+
+    const request = { keyPackage, seed: 0 }
+
+    await expect(
+      routeTest.client.request('multisig/createSigningCommitment', request).waitForEnd(),
+    ).rejects.toThrow('InvalidData')
+  })
+})

--- a/ironfish/src/rpc/routes/multisig/createSigningCommitment.ts
+++ b/ironfish/src/rpc/routes/multisig/createSigningCommitment.ts
@@ -26,7 +26,7 @@ export const CreateSigningCommitmentResponseSchema: yup.ObjectSchema<CreateSigni
   RpcSigningCommitmentsSchema
 
 routes.register<typeof CreateSigningCommitmentRequestSchema, CreateSigningCommitmentResponse>(
-  `${ApiNamespace.wallet}/createSigningCommitment`,
+  `${ApiNamespace.multisig}/createSigningCommitment`,
   CreateSigningCommitmentRequestSchema,
   (request, _context): void => {
     const result = roundOne(request.data.keyPackage, request.data.seed)

--- a/ironfish/src/rpc/routes/multisig/createSigningCommitment.ts
+++ b/ironfish/src/rpc/routes/multisig/createSigningCommitment.ts
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { roundOne } from '@ironfish/rust-nodejs'
+import * as yup from 'yup'
+import { ApiNamespace } from '../namespaces'
+import { routes } from '../router'
+import { RpcSigningCommitments, RpcSigningCommitmentsSchema } from './types'
+
+export type CreateSigningCommitmentRequest = {
+  keyPackage: string
+  seed: number
+}
+
+export type CreateSigningCommitmentResponse = RpcSigningCommitments
+
+export const CreateSigningCommitmentRequestSchema: yup.ObjectSchema<CreateSigningCommitmentRequest> =
+  yup
+    .object({
+      keyPackage: yup.string().defined(),
+      seed: yup.number().defined(),
+    })
+    .defined()
+
+export const CreateSigningCommitmentResponseSchema: yup.ObjectSchema<CreateSigningCommitmentResponse> =
+  RpcSigningCommitmentsSchema
+
+routes.register<typeof CreateSigningCommitmentRequestSchema, CreateSigningCommitmentResponse>(
+  `${ApiNamespace.wallet}/createSigningCommitment`,
+  CreateSigningCommitmentRequestSchema,
+  (request, _context): void => {
+    const result = roundOne(request.data.keyPackage, request.data.seed)
+
+    request.end({
+      hiding: result.hiding,
+      binding: result.binding,
+    })
+  },
+)

--- a/ironfish/src/rpc/routes/multisig/createSigningCommitment.ts
+++ b/ironfish/src/rpc/routes/multisig/createSigningCommitment.ts
@@ -9,7 +9,7 @@ import { RpcSigningCommitments, RpcSigningCommitmentsSchema } from './types'
 
 export type CreateSigningCommitmentRequest = {
   keyPackage: string
-  seed: number
+  seed: number //  TODO: remove when we have deterministic nonces
 }
 
 export type CreateSigningCommitmentResponse = RpcSigningCommitments

--- a/ironfish/src/rpc/routes/multisig/index.ts
+++ b/ironfish/src/rpc/routes/multisig/index.ts
@@ -2,4 +2,5 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+export * from './createSigningCommitment'
 export * from './createTrustedDealerKeyPackage'

--- a/ironfish/src/rpc/routes/multisig/types.ts
+++ b/ironfish/src/rpc/routes/multisig/types.ts
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import * as yup from 'yup'
+
+export type RpcSigningCommitments = {
+  hiding: string
+  binding: string
+}
+
+export const RpcSigningCommitmentsSchema: yup.ObjectSchema<RpcSigningCommitments> = yup
+  .object({
+    hiding: yup.string().defined(),
+    binding: yup.string().defined(),
+  })
+  .defined()


### PR DESCRIPTION
## Summary

Adds RPC for creating signing commitment using the FROST protocol
Adds a type file that includes common types for the multi sign RPC

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
