### PR TITLE
Move createMinersFee() to Blockchain

### DIFF
--- a/ironfish/src/blockchain/blockchain.test.ts
+++ b/ironfish/src/blockchain/blockchain.test.ts
@@ -1737,7 +1737,7 @@ describe('Blockchain', () => {
 
           return node.chain.newBlock(
             [burnTransaction, spendTransaction],
-            await node.strategy.createMinersFee(fee, 3, generateKey().spendingKey),
+            await node.chain.createMinersFee(fee, 3, generateKey().spendingKey),
           )
         })
 
@@ -1937,6 +1937,19 @@ describe('Blockchain', () => {
         const blockHashA = await nodeA.chain.getBlockHashByTransactionHash(transaction.hash())
         expect(blockHashA).toBeNull()
       }
+    })
+  })
+
+  describe('createMinersFee()', () => {
+    it('Creates transactions with the correct version based on the sequence', async () => {
+      const spendingKey = generateKey().spendingKey
+      nodeTest.chain.consensus.parameters.enableAssetOwnership = 1234
+
+      const minersFee1 = await nodeTest.chain.createMinersFee(0n, 1233, spendingKey)
+      const minersFee2 = await nodeTest.chain.createMinersFee(0n, 1234, spendingKey)
+
+      expect(minersFee1.version()).toEqual(TransactionVersion.V1)
+      expect(minersFee2.version()).toEqual(TransactionVersion.V2)
     })
   })
 })

