### PR TITLE
adds wallet/buildTransaction RPC

### DIFF
--- a/ironfish/src/rpc/clients/client.ts
+++ b/ironfish/src/rpc/clients/client.ts
@@ -13,6 +13,8 @@ import type {
   BlockTemplateStreamResponse,
   BroadcastTransactionRequest,
   BroadcastTransactionResponse,
+  BuildTransactionRequest,
+  BuildTransactionResponse,
   BurnAssetRequest,
   BurnAssetResponse,
   CreateAccountRequest,
@@ -417,6 +419,15 @@ export abstract class RpcClient {
       return this.request<void, GetNodeStatusResponse>(`${ApiNamespace.wallet}/getNodeStatus`, {
         stream: true,
       })
+    },
+
+    buildTransaction: (
+      params: BuildTransactionRequest,
+    ): Promise<RpcResponseEnded<BuildTransactionResponse>> => {
+      return this.request<BuildTransactionResponse>(
+        `${ApiNamespace.wallet}/buildTransaction`,
+        params,
+      ).waitForEnd()
     },
   }
 

--- a/ironfish/src/rpc/routes/wallet/__fixtures__/buildTransaction.test.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/__fixtures__/buildTransaction.test.ts.fixture
@@ -1,0 +1,40 @@
+{
+  "Route wallet/buildTransaction should build a raw transaction": [
+    {
+      "version": 3,
+      "id": "30daa269-2936-47a2-95a9-ab58c2f7751b",
+      "name": "existingAccount",
+      "spendingKey": "d607c65f38c478e0585949b83e5de1cac046fdb5899da9a8846e48b32b4e1737",
+      "viewKey": "327296b284f174e973c05fd4ffb43fa86904979cc2e61aafa003f0ebf3f7e1db511e89da3a566664d732ab8179b7428ab98a1d6bc625241813cdb31761cfcfdc",
+      "incomingViewKey": "9e049ba0c7544ff8ae772f6ffb31e90cd48a61e6c8fdd3bd8b29634f2d1da805",
+      "outgoingViewKey": "c3e456502ede854080505c09fd0290018bf73a266d209e14e1fb95fc30f08ca0",
+      "publicAddress": "25a33803af98590c1ab7337b586b730bd5a427351ff28555a9e3eed427725b56",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+        },
+        "sequence": 1
+      }
+    }
+  ],
+  "Route wallet/buildTransaction should return an error if the transaction won't deserialize": [
+    {
+      "version": 3,
+      "id": "1348a3cc-69fd-425b-aaf9-aaf0839452b3",
+      "name": "accountB",
+      "spendingKey": "7e72d9c22ee7f3fb2287c12b3cb3fd7e4751accadf0c474488ec94e7abd87532",
+      "viewKey": "b37fedc257197a65ba90f301277e5052e73b30bb0e2d9a139c3ea3d13c5901f3b39809d461b95b154e3daa653f3c02a38c7bd30b29a3ee0f0f4b63ded9504957",
+      "incomingViewKey": "faa7bba7993064e3b6d6b1718332f570947c3163e49146f56d2c84acb45f8006",
+      "outgoingViewKey": "4bcb6158b649de3f33e24b2339d5e025a9f0df752d913fcb3d0c40f697f43437",
+      "publicAddress": "cc81f41a5ac3273d1e67e4f004a2b49cb269c5f274ae36aff1b5a990e91c9f85",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+        },
+        "sequence": 1
+      }
+    }
+  ]
+}

