### PR TITLE
updates createTrustedDealerKeyPackage to return nsk

### DIFF
--- a/ironfish/src/rpc/routes/multisig/createTrustedDealerKeyPackage.test.ts
+++ b/ironfish/src/rpc/routes/multisig/createTrustedDealerKeyPackage.test.ts
@@ -33,7 +33,7 @@ describe('Route multisig/createTrustedDealerKeyPackage', () => {
         },
       ]),
       outgoingViewKey: expect.any(String),
-      proofGenerationKey: expect.any(String),
+      proofAuthorizingKey: expect.any(String),
       publicAddress: expect.any(String),
       publicKeyPackage: expect.any(String),
       verifyingKey: expect.any(String),

--- a/ironfish/src/rpc/routes/multisig/createTrustedDealerKeyPackage.ts
+++ b/ironfish/src/rpc/routes/multisig/createTrustedDealerKeyPackage.ts
@@ -15,7 +15,7 @@ export type CreateTrustedDealerKeyPackageRequest = {
 }
 export type CreateTrustedDealerKeyPackageResponse = {
   verifyingKey: string
-  proofGenerationKey: string
+  proofAuthorizingKey: string
   viewKey: string
   incomingViewKey: string
   outgoingViewKey: string
@@ -45,7 +45,7 @@ export const CreateTrustedDealerKeyPackageResponseSchema: yup.ObjectSchema<Creat
   yup
     .object({
       verifyingKey: yup.string().defined(),
-      proofGenerationKey: yup.string().defined(),
+      proofAuthorizingKey: yup.string().defined(),
       viewKey: yup.string().defined(),
       incomingViewKey: yup.string().defined(),
       outgoingViewKey: yup.string().defined(),
@@ -81,11 +81,6 @@ routes.register<
       identifiers,
     )
 
-    // TODO(hughy): update response type to use proofAuthorizingKey
-    const proofGenerationKey = trustedDealerPackage.viewKey
-      .slice(0, 64)
-      .concat(trustedDealerPackage.proofAuthorizingKey)
-
-    request.end({ ...trustedDealerPackage, proofGenerationKey })
+    request.end(trustedDealerPackage)
   },
 )


### PR DESCRIPTION
## Summary

RPC returns proofAuthorizingKey (nsk) instead of proofGenerationKey

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
