### PR TITLE
adds version to RawTransactionSerde

### DIFF
--- a/ironfish/src/wallet/wallet.test.ts
+++ b/ironfish/src/wallet/wallet.test.ts
@@ -1255,21 +1255,21 @@ describe('Wallet', () => {
 
           // default expiration
           let tx = await wallet.createTransaction({ account, fee: 0n })
-          expect(tx.version).toEqual(expectedVersion)
+          expect(tx.transactionVersion).toEqual(expectedVersion)
 
           tx = await wallet.createTransaction({
             account,
             fee: 0n,
             expirationDelta: delta,
           })
-          expect(tx.version).toEqual(expectedVersion)
+          expect(tx.transactionVersion).toEqual(expectedVersion)
 
           tx = await wallet.createTransaction({
             account,
             fee: 0n,
             expiration: chain.head.sequence + delta,
           })
-          expect(tx.version).toEqual(expectedVersion)
+          expect(tx.transactionVersion).toEqual(expectedVersion)
         })
       })
     })


### PR DESCRIPTION
## Summary

if and when we change the serialization of a RawTransaction we risk breaking offline signing on transactions that were created on prior versions of the code. we may have already done this once

including a version in the serialization of the RawTransaction will clarify errors deserializing old serialized transactions and enable us to support backwards-compatibility by version

- renames version field used for transaction version to 'transactionVersion'
- adds version field for serde version
- sets RawTransactionSerde version to 3: this is the second time we've changed it, and 3 avoids collision with any transaction versions
- throws error if version does not match current version when deserializing

## Testing Plan

- updates unit tests
- adds unit test

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
