### PR TITLE
filestore handles empty file

### DIFF
--- a/ironfish/src/fileStores/fileStore.test.ts
+++ b/ironfish/src/fileStores/fileStore.test.ts
@@ -23,7 +23,6 @@ describe('FileStore', () => {
     const dir = getUniqueTestDataDir()
     const files = await new NodeFileProvider().init()
 
-    // create empty file
     const path = files.resolve(dir + '/test')
     await files.mkdir(files.dirname(path), { recursive: true })
     await files.writeFile(path, '')

--- a/ironfish/src/fileStores/fileStore.test.ts
+++ b/ironfish/src/fileStores/fileStore.test.ts
@@ -23,17 +23,15 @@ describe('FileStore', () => {
     const dir = getUniqueTestDataDir()
     const files = await new NodeFileProvider().init()
 
-    const path = files.resolve(dir + '/test')
-    await files.mkdir(files.dirname(path), { recursive: true })
-    await files.writeFile(path, '')
+    await files.mkdir(dir, { recursive: true })
+    await files.writeFile(files.join(dir, '/test'), '')
 
-    const store = new FileStore<{ foo: string }>(files, 'test', dir)
+    const store = new FileStore(files, 'test', dir)
     const result = await store.load()
     expect(result).toBeNull()
+
     await store.save({ foo: 'hello' })
-
     const loaded = await store.load()
-
     expect(loaded).toMatchObject({ foo: 'hello' })
   })
 

--- a/ironfish/src/fileStores/fileStore.test.ts
+++ b/ironfish/src/fileStores/fileStore.test.ts
@@ -19,6 +19,25 @@ describe('FileStore', () => {
     expect(loaded).toMatchObject({ foo: 'hello' })
   })
 
+  it('should load file if it is empty', async () => {
+    const dir = getUniqueTestDataDir()
+    const files = await new NodeFileProvider().init()
+
+    // create empty file
+    const path = files.resolve(dir + '/test')
+    await files.mkdir(files.dirname(path), { recursive: true })
+    await files.writeFile(path, '')
+
+    const store = new FileStore<{ foo: string }>(files, 'test', dir)
+    const result = await store.load()
+    expect(result).toBeNull()
+    await store.save({ foo: 'hello' })
+
+    const loaded = await store.load()
+
+    expect(loaded).toMatchObject({ foo: 'hello' })
+  })
+
   it('should prevent multiple writes to the file before the promise completes', async () => {
     const dir = getUniqueTestDataDir()
     const files = new NodeFileProvider()

--- a/ironfish/src/fileStores/fileStore.ts
+++ b/ironfish/src/fileStores/fileStore.ts
@@ -21,20 +21,19 @@ export class FileStore<T extends Record<string, unknown>> {
   }
 
   async load(): Promise<PartialRecursive<T> | null> {
-    const configExists = await this.files.exists(this.configPath)
+    const exists = await this.files.exists(this.configPath)
 
-    let config = null
-
-    if (configExists) {
-      const data = await this.files.readFile(this.configPath)
-
-      if (data.length === 0) {
-        return null
-      }
-      config = JSONUtils.parse<PartialRecursive<T>>(data, this.configName)
+    if (!exists) {
+      return null
     }
 
-    return config
+    const data = await this.files.readFile(this.configPath)
+
+    if (data.length === 0) {
+      return null
+    }
+
+    return JSONUtils.parse<PartialRecursive<T>>(data, this.configName)
   }
 
   async save(data: PartialRecursive<T>): Promise<void> {

--- a/ironfish/src/fileStores/fileStore.ts
+++ b/ironfish/src/fileStores/fileStore.ts
@@ -27,6 +27,10 @@ export class FileStore<T extends Record<string, unknown>> {
 
     if (configExists) {
       const data = await this.files.readFile(this.configPath)
+
+      if (data.length === 0) {
+        return null
+      }
       config = JSONUtils.parse<PartialRecursive<T>>(data, this.configName)
     }
 


### PR DESCRIPTION
## Summary

Our users seem to have a recurring problem where if a fileStore .json file is empty, the app crashes. This prevents it from happening in effect creating an empty json object, which then gets replaced with the required json object

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
