### PR TITLE
chore: refactor frost utils

### DIFF
--- a/ironfish-rust-nodejs/index.d.ts
+++ b/ironfish-rust-nodejs/index.d.ts
@@ -11,8 +11,8 @@ export interface IdentifierCommitment {
   identifier: string
   commitment: Commitment
 }
-export function roundOne(keyPackage: string, seed: number): Commitment
-export function roundTwo(signingPackage: string, keyPackage: string, publicKeyRandomness: string, seed: number): string
+export function createSigningCommitment(keyPackage: string, seed: number): Commitment
+export function createSigningShare(signingPackage: string, keyPackage: string, publicKeyRandomness: string, seed: number): string
 export function splitSecret(coordinatorSaplingKey: string, minSigners: number, maxSigners: number, identifiers: Array<string>): TrustedDealerKeyPackages
 export function contribute(inputPath: string, outputPath: string, seed?: string | undefined | null): Promise<string>
 export function verifyTransform(paramsPath: string, newParamsPath: string): Promise<string>

--- a/ironfish-rust-nodejs/index.js
+++ b/ironfish-rust-nodejs/index.js
@@ -252,11 +252,11 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { FishHashContext, roundOne, roundTwo, ParticipantSecret, ParticipantIdentity, splitSecret, contribute, verifyTransform, KEY_LENGTH, NONCE_LENGTH, BoxKeyPair, randomBytes, boxMessage, unboxMessage, RollingFilter, initSignalHandler, triggerSegfault, ASSET_ID_LENGTH, ASSET_METADATA_LENGTH, ASSET_NAME_LENGTH, ASSET_LENGTH, Asset, NOTE_ENCRYPTION_KEY_LENGTH, MAC_LENGTH, ENCRYPTED_NOTE_PLAINTEXT_LENGTH, ENCRYPTED_NOTE_LENGTH, NoteEncrypted, PUBLIC_ADDRESS_LENGTH, RANDOMNESS_LENGTH, MEMO_LENGTH, AMOUNT_VALUE_LENGTH, DECRYPTED_NOTE_LENGTH, Note, PROOF_LENGTH, TRANSACTION_SIGNATURE_LENGTH, TRANSACTION_PUBLIC_KEY_RANDOMNESS_LENGTH, TRANSACTION_EXPIRATION_LENGTH, TRANSACTION_FEE_LENGTH, LATEST_TRANSACTION_VERSION, TransactionPosted, Transaction, verifyTransactions, UnsignedTransaction, LanguageCode, generateKey, spendingKeyToWords, wordsToSpendingKey, generateKeyFromPrivateKey, initializeSapling, FoundBlockResult, ThreadPoolHandler, isValidPublicAddress } = nativeBinding
+const { FishHashContext, createSigningCommitment, createSigningShare, ParticipantSecret, ParticipantIdentity, splitSecret, contribute, verifyTransform, KEY_LENGTH, NONCE_LENGTH, BoxKeyPair, randomBytes, boxMessage, unboxMessage, RollingFilter, initSignalHandler, triggerSegfault, ASSET_ID_LENGTH, ASSET_METADATA_LENGTH, ASSET_NAME_LENGTH, ASSET_LENGTH, Asset, NOTE_ENCRYPTION_KEY_LENGTH, MAC_LENGTH, ENCRYPTED_NOTE_PLAINTEXT_LENGTH, ENCRYPTED_NOTE_LENGTH, NoteEncrypted, PUBLIC_ADDRESS_LENGTH, RANDOMNESS_LENGTH, MEMO_LENGTH, AMOUNT_VALUE_LENGTH, DECRYPTED_NOTE_LENGTH, Note, PROOF_LENGTH, TRANSACTION_SIGNATURE_LENGTH, TRANSACTION_PUBLIC_KEY_RANDOMNESS_LENGTH, TRANSACTION_EXPIRATION_LENGTH, TRANSACTION_FEE_LENGTH, LATEST_TRANSACTION_VERSION, TransactionPosted, Transaction, verifyTransactions, UnsignedTransaction, LanguageCode, generateKey, spendingKeyToWords, wordsToSpendingKey, generateKeyFromPrivateKey, initializeSapling, FoundBlockResult, ThreadPoolHandler, isValidPublicAddress } = nativeBinding
 
 module.exports.FishHashContext = FishHashContext