--- a/ironfish/src/rpc/routes/wallet/__fixtures__/buildTransaction.test.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/__fixtures__/buildTransaction.test.ts.fixture
@@ -1,23 +1,4 @@
 {
-  "Route wallet/buildTransaction should build a raw transaction": [
-    {
-      "version": 3,
-      "id": "30daa269-2936-47a2-95a9-ab58c2f7751b",
-      "name": "existingAccount",
-      "spendingKey": "d607c65f38c478e0585949b83e5de1cac046fdb5899da9a8846e48b32b4e1737",
-      "viewKey": "327296b284f174e973c05fd4ffb43fa86904979cc2e61aafa003f0ebf3f7e1db511e89da3a566664d732ab8179b7428ab98a1d6bc625241813cdb31761cfcfdc",
-      "incomingViewKey": "9e049ba0c7544ff8ae772f6ffb31e90cd48a61e6c8fdd3bd8b29634f2d1da805",
-      "outgoingViewKey": "c3e456502ede854080505c09fd0290018bf73a266d209e14e1fb95fc30f08ca0",
-      "publicAddress": "25a33803af98590c1ab7337b586b730bd5a427351ff28555a9e3eed427725b56",
-      "createdAt": {
-        "hash": {
-          "type": "Buffer",
-          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-        },
-        "sequence": 1
-      }
-    }
-  ],
   "Route wallet/buildTransaction should return an error if the transaction won't deserialize": [
     {
       "version": 3,
@@ -35,6 +16,72 @@
         },
         "sequence": 1
       }
+    }
+  ],
+  "Route wallet/buildTransaction should produce output that can be signed": [
+    {
+      "version": 4,
+      "id": "048be9c4-1135-45c8-b817-d4ca56167a3e",
+      "name": "signingAccount",
+      "spendingKey": "19e7f4291589c19a3bad9b172206cde21cb2e2107c2f1202c196a809bf00d8f1",
+      "viewKey": "bc74d81628ad18402809fd7289cc5229160e7aaf16a34da745fe668e9edcfa2aeb4970910bdaf5aa90a149e17b3d404660301d1ec1d62403b39594928c58db30",
+      "incomingViewKey": "239381e7b71557b33182f25506b63c06bc5c8966a0ab08db9e5b8a0162c35902",
+      "outgoingViewKey": "7c0bdfbb0137764cacbff4aa4d82c6928909af4286252ea8f8d3d6e2f2cedfe3",
+      "publicAddress": "237e70040b30e618734605c38cef3a59715b2d46091c547e933745105a38b913",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+        },
+        "sequence": 1
+      },
+      "proofAuthorizingKey": "bd7367bbdc4f09dbc0d2478a7bf4dc9cfcee8f24d6cfaa41cbe913ccf7b66200"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "4791D7AE9F97DF100EF1558E84772D6A09B43762388283F75C6F20A32A88AA86",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:2+Dn+nIMqKQquXAtq+I35fUUofnjQJIQnQGdFdOxQDc="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:hudyndzwKZN4odHKqirsmQfZcSUbZl5dvvHw91Qkk8w="
+        },
+        "target": "9282972777491357380673661573939192202192629606981189395159182914949423",
+        "randomness": "0",
+        "timestamp": 1706896235243,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AgAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAokrFZ9o3nanSiWvkgU7PPUmJBomNUvbij4QVfCHqH7al83inNta5Vp8F7dY5QJpnjlJ1yHzDLCRPTu8jrRDbVk4IBDF+vpPGiOiUPqeAvPGmzPbS5MecutgEl7H4dE4Mn+NH4bw+wVWhA1jR31uM3DlL7o2j6LIEG0s9NNzUM48Lq/8Cvwle1mkkuESZnsMJYBu1TEcWN6Z6DyHWo7LKqcz4F+dVET2HDF9ZkCWNue+oj4mmwPJNdN23ss30J+i95WsLpAf76+g3yTKaMQCzTqsG9t2bvoPknr7sbx5PbqnID/sPzm9M9PJTtOVb6qxK1pE8sZQxAEVy65xadEeqv7jIJa++owI/sYYc24axA9/DJ9Lw48qSaiKxCL+oVz0SpB1HwZMRy0kRQ3xwaXaKdE3FQcUBhWaarkvV/IE4O4Zlr0939bCLJRuL7NUMPtbl76NxQfp2VxmWLY3K7WS5H1fph/8q8EnGq13IWoN0mQiuSS6tflXM4vV3jXGgM+G9jaEI2SP4YW0PSl9OL9Y6sIppuB2B3bNAb3vo6oFsvBsevs9EuADCQ0kVGrTbB/xObtgDiMmz7uwd9yhchgXtCnAr/Hmc+re98hC0pYEbAnjuZgbgMdTpIklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwTo7GuYUlvIkY5oVuH7P3wDUjr12DT2EkHcN8YFIFVsNf5AcG1XHE5ZLrP7mWcgiYn1L7DgmYOeHVFPBeXS2PAw=="
+        }
+      ]
+    }
+  ],
+  "Route wallet/buildTransaction should build a raw transaction": [
+    {
+      "version": 4,
+      "id": "20889d6c-b5bc-4969-b99e-23dde557c1c8",
+      "name": "existingAccount",
+      "spendingKey": "02c073d7c8ad143d3ee5b0bf8b8fcc33a242f8e463e9ec242a9a25b78568a5b6",
+      "viewKey": "4dcca58768a588558368876dc3335c2d8393758c7c13c9f9fa85d25d3aa47833a32e7745da802e51442727b24f948da4cba364f4b1cc68350e06d7c5c46db0d5",
+      "incomingViewKey": "4ce28c8faf16595d0c67ceedaa3b6770b0f8fed935c3420355df1ed07e6b2604",
+      "outgoingViewKey": "488c0257b3eb24d2594735a01c53c9e61a31990ad5e3425aebffe99ee3b60896",
+      "publicAddress": "184b79b4c9be7151d19198d3334ca137066c0adb30ccb2c944073456c8382526",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+        },
+        "sequence": 1
+      },
+      "proofAuthorizingKey": "7678dd516c7cd8e38a6af96e5396a273dd4b525709da076567c946a8ecbfe50c"
     }
   ]
 }

