### PR TITLE
updates TrustedDealerKeyPackage to use proofAuthorizingKey

### DIFF
--- a/ironfish-rust-nodejs/index.d.ts
+++ b/ironfish-rust-nodejs/index.d.ts
@@ -66,7 +66,7 @@ export interface IdentiferKeyPackage {
 }
 export interface TrustedDealerKeyPackages {
   verifyingKey: string
-  proofGenerationKey: string
+  proofAuthorizingKey: string
   viewKey: string
   incomingViewKey: string
   outgoingViewKey: string

--- a/ironfish-rust-nodejs/src/frost.rs
+++ b/ironfish-rust-nodejs/src/frost.rs
@@ -14,7 +14,7 @@ use ironfish::{
         signing_share::create_signing_share as create_signing_share_rust,
     },
     participant::{Identity, Secret},
-    serializing::{bytes_to_hex, hex_to_bytes, hex_to_vec_bytes},
+    serializing::{bytes_to_hex, fr::FrSerializable, hex_to_bytes, hex_to_vec_bytes},
     SaplingKey,
 };
 use napi::{bindgen_prelude::*, JsBuffer};
@@ -176,7 +176,7 @@ pub fn split_secret(
 
     Ok(TrustedDealerKeyPackages {
         verifying_key: bytes_to_hex(&t.verifying_key),
-        proof_authorizing_key: bytes_to_hex(&t.proof_authorizing_key.to_bytes()),
+        proof_authorizing_key: t.proof_authorizing_key.hex_key(),
         view_key: t.view_key.hex_key(),
         incoming_view_key: t.incoming_view_key.hex_key(),
         outgoing_view_key: t.outgoing_view_key.hex_key(),

--- a/ironfish-rust-nodejs/src/frost.rs
+++ b/ironfish-rust-nodejs/src/frost.rs
@@ -177,7 +177,7 @@ pub fn split_secret(
 
     Ok(TrustedDealerKeyPackages {
         verifying_key: bytes_to_hex(&t.verifying_key),
-        proof_generation_key: t.proof_generation_key.hex_key(),
+        proof_authorizing_key: bytes_to_hex(&t.proof_authorizing_key.to_bytes()),
         view_key: t.view_key.hex_key(),
         incoming_view_key: t.incoming_view_key.hex_key(),
         outgoing_view_key: t.outgoing_view_key.hex_key(),

--- a/ironfish-rust-nodejs/src/frost.rs
+++ b/ironfish-rust-nodejs/src/frost.rs
@@ -6,7 +6,6 @@ use crate::{
     structs::{IdentiferKeyPackage, TrustedDealerKeyPackages},
     to_napi_err,
 };
-use ironfish::keys::ProofGenerationKeySerializable;
 use ironfish::{
     frost::{keys::KeyPackage, round2::Randomizer, Identifier, SigningPackage},
     frost_utils::split_spender_key::split_spender_key,

--- a/ironfish-rust-nodejs/src/structs/key_packages.rs
+++ b/ironfish-rust-nodejs/src/structs/key_packages.rs
@@ -13,7 +13,7 @@ pub struct IdentiferKeyPackage {
 
 pub struct TrustedDealerKeyPackages {
     pub verifying_key: String,
-    pub proof_generation_key: String,
+    pub proof_authorizing_key: String,
     pub view_key: String,
     pub incoming_view_key: String,
     pub outgoing_view_key: String,

--- a/ironfish-rust/src/frost_utils/split_spender_key.rs
+++ b/ironfish-rust/src/frost_utils/split_spender_key.rs
@@ -7,7 +7,7 @@ use ironfish_frost::frost::{
     keys::{IdentifierList, KeyPackage, PublicKeyPackage},
     Identifier,
 };
-use ironfish_zkp::{constants::PROOF_GENERATION_KEY_GENERATOR, ProofGenerationKey};
+use ironfish_zkp::constants::PROOF_GENERATION_KEY_GENERATOR;
 use jubjub::SubgroupPoint;
 use rand::thread_rng;
 use std::collections::HashMap;

--- a/ironfish-rust/src/frost_utils/split_spender_key.rs
+++ b/ironfish-rust/src/frost_utils/split_spender_key.rs
@@ -23,7 +23,7 @@ type AuthorizingKey = [u8; 32];
 
 pub struct TrustedDealerKeyPackages {
     pub verifying_key: AuthorizingKey, // verifying_key is the name given to this field in the frost protocol
-    pub proof_generation_key: ProofGenerationKey,
+    pub proof_authorizing_key: jubjub::Fr,
     pub view_key: ViewKey,
     pub incoming_view_key: IncomingViewKey,
     pub outgoing_view_key: OutgoingViewKey,
@@ -61,10 +61,7 @@ pub fn split_spender_key(
     let authorizing_key = Option::from(SubgroupPoint::from_bytes(&authorizing_key_bytes))
         .ok_or_else(|| IronfishError::new(IronfishErrorKind::InvalidAuthorizingKey))?;
 
-    let proof_generation_key = ProofGenerationKey {
-        ak: authorizing_key,
-        nsk: coordinator_sapling_key.sapling_proof_generation_key().nsk,
-    };
+    let proof_authorizing_key = coordinator_sapling_key.sapling_proof_generation_key().nsk;
 
     let nullifier_deriving_key = *PROOF_GENERATION_KEY_GENERATOR
         * coordinator_sapling_key.sapling_proof_generation_key().nsk;
@@ -82,7 +79,7 @@ pub fn split_spender_key(
 
     Ok(TrustedDealerKeyPackages {
         verifying_key: authorizing_key_bytes,
-        proof_generation_key,
+        proof_authorizing_key,
         view_key,
         incoming_view_key,
         outgoing_view_key,

--- a/ironfish-rust/src/transaction/tests.rs
+++ b/ironfish-rust/src/transaction/tests.rs
@@ -10,7 +10,6 @@ use super::{ProposedTransaction, Transaction};
 use crate::frost_utils::{
     signing_commitment::create_signing_commitment, signing_share::create_signing_share,
 };
-use crate::keys::proof_generation_key;
 use crate::transaction::tests::split_spender_key::split_spender_key;
 use crate::{
     assets::{asset::Asset, asset_identifier::NATIVE_ASSET},
@@ -31,8 +30,6 @@ use ff::Field;
 use ironfish_frost::frost::round2::{Randomizer, SignatureShare};
 use ironfish_frost::frost::Identifier;
 use ironfish_frost::participant::Secret;
-use ironfish_zkp::constants::proof;
-use ironfish_zkp::ProofGenerationKey;
 use ironfish_zkp::{
     constants::{ASSET_ID_LENGTH, SPENDING_KEY_GENERATOR, TREE_DEPTH},
     proofs::{MintAsset, Output, Spend},

--- a/ironfish-rust/src/transaction/tests.rs
+++ b/ironfish-rust/src/transaction/tests.rs
@@ -10,6 +10,7 @@ use super::{ProposedTransaction, Transaction};
 use crate::frost_utils::{
     signing_commitment::create_signing_commitment, signing_share::create_signing_share,
 };
+use crate::keys::proof_generation_key;
 use crate::transaction::tests::split_spender_key::split_spender_key;
 use crate::{
     assets::{asset::Asset, asset_identifier::NATIVE_ASSET},
@@ -30,6 +31,8 @@ use ff::Field;
 use ironfish_frost::frost::round2::{Randomizer, SignatureShare};
 use ironfish_frost::frost::Identifier;
 use ironfish_frost::participant::Secret;
+use ironfish_zkp::constants::proof;
+use ironfish_zkp::ProofGenerationKey;
 use ironfish_zkp::{
     constants::{ASSET_ID_LENGTH, SPENDING_KEY_GENERATOR, TREE_DEPTH},
     proofs::{MintAsset, Output, Spend},
@@ -779,7 +782,7 @@ fn test_sign_frost() {
     // build UnsignedTransaction without signing
     let mut unsigned_transaction = transaction
         .build(
-            key_packages.proof_generation_key.nsk,
+            key_packages.proof_authorizing_key,
             key_packages.view_key,
             key_packages.outgoing_view_key,
             intended_fee,

--- a/ironfish/src/rpc/routes/multisig/createTrustedDealerKeyPackage.ts
+++ b/ironfish/src/rpc/routes/multisig/createTrustedDealerKeyPackage.ts
@@ -80,6 +80,12 @@ routes.register<
       maxSigners,
       identifiers,
     )
-    request.end(trustedDealerPackage)
+
+    // TODO(hughy): update response type to use proofAuthorizingKey
+    const proofGenerationKey = trustedDealerPackage.viewKey
+      .slice(0, 64)
+      .concat(trustedDealerPackage.proofAuthorizingKey)
+
+    request.end({ ...trustedDealerPackage, proofGenerationKey })
   },
 )

--- a/ironfish/src/wallet/wallet.test.slow.ts
+++ b/ironfish/src/wallet/wallet.test.slow.ts
@@ -1162,11 +1162,16 @@ describe('Wallet', () => {
         identifiers,
       )
 
+      // TODO(hughy): replace when account imports use proofAuthorizingKey
+      const proofGenerationKey = trustedDealerPackage.viewKey
+        .slice(0, 64)
+        .concat(trustedDealerPackage.proofAuthorizingKey)
+
       const getMultiSigKeys = (index: number) => {
         return {
           identifier: trustedDealerPackage.keyPackages[index].identifier,
           keyPackage: trustedDealerPackage.keyPackages[index].keyPackage,
-          proofGenerationKey: trustedDealerPackage.proofGenerationKey,
+          proofGenerationKey: proofGenerationKey,
         }
       }
 
@@ -1272,7 +1277,7 @@ describe('Wallet', () => {
       })
 
       const unsignedTransaction = rawTransaction.build(
-        trustedDealerPackage.proofGenerationKey.slice(64, 128),
+        trustedDealerPackage.proofAuthorizingKey,
         trustedDealerPackage.viewKey,
         trustedDealerPackage.outgoingViewKey,
       )


### PR DESCRIPTION
## Summary

we plan to store proofAuthorizingKey (nsk) on each account in the walletDb instead of storing proofGenerationKey (ak, nsk)

updates split_secret to return proofAuthorizingKey as part of the TrustedDealerKeyPackage instead of proofGenerationKey

propagates changes through napi

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