-module.exports.roundOne = roundOne
-module.exports.roundTwo = roundTwo
+module.exports.createSigningCommitment = createSigningCommitment
+module.exports.createSigningShare = createSigningShare
 module.exports.ParticipantSecret = ParticipantSecret
 module.exports.ParticipantIdentity = ParticipantIdentity
 module.exports.splitSecret = splitSecret

--- a/ironfish-rust/src/frost_utils/mod.rs
+++ b/ironfish-rust/src/frost_utils/mod.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-pub mod round_one;
-pub mod round_two;
+pub mod signing_commitment;
+pub mod signing_share;
 pub mod split_secret;
 pub mod split_spender_key;

--- a/ironfish-rust/src/frost_utils/signing_commitment.rs
+++ b/ironfish-rust/src/frost_utils/signing_commitment.rs
@@ -10,7 +10,10 @@ use ironfish_frost::frost::{
 use rand::{rngs::StdRng, SeedableRng};
 
 // Small wrapper around frost::round1::commit that provides a seedable rng
-pub fn round_one(key_package: &KeyPackage, seed: u64) -> (SigningNonces, SigningCommitments) {
+pub fn create_signing_commitment(
+    key_package: &KeyPackage,
+    seed: u64,
+) -> (SigningNonces, SigningCommitments) {
     let mut rng = StdRng::seed_from_u64(seed);
     frost::round1::commit(key_package.signing_share(), &mut rng)
 }
@@ -46,8 +49,8 @@ mod test {
             .next()
             .expect("key package to be created")
             .1;
-        let (nonces, commitments) = super::round_one(&key_package, seed);
-        let (nonces2, commitments2) = super::round_one(&key_package, seed);
+        let (nonces, commitments) = super::create_signing_commitment(&key_package, seed);
+        let (nonces2, commitments2) = super::create_signing_commitment(&key_package, seed);
         assert_eq!(nonces.hiding().serialize(), nonces2.hiding().serialize());
         assert_eq!(nonces.binding().serialize(), nonces2.binding().serialize());
         assert_eq!(commitments, commitments2);

--- a/ironfish-rust/src/frost_utils/signing_share.rs
+++ b/ironfish-rust/src/frost_utils/signing_share.rs
@@ -14,7 +14,7 @@ use rand::{rngs::StdRng, SeedableRng};
 use crate::errors::{IronfishError, IronfishErrorKind};
 
 // Wrapper around frost::round2::sign that provides a seedable rng from u64
-pub fn round_two(
+pub fn create_signing_share(
     signing_package: SigningPackage,
     key_package: KeyPackage,
     randomizer: Randomizer,

--- a/ironfish-rust/src/transaction/tests.rs
+++ b/ironfish-rust/src/transaction/tests.rs
@@ -7,7 +7,9 @@ use std::collections::BTreeMap;
 #[cfg(test)]
 use super::internal_batch_verify_transactions;
 use super::{ProposedTransaction, Transaction};
-use crate::frost_utils::{round_one::round_one, round_two::round_two};
+use crate::frost_utils::{
+    signing_commitment::create_signing_commitment, signing_share::create_signing_share,
+};
 use crate::transaction::tests::split_spender_key::split_spender_key;
 use crate::{
     assets::{asset::Asset, asset_identifier::NATIVE_ASSET},
@@ -789,7 +791,7 @@ fn test_sign_frost() {
 
     // simulate round 1
     for key_package in key_packages.key_packages.iter() {
-        let (_nonce, commitment) = round_one(key_package.1, 0);
+        let (_nonce, commitment) = create_signing_commitment(key_package.1, 0);
         commitments.insert(*key_package.0, commitment);
     }
 
@@ -805,7 +807,7 @@ fn test_sign_frost() {
             .expect("should be able to deserialize randomizer");
 
     for key_package in key_packages.key_packages.iter() {
-        let signature_share = round_two(
+        let signature_share = create_signing_share(
             signing_package.clone(),
             key_package.1.clone(),
             randomizer,

--- a/ironfish/src/rpc/routes/multisig/createSigningCommitment.ts
+++ b/ironfish/src/rpc/routes/multisig/createSigningCommitment.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { roundOne } from '@ironfish/rust-nodejs'
+import { createSigningCommitment } from '@ironfish/rust-nodejs'
 import * as yup from 'yup'
 import { ApiNamespace } from '../namespaces'
 import { routes } from '../router'
@@ -29,7 +29,7 @@ routes.register<typeof CreateSigningCommitmentRequestSchema, CreateSigningCommit
   `${ApiNamespace.multisig}/createSigningCommitment`,
   CreateSigningCommitmentRequestSchema,
   (request, _context): void => {
-    const result = roundOne(request.data.keyPackage, request.data.seed)
+    const result = createSigningCommitment(request.data.keyPackage, request.data.seed)
 
     request.end({
       hiding: result.hiding,

--- a/ironfish/src/rpc/routes/multisig/createSigningShare.ts
+++ b/ironfish/src/rpc/routes/multisig/createSigningShare.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { roundTwo, UnsignedTransaction } from '@ironfish/rust-nodejs'
+import { createSigningShare, UnsignedTransaction } from '@ironfish/rust-nodejs'
 import * as yup from 'yup'
 import { ApiNamespace } from '../namespaces'
 import { routes } from '../router'
@@ -41,7 +41,7 @@ routes.register<typeof CreateSigningCommitmentRequestSchema, CreateSigningCommit
     const unsigned = new UnsignedTransaction(
       Buffer.from(request.data.unsignedTransaction, 'hex'),
     )
-    const result = roundTwo(
+    const result = createSigningShare(
       request.data.signingPackage,
       request.data.keyPackage,
       unsigned.publicKeyRandomness(),

--- a/ironfish/src/wallet/wallet.test.slow.ts
+++ b/ironfish/src/wallet/wallet.test.slow.ts
@@ -4,10 +4,10 @@
 import {
   Asset,
   ASSET_ID_LENGTH,
+  createSigningCommitment,
+  createSigningShare,
   generateKey,
   ParticipantSecret,
-  roundOne,
-  roundTwo,
   splitSecret,
   TrustedDealerKeyPackages,
 } from '@ironfish/rust-nodejs'
@@ -1205,15 +1205,15 @@ describe('Wallet', () => {
       const signingCommitments = [
         {
           identifier: participantA.multiSigKeys.identifier,
-          commitment: roundOne(participantA.multiSigKeys.keyPackage, seed),
+          commitment: createSigningCommitment(participantA.multiSigKeys.keyPackage, seed),
         },
         {
           identifier: participantB.multiSigKeys.identifier,
-          commitment: roundOne(participantB.multiSigKeys.keyPackage, seed),
+          commitment: createSigningCommitment(participantB.multiSigKeys.keyPackage, seed),
         },
         {
           identifier: participantC.multiSigKeys.identifier,
-          commitment: roundOne(participantC.multiSigKeys.keyPackage, seed),
+          commitment: createSigningCommitment(participantC.multiSigKeys.keyPackage, seed),
         },
       ]
 
@@ -1281,19 +1281,19 @@ describe('Wallet', () => {
       const publicKeyRandomness = unsignedTransaction.publicKeyRandomness()
 
       const signatureShares: Record<string, string> = {
-        [participantA.multiSigKeys.identifier]: roundTwo(
+        [participantA.multiSigKeys.identifier]: createSigningShare(
           signingPackage,
           participantA.multiSigKeys.keyPackage,
           publicKeyRandomness,
           seed,
         ),
-        [participantB.multiSigKeys.identifier]: roundTwo(
+        [participantB.multiSigKeys.identifier]: createSigningShare(
           signingPackage,
           participantB.multiSigKeys.keyPackage,
           publicKeyRandomness,
           seed,
         ),
-        [participantC.multiSigKeys.identifier]: roundTwo(
+        [participantC.multiSigKeys.identifier]: createSigningShare(
           signingPackage,
           participantC.multiSigKeys.keyPackage,
           publicKeyRandomness,


### PR DESCRIPTION
## Summary
Cleanliness refactor that purely renames:
1. `roundOne` -> `createSigningCommitment`
2. `roundTwo` -> `createSigningShare`
## Testing Plan
Tests pass
## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
