### PR TITLE
chore: simplifies signing commitment test

### DIFF
--- a/ironfish/src/rpc/routes/multisig/createSigningCommitment.test.ts
+++ b/ironfish/src/rpc/routes/multisig/createSigningCommitment.test.ts
@@ -2,9 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { ParticipantSecret, TrustedDealerKeyPackages } from '@ironfish/rust-nodejs'
-import { v4 as uuid } from 'uuid'
-import { Assert } from '../../../assert'
-import { createNodeTest } from '../../../testUtilities'
 import { createRouteTest } from '../../../testUtilities/routeTest'
 
 describe('Route multisig/createSigningCommitment', () => {
@@ -21,68 +18,21 @@ describe('Route multisig/createSigningCommitment', () => {
   })
 
   it('should create signing commitment', async () => {
-    const seed = 420
-    const nodeTest = createNodeTest()
-    const { node } = await nodeTest.createSetup()
+    const participants = Array.from({ length: 3 }, () => ({
+      identifier: ParticipantSecret.random().toIdentity().toFrostIdentifier(),
+    }))
 
-    const participants: { identifier: string }[] = []
-    for (let i = 0; i < 3; i++) {
-      const identifier = ParticipantSecret.random().toIdentity().toFrostIdentifier()
-      participants.push({
-        identifier: identifier,
-      })
-    }
     const request = { minSigners: 2, maxSigners: 3, participants }
     const response = await routeTest.client
       .request('multisig/createTrustedDealerKeyPackage', request)
       .waitForEnd()
 
-    const trustedDealerPackage = response.content as TrustedDealerKeyPackages
-
-    const getMultiSigKeys = (index: number) => {
-      return {
-        identifier: trustedDealerPackage.keyPackages[index].identifier,
-        keyPackage: trustedDealerPackage.keyPackages[index].keyPackage,
-        proofGenerationKey: trustedDealerPackage.proofGenerationKey,
-      }
-    }
-
-    const participantA = await node.wallet.importAccount({
-      version: 2,
-      id: uuid(),
-      name: trustedDealerPackage.keyPackages[0].identifier,
-      spendingKey: null,
-      createdAt: null,
-      multiSigKeys: getMultiSigKeys(0),
-      ...trustedDealerPackage,
-    })
-    const participantB = await node.wallet.importAccount({
-      version: 2,
-      id: uuid(),
-      name: trustedDealerPackage.keyPackages[1].identifier,
-      spendingKey: null,
-      createdAt: null,
-      multiSigKeys: getMultiSigKeys(1),
-      ...trustedDealerPackage,
-    })
-    const participantC = await node.wallet.importAccount({
-      version: 2,
-      id: uuid(),
-      name: trustedDealerPackage.keyPackages[2].identifier,
-      spendingKey: null,
-      createdAt: null,
-      multiSigKeys: getMultiSigKeys(2),
-      ...trustedDealerPackage,
-    })
-
-    Assert.isNotUndefined(participantA.multiSigKeys)
-    Assert.isNotUndefined(participantB.multiSigKeys)
-    Assert.isNotUndefined(participantC.multiSigKeys)
+    const trustedDealerKeyPackage = response.content as TrustedDealerKeyPackages
 
     const signingCommitment = await routeTest.client
       .request('multisig/createSigningCommitment', {
-        keyPackage: participantA.multiSigKeys.keyPackage,
-        seed,
+        keyPackage: trustedDealerKeyPackage.keyPackages[0].keyPackage,
+        seed: 420,
       })
       .waitForEnd()
 


### PR DESCRIPTION
## Summary

The test I wrote earlier didn't need the participants to be set up. This dramatically simplifies the test

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
