### PR TITLE
Rahul/ifl 2146 replace pgk on build with proof authorizing key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1578,6 +1578,7 @@ dependencies = [
  "fish_hash",
  "ironfish",
  "ironfish_mpc",
+ "jubjub 0.9.0 (git+https://github.com/iron-fish/jubjub.git?branch=blstrs)",
  "napi",
  "napi-build",
  "napi-derive",

--- a/ironfish-rust-nodejs/Cargo.toml
+++ b/ironfish-rust-nodejs/Cargo.toml
@@ -32,6 +32,7 @@ ironfish = { path = "../ironfish-rust" }
 ironfish_mpc = { path = "../ironfish-mpc" }
 napi = { version = "2.13.2", features = ["napi6"] }
 napi-derive = "2.13.0"
+jubjub = { git = "https://github.com/iron-fish/jubjub.git", branch = "blstrs" }
 rand = "0.8.5"
 
 [build-dependencies]

--- a/ironfish-rust-nodejs/index.d.ts
+++ b/ironfish-rust-nodejs/index.d.ts
@@ -242,7 +242,7 @@ export class Transaction {
    * aka: self.value_balance - intended_transaction_fee - change = 0
    */
   post(spenderHexKey: string, changeGoesTo: string | undefined | null, intendedTransactionFee: bigint): Buffer
-  build(proofGenerationKeyStr: string, viewKeyStr: string, outgoingViewKeyStr: string, intendedTransactionFee: bigint, changeGoesTo?: string | undefined | null): Buffer
+  build(proofAuthorizingKeyStr: string, viewKeyStr: string, outgoingViewKeyStr: string, intendedTransactionFee: bigint, changeGoesTo?: string | undefined | null): Buffer
   setExpiration(sequence: number): void
 }
 export type NativeUnsignedTransaction = UnsignedTransaction

--- a/ironfish-rust-nodejs/tests/unsigned.test.slow.ts
+++ b/ironfish-rust-nodejs/tests/unsigned.test.slow.ts
@@ -12,7 +12,7 @@ describe("UnsignedTransaction", () => {
       const proposedTx = new Transaction(2);
       proposedTx.mint(asset, 5n);
       const unsignedTxBuffer = proposedTx.build(
-        key.viewKey.slice(0, 64) + key.proofAuthorizingKey, //todo(rahul): change this to accept just proof authorizing key when the interface changes
+        key.proofAuthorizingKey,
         key.viewKey,
         key.outgoingViewKey,
         0n

--- a/ironfish-rust/src/errors.rs
+++ b/ironfish-rust/src/errors.rs
@@ -49,6 +49,7 @@ pub enum IronfishErrorKind {
     InvalidNullifierDerivingKey,
     InvalidOutputProof,
     InvalidPaymentAddress,
+    InvalidProofAuthorizingKey,
     InvalidPublicAddress,
     InvalidSecret,
     InvalidRandomizer,

--- a/ironfish-rust/src/errors.rs
+++ b/ironfish-rust/src/errors.rs
@@ -49,7 +49,6 @@ pub enum IronfishErrorKind {
     InvalidNullifierDerivingKey,
     InvalidOutputProof,
     InvalidPaymentAddress,
-    InvalidProofAuthorizingKey,
     InvalidPublicAddress,
     InvalidSecret,
     InvalidRandomizer,

--- a/ironfish-rust/src/transaction/tests.rs
+++ b/ironfish-rust/src/transaction/tests.rs
@@ -242,7 +242,7 @@ fn test_proposed_transaction_build() {
 
     let unsigned_transaction = transaction
         .build(
-            spender_key.sapling_proof_generation_key(),
+            spender_key.proof_authorizing_key,
             spender_key.view_key().clone(),
             spender_key.outgoing_view_key().clone(),
             intended_fee,
@@ -685,7 +685,7 @@ fn test_sign_simple() {
     // build transaction, generate proofs
     let unsigned_transaction = transaction
         .build(
-            spender_key.sapling_proof_generation_key(),
+            spender_key.proof_authorizing_key,
             spender_key.view_key().clone(),
             spender_key.outgoing_view_key().clone(),
             1,
@@ -779,7 +779,7 @@ fn test_sign_frost() {
     // build UnsignedTransaction without signing
     let mut unsigned_transaction = transaction
         .build(
-            key_packages.proof_generation_key,
+            key_packages.proof_generation_key.nsk,
             key_packages.view_key,
             key_packages.outgoing_view_key,
             intended_fee,

--- a/ironfish/src/primitives/rawTransaction.ts
+++ b/ironfish/src/primitives/rawTransaction.ts
@@ -163,14 +163,14 @@ export class RawTransaction {
   }
 
   build(
-    proofGenerationKey: string,
+    proofAuthorizingKey: string,
     viewKey: string,
     outgoingViewKey: string,
   ): UnsignedTransaction {
     const builder = this._build()
 
     const serialized = builder.build(
-      proofGenerationKey,
+      proofAuthorizingKey,
       viewKey,
       outgoingViewKey,
       this.fee,

--- a/ironfish/src/testUtilities/fixtures/transactions.ts
+++ b/ironfish/src/testUtilities/fixtures/transactions.ts
@@ -128,11 +128,7 @@ export async function useUnsignedTxFixture(
       Assert.isNotNull(from.spendingKey)
       const key = generateKeyFromPrivateKey(from.spendingKey)
       const unsignedBuffer = raw
-        .build(
-          key.viewKey.slice(0, 64) + key.proofAuthorizingKey, //todo(rahul): change this to accept just proof authorizing key when the interface changes
-          key.viewKey,
-          key.outgoingViewKey,
-        )
+        .build(key.proofAuthorizingKey, key.viewKey, key.outgoingViewKey)
         .serialize()
       return new UnsignedTransaction(unsignedBuffer)
     })

--- a/ironfish/src/wallet/wallet.test.slow.ts
+++ b/ironfish/src/wallet/wallet.test.slow.ts
@@ -1272,7 +1272,7 @@ describe('Wallet', () => {
       })
 
       const unsignedTransaction = rawTransaction.build(
-        trustedDealerPackage.proofGenerationKey,
+        trustedDealerPackage.proofGenerationKey.slice(64, 128),
         trustedDealerPackage.viewKey,
         trustedDealerPackage.outgoingViewKey,
       )


### PR DESCRIPTION
## Summary

Now we can build an unsigned transaction using the authorizing key as input instead of the proof generation key. 

This is in line with our need to store the authorizing key on a view only account so that these accounts can generate the proofs needed for building an unsigned transaction

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