--- a/ironfish/src/genesis/genesis.test.slow.ts
+++ b/ironfish/src/genesis/genesis.test.slow.ts
@@ -29,7 +29,7 @@ describe('Read genesis block', () => {
   it('Can start a chain with the existing genesis block', async () => {
     // We should also be able to create new blocks after the genesis block
     // has been added
-    const minersfee = await nodeTest.strategy.createMinersFee(
+    const minersfee = await nodeTest.chain.createMinersFee(
       BigInt(0),
       nodeTest.chain.head.sequence + 1,
       generateKey().spendingKey,
@@ -56,7 +56,6 @@ describe('Create genesis block', () => {
 
   it('Can generate a valid genesis block', async () => {
     // Initialize the database and chain
-    const strategy = nodeTest.strategy
     const node = nodeTest.node
     const chain = nodeTest.chain
 
@@ -103,7 +102,7 @@ describe('Create genesis block', () => {
     })
 
     // Ensure we can construct blocks after that block
-    const minersfee = await strategy.createMinersFee(
+    const minersfee = await chain.createMinersFee(
       BigInt(0),
       block.header.sequence + 1,
       generateKey().spendingKey,
@@ -141,7 +140,7 @@ describe('Create genesis block', () => {
     })
 
     // Ensure we can construct blocks after that block
-    const newMinersfee = await strategy.createMinersFee(
+    const newMinersfee = await chain.createMinersFee(
       BigInt(0),
       deserializedBlock.header.sequence + 1,
       generateKey().spendingKey,
@@ -261,7 +260,7 @@ describe('addGenesisTransaction', () => {
     })
 
     // Create a new node
-    const { strategy, chain, node } = await nodeTest.createSetup()
+    const { chain, node } = await nodeTest.createSetup()
 
     // Import accounts
     const account1 = await node.wallet.importAccount(account1Original)
@@ -295,7 +294,7 @@ describe('addGenesisTransaction', () => {
     })
 
     // Ensure we can construct blocks after that block
-    const minersfee = await strategy.createMinersFee(
+    const minersfee = await chain.createMinersFee(
       BigInt(0),
       block.header.sequence + 1,
       generateKey().spendingKey,

--- a/ironfish/src/mining/manager.ts
+++ b/ironfish/src/mining/manager.ts
@@ -323,7 +323,7 @@ export class MiningManager {
       currBlockSize = newBlockSize
 
       // Calculate the final fee for the miner of this block
-      minersFee = await this.node.strategy.createMinersFee(
+      minersFee = await this.node.chain.createMinersFee(
         totalFees,
         newBlockSequence,
         account.spendingKey,

--- a/ironfish/src/mining/minersFeeCache.ts
+++ b/ironfish/src/mining/minersFeeCache.ts
@@ -34,7 +34,7 @@ export class MinersFeeCache {
       return cached
     }
 
-    const minersFeePromise = this.node.strategy.createMinersFee(
+    const minersFeePromise = this.node.chain.createMinersFee(
       BigInt(0),
       sequence,
       account.spendingKey,
@@ -48,7 +48,7 @@ export class MinersFeeCache {
   startCreatingEmptyMinersFee(sequence: number, account: SpendingAccount): void {
     const key = `${sequence}-${account.publicAddress}`
 
-    const minersFeePromise = this.node.strategy.createMinersFee(
+    const minersFeePromise = this.node.chain.createMinersFee(
       BigInt(0),
       sequence,
       account.spendingKey,

--- a/ironfish/src/rpc/routes/miner/blockTemplateStream.test.slow.ts
+++ b/ironfish/src/rpc/routes/miner/blockTemplateStream.test.slow.ts
@@ -88,12 +88,12 @@ describe('Block template stream', () => {
     await nodeTest.teardownAll()
 
     // Now, spy on some functions
-    const actual = node.strategy.createMinersFee
+    const actual = node.chain.createMinersFee.bind(node.chain)
     const [p, res] = PromiseUtils.split<void>()
 
-    jest.spyOn(node.strategy, 'createMinersFee').mockImplementation(async (a, b, c) => {
+    jest.spyOn(node.chain, 'createMinersFee').mockImplementation(async (a, b, c) => {
       await p
-      return await actual.bind(node.strategy)(a, b, c)
+      return await actual(a, b, c)
     })
 
     const newBlockSpy = jest.spyOn(node.chain, 'newBlock')
@@ -108,7 +108,7 @@ describe('Block template stream', () => {
     await expect(chain).toAddBlock(block2)
     await expect(chain).toAddBlock(block3)
 
-    // Resolve the createMinersSpy promise, allowing block creation to proceed to newBlock
+    // Resolve the createMinersFee promise, allowing block creation to proceed to newBlock
     res()
 
     // Finish up the response
@@ -116,6 +116,7 @@ describe('Block template stream', () => {
     await expect(response.waitForRoute()).resolves.toEqual(expect.anything())
 
     // newBlock should have thrown an error, but the response should not have crashed
+    expect(newBlockSpy).toHaveBeenCalled()
     await expect(newBlockSpy.mock.results[0].value).rejects.toThrow()
   })
 })

--- a/ironfish/src/strategy.ts
+++ b/ironfish/src/strategy.ts
@@ -3,7 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { BlockHasher } from './blockHasher'
 import { Consensus } from './consensus'
-import { Transaction } from './primitives/transaction'
 import { MathUtils } from './utils'
 import { WorkerPool } from './workerPool'
 
@@ -68,34 +67,5 @@ export class Strategy {
 
   convertIronToOre(iron: number): number {
     return Math.round(iron * 10 ** 8)
-  }
-
-  /**
-   * Create the miner's fee transaction for a given block.
-   *
-   * The miner's fee is a special transaction with one output and
-   * zero spends. Its output value must be the total transaction fees
-   * in the block plus the mining reward for the block.
-   *
-   * The mining reward may change over time, so we accept the block sequence
-   * to calculate the mining reward from.
-   *
-   * @param totalTransactionFees is the sum of the transaction fees intended to go
-   * in this block.
-   * @param blockSequence the sequence of the block for which the miner's fee is being created
-   * @param minerKey the spending key for the miner.
-   */
-  async createMinersFee(
-    totalTransactionFees: bigint,
-    blockSequence: number,
-    minerSpendKey: string,
-  ): Promise<Transaction> {
-    // Create a new note with value equal to the inverse of the sum of the
-    // transaction fees and the mining reward
-    const amount = totalTransactionFees + BigInt(this.miningReward(blockSequence))
-
-    const transactionVersion = this.consensus.getActiveTransactionVersion(blockSequence)
-
-    return this.workerPool.createMinersFee(minerSpendKey, amount, '', transactionVersion)
   }
 }

--- a/ironfish/src/testUtilities/fixtures/blocks.ts
+++ b/ironfish/src/testUtilities/fixtures/blocks.ts
@@ -80,7 +80,7 @@ export async function useMinerBlockFixture(
     async () =>
       chain.newBlock(
         transactions,
-        await chain.strategy.createMinersFee(
+        await chain.createMinersFee(
           transactionFees,
           sequence || chain.head.sequence + 1,
           spendingKey,
@@ -197,7 +197,7 @@ export async function useBlockWithRawTxFixture(
 
     return chain.newBlock(
       [transaction],
-      await chain.strategy.createMinersFee(transaction.fee(), sequence, sender.spendingKey),
+      await chain.createMinersFee(transaction.fee(), sequence, sender.spendingKey),
     )
   }
 
@@ -269,7 +269,7 @@ export async function useBlockWithTx(
 
     return node.chain.newBlock(
       [transaction],
-      await node.strategy.createMinersFee(transaction.fee(), 3, generateKey().spendingKey),
+      await node.chain.createMinersFee(transaction.fee(), 3, generateKey().spendingKey),
     )
   })
 
@@ -335,7 +335,7 @@ export async function useBlockWithCustomTxs(
 
       return node.chain.newBlock(
         transactions,
-        await node.strategy.createMinersFee(transactionFees, 3, generateKey().spendingKey),
+        await node.chain.createMinersFee(transactionFees, 3, generateKey().spendingKey),
       )
     },
     node.wallet,

--- a/ironfish/src/testUtilities/fixtures/transactions.ts
+++ b/ironfish/src/testUtilities/fixtures/transactions.ts
@@ -156,7 +156,7 @@ export async function useMinersTxFixture(
     Assert.isNotUndefined(to)
     Assert.isNotNull(to.spendingKey)
 
-    return node.chain.strategy.createMinersFee(
+    return node.chain.createMinersFee(
       BigInt(amount),
       sequence || node.chain.head.sequence + 1,
       to.spendingKey,

--- a/ironfish/src/wallet/wallet.test.slow.ts
+++ b/ironfish/src/wallet/wallet.test.slow.ts
@@ -72,7 +72,7 @@ describe('Wallet', () => {
     })
 
     // Create a block with a miner's fee
-    const minersfee = await nodeTest.strategy.createMinersFee(BigInt(0), 2, account.spendingKey)
+    const minersfee = await nodeTest.chain.createMinersFee(BigInt(0), 2, account.spendingKey)
     const newBlock = await chain.newBlock([], minersfee)
     const addResult = await chain.addBlock(newBlock)
     expect(addResult.isAdded).toBeTruthy()
@@ -88,7 +88,6 @@ describe('Wallet', () => {
 
   it('Lowers the balance after using send to spend a note', async () => {
     // Initialize the database and chain
-    const strategy = nodeTest.strategy
     const node = nodeTest.node
     const chain = nodeTest.chain
 
@@ -108,7 +107,7 @@ describe('Wallet', () => {
     })
 
     // Create a block with a miner's fee
-    const minersfee = await strategy.createMinersFee(BigInt(0), 2, account.spendingKey)
+    const minersfee = await chain.createMinersFee(BigInt(0), 2, account.spendingKey)
     const newBlock = await chain.newBlock([], minersfee)
     const addResult = await chain.addBlock(newBlock)
     expect(addResult.isAdded).toBeTruthy()
@@ -137,7 +136,7 @@ describe('Wallet', () => {
     })
 
     // Create a block with a miner's fee
-    const minersfee2 = await strategy.createMinersFee(
+    const minersfee2 = await chain.createMinersFee(
       transaction.fee(),
       newBlock.header.sequence + 1,
       generateKey().spendingKey,
@@ -156,7 +155,6 @@ describe('Wallet', () => {
 
   it('Creates valid transactions when the worker pool is enabled', async () => {
     // Initialize the database and chain
-    const strategy = nodeTest.strategy
     const node = nodeTest.node
     const chain = nodeTest.chain
 
@@ -176,7 +174,7 @@ describe('Wallet', () => {
     })
 
     // Create a block with a miner's fee
-    const minersfee = await strategy.createMinersFee(BigInt(0), 2, account.spendingKey)
+    const minersfee = await chain.createMinersFee(BigInt(0), 2, account.spendingKey)
     const newBlock = await chain.newBlock([], minersfee)
     const addResult = await chain.addBlock(newBlock)
     expect(addResult.isAdded).toBeTruthy()
@@ -208,7 +206,7 @@ describe('Wallet', () => {
     )
 
     // Create a block with a miner's fee
-    const minersfee2 = await strategy.createMinersFee(
+    const minersfee2 = await chain.createMinersFee(
       transaction.fee(),
       newBlock.header.sequence + 1,
       generateKey().spendingKey,
@@ -227,7 +225,6 @@ describe('Wallet', () => {
 
   it('creates valid transactions with multiple outputs', async () => {
     // Initialize the database and chain
-    const strategy = nodeTest.strategy
     const node = nodeTest.node
     const chain = nodeTest.chain
 
@@ -247,7 +244,7 @@ describe('Wallet', () => {
     })
 
     // Create a block with a miner's fee
-    const minersfee = await strategy.createMinersFee(BigInt(0), 2, account.spendingKey)
+    const minersfee = await chain.createMinersFee(BigInt(0), 2, account.spendingKey)
     const newBlock = await chain.newBlock([], minersfee)
     const addResult = await chain.addBlock(newBlock)
     expect(addResult.isAdded).toBeTruthy()
@@ -290,7 +287,7 @@ describe('Wallet', () => {
     )
 
     // Create a block with a miner's fee
-    const minersfee2 = await strategy.createMinersFee(
+    const minersfee2 = await chain.createMinersFee(
       transaction.fee(),
       newBlock.header.sequence + 1,
       generateKey().spendingKey,
@@ -332,7 +329,6 @@ describe('Wallet', () => {
 
   it('Expires transactions when calling expireTransactions', async () => {
     // Initialize the database and chain
-    const strategy = nodeTest.strategy
     const node = nodeTest.node
     const chain = nodeTest.chain
 
@@ -355,7 +351,7 @@ describe('Wallet', () => {
     })
 
     // Create a block with a miner's fee
-    const minersfee = await strategy.createMinersFee(BigInt(0), 2, account.spendingKey)
+    const minersfee = await chain.createMinersFee(BigInt(0), 2, account.spendingKey)
     const newBlock = await chain.newBlock([], minersfee)
     const addResult = await chain.addBlock(newBlock)
     expect(addResult.isAdded).toBeTruthy()
@@ -396,7 +392,7 @@ describe('Wallet', () => {
     })
 
     // Create a block with a miner's fee
-    const minersfee2 = await strategy.createMinersFee(
+    const minersfee2 = await chain.createMinersFee(
       transaction.fee(),
       newBlock.header.sequence + 1,
       generateKey().spendingKey,
@@ -415,7 +411,6 @@ describe('Wallet', () => {
 
   it('Expires transactions when calling expireTransactions with restarts', async () => {
     // Initialize the database and chain
-    const strategy = nodeTest.strategy
     const node = nodeTest.node
     const chain = nodeTest.chain
 
@@ -441,7 +436,7 @@ describe('Wallet', () => {
     })
 
     // Create a block with a miner's fee
-    const minersfee = await strategy.createMinersFee(BigInt(0), 2, account.spendingKey)
+    const minersfee = await chain.createMinersFee(BigInt(0), 2, account.spendingKey)
     const newBlock = await chain.newBlock([], minersfee)
     await expect(chain).toAddBlock(newBlock)
 
@@ -478,7 +473,7 @@ describe('Wallet', () => {
     await node.wallet.open()
 
     // Create a block with a miner's fee
-    const minersfee2 = await strategy.createMinersFee(
+    const minersfee2 = await chain.createMinersFee(
       transaction.fee(),
       newBlock.header.sequence + 1,
       generateKey().spendingKey,
@@ -536,7 +531,7 @@ describe('Wallet', () => {
       // Create block 2
       return nodeA.chain.newBlock(
         [transaction],
-        await nodeA.strategy.createMinersFee(transaction.fee(), 3, generateKey().spendingKey),
+        await nodeA.chain.createMinersFee(transaction.fee(), 3, generateKey().spendingKey),
       )
     })
 
@@ -631,7 +626,6 @@ describe('Wallet', () => {
 
   it('View only accounts can observe received and spent notes', async () => {
     // Initialize the database and chain
-    const strategy = nodeTest.strategy
     const node = nodeTest.node
     // need separate node because a node cannot have a view only wallet + spend wallet for same account
     const { node: viewOnlyNode } = await nodeTest.createSetup()
@@ -653,7 +647,7 @@ describe('Wallet', () => {
     const viewOnlyAccount = await viewOnlyNode.wallet.importAccount(accountValue)
 
     // Create a block with a miner's fee
-    const minersfee = await strategy.createMinersFee(BigInt(0), 2, account.spendingKey)
+    const minersfee = await chain.createMinersFee(BigInt(0), 2, account.spendingKey)
     const newBlock = await chain.newBlock([], minersfee)
     const addResult = await chain.addBlock(newBlock)
     const addResultViewOnly = await viewOnlyChain.addBlock(newBlock)
@@ -691,7 +685,7 @@ describe('Wallet', () => {
     })
 
     // Create a block with a miner's fee
-    const minersfee2 = await strategy.createMinersFee(
+    const minersfee2 = await chain.createMinersFee(
       transaction.fee(),
       newBlock.header.sequence + 1,
       generateKey().spendingKey,
@@ -768,7 +762,7 @@ describe('Wallet', () => {
         // Create block A2
         return nodeA.chain.newBlock(
           [transaction],
-          await nodeA.strategy.createMinersFee(BigInt(0), 3, generateKey().spendingKey),
+          await nodeA.chain.createMinersFee(BigInt(0), 3, generateKey().spendingKey),
         )
       },
       nodeA.wallet,
@@ -881,7 +875,7 @@ describe('Wallet', () => {
         // Create block A2
         return nodeA.chain.newBlock(
           [transaction],
-          await nodeA.strategy.createMinersFee(BigInt(0), 3, generateKey().spendingKey),
+          await nodeA.chain.createMinersFee(BigInt(0), 3, generateKey().spendingKey),
         )
       },
       nodeB.wallet,
@@ -894,7 +888,7 @@ describe('Wallet', () => {
     const blockB2 = await useBlockFixture(nodeB.chain, async () =>
       nodeB.chain.newBlock(
         [],
-        await nodeB.strategy.createMinersFee(BigInt(0), 3, generateKey().spendingKey),
+        await nodeB.chain.createMinersFee(BigInt(0), 3, generateKey().spendingKey),
       ),
     )
     addedBlock = await nodeB.chain.addBlock(blockB2)
@@ -904,7 +898,7 @@ describe('Wallet', () => {
     const blockB3 = await useBlockFixture(nodeB.chain, async () =>
       nodeB.chain.newBlock(
         [],
-        await nodeB.strategy.createMinersFee(BigInt(0), 4, generateKey().spendingKey),
+        await nodeB.chain.createMinersFee(BigInt(0), 4, generateKey().spendingKey),
       ),
     )
     addedBlock = await nodeB.chain.addBlock(blockB3)
@@ -1004,7 +998,7 @@ describe('Wallet', () => {
 
         const mintBlock = await node.chain.newBlock(
           [transaction],
-          await node.strategy.createMinersFee(transaction.fee(), 4, generateKey().spendingKey),
+          await node.chain.createMinersFee(transaction.fee(), 4, generateKey().spendingKey),
         )
         await expect(node.chain).toAddBlock(mintBlock)
         await node.wallet.updateHead()
@@ -1246,7 +1240,7 @@ describe('Wallet', () => {
       })
 
       // Create a block with a miner's fee and the transaction to send IRON to the multisig account
-      const minersfee2 = await nodeTest.strategy.createMinersFee(
+      const minersfee2 = await nodeTest.chain.createMinersFee(
         transaction.fee(),
         block.header.sequence + 1,
         miner.spendingKey,
@@ -1314,7 +1308,7 @@ describe('Wallet', () => {
       )
       const frostTransaction = new Transaction(serializedFrostTransaction)
 
-      const minersfee3 = await nodeTest.strategy.createMinersFee(
+      const minersfee3 = await nodeTest.chain.createMinersFee(
         transaction.fee(),
         newBlock2.header.sequence + 1,
         miner.spendingKey,

--- a/ironfish/src/workerPool/job.test.slow.ts
+++ b/ironfish/src/workerPool/job.test.slow.ts
@@ -12,13 +12,13 @@ describe('Worker Pool', () => {
   const nodeTest = createNodeTest(false, { config: { nodeWorkers: 1 } })
 
   it('createMinersFee', async () => {
-    const { workerPool, strategy } = nodeTest
+    const { workerPool, chain } = nodeTest
     workerPool.start()
 
     expect(workerPool.workers.length).toBe(1)
     expect(workerPool.completed).toBe(0)
 
-    const minersFee = await strategy.createMinersFee(BigInt(0), 0, generateKey().spendingKey)
+    const minersFee = await chain.createMinersFee(BigInt(0), 0, generateKey().spendingKey)
     expect(minersFee.serialize()).toBeInstanceOf(Buffer)
 
     expect(workerPool.completed).toBe(1)


### PR DESCRIPTION
## Summary

This moves the createMinersFee() off Strategy to Blockchain.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
