### PR TITLE
adds napi binding for UnsignedTransaction.sign

### DIFF
--- a/ironfish-rust-nodejs/index.d.ts
+++ b/ironfish-rust-nodejs/index.d.ts
@@ -247,6 +247,7 @@ export class UnsignedTransaction {
   serialize(): Buffer
   publicKeyRandomness(): string
   signingPackage(nativeCommitments: Record<string, SigningCommitments>): string
+  sign(spenderHexKey: string): Buffer
   signFrost(publicKeyPackageStr: string, signingPackageStr: string, signatureSharesMap: Record<string, string>): Buffer
 }
 export class FoundBlockResult {

--- a/ironfish-rust-nodejs/src/structs/transaction.rs
+++ b/ironfish-rust-nodejs/src/structs/transaction.rs
@@ -445,6 +445,18 @@ impl NativeUnsignedTransaction {
     }
 
     #[napi]
+    pub fn sign(&mut self, spender_hex_key: String) -> Result<Buffer> {
+        let spender_key = SaplingKey::from_hex(&spender_hex_key).map_err(to_napi_err)?;
+
+        let posted_transaction = self.transaction.sign(&spender_key).map_err(to_napi_err)?;
+
+        let mut vec: Vec<u8> = vec![];
+        posted_transaction.write(&mut vec).map_err(to_napi_err)?;
+
+        Ok(Buffer::from(vec))
+    }
+
+    #[napi]
     pub fn sign_frost(
         &mut self,
         public_key_package_str: String,


### PR DESCRIPTION
## Summary

exposing 'sign' on the TypeScript side will be useful in the future for signing transactions with pre-computed proofs, and it will be useful now for testing

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
