### PR TITLE
feat(IFL-2027): createSigningPackage RPC

### DIFF
--- a/ironfish/src/rpc/clients/client.ts
+++ b/ironfish/src/rpc/clients/client.ts
@@ -17,8 +17,14 @@ import type {
   BurnAssetResponse,
   CreateAccountRequest,
   CreateAccountResponse,
+  CreateSigningCommitmentRequest,
+  CreateSigningCommitmentResponse,
+  CreateSigningPackageRequest,
+  CreateSigningPackageResponse,
   CreateTransactionRequest,
   CreateTransactionResponse,
+  CreateTrustedDealerKeyPackageRequest,
+  CreateTrustedDealerKeyPackageResponse,
   EstimateFeeRateRequest,
   EstimateFeeRateResponse,
   EstimateFeeRatesRequest,
@@ -35,6 +41,8 @@ import type {
   GetAccountsResponse,
   GetAccountsStatusRequest,
   GetAccountsStatusResponse,
+  GetAccountStatusRequest,
+  GetAccountStatusResponse,
   GetAccountTransactionRequest,
   GetAccountTransactionResponse,
   GetAccountTransactionsRequest,
@@ -132,10 +140,6 @@ import type {
   UseAccountResponse,
 } from '../routes'
 import { ApiNamespace } from '../routes/namespaces'
-import {
-  GetAccountStatusRequest,
-  GetAccountStatusResponse,
-} from '../routes/wallet/getAccountStatus'
 
 export abstract class RpcClient {
   abstract request<TEnd = unknown, TStream = unknown>(
@@ -799,6 +803,34 @@ export abstract class RpcClient {
     ): Promise<RpcResponseEnded<UploadConfigResponse>> => {
       return this.request<UploadConfigResponse>(
         `${ApiNamespace.config}/uploadConfig`,
+        params,
+      ).waitForEnd()
+    },
+  }
+  multisig = {
+    createTrustedDealerKeyPackage: (
+      params: CreateTrustedDealerKeyPackageRequest,
+    ): Promise<RpcResponseEnded<CreateTrustedDealerKeyPackageResponse>> => {
+      return this.request<CreateTrustedDealerKeyPackageResponse>(
+        `${ApiNamespace.multisig}/createTrustedDealerKeyPackage`,
+        params,
+      ).waitForEnd()
+    },
+
+    createSigningPackage: (
+      params: CreateSigningPackageRequest,
+    ): Promise<RpcResponseEnded<CreateSigningPackageResponse>> => {
+      return this.request<CreateSigningPackageResponse>(
+        `${ApiNamespace.multisig}/createSigningPackage`,
+        params,
+      ).waitForEnd()
+    },
+
+    createSigningCommitment: (
+      params: CreateSigningCommitmentRequest,
+    ): Promise<RpcResponseEnded<CreateSigningCommitmentResponse>> => {
+      return this.request<CreateSigningCommitmentResponse>(
+        `${ApiNamespace.multisig}/createSigningCommitment`,
         params,
       ).waitForEnd()
     },

--- a/ironfish/src/rpc/routes/multisig/__fixtures__/createSigningPackage.test.ts.fixture
+++ b/ironfish/src/rpc/routes/multisig/__fixtures__/createSigningPackage.test.ts.fixture
@@ -1,0 +1,51 @@
+{
+  "Route multisig/createSigningPackage should create signing package": [
+    {
+      "version": 3,
+      "id": "c7b0571b-0f15-401a-976e-788da2104081",
+      "name": "test",
+      "spendingKey": "3b12e9d3dbb69b824110bdff03e75c8ca1dfd1bd36ac6fba29f1b44f7bc0289f",
+      "viewKey": "aa59653f676b2ae91df96373c0253f8be3ab617f9ad00b5e99bb5eddeb0104cca531b3cf2d128d2dd2faf0f2a565185de18e1d189415406e560da54263b5e28c",
+      "incomingViewKey": "ae34aca726e88d23540186859785ce2d8227faa17977f895e3f1118dd160d302",
+      "outgoingViewKey": "459ec04e08888cdf197b797c51465a61651ada3f67c7feab4545ffe8cc3f24e4",
+      "publicAddress": "4adaa758c9b56e6ba43cb5b2145e4cfb2cd452bd465907c2d793bf24532db631",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "4791D7AE9F97DF100EF1558E84772D6A09B43762388283F75C6F20A32A88AA86",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:vaK33l3E/GmTTFDrGd2UtxfEDTKnLQY28V+ih3Si/24="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:ufZmlvhr5ZtCO3/XymAQWSmPPTQLa+hU54481nEs4dg="
+        },
+        "target": "9282972777491357380673661573939192202192629606981189395159182914949423",
+        "randomness": "0",
+        "timestamp": 1706309118482,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AgAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAFHNAEBkCnTEIA3pRYFGgT/ipR7SLYCKYCY6XKmMY472s+VDxRfCXrSHUgAGLs7G7eN03RgNPaj6gaD5EP1zJc6OsGoJELGoih6SQm/IwsWqMdLU14LVtPaVaS4lrTXARaE7d/YY/JvA3Ja9xb2DqRZo9Eovv86YQg9R5zp9ZVMQVuL9SwJbRAoqYJaODy8lgKCCn3Ec0fZMwqZtmc89ASConpI0c/KttzEHRl48Kk+GSuhYDbSj/gyUOTEDkftOUjVsPh8jgII13y/TkdmskMqGpKyNh85mu/lhWkx0GveWNgFWIP6diQDvAlRpo9o93rns4IZsRnZrzxLa+gp4jwZ9SEMO5mjLvDTisUbl75v/5zhNXbYzoYNbpcGkUr38ueaEoGu9PTlH8skhV5dJuMQ9X2UM8wzqp44n8uuEQ2LR2krg8jCGwqilVWYmiFYyWemn5G270dPEQMi6KUjOCwCMTwNHuMEzp85jnMTFen4GdXabXoAPXvUi46pK15OIwUVLZxrS/O+1Edjy8dsy/aECqDs4Zv0czLkH/m7dEZdVIvkd6KSeAIYiaiQrSLrbJv+jBltX+B8Vf52OI5i5lJXpjivWHQBH3MRXbGx3HOBNPqM4X7aOHkklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwHjjydQEIy3hNZFVS0N/K9WYFzNBnsHwfy/hEeLWZjVyrLA/UwTN459cYzDHP5swmBM9dWgfMfVBcbbUah0h4Bw=="
+        }
+      ]
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AgEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY4PWRSWfZBXikAz3xPf9b4aZauTLwiuxT8+wiKSTjyJsrCf0Qq9khrLpAhUE3e+qI5m9STHe4DhXQent1li/C2ysJ/RCr2SGsukCFQTd76ojmb1JMd7gOFdB6e3WWL8LuXBvLWBLBdJ7DwrCgYRk78sLaRbXdwecA9MgWJs6YgGpiO6B0M/xDT9zrAqQAbwDkkM1YNds5uGMHcKVbFrPUQRwMFt4BywJBdZ6dqsYlDeKJZVAnpwNC7e08kJoCpqPB3F7/DFBDM+559bw4+OZr90V/ToI+Ihzrp0vnSYoc40iRxc+O+/L3nABWJcBw5CrqezcLqGs9fcXfWqzjjNqqckrl7eC2naM6ZNt8ozB+veEd1+1duQbvPsa08CSSHev0PdehYS3JlGvwr31fB4Rwrhu3uWdLP3+RU7dKyAWNtO9orfeXcT8aZNMUOsZ3ZS3F8QNMqctBjbxX6KHdKL/bgQAAADUKVqPY5OMPk4KxBTT+kCt9y+qcpwYO0PYTSJmEdTdjwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACqPiDSNBm5nG/dPjP8In++HLcUMXe6gXcqKPxwrRxqU7ZbGHF0qD70YOPLX2TfDvSooZIoNI3CipVlqUpAyTk1hGW+h/cRnGzXb8KNqn52KgpoWu7+w+lmNBlVr1eJWsEIWHQMBEZLQQGFZBIJQbrehbAIQIEMDna7hb8S26Y9wGZ4FZCCNRSeVrzx9s4JP32OK1IxHXS4UulcoC09/lNc2fusFgz0rVPISvKj/zWS14haqg9VVW3GSxFOaoGc6tcuJXYixk1JIDBUasI2eHGi26rCA3zkHUF7f25RoFSy8eWbBKjkAdq6iIEh+btD0jE1cFD5WWjjWm6vlQKop04tU14wgqOlJxFmAsWSAEFuEefWLQ4XKIELb25MECBTuYDpZ1gc0FlHrjogCumekb3oxG1X8+gwFe/dBZ1I+thdaEjsBwGCubtgf6e6OKhAsi3tuSQkq+ueSezEr/BoiY/iKTBegyyS4CCntdLfH9hupvFUvZ/2FbxwnE8nHKYsecE/bY8C46O+XHGoRSn80Z1HsATGloYuviODYiUZvz/LAWEAMzQCgz2FXZNi4QhbvgMooNGLgMoa8lhEgK5GB5qgz8w9023yO1g3MzW6YMZNYj+GT2VvE6j5LC206dPQQad+FHeteMYF0/9904J2T+eCkW7JJ118PyK0LQ6lLfRbogGpx4KbbEFHtlFJvHHqNgeydH3sDJ/e/FwzNfENZZKC/MvB1rHNqtjHYnxD8qy7OXkE066GIZvdijrtbYa8tNlGZkYLi8wzC467Ut951j9NWPdy1iLx20fjIo/maZ99txFa3X9pZo7OACwPD3j989GFq2S/Xm/75+DDL4Ti57Km8vLqmUcWe819ZuBmbhXZT7zg3Mg7mkyLowdMvTdS7QrV1YmucxGsB9JmOCuM5yXjZiImoXYHARzZWw7wiWn+HyUG92su4ZGSRIbUk0b0zW8KRNEsnitE381e5XWIwzU4ldXwJ/z8zakDGUXvJN/wdbdBw5Y/g6Neo6nooXY4PJgvTv21JAjdScfCPTALF1wDwZpUxZzTzJj5skzf7vWq3S/4objNLApS8PGa0lAs5DF3rRljv4Oa9suGOJPe6yqcdydBEffOt3MmzsD7u2rzl6W21soFhLnVuiCRhus/7VSPx5//JpQ+QPSC7ucexCvJGuFb1YpWVCJX2CZJpoNrqcxAWvuOtdtAaRp53AVFfPdQ5G14d2qTktCWgiEzZ9gj2+3aPzHTqSvT0XhG85Ap4uamadYvF0DnIMRzotJMoN92meWpSoRBlFLH51cupA6GDodKNj5L/sjfk2d+Cupy2MNv3DSghpf8WrbeNhJCptPQvbctJTPzeT1pPuQAO2LekaX5Y+LSJmwKuipiXj1kmU7sz6jAvhncOVFDpJ9HvJyfhhdeyaQX6UqeKg5z8ZiFiXwM4JWWS5VbO5yDT3RcqoTNFr9ngpGgZi3qqrqEiAA="
+    }
+  ]
+}

--- a/ironfish/src/rpc/routes/multisig/createSigningCommitment.test.ts
+++ b/ironfish/src/rpc/routes/multisig/createSigningCommitment.test.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { ParticipantSecret, TrustedDealerKeyPackages } from '@ironfish/rust-nodejs'
+import { ParticipantSecret } from '@ironfish/rust-nodejs'
 import { createRouteTest } from '../../../testUtilities/routeTest'
 
 describe('Route multisig/createSigningCommitment', () => {
@@ -9,9 +9,7 @@ describe('Route multisig/createSigningCommitment', () => {
 
   it('should error on invalid keypackage', async () => {
     const keyPackage = 'invalid key package'
-
     const request = { keyPackage, seed: 0 }
-
     await expect(
       routeTest.client.request('multisig/createSigningCommitment', request).waitForEnd(),
     ).rejects.toThrow('InvalidData')
@@ -23,15 +21,13 @@ describe('Route multisig/createSigningCommitment', () => {
     }))
 
     const request = { minSigners: 2, maxSigners: 3, participants }
-    const response = await routeTest.client
-      .request('multisig/createTrustedDealerKeyPackage', request)
-      .waitForEnd()
+    const response = await routeTest.client.multisig.createTrustedDealerKeyPackage(request)
 
-    const trustedDealerKeyPackage = response.content as TrustedDealerKeyPackages
+    const trustedDealerPackage = response.content
 
     const signingCommitment = await routeTest.client
       .request('multisig/createSigningCommitment', {
-        keyPackage: trustedDealerKeyPackage.keyPackages[0].keyPackage,
+        keyPackage: trustedDealerPackage.keyPackages[0].keyPackage,
         seed: 420,
       })
       .waitForEnd()

--- a/ironfish/src/rpc/routes/multisig/createSigningPackage.test.ts
+++ b/ironfish/src/rpc/routes/multisig/createSigningPackage.test.ts
@@ -1,0 +1,69 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { ParticipantSecret, SigningCommitments } from '@ironfish/rust-nodejs'
+import {
+  createNodeTest,
+  useAccountFixture,
+  useMinerBlockFixture,
+  useUnsignedTxFixture,
+} from '../../../testUtilities'
+import { createRouteTest } from '../../../testUtilities/routeTest'
+
+describe('Route multisig/createSigningPackage', () => {
+  const routeTest = createRouteTest()
+  const nodeTest = createNodeTest()
+
+  it('should create signing package', async () => {
+    const seed = 420
+
+    const participants = Array.from({ length: 3 }, () => ({
+      identifier: ParticipantSecret.random().toIdentity().toFrostIdentifier(),
+    }))
+
+    const request = {
+      minSigners: 2,
+      maxSigners: 3,
+      participants,
+    }
+    const response = await routeTest.client.multisig.createTrustedDealerKeyPackage(request)
+
+    const trustedDealerPackage = response.content
+
+    const commitments: Array<{ identifier: string; commitment: SigningCommitments }> = []
+    for (let i = 0; i < 3; i++) {
+      const commitment = await routeTest.client.multisig.createSigningCommitment({
+        keyPackage: trustedDealerPackage.keyPackages[i].keyPackage,
+        seed,
+      })
+
+      commitments.push({
+        identifier: trustedDealerPackage.keyPackages[i].identifier,
+        commitment: commitment.content,
+      })
+    }
+
+    const account = await useAccountFixture(nodeTest.wallet)
+
+    // fund account
+    const block = await useMinerBlockFixture(
+      nodeTest.chain,
+      undefined,
+      account,
+      nodeTest.wallet,
+    )
+    await nodeTest.chain.addBlock(block)
+    await nodeTest.wallet.updateHead()
+
+    const unsignedTransaction = await useUnsignedTxFixture(nodeTest.wallet, account, account)
+    const unsignedString = unsignedTransaction.serialize().toString('hex')
+    const responseSigningPackage = await routeTest.client.multisig.createSigningPackage({
+      commitments,
+      unsignedTransaction: unsignedString,
+    })
+
+    expect(responseSigningPackage.content).toMatchObject({
+      signingPackage: expect.any(String),
+    })
+  })
+})

--- a/ironfish/src/rpc/routes/multisig/createSigningPackage.ts
+++ b/ironfish/src/rpc/routes/multisig/createSigningPackage.ts
@@ -1,0 +1,66 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { SigningCommitments, UnsignedTransaction } from '@ironfish/rust-nodejs'
+import * as yup from 'yup'
+import { ApiNamespace } from '../namespaces'
+import { routes } from '../router'
+import { RpcSigningCommitments, RpcSigningCommitmentsSchema } from './types'
+
+export type CreateSigningPackageRequest = {
+  unsignedTransaction: string
+  commitments: Array<{
+    identifier: string
+    commitment: RpcSigningCommitments
+  }>
+}
+
+export type CreateSigningPackageResponse = {
+  signingPackage: string
+}
+
+export const CreateSigningPackageRequestSchema: yup.ObjectSchema<CreateSigningPackageRequest> =
+  yup
+    .object({
+      unsignedTransaction: yup.string().defined(),
+      commitments: yup
+        .array(
+          yup
+            .object({
+              identifier: yup.string().defined(),
+              commitment: RpcSigningCommitmentsSchema,
+            })
+            .defined(),
+        )
+        .defined(),
+    })
+    .defined()
+
+export const CreateSigningPackageResponseSchema: yup.ObjectSchema<CreateSigningPackageResponse> =
+  yup
+    .object({
+      signingPackage: yup.string().defined(),
+    })
+    .defined()
+
+routes.register<typeof CreateSigningPackageRequestSchema, CreateSigningPackageResponse>(
+  `${ApiNamespace.multisig}/createSigningPackage`,
+  CreateSigningPackageRequestSchema,
+  (request, _context): void => {
+    const unsignedTransaction = new UnsignedTransaction(
+      Buffer.from(request.data.unsignedTransaction, 'hex'),
+    )
+    const map = request.data.commitments.reduce(
+      (acc: { [key: string]: SigningCommitments }, { identifier, commitment }) => {
+        acc[identifier] = commitment
+        return acc
+      },
+      {},
+    )
+    const signingPackage = unsignedTransaction.signingPackage(map)
+
+    request.end({
+      signingPackage,
+    })
+  },
+)

--- a/ironfish/src/rpc/routes/multisig/createTrustedDealerKeyPackage.test.ts
+++ b/ironfish/src/rpc/routes/multisig/createTrustedDealerKeyPackage.test.ts
@@ -8,13 +8,9 @@ describe('Route multisig/createTrustedDealerKeyPackage', () => {
   const routeTest = createRouteTest()
 
   it('should create trusted dealer key package', async () => {
-    const participants: { identifier: string }[] = []
-    for (let i = 0; i < 3; i++) {
-      const identifier = ParticipantSecret.random().toIdentity().toFrostIdentifier()
-      participants.push({
-        identifier: identifier,
-      })
-    }
+    const participants = Array.from({ length: 3 }, () => ({
+      identifier: ParticipantSecret.random().toIdentity().toFrostIdentifier(),
+    }))
     const request = { minSigners: 2, maxSigners: 3, participants }
     const response = await routeTest.client
       .request('multisig/createTrustedDealerKeyPackage', request)

--- a/ironfish/src/rpc/routes/multisig/index.ts
+++ b/ironfish/src/rpc/routes/multisig/index.ts
@@ -3,4 +3,5 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 export * from './createSigningCommitment'
+export * from './createSigningPackage'
 export * from './createTrustedDealerKeyPackage'


### PR DESCRIPTION
## Summary
1. Adds `createSigningPackage` RPC
2. Exposes typed RPC calls to the SDK for usage in tests (and js sdk)
3. Adds test fixture for `UnsignedTransaction`
## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
