### PR TITLE
derives public_address from view_key in build

### DIFF
--- a/ironfish-rust-nodejs/index.d.ts
+++ b/ironfish-rust-nodejs/index.d.ts
@@ -238,7 +238,7 @@ export class Transaction {
    * aka: self.value_balance - intended_transaction_fee - change = 0
    */
   post(spenderHexKey: string, changeGoesTo: string | undefined | null, intendedTransactionFee: bigint): Buffer
-  build(proofGenerationKeyStr: string, viewKeyStr: string, outgoingViewKeyStr: string, publicAddressStr: string, intendedTransactionFee: bigint, changeGoesTo?: string | undefined | null): Buffer
+  build(proofGenerationKeyStr: string, viewKeyStr: string, outgoingViewKeyStr: string, intendedTransactionFee: bigint, changeGoesTo?: string | undefined | null): Buffer
   setExpiration(sequence: number): void
 }
 export type NativeUnsignedTransaction = UnsignedTransaction

--- a/ironfish-rust-nodejs/src/structs/transaction.rs
+++ b/ironfish-rust-nodejs/src/structs/transaction.rs
@@ -329,14 +329,12 @@ impl NativeTransaction {
         proof_generation_key_str: String,
         view_key_str: String,
         outgoing_view_key_str: String,
-        public_address_str: String,
         intended_transaction_fee: BigInt,
         change_goes_to: Option<String>,
     ) -> Result<Buffer> {
         let view_key = ViewKey::from_hex(&view_key_str).map_err(to_napi_err)?;
         let outgoing_view_key =
             OutgoingViewKey::from_hex(&outgoing_view_key_str).map_err(to_napi_err)?;
-        let public_address = PublicAddress::from_hex(&public_address_str).map_err(to_napi_err)?;
         let proof_generation_key = ProofGenerationKey::from_hex(&proof_generation_key_str)
             .map_err(|_| to_napi_err("PublicKeyPackage hex to bytes failed"))?;
         let change_address = match change_goes_to {
@@ -349,7 +347,6 @@ impl NativeTransaction {
                 proof_generation_key,
                 view_key,
                 outgoing_view_key,
-                public_address,
                 intended_transaction_fee.get_i64().0,
                 change_address,
             )

--- a/ironfish-rust-nodejs/tests/unsigned.test.slow.ts
+++ b/ironfish-rust-nodejs/tests/unsigned.test.slow.ts
@@ -16,7 +16,6 @@ describe('UnsignedTransaction', () => {
                 key.proofGenerationKey,
                 key.viewKey,
                 key.outgoingViewKey,
-                key.publicAddress,
                 0n,
             )
 

--- a/ironfish-rust/src/keys/mod.rs
+++ b/ironfish-rust/src/keys/mod.rs
@@ -243,7 +243,7 @@ impl SaplingKey {
     ///
     /// This method is only called once, but it's kind of messy, so I pulled it
     /// out of the constructor for easier maintenance.
-    fn hash_viewing_key(
+    pub fn hash_viewing_key(
         authorizing_key: &SubgroupPoint,
         nullifier_deriving_key: &SubgroupPoint,
     ) -> Result<jubjub::Fr, IronfishError> {

--- a/ironfish-rust/src/keys/view_keys.rs
+++ b/ironfish-rust/src/keys/view_keys.rs
@@ -16,6 +16,7 @@ use super::PublicAddress;
 use crate::{
     errors::{IronfishError, IronfishErrorKind},
     serializing::{bytes_to_hex, hex_to_bytes, read_scalar},
+    SaplingKey,
 };
 use bip39::{Language, Mnemonic};
 use blake2b_simd::Params as Blake2b;
@@ -135,6 +136,17 @@ impl ViewKey {
         result[..32].copy_from_slice(&self.authorizing_key.to_bytes());
         result[32..].copy_from_slice(&self.nullifier_deriving_key.to_bytes());
         result
+    }
+
+    pub fn public_address(&self) -> Result<PublicAddress, IronfishError> {
+        let ivk = IncomingViewKey {
+            view_key: SaplingKey::hash_viewing_key(
+                &self.authorizing_key,
+                &self.nullifier_deriving_key,
+            )?,
+        };
+
+        Ok(ivk.public_address())
     }
 }
 

--- a/ironfish-rust/src/transaction/mod.rs
+++ b/ironfish-rust/src/transaction/mod.rs
@@ -234,10 +234,11 @@ impl ProposedTransaction {
         proof_generation_key: ProofGenerationKey,
         view_key: ViewKey,
         outgoing_view_key: OutgoingViewKey,
-        public_address: PublicAddress,
         intended_transaction_fee: i64,
         change_goes_to: Option<PublicAddress>,
     ) -> Result<UnsignedTransaction, IronfishError> {
+        let public_address = view_key.public_address()?;
+
         // skip adding change notes if this is special case of a miners fee transaction
         let is_miners_fee = self.outputs.iter().any(|output| output.get_is_miners_fee());
         if !is_miners_fee {
@@ -341,7 +342,6 @@ impl ProposedTransaction {
             spender_key.sapling_proof_generation_key(),
             spender_key.view_key().clone(),
             spender_key.outgoing_view_key().clone(),
-            public_address,
             i64_fee,
             change_goes_to,
         )?;
@@ -382,7 +382,6 @@ impl ProposedTransaction {
             spender_key.sapling_proof_generation_key(),
             spender_key.view_key().clone(),
             spender_key.outgoing_view_key().clone(),
-            spender_key.public_address(),
             *self.value_balances.fee(),
             None,
         )?;

--- a/ironfish-rust/src/transaction/mod.rs
+++ b/ironfish-rust/src/transaction/mod.rs
@@ -334,8 +334,6 @@ impl ProposedTransaction {
         change_goes_to: Option<PublicAddress>,
         intended_transaction_fee: u64,
     ) -> Result<Transaction, IronfishError> {
-        let public_address = spender_key.public_address();
-
         let i64_fee = i64::try_from(intended_transaction_fee)?;
 
         let unsigned = self.build(

--- a/ironfish-rust/src/transaction/tests.rs
+++ b/ironfish-rust/src/transaction/tests.rs
@@ -243,7 +243,6 @@ fn test_proposed_transaction_build() {
             spender_key.sapling_proof_generation_key(),
             spender_key.view_key().clone(),
             spender_key.outgoing_view_key().clone(),
-            spender_key.public_address(),
             intended_fee,
             Some(public_address),
         )
@@ -687,7 +686,6 @@ fn test_sign_simple() {
             spender_key.sapling_proof_generation_key(),
             spender_key.view_key().clone(),
             spender_key.outgoing_view_key().clone(),
-            spender_key.public_address(),
             1,
             Some(spender_key.public_address()),
         )
@@ -782,7 +780,6 @@ fn test_sign_frost() {
             key_packages.proof_generation_key,
             key_packages.view_key,
             key_packages.outgoing_view_key,
-            key_packages.public_address,
             intended_fee,
             Some(key_packages.public_address),
         )

--- a/ironfish/src/primitives/rawTransaction.ts
+++ b/ironfish/src/primitives/rawTransaction.ts
@@ -166,7 +166,6 @@ export class RawTransaction {
     proofGenerationKey: string,
     viewKey: string,
     outgoingViewKey: string,
-    publicAddress: string,
   ): UnsignedTransaction {
     const builder = this._build()
 
@@ -174,7 +173,6 @@ export class RawTransaction {
       proofGenerationKey,
       viewKey,
       outgoingViewKey,
-      publicAddress,
       this.fee,
       null,
     )

--- a/ironfish/src/wallet/wallet.test.slow.ts
+++ b/ironfish/src/wallet/wallet.test.slow.ts
@@ -1279,7 +1279,6 @@ describe('Wallet', () => {
         trustedDealerPackage.proofGenerationKey,
         trustedDealerPackage.viewKey,
         trustedDealerPackage.outgoingViewKey,
-        trustedDealerPackage.publicAddress,
       )
 
       const signingPackage = unsignedTransaction.signingPackage(signingCommitments)


### PR DESCRIPTION
## Summary

UnsignedTransaction.build currently takes both a ViewKey _and_ a PublicAddress as inputs

with a couple of small changes we can derive the public address from the view key so that we don't need to pass both of them around

this simplifies the signatures for build from TypeScript through napi and into Rust

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
