### PR TITLE
feat: create signing share

### DIFF
--- a/ironfish/src/rpc/routes/multisig/createSigningShare.ts
+++ b/ironfish/src/rpc/routes/multisig/createSigningShare.ts
@@ -1,0 +1,55 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { roundTwo, UnsignedTransaction } from '@ironfish/rust-nodejs'
+import * as yup from 'yup'
+import { ApiNamespace } from '../namespaces'
+import { routes } from '../router'
+
+export type CreateSigningShareRequest = {
+  signingPackage: string
+  keyPackage: string
+  unsignedTransaction: string
+  seed: number //  TODO: remove when we have deterministic nonces
+}
+
+export type CreateSigningCommitmentResponse = {
+  signingShare: string
+}
+
+export const CreateSigningCommitmentRequestSchema: yup.ObjectSchema<CreateSigningShareRequest> =
+  yup
+    .object({
+      signingPackage: yup.string().defined(),
+      keyPackage: yup.string().defined(),
+      unsignedTransaction: yup.string().defined(),
+      seed: yup.number().defined(),
+    })
+    .defined()
+
+export const CreateSigningCommitmentResponseSchema: yup.ObjectSchema<CreateSigningCommitmentResponse> =
+  yup
+    .object({
+      signingShare: yup.string().defined(),
+    })
+    .defined()
+
+routes.register<typeof CreateSigningCommitmentRequestSchema, CreateSigningCommitmentResponse>(
+  `${ApiNamespace.multisig}/createSigningShare`,
+  CreateSigningCommitmentRequestSchema,
+  (request, _context): void => {
+    const unsigned = new UnsignedTransaction(
+      Buffer.from(request.data.unsignedTransaction, 'hex'),
+    )
+    const result = roundTwo(
+      request.data.signingPackage,
+      request.data.keyPackage,
+      unsigned.publicKeyRandomness(),
+      request.data.seed,
+    )
+
+    request.end({
+      signingShare: result,
+    })
+  },
+)


### PR DESCRIPTION
## Summary
Wrapper around `roundTwo` method, which I will rename in subsequent PR to `createSigningShare` (along with `roundOne`->`createSigningCommitment`).
## Testing Plan
At this point the test becomes pretty complicated just to test serialization. Decided not to add a test here since the underlying code is tested thoroughly.
## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
