### PR TITLE
Changes frost test to use participantB address

### DIFF
--- a/ironfish/src/wallet/wallet.test.slow.ts
+++ b/ironfish/src/wallet/wallet.test.slow.ts
@@ -1230,6 +1230,9 @@ describe('Wallet', () => {
       await expect(node.chain).toAddBlock(block)
       await node.wallet.updateHead()
 
+      // we are using participant B and sending the transaction below from participant A
+      // to make it extremely obvious that the participants in the multisig account control
+      // the same account.
       const transaction = await node.wallet.send({
         account: miner,
         outputs: [

--- a/ironfish/src/wallet/wallet.test.slow.ts
+++ b/ironfish/src/wallet/wallet.test.slow.ts
@@ -1234,7 +1234,7 @@ describe('Wallet', () => {
         account: miner,
         outputs: [
           {
-            publicAddress: participantA.publicAddress,
+            publicAddress: participantB.publicAddress,
             amount: BigInt(2),
             memo: '',
             assetId: Asset.nativeId(),


### PR DESCRIPTION
The goal is to make it explicit in the test that the participants all have the same address.

This is solely a stylistic change. 

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
