### PR TITLE
Rahul/ifl 2144 refactor key object to return nsk instead of pgk

### DIFF
--- a/ironfish-rust-nodejs/index.d.ts
+++ b/ironfish-rust-nodejs/index.d.ts
@@ -90,7 +90,7 @@ export interface Key {
   incomingViewKey: string
   outgoingViewKey: string
   publicAddress: string
-  proofGenerationKey: string
+  proofAuthorizingKey: string
 }
 export function generateKey(): Key
 export function spendingKeyToWords(privateKey: string, languageCode: LanguageCode): string
@@ -242,7 +242,7 @@ export class Transaction {
    * aka: self.value_balance - intended_transaction_fee - change = 0
    */
   post(spenderHexKey: string, changeGoesTo: string | undefined | null, intendedTransactionFee: bigint): Buffer
-  build(proofGenerationKeyStr: string, viewKeyStr: string, outgoingViewKeyStr: string, intendedTransactionFee: bigint, changeGoesTo?: string | undefined | null): Buffer
+  build(proofAuthorizingKey: string, viewKeyStr: string, outgoingViewKeyStr: string, intendedTransactionFee: bigint, changeGoesTo?: string | undefined | null): Buffer
   setExpiration(sequence: number): void
 }
 export type NativeUnsignedTransaction = UnsignedTransaction

--- a/ironfish-rust-nodejs/src/lib.rs
+++ b/ironfish-rust-nodejs/src/lib.rs
@@ -5,7 +5,7 @@
 use std::fmt::Display;
 
 use ironfish::keys::Language;
-use ironfish::keys::ProofGenerationKeySerializable;
+use ironfish::keys::ProofAuthorizingKeySerializable;
 use ironfish::PublicAddress;
 use ironfish::SaplingKey;
 
@@ -65,7 +65,7 @@ pub struct Key {
     pub incoming_view_key: String,
     pub outgoing_view_key: String,
     pub public_address: String,
-    pub proof_generation_key: String,
+    pub proof_authorizing_key: String,
 }
 
 #[napi]
@@ -78,7 +78,7 @@ pub fn generate_key() -> Key {
         incoming_view_key: sapling_key.incoming_view_key().hex_key(),
         outgoing_view_key: sapling_key.outgoing_view_key().hex_key(),
         public_address: sapling_key.public_address().hex_public_address(),
-        proof_generation_key: sapling_key.sapling_proof_generation_key().hex_key(),
+        proof_authorizing_key: sapling_key.proof_authorizing_key().hex_key(),
     }
 }
 
@@ -105,7 +105,7 @@ pub fn generate_key_from_private_key(private_key: String) -> Result<Key> {
         incoming_view_key: sapling_key.incoming_view_key().hex_key(),
         outgoing_view_key: sapling_key.outgoing_view_key().hex_key(),
         public_address: sapling_key.public_address().hex_public_address(),
-        proof_generation_key: sapling_key.sapling_proof_generation_key().hex_key(),
+        proof_authorizing_key: sapling_key.proof_authorizing_key().hex_key(),
     })
 }
 

--- a/ironfish-rust-nodejs/src/structs/transaction.rs
+++ b/ironfish-rust-nodejs/src/structs/transaction.rs
@@ -14,6 +14,7 @@ use ironfish::frost::round1::SigningCommitments;
 use ironfish::frost::round2::SignatureShare;
 use ironfish::frost::Identifier;
 use ironfish::frost::SigningPackage;
+use ironfish::keys::{ProofAuthorizingKey, ProofAuthorizingKeySerializable};
 use ironfish::serializing::hex_to_vec_bytes;
 use ironfish::serializing::{bytes_to_hex, hex_to_bytes};
 use ironfish::transaction::unsigned::UnsignedTransaction;