--- a/ironfish/src/rpc/routes/wallet/buildTransaction.test.ts
+++ b/ironfish/src/rpc/routes/wallet/buildTransaction.test.ts
@@ -2,8 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import { UnsignedTransaction } from '@ironfish/rust-nodejs'
+import { Transaction } from '../../../primitives'
 import { RawTransactionSerde } from '../../../primitives/rawTransaction'
-import { useAccountFixture } from '../../../testUtilities'
+import { useAccountFixture, useMinerBlockFixture } from '../../../testUtilities'
 import { createRawTransaction } from '../../../testUtilities/helpers/transaction'
 import { createRouteTest } from '../../../testUtilities/routeTest'
 
@@ -25,6 +27,36 @@ describe('Route wallet/buildTransaction', () => {
 
     expect(response.status).toBe(200)
     expect(response.content.transaction).toBeDefined()
+  })
+
+  it('should produce output that can be signed', async () => {
+    const account = await useAccountFixture(routeTest.node.wallet, 'signingAccount')
+
+    const block = await useMinerBlockFixture(routeTest.node.chain, undefined, account)
+    await routeTest.node.chain.addBlock(block)
+    await routeTest.node.wallet.updateHead()
+
+    const rawTransaction = await createRawTransaction({
+      wallet: routeTest.node.wallet,
+      from: account,
+      expiration: 12345,
+    })
+
+    const response = await routeTest.client.wallet.buildTransaction({
+      transaction: RawTransactionSerde.serialize(rawTransaction).toString('hex'),
+      account: account.name,
+    })
+
+    expect(response.status).toBe(200)
+    expect(response.content.transaction).toBeDefined()
+
+    const unsignedTransaction = new UnsignedTransaction(
+      Buffer.from(response.content.transaction, 'hex'),
+    )
+    const signedTransaction = unsignedTransaction.sign(account.spendingKey)
+
+    const transaction = new Transaction(signedTransaction)
+    expect(transaction.expiration()).toEqual(rawTransaction.expiration)
   })
 
   it("should return an error if the transaction won't deserialize", async () => {

--- a/ironfish/src/rpc/routes/wallet/buildTransaction.test.ts
+++ b/ironfish/src/rpc/routes/wallet/buildTransaction.test.ts
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { RawTransactionSerde } from '../../../primitives/rawTransaction'
+import { useAccountFixture } from '../../../testUtilities'
+import { createRawTransaction } from '../../../testUtilities/helpers/transaction'
+import { createRouteTest } from '../../../testUtilities/routeTest'
+
+describe('Route wallet/buildTransaction', () => {
+  const routeTest = createRouteTest(true)
+
+  it('should build a raw transaction', async () => {
+    const account = await useAccountFixture(routeTest.node.wallet, 'existingAccount')
+
+    const rawTransaction = await createRawTransaction({
+      wallet: routeTest.node.wallet,
+      from: account,
+    })
+
+    const response = await routeTest.client.wallet.buildTransaction({
+      transaction: RawTransactionSerde.serialize(rawTransaction).toString('hex'),
+      account: account.name,
+    })
+
+    expect(response.status).toBe(200)
+    expect(response.content.transaction).toBeDefined()
+  })
+
+  it("should return an error if the transaction won't deserialize", async () => {
+    const account = await useAccountFixture(routeTest.node.wallet, 'accountB')
+
+    await expect(
+      routeTest.client.wallet.buildTransaction({
+        transaction: '0xdeadbeef',
+        account: account.name,
+      }),
+    ).rejects.toThrow('Out of bounds read (offset=0).')
+  })
+})

--- a/ironfish/src/rpc/routes/wallet/buildTransaction.test.ts
+++ b/ironfish/src/rpc/routes/wallet/buildTransaction.test.ts
@@ -21,12 +21,12 @@ describe('Route wallet/buildTransaction', () => {
     })
 
     const response = await routeTest.client.wallet.buildTransaction({
-      transaction: RawTransactionSerde.serialize(rawTransaction).toString('hex'),
+      rawTransaction: RawTransactionSerde.serialize(rawTransaction).toString('hex'),
       account: account.name,
     })
 
     expect(response.status).toBe(200)
-    expect(response.content.transaction).toBeDefined()
+    expect(response.content.unsignedTransaction).toBeDefined()
   })
 
   it('should produce output that can be signed', async () => {
@@ -43,15 +43,15 @@ describe('Route wallet/buildTransaction', () => {
     })
 
     const response = await routeTest.client.wallet.buildTransaction({
-      transaction: RawTransactionSerde.serialize(rawTransaction).toString('hex'),
+      rawTransaction: RawTransactionSerde.serialize(rawTransaction).toString('hex'),
       account: account.name,
     })
 
     expect(response.status).toBe(200)
-    expect(response.content.transaction).toBeDefined()
+    expect(response.content.unsignedTransaction).toBeDefined()
 
     const unsignedTransaction = new UnsignedTransaction(
-      Buffer.from(response.content.transaction, 'hex'),
+      Buffer.from(response.content.unsignedTransaction, 'hex'),
     )
     const signedTransaction = unsignedTransaction.sign(account.spendingKey)
 
@@ -64,7 +64,7 @@ describe('Route wallet/buildTransaction', () => {
 
     await expect(
       routeTest.client.wallet.buildTransaction({
-        transaction: '0xdeadbeef',
+        rawTransaction: '0xdeadbeef',
         account: account.name,
       }),
     ).rejects.toThrow('Out of bounds read (offset=0).')

--- a/ironfish/src/rpc/routes/wallet/buildTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/buildTransaction.ts
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import * as yup from 'yup'
+import { RawTransactionSerde } from '../../../primitives'
+import { ApiNamespace } from '../namespaces'
+import { routes } from '../router'
+import { AssertHasRpcContext } from '../rpcContext'
+import { getAccount } from './utils'
+
+export type BuildTransactionRequest = {
+  account?: string
+  transaction: string
+}
+
+export type BuildTransactionResponse = {
+  transaction: string
+}
+
+export const BuildTransactionRequestSchema: yup.ObjectSchema<BuildTransactionRequest> = yup
+  .object({
+    account: yup.string().optional(),
+    transaction: yup.string().defined(),
+  })
+  .defined()
+
+export const BuildTransactionResponseSchema: yup.ObjectSchema<BuildTransactionResponse> = yup
+  .object({
+    transaction: yup.string().defined(),
+  })
+  .defined()
+
+routes.register<typeof BuildTransactionRequestSchema, BuildTransactionResponse>(
+  `${ApiNamespace.wallet}/buildTransaction`,
+  BuildTransactionRequestSchema,
+  async (request, node): Promise<void> => {
+    AssertHasRpcContext(request, node, 'wallet')
+    AssertHasRpcContext(request, node, 'workerPool')
+
+    const account = getAccount(node.wallet, request.data.account)
+
+    const raw = RawTransactionSerde.deserialize(Buffer.from(request.data.transaction, 'hex'))
+
+    const unsigned = await node.wallet.build({ transaction: raw, account })
+
+    request.end({
+      transaction: unsigned.transaction.serialize().toString('hex'),
+    })
+  },
+)

--- a/ironfish/src/rpc/routes/wallet/buildTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/buildTransaction.ts
@@ -11,23 +11,23 @@ import { getAccount } from './utils'
 
 export type BuildTransactionRequest = {
   account?: string
-  transaction: string
+  rawTransaction: string
 }
 
 export type BuildTransactionResponse = {
-  transaction: string
+  unsignedTransaction: string
 }
 
 export const BuildTransactionRequestSchema: yup.ObjectSchema<BuildTransactionRequest> = yup
   .object({
     account: yup.string().optional(),
-    transaction: yup.string().defined(),
+    rawTransaction: yup.string().defined(),
   })
   .defined()
 
 export const BuildTransactionResponseSchema: yup.ObjectSchema<BuildTransactionResponse> = yup
   .object({
-    transaction: yup.string().defined(),
+    unsignedTransaction: yup.string().defined(),
   })
   .defined()
 
@@ -40,12 +40,12 @@ routes.register<typeof BuildTransactionRequestSchema, BuildTransactionResponse>(
 
     const account = getAccount(node.wallet, request.data.account)
 
-    const raw = RawTransactionSerde.deserialize(Buffer.from(request.data.transaction, 'hex'))
+    const raw = RawTransactionSerde.deserialize(Buffer.from(request.data.rawTransaction, 'hex'))
 
     const unsigned = await node.wallet.build({ transaction: raw, account })
 
     request.end({
-      transaction: unsigned.transaction.serialize().toString('hex'),
+      unsignedTransaction: unsigned.transaction.serialize().toString('hex'),
     })
   },
 )

--- a/ironfish/src/rpc/routes/wallet/index.ts
+++ b/ironfish/src/rpc/routes/wallet/index.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 export * from './addTransaction'
+export * from './buildTransaction'
 export * from './burnAsset'
 export * from './create'
 export * from './createAccount'

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -4,7 +4,6 @@
 import {
   Asset,
   generateKey,
-  generateKeyFromPrivateKey,
   Note as NativeNote,
   UnsignedTransaction,
 } from '@ironfish/rust-nodejs'

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -1066,24 +1066,14 @@ export class Wallet {
   async build(options: { transaction: RawTransaction; account: Account }): Promise<{
     transaction: UnsignedTransaction
   }> {
-    // TODO(hughy): replace with top-level proofAuthorizingKey property
-    let proofAuthorizingKey = null
-    if (options.account.spendingKey) {
-      proofAuthorizingKey = generateKeyFromPrivateKey(
-        options.account.spendingKey,
-      ).proofAuthorizingKey
-    } else if (options.account.multiSigKeys) {
-      proofAuthorizingKey = options.account.multiSigKeys.proofGenerationKey.slice(64)
-    }
-
     Assert.isNotNull(
-      proofAuthorizingKey,
+      options.account.proofAuthorizingKey,
       'proofAuthorizingKey is required to build transactions',
     )
 
     const transaction = await this.workerPool.buildTransaction(
       options.transaction,
-      proofAuthorizingKey,
+      options.account.proofAuthorizingKey,
       options.account.viewKey,
       options.account.outgoingViewKey,
     )


### PR DESCRIPTION
## Summary

buildTransaction takes a serialized RawTransaction and returns a serialized UnsignedTransaction

adds a 'build' method to the Wallet. for now, derives proofGenerationKey either from an account's spendingKey or from the account's multiSigKeys. invokes the buildTransaction worker pool task to build a RawTransaction

## Testing Plan

- adds unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
