### PR TITLE
adds BuildTransaction worker job

### DIFF
--- a/ironfish/src/workerPool/pool.ts
+++ b/ironfish/src/workerPool/pool.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import { UnsignedTransaction } from '@ironfish/rust-nodejs'
 import _ from 'lodash'
 import os from 'os'
 import { VerificationResult, VerificationResultReason } from '../consensus'
@@ -13,6 +14,7 @@ import { Metric } from '../telemetry/interfaces/metric'
 import { WorkerMessageStats } from './interfaces/workerMessageStats'
 import { Job } from './job'
 import { RoundRobinQueue } from './roundRobinQueue'
+import { BuildTransactionRequest, BuildTransactionResponse } from './tasks/buildTransaction'
 import { CreateMinersFeeRequest, CreateMinersFeeResponse } from './tasks/createMinersFee'
 import {
   DecryptedNote,
@@ -136,6 +138,28 @@ export class WorkerPool {
     }
 
     return new Transaction(Buffer.from(response.serializedTransactionPosted))
+  }
+
+  async buildTransaction(
+    transaction: RawTransaction,
+    proofGenerationKey: string,
+    viewKey: string,
+    outgoingViewKey: string,
+  ): Promise<UnsignedTransaction> {
+    const request = new BuildTransactionRequest(
+      transaction,
+      proofGenerationKey,
+      viewKey,
+      outgoingViewKey,
+    )
+
+    const response = await this.execute(request).result()
+
+    if (!(response instanceof BuildTransactionResponse)) {
+      throw new Error('Invalid response')
+    }
+
+    return response.transaction
   }
 
   async postTransaction(

--- a/ironfish/src/workerPool/tasks/__fixtures__/buildTransaction.test.ts.fixture
+++ b/ironfish/src/workerPool/tasks/__fixtures__/buildTransaction.test.ts.fixture
@@ -1,0 +1,141 @@
+{
+  "BuildTransactionRequest serializes the object into a buffer and deserializes to the original object": [
+    {
+      "version": 3,
+      "id": "9f71b71a-d261-4afb-811a-5a8281d7b537",
+      "name": "test",
+      "spendingKey": "7a7e4fcbb424bcafbc78e5b4f1928666de643459cf65a5625988792ae006fa18",
+      "viewKey": "4ba9ec601d42aff6e3c2bf14074b7863625ebc0c39302e3b2f275752f838c6452ac596ec3149813d3c1c693c32e30051db79cab6e95fe67108c83dbb134ba49b",
+      "incomingViewKey": "aa89cf7dc11ed1cf4931b1558190124bf2e1bf34c8833aec56e574514c395c06",
+      "outgoingViewKey": "8c3d594ffd7c63f00c8f0fdd1957503ad564701e603bf03be1b2c7dc94e283b7",
+      "publicAddress": "0a98ad5ca1648a1f30e49b9e555e7ef081e27ec68c14e654efa3d75a3fdab3bd",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "4791D7AE9F97DF100EF1558E84772D6A09B43762388283F75C6F20A32A88AA86",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:INGj8XXI3t2K0XCSA4gKO02BmgYeX6fHL+E3Wmsu3hc="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:jLn+jhu/WRDT0XsG45KtRcMTVJ8JJbVjTT/28UDjx2k="
+        },
+        "target": "9282972777491357380673661573939192202192629606981189395159182914949423",
+        "randomness": "0",
+        "timestamp": 1706644419506,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AgAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAEO9D7fdtjIH8Z32Fu6PsuRcPN/6iqYGo9S0Jo5GxOGSFCaHXlb3MaivG7TV05wZaZQ4vdUu7xjl0v/e6WPLZRBQ1DxG8ln0POKFeMYwPtsuNimcuy5rD3XSHPZFdyQ5rkKnYg5uAIbHSyDhfjJuTTDeccga1wG3jeAiC9girOQEYB1tH6UmkUCGeLoKpBLXcNroVecanVdjLCRuVlr1CIt/NLSSBh9z3g/LMaU60XD6xr4qjN0fPCcTC0xNq1vWDmKrKg3sd9/ls/dTnIN/QrRDtJaNJkOc5EsOASyviJ7Zc/N/3HzHgAvGyL6MMkfs3TZbXhtHwLa3Rb1IAQqqZRPAy3psCFn3bB/04d6+WqM3ruy4zfFvCIfHliAd+B45Gio0rvAxO47Ubce6lfmgE99LEXD7tbZABB9wwfmCrGWdJNTclCEzDBUTdABj/NwDITae94qwWqIYMK5QWivv8r24CTfqusOvrE3XfwubEa29yrSHpSu29upmDwV0d6QGOJL/Y98kh95C30/T860NBB807aGrzuvXz2GklmaxddZ+Cu+Zom6BhXuYvJ8tDO0o3Ee1pwAdOlXvu1nY2UEPDlcf13nnx5L8YS6u+3IHfnU71eb9tcV0Mt0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwUbFfGEV7nzmXbpW7tFNlADd/Qf9KK7OnUYDKSUP1US4MZuFRNDW+SSxBfwTAeVYQxw9u7N7/DvwkhM1YaQ8UBQ=="
+        }
+      ]
+    }
+  ],
+  "BuildTransactionResponse serializes the object into a buffer and deserializes to the original object": [
+    {
+      "version": 3,
+      "id": "0d2a89e5-238e-40f9-bdf8-99d4f352be49",
+      "name": "test",
+      "spendingKey": "9cab93527ea33e23485a4c84fc6798619a8cd7c7c79911b7f69937d7d882ef65",
+      "viewKey": "cf0465fabe6865aad5f5838a08d7f43c0b186a18f060c5881ff9a85bc81c28a963b09dc5d8d4af1e83ca793c3af43a98cb8493e3605e60497e94a0d3b455d1aa",
+      "incomingViewKey": "45642bd08bcfe723ee273a1156175caf2ac2cb39cb8d920f5a255a7fc0df6204",
+      "outgoingViewKey": "70daade00c02beb24c79dfddc33d593a76f456e54d1c8833ff16136660db4a41",
+      "publicAddress": "46723996880cdc7f7ece0f3b4ced788b05959211843ad65069135afd9f7920cc",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "4791D7AE9F97DF100EF1558E84772D6A09B43762388283F75C6F20A32A88AA86",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:N82JfcsyBkl81grj/NCKClOe6NbL8XByQdvZBeFnUG8="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:jC3IK5+jZG/zeVEsB+3CG6OMLSdXTEwvfKRg2Zd+FVw="
+        },
+        "target": "9282972777491357380673661573939192202192629606981189395159182914949423",
+        "randomness": "0",
+        "timestamp": 1706644600897,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AgAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAZkeN2nGDKKr3auTw6Pb8Z6weXnSubPS4wGgschIoDUeG/du+BRpKC6GUG7Qv4JrmN/vWeLShl2+aujsQ3OtN39iyi2ZIvs/k6xlkQfo1iQaIB8xHaQwIjuAm1R6i6qgkO6UhlWSzA5W8qPmryu2cvN/sVop/PFTfTF5JvWzevToSwSQS3GDQxmYxu8hBm19VlHcOwbnU4ecKMC3EmvYRXyTzJBTB9KlumRBWZZx+CviuTqxZne01G7N34EE4U1HoZlX+jfpLMSviZtFKVqPbVWHCRltjhuds0LTuHxV1Yia0cj9V6B0/rXWZGx7KKZbyp9M9SxehLBlfIsPMh4PsY8vSKlSaoSRHbo5ZzGZ4dVHUiI6U77v/L6lHlo/MnzZeKn04fApvxnIwwCq78S2Mr0ta7z/sId/f7TMp9V8jlQaKJ4S5huhLfMFb/sKe9i0gdUqi4YUtyjTia+JUlnqvkD06+Emrp97Wywjcs/2PrYqhsMdX3LHP2UMxPbMd+cnfTsXSX4wUwLzRtU48v2g5d0biz4UaVERkrgv0IqyM/hK2H/neIYu4kmEO14lTdTaV0SUXhfxKAxIbBs4//clSA6HkhN7U/NEZqO1FNQUT0VE2dUuOTieMcElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwTYaB+obt1kztvim38gDLePxQWID4c3IM3ii1fkT35MOhAQvUx+zMs0ynb+air/Sgxtkxw9JtvdygU5I+myRlBQ=="
+        }
+      ]
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AgEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAk98Z0WuKnYH4nCURSkZqqXQ7mT5RM0LAAP5PO26rR8uC12lsuz1LMhlNnGLXwagwDCCQ/jR07rHmPF3VIEaMCILXaWy7PUsyGU2cYtfBqDAMIJD+NHTuseY8XdUgRowIrjoRr8XbQkvGBcFYgdgeMmT/gwrX0RLPPPAR1LQtpezW+X/BT91bb+EaNVOCxwOfiGvo5TgTQMKGskSr84/C/9mIj4r3O0eYOPpVEBPbrYYWPN2jqde3YyVfjZN4vQRJAxLoedH6vTavDAe97C0+Z/0D2+7KONolM12nWEeeQsdXGKY4W3nW7rBfIIzyNBJxsm2vRp0YqqCOmvjAnDL57zT5IWNqiy3VzDg9VVcTRUqM+Bj5O2/0mdHbbqYWKyd/dbg9HDew7zcRQBr+cCZC4lpMe/UUWZ4TP/lALkvwI4s3zYl9yzIGSXzWCuP80IoKU57o1svxcHJB29kF4WdQbwQAAAC4mfJZYpIHd7oC9LkpQRnkzqjzqf/PdiSrR75rcLRrTwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACC8msur+7aXeuIvi5677E33Cl1QAmf9Fv/NW2RWdJA5/wH29eGp5pY7dddPl24dFG3OpqV1NbOaQJ5UrUImqttmWpExsSI+fkWoDQgtuuGV9NaFH9RQKgopoyrRuNnw+YIGkWmqQjJz3ECr0Svag5LiGQu0WES8bNT6utwGwvTFgg1sABtWyzrTgzJ49QV3QqYVViEr7cAC0B8am7uO0aTnG7VqibtJ85sTPjCC0hL5VxsNjbGqLqR360B4T2v//l67Xzy1v1ifZGhIXjKsTtUSjvMWwUUyXKEnA8vNVuLMmzAKnv9MDk6QtWHh+dWbkbBsqf1XliAXCMJzNT7W9MtxmSikRvRgf9HgKcPfivDndE60kTHWzAwtvVbh7LIpkB/xiAbYS0pmVs0cx6ARUkcCQA2NCy7J5QrBz1Rg73QNnOAB3ptUREDRdugeyZsc9XCHnKiAGxjajZHsJQCCDvuHy/E3eLSt3TErKzqj9Cfbia7xKZArfh+2S1s/a+T/uSMsiU7aLR3FhUHwNhAELu1EkxeMDSd1TDVRDotlhWanI/iKb58yG0QjN5lFtzNj78jLHc6tKQL2x431eVq1pHrQDidmGGC9wKkaeNXtcnI2Ylu5fda1THqTP+X3PMHeLA2kefJfWYkHPBDUzABRKw/0uwIvmziSSA783Krp5VkINcSzw1QRt3Ct5K+k+sry0c21h1K9uvpa9jQCtPz4o7JfvPd14VM8VdkkWShzNilZEBVC2Tpz8CkhmJ6ANHbEAL2Tho6ynrOH/EZhTIjWPNbKGiMRRdDUwPf+jVKres65MbOgumiHQsUFsVLYrNynOpIRbRCjahXxmgSObpezmcpy/jiFmowLxkolLr+Hpu7pPvlLl8kbvL8uMqYWjhnu4TORScGe8Gp4fwyCWRdkxyBwlqMHhG+rivInvq7tO7PG6vjOhSeNIjkNmOBFvOSVIcbUhiUnvMLgvmkYE7iIL7CanVK85wKDadgDItrNZ7oAm/DAhNK75Bg6/Lp+x3gHiVV1vjieteNBhfgX4LQMmx9ou1jFB0lnT2RnC/SFog42eeH65cz1tMkQAyvmOvukZtS38oxpyjfR/fBhPw91A81cyE6yKW+ZTFzErDRUTeysB3zyKAgRmCBvpfaRYEuaWNRnoizFBwHs6BlQYJ/KsSiBSMx/7oIr8tXHegvu2+zNIcRuXZRGf6SqXaHAQaWEgavaeG54+ZEBQSABjxC4Aems5WB2kzh1n3cZ/wCQrWcRFpwPrIt5yCqDBlUXcL9Brkmv2XV0gndfUYZ4rnpJ75uNsFpVcDKaGFtdh16JSjX2UnwG/MTnXz79PJbnsFTx9O/aCHE3EU2qYujNICbYH2BdFHDsQN7L/O3vz3ITQAlEwzauysjts1P8JsLL/zRRDGeJsKnxN6GoNtaQHUdFTExzV+wYcPBU8IonTG/6n5zZwUIlzwALsg7p+vkbNQESQA="
+    }
+  ],
+  "BuildTransactionTask builds the transaction": [
+    {
+      "version": 3,
+      "id": "17e2f867-f4c9-4eb1-b5b3-9377b4390fb3",
+      "name": "test",
+      "spendingKey": "6fa0f48b45cd51523397862ea5ff7a22ef04328ad3755c759a2614b1fe17bf11",
+      "viewKey": "5bb7ef6480ac5050069312af36219ee66db4346e0ecde560facd75776d57caef87867a60225a802878643c9232310e8cbdcc3c5a5abe77b16b28ab29db3029a2",
+      "incomingViewKey": "b10cf8e72ef349143fdeb051fd1245c953ba96c4e638da8b3191430426685a00",
+      "outgoingViewKey": "237d8233555590658676cc99e6e042d41bfe8ea17ccc5beba77f671c7352e700",
+      "publicAddress": "d1e2013661254c1d121d0438d03e1a55f09819d74552159e0dc4bf364a274d9e",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "4791D7AE9F97DF100EF1558E84772D6A09B43762388283F75C6F20A32A88AA86",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:ox27ewZw7py8zkzKxOQfTRFQtI2ZzLj6y/P9IPG842k="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:bhK29zy8xyqghDsjTdW635G3vIZqSTMakDMKpRKYwBU="
+        },
+        "target": "9282972777491357380673661573939192202192629606981189395159182914949423",
+        "randomness": "0",
+        "timestamp": 1706644420541,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AgAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA1soK32fL9a5LQrgTAo6MgxUFpJKmecagxXhyIwmXTUSQsvt7/gf/DbWVpL5u4QiBSr4Zrr/C5xeOqenAeeyk6ib3VRMIFwss9z4ssJ53RUCUzxfwJmXT6V9uJksPHZf1Dnyr37c65rA0P1IWED3M1VxO2u/wPW675fbzHaFdMtQHCfvSdVBNFPoL76uXypX3W/rqmOEn+nE989A8Ayizni/oh+qfcC1RhiZ0XXGa2kuGHtFRjFdXVOWwMSBQcI2RWUzAvwr4EJTxV/cy6eMWXfGrvktdpEkwbO0PkxgXrYlt5lXBvbrFLNn+YLc/WAoMJnv9pSwkPm6fRX0ndyQ4hmQjybscOyzw4kIZl8cU8CZz4N8+1g86+FVZwQkzXmZZbQJoenRzmfip566rFclLNUBORfihB2s9d27ZjRnJY0UHuVlwCCMPi1b6yJid2VvPJu084bQQ87pfKhzupEavl8s6VfHMga3k6YTBwJkPv8w10jKgtq0YEpUWMwwRZ8lRZ0T1dxuB4xFjHWXXP+pl/eWn1rw4qdAqpStaCmRS/15oc17mM7LadcvWSc1NX2fmNAmRj/FY/kY8VjzZGgr54OZSn57lfOszq8wvspf9eFxxFpoe4dZz3Ulyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw0m4uD89oSs5PSAmlB0X4XugeOWAU+7jBrRnVYeX0B9RGNOzI4yRfSIu51snErx+2LKyajtJ1fEJoKy5ddA4qDg=="
+        }
+      ]
+    }
+  ]
+}