@@ -22,7 +23,6 @@ use ironfish::transaction::{
     TRANSACTION_FEE_SIZE, TRANSACTION_PUBLIC_KEY_SIZE, TRANSACTION_SIGNATURE_SIZE,
 };
 use ironfish::{
-    keys::proof_generation_key::{ProofGenerationKey, ProofGenerationKeySerializable},
     MerkleNoteHash, OutgoingViewKey, ProposedTransaction, PublicAddress, SaplingKey, Transaction,
     ViewKey,
 };
@@ -327,7 +327,7 @@ impl NativeTransaction {
     #[napi]
     pub fn build(
         &mut self,
-        proof_generation_key_str: String,
+        proof_authorizing_key: String,
         view_key_str: String,
         outgoing_view_key_str: String,
         intended_transaction_fee: BigInt,
@@ -336,7 +336,7 @@ impl NativeTransaction {
         let view_key = ViewKey::from_hex(&view_key_str).map_err(to_napi_err)?;
         let outgoing_view_key =
             OutgoingViewKey::from_hex(&outgoing_view_key_str).map_err(to_napi_err)?;
-        let proof_generation_key = ProofGenerationKey::from_hex(&proof_generation_key_str)
+        let proof_authorizing_key = ProofAuthorizingKey::from_hex(&proof_authorizing_key)
             .map_err(|_| to_napi_err("PublicKeyPackage hex to bytes failed"))?;
         let change_address = match change_goes_to {
             Some(address) => Some(PublicAddress::from_hex(&address).map_err(to_napi_err)?),
@@ -345,7 +345,7 @@ impl NativeTransaction {
         let unsigned_transaction = self
             .transaction
             .build(
-                proof_generation_key,
+                proof_authorizing_key,
                 view_key,
                 outgoing_view_key,
                 intended_transaction_fee.get_i64().0,

--- a/ironfish-rust-nodejs/tests/unsigned.test.slow.ts
+++ b/ironfish-rust-nodejs/tests/unsigned.test.slow.ts
@@ -2,26 +2,24 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { UnsignedTransaction } from ".."
-import { Asset, Transaction, generateKey } from ".."
+import { Asset, Transaction, UnsignedTransaction, generateKey } from "..";
 
-describe('UnsignedTransaction', () => {
-    describe('ser/de', () => {
-        it('can create an unsigned tx and deserialize it', () => {
-            const key = generateKey()
-            const asset = new Asset(key.publicAddress, 'testcoin', '')
-            const proposedTx = new Transaction(2)
-            proposedTx.mint(asset, 5n)
-            const unsignedTxBuffer = proposedTx.build(
-                key.proofGenerationKey,
-                key.viewKey,
-                key.outgoingViewKey,
-                0n,
-            )
+describe("UnsignedTransaction", () => {
+  describe("ser/de", () => {
+    it("can create an unsigned tx and deserialize it", () => {
+      const key = generateKey();
+      const asset = new Asset(key.publicAddress, "testcoin", "");
+      const proposedTx = new Transaction(2);
+      proposedTx.mint(asset, 5n);
+      const unsignedTxBuffer = proposedTx.build(
+        key.proofAuthorizingKey,
+        key.viewKey,
+        key.outgoingViewKey,
+        0n
+      );
 
-            const unsignedTx = new UnsignedTransaction(unsignedTxBuffer)
-            expect(unsignedTx.serialize()).toEqual(unsignedTxBuffer)
-
-        })
-    })
-})
+      const unsignedTx = new UnsignedTransaction(unsignedTxBuffer);
+      expect(unsignedTx.serialize()).toEqual(unsignedTxBuffer);
+    });
+  });
+});

--- a/ironfish-rust/src/errors.rs
+++ b/ironfish-rust/src/errors.rs
@@ -48,6 +48,7 @@ pub enum IronfishErrorKind {
     InvalidNullifierDerivingKey,
     InvalidOutputProof,
     InvalidPaymentAddress,
+    InvalidProofAuthorizingKey,
     InvalidPublicAddress,
     InvalidSecret,
     InvalidRandomizer,

--- a/ironfish-rust/src/keys/mod.rs
+++ b/ironfish-rust/src/keys/mod.rs
@@ -27,6 +27,8 @@ mod view_keys;
 pub use view_keys::*;
 pub mod proof_generation_key;
 pub use proof_generation_key::*;
+pub mod proof_authorizing_key;
+pub use proof_authorizing_key::*;
 
 #[cfg(test)]
 mod test;
@@ -194,6 +196,11 @@ impl SaplingKey {
     /// Retrieve the publicly visible outgoing viewing key
     pub fn outgoing_view_key(&self) -> &OutgoingViewKey {
         &self.outgoing_viewing_key
+    }
+
+    // Retrieve the publicly visible proof authorizing key
+    pub fn proof_authorizing_key(&self) -> jubjub::Fr {
+        self.proof_authorizing_key
     }
 
     /// Retrieve the publicly visible incoming viewing key

--- a/ironfish-rust/src/keys/proof_authorizing_key.rs
+++ b/ironfish-rust/src/keys/proof_authorizing_key.rs
@@ -1,0 +1,112 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use jubjub::Fr;
+
+use crate::{
+    errors::{IronfishError, IronfishErrorKind},
+    serializing::{bytes_to_hex, hex_to_bytes},
+};
+
+pub type ProofAuthorizingKey = jubjub::Fr;
+
+pub trait ProofAuthorizingKeySerializable {
+    fn serialize(&self) -> [u8; 32];
+    fn deserialize(bytes: [u8; 32]) -> Result<ProofAuthorizingKey, IronfishError>;
+    fn hex_key(&self) -> String;
+    fn from_hex(hex_key: &str) -> Result<ProofAuthorizingKey, IronfishError>;
+}
+
+impl ProofAuthorizingKeySerializable for ProofAuthorizingKey {
+    fn serialize(&self) -> [u8; 32] {
+        self.to_bytes()
+    }
+
+    fn deserialize(bytes: [u8; 32]) -> Result<Self, IronfishError> {
+        let nsk = match Fr::from_bytes(&bytes).into() {
+            Some(nsk) => nsk,
+            None => {
+                return Err(IronfishError::new(
+                    IronfishErrorKind::InvalidProofAuthorizingKey,
+                ))
+            }
+        };
+
+        Ok(nsk)
+    }
+
+    fn hex_key(&self) -> String {
+        bytes_to_hex(&self.serialize())
+    }
+
+    fn from_hex(hex_key: &str) -> Result<ProofAuthorizingKey, IronfishError> {
+        let bytes = hex_to_bytes(hex_key)?;
+        ProofAuthorizingKey::deserialize(bytes)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::ProofAuthorizingKey;
+    use super::ProofAuthorizingKeySerializable;
+    use crate::errors::IronfishErrorKind;
+    use ff::Field;
+    use rand::{rngs::StdRng, SeedableRng};
+
+    #[test]
+    fn test_serialize() {
+        let mut rng = StdRng::seed_from_u64(0);
+
+        let proof_authorizing_key = ProofAuthorizingKey::random(&mut rng);
+
+        let serialized_bytes = proof_authorizing_key.serialize();
+
+        assert_eq!(serialized_bytes.len(), 32);
+    }
+
+    #[test]
+    fn test_deserialize_error() {
+        let mut proof_authorizing_key_bytes: [u8; 32] = [0; 32];
+        proof_authorizing_key_bytes[0..32].fill(0xFF);
+
+        let result = ProofAuthorizingKey::deserialize(proof_authorizing_key_bytes);
+
+        assert!(result.is_err());
+
+        let err = result.err().unwrap();
+
+        assert!(matches!(
+            err.kind,
+            IronfishErrorKind::InvalidProofAuthorizingKey
+        ));
+    }
+
+    #[test]
+    fn test_deserialize() {
+        let mut rng = StdRng::seed_from_u64(0);
+
+        let proof_authorizing_key = ProofAuthorizingKey::random(&mut rng);
+
+        let serialized_bytes = proof_authorizing_key.serialize();
+
+        let deserialized_proof_authorizing_key =
+            ProofAuthorizingKey::deserialize(serialized_bytes).expect("deserialization successful");
+
+        assert_eq!(proof_authorizing_key, deserialized_proof_authorizing_key);
+    }
+
+    #[test]
+    fn test_hex() {
+        let mut rng = StdRng::seed_from_u64(0);
+
+        let proof_authorizing_key = jubjub::Fr::random(&mut rng);
+
+        let hex_key = proof_authorizing_key.hex_key();
+
+        let deserialized_proof_authorizing_key =
+            ProofAuthorizingKey::from_hex(&hex_key).expect("deserialization successful");
+
+        assert_eq!(proof_authorizing_key, deserialized_proof_authorizing_key);
+    }
+}

--- a/ironfish-rust/src/transaction/tests.rs
+++ b/ironfish-rust/src/transaction/tests.rs
@@ -240,7 +240,7 @@ fn test_proposed_transaction_build() {
 
     let unsigned_transaction = transaction
         .build(
-            spender_key.sapling_proof_generation_key(),
+            spender_key.proof_authorizing_key(),
             spender_key.view_key().clone(),
             spender_key.outgoing_view_key().clone(),
             intended_fee,
@@ -683,7 +683,7 @@ fn test_sign_simple() {
     // build transaction, generate proofs
     let unsigned_transaction = transaction
         .build(
-            spender_key.sapling_proof_generation_key(),
+            spender_key.proof_authorizing_key(),
             spender_key.view_key().clone(),
             spender_key.outgoing_view_key().clone(),
             1,
@@ -777,7 +777,7 @@ fn test_sign_frost() {
     // build UnsignedTransaction without signing
     let mut unsigned_transaction = transaction
         .build(
-            key_packages.proof_generation_key,
+            key_packages.proof_generation_key.nsk,
             key_packages.view_key,
             key_packages.outgoing_view_key,
             intended_fee,

--- a/ironfish/src/primitives/rawTransaction.ts
+++ b/ironfish/src/primitives/rawTransaction.ts
@@ -163,14 +163,14 @@ export class RawTransaction {
   }
 
   build(
-    proofGenerationKey: string,
+    proofAuthorizingKey: string,
     viewKey: string,
     outgoingViewKey: string,
   ): UnsignedTransaction {
     const builder = this._build()
 
     const serialized = builder.build(
-      proofGenerationKey,
+      proofAuthorizingKey,
       viewKey,
       outgoingViewKey,
       this.fee,

--- a/ironfish/src/testUtilities/fixtures/transactions.ts
+++ b/ironfish/src/testUtilities/fixtures/transactions.ts
@@ -128,7 +128,7 @@ export async function useUnsignedTxFixture(
       Assert.isNotNull(from.spendingKey)
       const key = generateKeyFromPrivateKey(from.spendingKey)
       const unsignedBuffer = raw
-        .build(key.proofGenerationKey, key.viewKey, key.outgoingViewKey)
+        .build(key.proofAuthorizingKey, key.viewKey, key.outgoingViewKey)
         .serialize()
       return new UnsignedTransaction(unsignedBuffer)
     })

--- a/ironfish/src/wallet/wallet.test.slow.ts
+++ b/ironfish/src/wallet/wallet.test.slow.ts
@@ -1272,7 +1272,7 @@ describe('Wallet', () => {
       })
 
       const unsignedTransaction = rawTransaction.build(
-        trustedDealerPackage.proofGenerationKey,
+        trustedDealerPackage.proofGenerationKey.slice(64), // total 64 bytes, first 32 are the ak and the last 32 are the nsk
         trustedDealerPackage.viewKey,
         trustedDealerPackage.outgoingViewKey,
       )


### PR DESCRIPTION
## Summary

We will allow view only accounts now to construct proofs for creating unsigned transactions. 

As a part of this, we need the view only accounts to contain the proof authorizing key. 

Currently we return all the view keys and the proof generation key (which was added in the last release). The authorizing key can be derived from the generation key.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
