### PR TITLE
Move RawBlock/Header constructors onto Bockchain

### DIFF
--- a/ironfish/src/consensus/verifier.test.ts
+++ b/ironfish/src/consensus/verifier.test.ts
@@ -199,7 +199,7 @@ describe('Verifier', () => {
       const { block } = await useBlockWithTx(nodeTest.node)
 
       const reorderedTransactions = [block.transactions[1], block.transactions[0]]
-      const invalidBlock = nodeTest.strategy.newBlock({
+      const invalidBlock = nodeTest.chain.newBlockFromRaw({
         header: {
           ...block.header,
           transactionCommitment: transactionCommitment(reorderedTransactions),
@@ -219,7 +219,7 @@ describe('Verifier', () => {
       const minersFee = await useMinersTxFixture(nodeTest.node, account, undefined, 0)
 
       const reorderedTransactions = [block.transactions[0], minersFee]
-      const invalidBlock = nodeTest.strategy.newBlock({
+      const invalidBlock = nodeTest.chain.newBlockFromRaw({
         header: {
           ...block.header,
           transactionCommitment: transactionCommitment(reorderedTransactions),
@@ -272,7 +272,7 @@ describe('Verifier', () => {
         },
       )
 
-      const invalidMinersBlock = nodeTest.strategy.newBlock({
+      const invalidMinersBlock = nodeTest.chain.newBlockFromRaw({
         header: {
           ...minersBlock.header,
           transactionCommitment: transactionCommitment([invalidMinersTransaction]),
@@ -289,7 +289,7 @@ describe('Verifier', () => {
     it('rejects a block with no transactions', async () => {
       const block = await useMinerBlockFixture(nodeTest.node.chain)
 
-      const invalidBlock = nodeTest.strategy.newBlock({
+      const invalidBlock = nodeTest.chain.newBlockFromRaw({
         header: {
           ...block.header,
           transactionCommitment: transactionCommitment([]),
@@ -316,7 +316,7 @@ describe('Verifier', () => {
 
       const invalidTransactions = [...block.transactions, extraTransaction]
 
-      const invalidBlock = nodeTest.strategy.newBlock({
+      const invalidBlock = nodeTest.chain.newBlockFromRaw({
         header: {
           ...block.header,
           transactionCommitment: transactionCommitment(invalidTransactions),
@@ -639,7 +639,7 @@ describe('Verifier', () => {
       nodeTest.verifier.enableVerifyTarget = true
       const block = await useMinerBlockFixture(nodeTest.chain)
 
-      const invalidHeader = nodeTest.strategy.newBlockHeader({
+      const invalidHeader = nodeTest.chain.newBlockHeaderFromRaw({
         ...block.header,
         target: Target.minTarget(),
       })
@@ -655,7 +655,7 @@ describe('Verifier', () => {
     it('Is invalid when the sequence is wrong', async () => {
       const block = await useMinerBlockFixture(nodeTest.chain)
 
-      const invalidHeader = nodeTest.strategy.newBlockHeader({
+      const invalidHeader = nodeTest.chain.newBlockHeaderFromRaw({
         ...block.header,
         sequence: 9999,
       })
@@ -692,7 +692,7 @@ describe('Verifier', () => {
       })
 
       it('fails validation when timestamp is too low', async () => {
-        const invalidHeader = nodeTest.strategy.newBlockHeader({
+        const invalidHeader = nodeTest.chain.newBlockHeaderFromRaw({
           ...header,
           timestamp: new Date(
             prevHeader.timestamp.getTime() -
@@ -713,7 +713,7 @@ describe('Verifier', () => {
           .spyOn(global.Date, 'now')
           .mockImplementationOnce(() => prevHeader.timestamp.getTime() + 40 * 1000)
 
-        const invalidHeader = nodeTest.strategy.newBlockHeader({
+        const invalidHeader = nodeTest.chain.newBlockHeaderFromRaw({
           ...header,
           timestamp: new Date(
             prevHeader.timestamp.getTime() +
@@ -734,7 +734,7 @@ describe('Verifier', () => {
           .spyOn(global.Date, 'now')
           .mockImplementationOnce(() => prevHeader.timestamp.getTime() + 1 * 1000)
 
-        const invalidHeader = nodeTest.strategy.newBlockHeader({
+        const invalidHeader = nodeTest.chain.newBlockHeaderFromRaw({
           ...header,
           timestamp: new Date(prevHeader.timestamp.getTime() - 1 * 1000),
         })
@@ -751,7 +751,7 @@ describe('Verifier', () => {
           .spyOn(global.Date, 'now')
           .mockImplementationOnce(() => prevHeader.timestamp.getTime() + 1 * 1000)
 
-        const invalidHeader = nodeTest.strategy.newBlockHeader({
+        const invalidHeader = nodeTest.chain.newBlockHeaderFromRaw({
           ...header,
           timestamp: new Date(prevHeader.timestamp.getTime() + 1 * 1000),
         })
@@ -792,7 +792,7 @@ describe('Verifier', () => {
       })
 
       it('fails validation when timestamp is too low', async () => {
-        const invalidHeader = nodeTest.strategy.newBlockHeader({
+        const invalidHeader = nodeTest.chain.newBlockHeaderFromRaw({
           ...header,
           timestamp: new Date(
             prevHeader.timestamp.getTime() -
@@ -813,7 +813,7 @@ describe('Verifier', () => {
           .spyOn(global.Date, 'now')
           .mockImplementationOnce(() => prevHeader.timestamp.getTime() + 40 * 1000)
 
-        const invalidHeader = nodeTest.strategy.newBlockHeader({
+        const invalidHeader = nodeTest.chain.newBlockHeaderFromRaw({
           ...header,
           timestamp: new Date(
             prevHeader.timestamp.getTime() +
@@ -830,7 +830,7 @@ describe('Verifier', () => {
       })
 
       it('fails validation when timestamp is smaller than previous block', async () => {
-        const invalidHeader = nodeTest.strategy.newBlockHeader({
+        const invalidHeader = nodeTest.chain.newBlockHeaderFromRaw({
           ...header,
           timestamp: new Date(prevHeader.timestamp.getTime() - 1 * 1000),
         })
@@ -844,7 +844,7 @@ describe('Verifier', () => {
       })
 
       it('fails validation when timestamp is same as previous block', async () => {
-        const invalidHeader = nodeTest.strategy.newBlockHeader({
+        const invalidHeader = nodeTest.chain.newBlockHeaderFromRaw({
           ...header,
           timestamp: new Date(prevHeader.timestamp.getTime()),
         })
@@ -862,7 +862,7 @@ describe('Verifier', () => {
           .spyOn(global.Date, 'now')
           .mockImplementationOnce(() => prevHeader.timestamp.getTime() + 1 * 1000)
 
-        const invalidHeader = nodeTest.strategy.newBlockHeader({
+        const invalidHeader = nodeTest.chain.newBlockHeaderFromRaw({
           ...header,
           timestamp: new Date(prevHeader.timestamp.getTime() + 1 * 1000),
         })
@@ -895,7 +895,7 @@ describe('Verifier', () => {
       const newBlock = await useMinerBlockFixture(chain)
       await expect(chain).toAddBlock(newBlock)
 
-      const invalidNewBlock = nodeTest.strategy.newBlock(
+      const invalidNewBlock = nodeTest.chain.newBlockFromRaw(
         {
           header: {
             ...newBlock.header,

--- a/ironfish/src/genesis/addGenesisTransaction.ts
+++ b/ironfish/src/genesis/addGenesisTransaction.ts
@@ -141,7 +141,7 @@ export async function addGenesisTransaction(
     graffiti: genesisBlock.header.graffiti,
   }
 
-  const newGenesisHeader = node.chain.strategy.newBlockHeader(rawHeader, noteSize)
+  const newGenesisHeader = node.chain.newBlockHeaderFromRaw(rawHeader, noteSize)
 
   genesisBlock.header = newGenesisHeader
 

--- a/ironfish/src/genesis/genesis.test.slow.ts
+++ b/ironfish/src/genesis/genesis.test.slow.ts
@@ -121,7 +121,7 @@ describe('Create genesis block', () => {
 
     // Deserialize the block and add it to the new chain
     const result = IJSON.parse(jsonedBlock) as SerializedBlock
-    const deserializedBlock = BlockSerde.deserialize(result, nodeTest.strategy)
+    const deserializedBlock = BlockSerde.deserialize(result, nodeTest.chain)
     const addedBlock = await newChain.addBlock(deserializedBlock)
     expect(addedBlock.isAdded).toBe(true)
 
@@ -274,7 +274,7 @@ describe('addGenesisTransaction', () => {
 
     // Deserialize the block and add it to the new chain
     const result = IJSON.parse(jsonedBlock) as SerializedBlock
-    const deserializedBlock = BlockSerde.deserialize(result, nodeTest.strategy)
+    const deserializedBlock = BlockSerde.deserialize(result, nodeTest.chain)
     const addedBlock = await chain.addBlock(deserializedBlock)
     expect(addedBlock.isAdded).toBe(true)
 

--- a/ironfish/src/genesis/makeGenesisBlock.ts
+++ b/ironfish/src/genesis/makeGenesisBlock.ts
@@ -170,7 +170,7 @@ export async function makeGenesisBlock(
     GraffitiUtils.fromString('genesis'),
   )
 
-  const genesisBlock = chain.strategy.newBlock(
+  const genesisBlock = chain.newBlockFromRaw(
     {
       header: {
         ...block.header,

--- a/ironfish/src/mining/manager.test.slow.ts
+++ b/ironfish/src/mining/manager.test.slow.ts
@@ -626,7 +626,7 @@ describe('Mining manager', () => {
       // Create 2 blocks at the same sequence, one with higher difficulty
       const blockA1 = await useMinerBlockFixture(chain, undefined, account, wallet)
       const blockB1Temp = await useMinerBlockFixture(chain, undefined, account, wallet)
-      const blockB1 = nodeTest.strategy.newBlock({
+      const blockB1 = nodeTest.chain.newBlockFromRaw({
         header: {
           ...blockB1Temp.header,
           target: Target.fromDifficulty(blockA1.header.target.toDifficulty() + 1n),
@@ -641,8 +641,8 @@ describe('Mining manager', () => {
       await expect(chain).toAddBlock(blockB1)
 
       // Increase difficulty of submitted template so it
-      const blockA2Temp = BlockTemplateSerde.deserialize(templateA2, nodeTest.strategy)
-      const blockA2 = nodeTest.strategy.newBlock({
+      const blockA2Temp = BlockTemplateSerde.deserialize(templateA2, nodeTest.chain)
+      const blockA2 = nodeTest.chain.newBlockFromRaw({
         header: {
           ...blockA2Temp.header,
           target: Target.fromDifficulty(blockA2Temp.header.target.toDifficulty() + 2n),
@@ -680,7 +680,7 @@ describe('Mining manager', () => {
         MINED_RESULT.SUCCESS,
       )
 
-      const submittedBlock = BlockTemplateSerde.deserialize(template, nodeTest.strategy)
+      const submittedBlock = BlockTemplateSerde.deserialize(template, nodeTest.chain)
       const newBlock = onNewBlockSpy.mock.calls[0][0]
       expect(newBlock.header.hash).toEqual(submittedBlock.header.hash)
     })

--- a/ironfish/src/mining/manager.ts
+++ b/ironfish/src/mining/manager.ts
@@ -198,7 +198,7 @@ export class MiningManager {
       this.metrics.mining_newBlockTemplate.add(BenchUtils.end(connectedAt))
       this.streamBlockTemplate(currentBlock, template)
 
-      const block = BlockTemplateSerde.deserialize(template, this.chain.strategy)
+      const block = BlockTemplateSerde.deserialize(template, this.chain)
       const verification = await this.chain.verifier.verifyBlock(block, {
         verifyTarget: false,
       })
@@ -366,7 +366,7 @@ export class MiningManager {
   }
 
   async submitBlockTemplate(blockTemplate: SerializedBlockTemplate): Promise<MINED_RESULT> {
-    const block = BlockTemplateSerde.deserialize(blockTemplate, this.chain.strategy)
+    const block = BlockTemplateSerde.deserialize(blockTemplate, this.chain)
 
     const blockDisplay = `${block.header.hash.toString('hex')} (${block.header.sequence})`
     if (!block.header.previousBlockHash.equals(this.node.chain.head.hash)) {

--- a/ironfish/src/network/messages/getBlocks.test.ts
+++ b/ironfish/src/network/messages/getBlocks.test.ts
@@ -36,7 +36,7 @@ describe('GetBlocksResponse', () => {
     const message = new GetBlocksResponse(
       [
         new Block(
-          nodeTest.strategy.newBlockHeader({
+          nodeTest.chain.newBlockHeaderFromRaw({
             sequence: 2,
             previousBlockHash: Buffer.alloc(32, 2),
             noteCommitment: Buffer.alloc(32, 4),
@@ -49,7 +49,7 @@ describe('GetBlocksResponse', () => {
           [transactionA, transactionB],
         ),
         new Block(
-          nodeTest.strategy.newBlockHeader({
+          nodeTest.chain.newBlockHeaderFromRaw({
             sequence: 2,
             previousBlockHash: Buffer.alloc(32, 1),
             noteCommitment: Buffer.alloc(32, 5),

--- a/ironfish/src/network/messages/getCompactBlock.test.ts
+++ b/ironfish/src/network/messages/getCompactBlock.test.ts
@@ -33,7 +33,7 @@ describe('GetCompactBlockResponse', () => {
     const transactionB = await useMinersTxFixture(nodeTest.node, account)
 
     const compactBlock: CompactBlock = {
-      header: nodeTest.strategy.newBlockHeader({
+      header: nodeTest.chain.newBlockHeaderFromRaw({
         sequence: 2,
         previousBlockHash: Buffer.alloc(32, 2),
         noteCommitment: Buffer.alloc(32, 1),

--- a/ironfish/src/network/peerNetwork.test.ts
+++ b/ironfish/src/network/peerNetwork.test.ts
@@ -763,7 +763,7 @@ describe('PeerNetwork', () => {
             expect(sendSpy).not.toHaveBeenCalled()
           }
 
-          const invalidHeader = nodeTest.strategy.newBlockHeader(invalidBlock.header)
+          const invalidHeader = nodeTest.chain.newBlockHeaderFromRaw(invalidBlock.header)
           await expect(chain.hasBlock(invalidHeader.hash)).resolves.toBe(false)
           expect(chain.isInvalid(invalidHeader)).toBe(reason)
         }

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -615,7 +615,7 @@ export class PeerNetwork {
     }
 
     const headers = response.headers.map((rawHeader) =>
-      this.chain.strategy.newBlockHeader(rawHeader),
+      this.chain.newBlockHeaderFromRaw(rawHeader),
     )
 
     return { headers, time: BenchUtils.end(begin) }
@@ -639,7 +639,7 @@ export class PeerNetwork {
     const exceededSoftLimit = response.getSize() >= SOFT_MAX_MESSAGE_SIZE
     const isMessageFull = exceededSoftLimit || response.blocks.length >= limit
 
-    const blocks = response.blocks.map((rawBlock) => this.chain.strategy.newBlock(rawBlock))
+    const blocks = response.blocks.map((rawBlock) => this.chain.newBlockFromRaw(rawBlock))
 
     return { blocks, time: BenchUtils.end(begin), isMessageFull }
   }
@@ -789,7 +789,7 @@ export class PeerNetwork {
       return
     }
 
-    const header = this.chain.strategy.newBlockHeader(compactBlock.header)
+    const header = this.chain.newBlockHeaderFromRaw(compactBlock.header)
 
     // mark the block as received in the block fetcher and decide whether to continue
     // to validate this compact block or not
@@ -1175,7 +1175,7 @@ export class PeerNetwork {
       return
     }
 
-    const block = this.chain.strategy.newBlock(rawBlock)
+    const block = this.chain.newBlockFromRaw(rawBlock)
 
     if (await this.alreadyHaveBlock(block.header)) {
       return

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -5,6 +5,7 @@ import { BoxKeyPair, FishHashContext } from '@ironfish/rust-nodejs'
 import { v4 as uuid } from 'uuid'
 import { AssetsVerifier } from './assets'
 import { Blockchain } from './blockchain'
+import { BlockHasher } from './blockHasher'
 import { Consensus } from './consensus'
 import {
   Config,
@@ -277,8 +278,13 @@ export class FullNode {
       fishHashContext = new FishHashContext(isFull)
     }
 
+    const blockHasher = new BlockHasher({
+      consensus: consensus,
+      context: fishHashContext,
+    })
+
     strategyClass = strategyClass || Strategy
-    const strategy = new strategyClass({ workerPool, consensus, fishHashContext })
+    const strategy = new strategyClass({ workerPool, consensus, blockHasher })
 
     const chain = new Blockchain({
       location: config.chainDatabasePath,
@@ -291,6 +297,7 @@ export class FullNode {
       consensus,
       genesis: networkDefinition.genesis,
       config,
+      blockHasher,
     })
 
     const feeEstimator = new FeeEstimator({

--- a/ironfish/src/primitives/block.test.ts
+++ b/ironfish/src/primitives/block.test.ts
@@ -36,13 +36,13 @@ describe('Block', () => {
     const serialized = BlockSerde.serialize(block)
     expect(serialized).toMatchObject({ header: { timestamp: expect.any(Number) } })
 
-    const deserialized = BlockSerde.deserialize(serialized, nodeTest.strategy)
+    const deserialized = BlockSerde.deserialize(serialized, nodeTest.chain)
     expect(block.equals(deserialized)).toBe(true)
   })
 
   it('throws when deserializing invalid block', () => {
     expect(() =>
-      BlockSerde.deserialize({ bad: 'data' } as unknown as SerializedBlock, nodeTest.strategy),
+      BlockSerde.deserialize({ bad: 'data' } as unknown as SerializedBlock, nodeTest.chain),
     ).toThrow('Unable to deserialize')
   })
 
@@ -52,10 +52,10 @@ describe('Block', () => {
     const { block: block1 } = await useBlockWithTx(nodeTest.node, account, account)
 
     // Header change
-    const block2 = BlockSerde.deserialize(BlockSerde.serialize(block1), nodeTest.strategy)
+    const block2 = BlockSerde.deserialize(BlockSerde.serialize(block1), nodeTest.chain)
     expect(block1.equals(block2)).toBe(true)
 
-    let toCompare = nodeTest.strategy.newBlock({
+    let toCompare = nodeTest.chain.newBlockFromRaw({
       header: {
         ...block2.header,
         randomness: BigInt(400),
@@ -64,7 +64,7 @@ describe('Block', () => {
     })
     expect(block1.equals(toCompare)).toBe(false)
 
-    toCompare = nodeTest.strategy.newBlock({
+    toCompare = nodeTest.chain.newBlockFromRaw({
       header: {
         ...block2.header,
         sequence: block2.header.sequence + 1,
@@ -73,7 +73,7 @@ describe('Block', () => {
     })
     expect(block1.equals(toCompare)).toBe(false)
 
-    toCompare = nodeTest.strategy.newBlock({
+    toCompare = nodeTest.chain.newBlockFromRaw({
       header: {
         ...block2.header,
         timestamp: new Date(block2.header.timestamp.valueOf() + 1),
@@ -83,13 +83,13 @@ describe('Block', () => {
     expect(block1.equals(toCompare)).toBe(false)
 
     // Transactions length
-    const block3 = BlockSerde.deserialize(BlockSerde.serialize(block1), nodeTest.strategy)
+    const block3 = BlockSerde.deserialize(BlockSerde.serialize(block1), nodeTest.chain)
     expect(block1.equals(block3)).toBe(true)
     block3.transactions.pop()
     expect(block1.equals(block3)).toBe(false)
 
     // Transaction equality
-    const block4 = BlockSerde.deserialize(BlockSerde.serialize(block1), nodeTest.strategy)
+    const block4 = BlockSerde.deserialize(BlockSerde.serialize(block1), nodeTest.chain)
     expect(block1.equals(block4)).toBe(true)
     block4.transactions.pop()
     block4.transactions.push(tx)

--- a/ironfish/src/primitives/block.ts
+++ b/ironfish/src/primitives/block.ts
@@ -4,7 +4,7 @@
 
 import { zip } from 'lodash'
 import { Assert } from '../assert'
-import { Strategy } from '../strategy'
+import { Blockchain } from '../blockchain'
 import {
   BlockHeader,
   BlockHeaderSerde,
@@ -174,7 +174,7 @@ export class BlockSerde {
     }
   }
 
-  static deserialize(data: SerializedBlock, strategy: Strategy): Block {
+  static deserialize(data: SerializedBlock, chain: Blockchain): Block {
     if (
       typeof data === 'object' &&
       data !== null &&
@@ -182,7 +182,7 @@ export class BlockSerde {
       'transactions' in data &&
       Array.isArray(data.transactions)
     ) {
-      const header = BlockHeaderSerde.deserialize(data.header, strategy)
+      const header = BlockHeaderSerde.deserialize(data.header, chain)
       const transactions = data.transactions.map((t) => new Transaction(t))
       return new Block(header, transactions)
     }

--- a/ironfish/src/primitives/blockheader.ts
+++ b/ironfish/src/primitives/blockheader.ts
@@ -5,8 +5,8 @@
 import { blake3 } from '@napi-rs/blake-hash'
 import bufio from 'bufio'
 import { Assert } from '../assert'
+import { Blockchain } from '../blockchain'
 import { BlockHashSerdeInstance, GraffitiSerdeInstance } from '../serde'
-import { Strategy } from '../strategy'
 import { BigIntUtils } from '../utils/bigint'
 import { NoteEncryptedHash, SerializedNoteEncryptedHash } from './noteEncrypted'
 import { Target } from './target'
@@ -273,8 +273,8 @@ export class BlockHeaderSerde {
     }
   }
 
-  static deserialize(data: SerializedBlockHeader, strategy: Strategy): BlockHeader {
-    return strategy.newBlockHeader(
+  static deserialize(data: SerializedBlockHeader, chain: Blockchain): BlockHeader {
+    return chain.newBlockHeaderFromRaw(
       {
         sequence: Number(data.sequence),
         previousBlockHash: Buffer.from(

--- a/ironfish/src/serde/BlockTemplateSerde.ts
+++ b/ironfish/src/serde/BlockTemplateSerde.ts
@@ -2,11 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import { Blockchain } from '../blockchain'
 import { Block, RawBlock } from '../primitives/block'
 import { NoteEncryptedHashSerde } from '../primitives/noteEncrypted'
 import { Target } from '../primitives/target'
 import { Transaction } from '../primitives/transaction'
-import { Strategy } from '../strategy'
 import { BigIntUtils } from '../utils'
 
 export type SerializedBlockTemplate = {
@@ -84,9 +84,9 @@ export class BlockTemplateSerde {
     return RawBlockTemplateSerde.serialize(block, previousBlock)
   }
 
-  static deserialize(blockTemplate: SerializedBlockTemplate, strategy: Strategy): Block {
+  static deserialize(blockTemplate: SerializedBlockTemplate, chain: Blockchain): Block {
     const rawBlock = RawBlockTemplateSerde.deserialize(blockTemplate)
 
-    return strategy.newBlock(rawBlock)
+    return chain.newBlockFromRaw(rawBlock)
   }
 }

--- a/ironfish/src/strategy.test.ts
+++ b/ironfish/src/strategy.test.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import { BlockHasher } from './blockHasher'
 import { Consensus, ConsensusParameters } from './consensus'
 import { Strategy } from './strategy'
 import { FISH_HASH_CONTEXT } from './testUtilities'
@@ -23,10 +24,12 @@ describe('Miners reward', () => {
   }
 
   beforeAll(() => {
+    const consensus = new Consensus(consensusParameters)
+    const blockHasher = new BlockHasher({ consensus, context: FISH_HASH_CONTEXT })
     strategy = new Strategy({
       workerPool: new WorkerPool(),
-      consensus: new Consensus(consensusParameters),
-      fishHashContext: FISH_HASH_CONTEXT,
+      consensus,
+      blockHasher,
     })
   })
 

--- a/ironfish/src/strategy.ts
+++ b/ironfish/src/strategy.ts
@@ -1,11 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { FishHashContext } from '@ironfish/rust-nodejs'
 import { BlockHasher } from './blockHasher'
 import { Consensus } from './consensus'
-import { Block, RawBlock } from './primitives/block'
-import { BlockHeader, RawBlockHeader } from './primitives/blockheader'
 import { Transaction } from './primitives/transaction'
 import { MathUtils } from './utils'
 import { WorkerPool } from './workerPool'
@@ -23,15 +20,12 @@ export class Strategy {
   constructor(options: {
     workerPool: WorkerPool
     consensus: Consensus
-    fishHashContext?: FishHashContext
+    blockHasher: BlockHasher
   }) {
     this.miningRewardCachedByYear = new Map<number, number>()
     this.workerPool = options.workerPool
     this.consensus = options.consensus
-    this.blockHasher = new BlockHasher({
-      consensus: this.consensus,
-      context: options.fishHashContext,
-    })
+    this.blockHasher = options.blockHasher
   }
 
   /**
@@ -103,15 +97,5 @@ export class Strategy {
     const transactionVersion = this.consensus.getActiveTransactionVersion(blockSequence)
 
     return this.workerPool.createMinersFee(minerSpendKey, amount, '', transactionVersion)
-  }
-
-  newBlockHeader(raw: RawBlockHeader, noteSize?: number | null, work?: bigint): BlockHeader {
-    const hash = this.blockHasher.hashHeader(raw)
-    return new BlockHeader(raw, hash, noteSize, work)
-  }
-
-  newBlock(raw: RawBlock, noteSize?: number | null, work?: bigint): Block {
-    const header = this.newBlockHeader(raw.header, noteSize, work)
-    return new Block(header, raw.transactions)
   }
 }

--- a/ironfish/src/testUtilities/fixtures/blocks.ts
+++ b/ironfish/src/testUtilities/fixtures/blocks.ts
@@ -57,7 +57,7 @@ export async function useBlockFixture(
       return BlockSerde.serialize(block)
     },
     deserialize: (serialized: SerializedBlock): Block => {
-      return BlockSerde.deserialize(serialized, chain.strategy)
+      return BlockSerde.deserialize(serialized, chain)
     },
   })
 }

--- a/ironfish/src/utils/blockutil.test.ts
+++ b/ironfish/src/utils/blockutil.test.ts
@@ -68,7 +68,7 @@ describe('BlockchainUtils', () => {
       [{ start: 3.14, stop: 6.28 }, 3, 6],
       [{ start: 6.28, stop: 3.14 }, 6, 6],
     ])('%o returns %d %d', (param, expectedStart, expectedStop) => {
-      nodeTest.chain.latest = nodeTest.strategy.newBlockHeader({
+      nodeTest.chain.latest = nodeTest.chain.newBlockHeaderFromRaw({
         ...nodeTest.chain.latest,
         sequence: 10000,
       })
@@ -79,7 +79,7 @@ describe('BlockchainUtils', () => {
     })
 
     it('{ start: null, stop: 6000 } returns 1 6000', () => {
-      nodeTest.chain.latest = nodeTest.strategy.newBlockHeader({
+      nodeTest.chain.latest = nodeTest.chain.newBlockHeaderFromRaw({
         ...nodeTest.chain.latest,
         sequence: 10000,
       })
@@ -90,7 +90,7 @@ describe('BlockchainUtils', () => {
     })
 
     it('{ start: 6000, stop: null } returns 6000 10000', () => {
-      nodeTest.chain.latest = nodeTest.strategy.newBlockHeader({
+      nodeTest.chain.latest = nodeTest.chain.newBlockHeaderFromRaw({
         ...nodeTest.chain.latest,
         sequence: 10000,
       })


### PR DESCRIPTION
## Summary

This is a move in an effort to delete Strategy. This moves the `Strategy.newBlock` and `Strategy.newBlockHeader` methods onto Blockchain and renames them to indicate they are just conversion functions.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