--- a/ironfish/src/workerPool/tasks/buildTransaction.test.ts
+++ b/ironfish/src/workerPool/tasks/buildTransaction.test.ts
@@ -61,6 +61,15 @@ describe('BuildTransactionResponse', () => {
   it('serializes the object into a buffer and deserializes to the original object', async () => {
     const account = await useAccountFixture(nodeTest.wallet)
 
+    const block = await useMinerBlockFixture(
+      nodeTest.chain,
+      undefined,
+      account,
+      nodeTest.wallet,
+    )
+    await expect(nodeTest.chain).toAddBlock(block)
+    await nodeTest.wallet.updateHead()
+
     const transaction = await useUnsignedTxFixture(nodeTest.wallet, account, account)
 
     const unsigned = transaction.takeReference()

--- a/ironfish/src/workerPool/tasks/buildTransaction.test.ts
+++ b/ironfish/src/workerPool/tasks/buildTransaction.test.ts
@@ -1,0 +1,117 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { generateKeyFromPrivateKey } from '@ironfish/rust-nodejs'
+import { Transaction } from '../../primitives'
+import {
+  createNodeTest,
+  serializePayloadToBuffer,
+  useAccountFixture,
+  useMinerBlockFixture,
+  useUnsignedTxFixture,
+} from '../../testUtilities'
+import { createRawTransaction } from '../../testUtilities/helpers/transaction'
+import {
+  BuildTransactionRequest,
+  BuildTransactionResponse,
+  BuildTransactionTask,
+} from './buildTransaction'
+
+describe('BuildTransactionRequest', () => {
+  const nodeTest = createNodeTest()
+
+  it('serializes the object into a buffer and deserializes to the original object', async () => {
+    const account = await useAccountFixture(nodeTest.wallet)
+
+    const block = await useMinerBlockFixture(
+      nodeTest.chain,
+      undefined,
+      account,
+      nodeTest.wallet,
+    )
+    await expect(nodeTest.chain).toAddBlock(block)
+    await nodeTest.wallet.updateHead()
+
+    const raw = await createRawTransaction({
+      wallet: nodeTest.wallet,
+      from: account,
+      fee: 1n,
+      expiration: 5,
+    })
+
+    const key = generateKeyFromPrivateKey(account.spendingKey)
+
+    const request = new BuildTransactionRequest(
+      raw,
+      key.proofGenerationKey,
+      account.viewKey,
+      account.outgoingViewKey,
+    )
+    const buffer = serializePayloadToBuffer(request)
+    const deserialized = BuildTransactionRequest.deserializePayload(request.jobId, buffer)
+
+    expect(deserialized).toEqual(request)
+  })
+})
+
+describe('BuildTransactionResponse', () => {
+  const nodeTest = createNodeTest()
+
+  it('serializes the object into a buffer and deserializes to the original object', async () => {
+    const account = await useAccountFixture(nodeTest.wallet)
+
+    const transaction = await useUnsignedTxFixture(nodeTest.wallet, account, account)
+
+    const unsigned = transaction.takeReference()
+
+    const response = new BuildTransactionResponse(unsigned, 0)
+    const serialized = serializePayloadToBuffer(response)
+
+    const deserialized = BuildTransactionResponse.deserializePayload(response.jobId, serialized)
+    expect(deserialized.transaction.serialize().equals(transaction.serialize())).toBe(true)
+
+    transaction.returnReference()
+  })
+})
+
+describe('BuildTransactionTask', () => {
+  const nodeTest = createNodeTest()
+
+  it('builds the transaction', async () => {
+    const account = await useAccountFixture(nodeTest.wallet)
+
+    const block = await useMinerBlockFixture(
+      nodeTest.chain,
+      undefined,
+      account,
+      nodeTest.wallet,
+    )
+    await expect(nodeTest.chain).toAddBlock(block)
+    await nodeTest.wallet.updateHead()
+
+    const raw = await createRawTransaction({
+      wallet: nodeTest.wallet,
+      from: account,
+      fee: 5n,
+      expiration: 9,
+    })
+
+    const key = generateKeyFromPrivateKey(account.spendingKey)
+
+    const request = new BuildTransactionRequest(
+      raw,
+      key.proofGenerationKey,
+      account.viewKey,
+      account.outgoingViewKey,
+    )
+    const task = new BuildTransactionTask()
+    const response = task.execute(request)
+
+    const postedTransactionSerialized = response.transaction.sign(account.spendingKey)
+    const transaction = new Transaction(postedTransactionSerialized)
+
+    expect(transaction.fee()).toEqual(5n)
+    expect(transaction.expiration()).toEqual(9)
+  })
+})

--- a/ironfish/src/workerPool/tasks/buildTransaction.ts
+++ b/ironfish/src/workerPool/tasks/buildTransaction.ts
@@ -1,0 +1,109 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { UnsignedTransaction } from '@ironfish/rust-nodejs'
+import bufio from 'bufio'
+import { RawTransaction, RawTransactionSerde } from '../../primitives/rawTransaction'
+import { ACCOUNT_KEY_LENGTH } from '../../wallet'
+import { VIEW_KEY_LENGTH } from '../../wallet/walletdb/accountValue'
+import { WorkerMessage, WorkerMessageType } from './workerMessage'
+import { WorkerTask } from './workerTask'
+
+export class BuildTransactionRequest extends WorkerMessage {
+  readonly transaction: RawTransaction
+  readonly proofGenerationKey: string
+  readonly viewKey: string
+  readonly outgoingViewKey: string
+
+  constructor(
+    transaction: RawTransaction,
+    proofGenerationKey: string,
+    viewKey: string,
+    outgoingViewKey: string,
+    jobId?: number,
+  ) {
+    super(WorkerMessageType.BuildTransaction, jobId)
+    this.transaction = transaction
+    this.proofGenerationKey = proofGenerationKey
+    this.viewKey = viewKey
+    this.outgoingViewKey = outgoingViewKey
+  }
+
+  serializePayload(bw: bufio.StaticWriter | bufio.BufferWriter): void {
+    bw.writeBytes(Buffer.from(this.proofGenerationKey, 'hex'))
+    bw.writeBytes(Buffer.from(this.viewKey, 'hex'))
+    bw.writeBytes(Buffer.from(this.outgoingViewKey, 'hex'))
+    bw.writeBytes(RawTransactionSerde.serialize(this.transaction))
+  }
+
+  static deserializePayload(jobId: number, buffer: Buffer): BuildTransactionRequest {
+    const reader = bufio.read(buffer, true)
+    const proofGenerationKey = reader.readBytes(VIEW_KEY_LENGTH).toString('hex')
+    const viewKey = reader.readBytes(VIEW_KEY_LENGTH).toString('hex')
+    const outgoingViewKeyiewKey = reader.readBytes(ACCOUNT_KEY_LENGTH).toString('hex')
+    const raw = RawTransactionSerde.deserialize(
+      reader.readBytes(buffer.length - ACCOUNT_KEY_LENGTH),
+    )
+    return new BuildTransactionRequest(
+      raw,
+      proofGenerationKey,
+      viewKey,
+      outgoingViewKeyiewKey,
+      jobId,
+    )
+  }
+
+  getSize(): number {
+    return (
+      RawTransactionSerde.getSize(this.transaction) + // rawTransaction
+      VIEW_KEY_LENGTH + // proofGenerationKey
+      VIEW_KEY_LENGTH + // viewKey
+      ACCOUNT_KEY_LENGTH // outgoingViewKey
+    )
+  }
+}
+
+export class BuildTransactionResponse extends WorkerMessage {
+  readonly transaction: UnsignedTransaction
+
+  constructor(transaction: UnsignedTransaction, jobId: number) {
+    super(WorkerMessageType.BuildTransaction, jobId)
+    this.transaction = transaction
+  }
+
+  serializePayload(bw: bufio.StaticWriter | bufio.BufferWriter): void {
+    bw.writeVarBytes(this.transaction.serialize())
+  }
+
+  static deserializePayload(jobId: number, buffer: Buffer): BuildTransactionResponse {
+    const reader = bufio.read(buffer, true)
+    const transaction = new UnsignedTransaction(reader.readVarBytes())
+    return new BuildTransactionResponse(transaction, jobId)
+  }
+
+  getSize(): number {
+    return bufio.sizeVarBytes(this.transaction.serialize())
+  }
+}
+
+export class BuildTransactionTask extends WorkerTask {
+  private static instance: BuildTransactionTask | undefined
+
+  static getInstance(): BuildTransactionTask {
+    if (!BuildTransactionTask.instance) {
+      BuildTransactionTask.instance = new BuildTransactionTask()
+    }
+
+    return BuildTransactionTask.instance
+  }
+
+  execute(request: BuildTransactionRequest): BuildTransactionResponse {
+    const unsigned = request.transaction.build(
+      request.proofGenerationKey,
+      request.viewKey,
+      request.outgoingViewKey,
+    )
+    return new BuildTransactionResponse(unsigned, request.jobId)
+  }
+}

--- a/ironfish/src/workerPool/tasks/buildTransaction.ts
+++ b/ironfish/src/workerPool/tasks/buildTransaction.ts
@@ -43,7 +43,9 @@ export class BuildTransactionRequest extends WorkerMessage {
     const viewKey = reader.readBytes(VIEW_KEY_LENGTH).toString('hex')
     const outgoingViewKeyiewKey = reader.readBytes(ACCOUNT_KEY_LENGTH).toString('hex')
     const raw = RawTransactionSerde.deserialize(
-      reader.readBytes(buffer.length - ACCOUNT_KEY_LENGTH),
+      reader.readBytes(
+        buffer.length - (VIEW_KEY_LENGTH + VIEW_KEY_LENGTH + ACCOUNT_KEY_LENGTH),
+      ),
     )
     return new BuildTransactionRequest(
       raw,

--- a/ironfish/src/workerPool/tasks/handlers.ts
+++ b/ironfish/src/workerPool/tasks/handlers.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Job } from '../job'
+import { BuildTransactionTask } from './buildTransaction'
 import { CreateMinersFeeTask } from './createMinersFee'
 import { DecryptNotesTask } from './decryptNotes'
 import { PostTransactionTask } from './postTransaction'
@@ -20,6 +21,7 @@ export const handlers: Record<WorkerMessageType, WorkerTask | undefined> = {
   [WorkerMessageType.Sleep]: SleepTask.getInstance(),
   [WorkerMessageType.SubmitTelemetry]: SubmitTelemetryTask.getInstance(),
   [WorkerMessageType.VerifyTransactions]: VerifyTransactionsTask.getInstance(),
+  [WorkerMessageType.BuildTransaction]: BuildTransactionTask.getInstance(),
 }
 
 export async function handleRequest(request: WorkerMessage, job: Job): Promise<WorkerMessage> {

--- a/ironfish/src/workerPool/tasks/workerMessage.ts
+++ b/ironfish/src/workerPool/tasks/workerMessage.ts
@@ -17,6 +17,7 @@ export enum WorkerMessageType {
   SubmitTelemetry = 6,
   VerifyTransactions = 7,
   PostTransaction = 8,
+  BuildTransaction = 9,
 }
 
 export abstract class WorkerMessage implements Serializable {

--- a/ironfish/src/workerPool/worker.ts
+++ b/ironfish/src/workerPool/worker.ts
@@ -8,6 +8,7 @@ import { Assert } from '../assert'
 import { createRootLogger, Logger } from '../logger'
 import { WorkerHeader } from './interfaces/workerHeader'
 import { Job } from './job'
+import { BuildTransactionRequest, BuildTransactionResponse } from './tasks/buildTransaction'
 import { CreateMinersFeeRequest, CreateMinersFeeResponse } from './tasks/createMinersFee'
 import { DecryptNotesRequest, DecryptNotesResponse } from './tasks/decryptNotes'
 import { JobAbortedError, JobAbortedMessage } from './tasks/jobAbort'
@@ -231,6 +232,8 @@ export class Worker {
         return SubmitTelemetryRequest.deserializePayload(jobId, request)
       case WorkerMessageType.VerifyTransactions:
         return VerifyTransactionsRequest.deserializePayload(jobId, request)
+      case WorkerMessageType.BuildTransaction:
+        return BuildTransactionRequest.deserializePayload(jobId, request)
     }
   }
 
@@ -256,6 +259,8 @@ export class Worker {
         return SubmitTelemetryResponse.deserializePayload(jobId)
       case WorkerMessageType.VerifyTransactions:
         return VerifyTransactionsResponse.deserializePayload(jobId, response)
+      case WorkerMessageType.BuildTransaction:
+        return BuildTransactionResponse.deserializePayload(jobId, response)
     }
   }
 }


### PR DESCRIPTION
## Summary

we offload PostTransaction to the worker pool because proof generation is compute intensive and could otherwise bog down the node process

creating an UnsignedTransaction using 'build' generates proofs and would create the same problem

the new job allows us to offload compute to the worker pool in RPC calls that build UnsignedTransactions

## Testing Plan

- adds unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
