### PR TITLE
removes publicAddress from build args in fixture

### DIFF
--- a/ironfish/src/testUtilities/fixtures/transactions.ts
+++ b/ironfish/src/testUtilities/fixtures/transactions.ts
@@ -128,7 +128,7 @@ export async function useUnsignedTxFixture(
       Assert.isNotNull(from.spendingKey)
       const key = generateKeyFromPrivateKey(from.spendingKey)
       const unsignedBuffer = raw
-        .build(key.proofGenerationKey, key.viewKey, key.outgoingViewKey, key.publicAddress)
+        .build(key.proofGenerationKey, key.viewKey, key.outgoingViewKey)
         .serialize()
       return new UnsignedTransaction(unsignedBuffer)
     })


### PR DESCRIPTION
## Summary

one PR added a fixture, another PR changed the arguments of a function that the fixture called

when both PRs merged soon after each other, we ended up with a broken build

removes the extra argument

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
