### PR TITLE
Add a consensus parameter for adjusting the max difficulty buckets

### DIFF
--- a/ironfish/src/blockHasher.test.ts
+++ b/ironfish/src/blockHasher.test.ts
@@ -19,6 +19,7 @@ const consensusParameters = {
   enableAssetOwnership: 1,
   enforceSequentialBlockTime: 1,
   enableFishHash: 100001,
+  enableIncreasedDifficultyChange: 100001,
 }
 
 describe('Hashes blocks with correct hashing algorithm', () => {

--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -925,6 +925,7 @@ export class Blockchain {
           heaviestHead.target,
           this.consensus.parameters.targetBlockTimeInSeconds,
           this.consensus.parameters.targetBucketTimeInSeconds,
+          this.consensus.getDifficultyBucketMax(previousSequence + 1),
         )
       }
 

--- a/ironfish/src/consensus/consensus.test.ts
+++ b/ironfish/src/consensus/consensus.test.ts
@@ -16,6 +16,7 @@ describe('Consensus', () => {
     enableAssetOwnership: 7,
     enforceSequentialBlockTime: 8,
     enableFishHash: 9,
+    enableIncreasedDifficultyChange: 10,
   }
 
   const consensus = new Consensus(params)
@@ -25,6 +26,7 @@ describe('Consensus', () => {
     enableAssetOwnership: null,
     enforceSequentialBlockTime: null,
     enableFishHash: null,
+    enableIncreasedDifficultyChange: null,
   })
 
   describe('isActive', () => {
@@ -37,6 +39,7 @@ describe('Consensus', () => {
       expect(consensus.isActive('enableAssetOwnership', 6)).toBe(false)
       expect(consensus.isActive('enforceSequentialBlockTime', 7)).toBe(false)
       expect(consensus.isActive('enableFishHash', 8)).toBe(false)
+      expect(consensus.isActive('enableIncreasedDifficultyChange', 9)).toBe(false)
     })
 
     it('returns true when the sequence is equal to the upgrade number', () => {
@@ -48,6 +51,7 @@ describe('Consensus', () => {
       expect(consensus.isActive('enableAssetOwnership', 7)).toBe(true)
       expect(consensus.isActive('enforceSequentialBlockTime', 8)).toBe(true)
       expect(consensus.isActive('enableFishHash', 9)).toBe(true)
+      expect(consensus.isActive('enableIncreasedDifficultyChange', 10)).toBe(true)
     })
 
     it('returns true when the sequence is greater than the upgrade number', () => {
@@ -59,6 +63,7 @@ describe('Consensus', () => {
       expect(consensus.isActive('enableAssetOwnership', 8)).toBe(true)
       expect(consensus.isActive('enforceSequentialBlockTime', 9)).toBe(true)
       expect(consensus.isActive('enableFishHash', 10)).toBe(true)
+      expect(consensus.isActive('enableIncreasedDifficultyChange', 11)).toBe(true)
     })
 
     it('uses a minimum sequence of 1 if given a smaller sequence', () => {
@@ -71,6 +76,7 @@ describe('Consensus', () => {
       expect(consensusWithInactives.isActive('enableAssetOwnership', 3)).toBe(false)
       expect(consensusWithInactives.isActive('enforceSequentialBlockTime', 3)).toBe(false)
       expect(consensusWithInactives.isActive('enableFishHash', 3)).toBe(false)
+      expect(consensusWithInactives.isActive('enableIncreasedDifficultyChange', 3)).toBe(false)
     })
   })
 
@@ -79,12 +85,14 @@ describe('Consensus', () => {
       expect(consensusWithInactives.isNeverActive('enableAssetOwnership')).toBe(true)
       expect(consensusWithInactives.isNeverActive('enforceSequentialBlockTime')).toBe(true)
       expect(consensusWithInactives.isNeverActive('enableFishHash')).toBe(true)
+      expect(consensusWithInactives.isNeverActive('enableIncreasedDifficultyChange')).toBe(true)
     })
 
     it('returns false if flag has activation sequence', () => {
       expect(consensus.isNeverActive('enableAssetOwnership')).toBe(false)
       expect(consensus.isNeverActive('enforceSequentialBlockTime')).toBe(false)
       expect(consensus.isNeverActive('enableFishHash')).toBe(false)
+      expect(consensus.isNeverActive('enableIncreasedDifficultyChange')).toBe(false)
     })
   })
 
@@ -100,6 +108,19 @@ describe('Consensus', () => {
       expect(consensusWithInactives.getActiveTransactionVersion(5)).toEqual(
         TransactionVersion.V1,
       )
+    })
+  })
+
+  describe('getDifficultyBucketMax', () => {
+    it('returns the correct max bucket number based on activation sequence', () => {
+      expect(consensus.getDifficultyBucketMax(8)).toEqual(99)
+      expect(consensus.getDifficultyBucketMax(9)).toEqual(99)
+      expect(consensus.getDifficultyBucketMax(10)).toEqual(200)
+      expect(consensus.getDifficultyBucketMax(11)).toEqual(200)
+    })
+
+    it('returns 99 when activation flag is never', () => {
+      expect(consensusWithInactives.getDifficultyBucketMax(5)).toEqual(99)
     })
   })
 })

--- a/ironfish/src/consensus/consensus.ts
+++ b/ironfish/src/consensus/consensus.ts
@@ -55,6 +55,12 @@ export type ConsensusParameters = {
    * to the beginning of the block header before mining.
    */
   enableFishHash: ActivationSequence
+
+  /**
+   * Sequence at which to use an increased max bucket in the target calculation,
+   * allowing for a greater per-block downward shift.
+   */
+  enableIncreasedDifficultyChange: ActivationSequence
 }
 
 export class Consensus {
@@ -84,6 +90,14 @@ export class Consensus {
       return TransactionVersion.V2
     } else {
       return TransactionVersion.V1
+    }
+  }
+
+  getDifficultyBucketMax(sequence: number): number {
+    if (this.isActive('enableIncreasedDifficultyChange', sequence)) {
+      return 200
+    } else {
+      return 99
     }
   }
 }

--- a/ironfish/src/consensus/verifier.ts
+++ b/ironfish/src/consensus/verifier.ts
@@ -387,6 +387,7 @@ export class Verifier {
       previous.target,
       this.chain.consensus.parameters.targetBlockTimeInSeconds,
       this.chain.consensus.parameters.targetBucketTimeInSeconds,
+      this.chain.consensus.getDifficultyBucketMax(header.sequence),
     )
 
     return header.target.targetValue === expectedTarget.targetValue

--- a/ironfish/src/mining/soloMiner.ts
+++ b/ironfish/src/mining/soloMiner.ts
@@ -155,6 +155,7 @@ export class MiningSoloMiner {
       this.restartCalculateTargetInterval(
         this.consensus.parameters.targetBlockTimeInSeconds,
         this.consensus.parameters.targetBucketTimeInSeconds,
+        this.consensus.getDifficultyBucketMax(payload.header.sequence),
       )
       this.startNewWork(payload)
     }
@@ -272,6 +273,7 @@ export class MiningSoloMiner {
   private recalculateTarget(
     targetBlockTimeInSeconds: number,
     targetBucketTimeInSeconds: number,
+    maxBuckets: number,
   ) {
     Assert.isNotNull(this.currentHeadTimestamp)
     Assert.isNotNull(this.currentHeadDifficulty)
@@ -287,6 +289,7 @@ export class MiningSoloMiner {
         this.currentHeadDifficulty,
         targetBlockTimeInSeconds,
         targetBucketTimeInSeconds,
+        maxBuckets,
       ),
     )
 
@@ -299,13 +302,14 @@ export class MiningSoloMiner {
   private restartCalculateTargetInterval(
     targetBlockTimeInSeconds: number,
     targetBucketTimeInSeconds: number,
+    maxBuckets: number,
   ) {
     if (this.recalculateTargetInterval) {
       clearInterval(this.recalculateTargetInterval)
     }
 
     this.recalculateTargetInterval = setInterval(() => {
-      this.recalculateTarget(targetBlockTimeInSeconds, targetBucketTimeInSeconds)
+      this.recalculateTarget(targetBlockTimeInSeconds, targetBucketTimeInSeconds, maxBuckets)
     }, RECALCULATE_TARGET_TIMEOUT)
   }
 }

--- a/ironfish/src/networks/definitions/devnet.ts
+++ b/ironfish/src/networks/definitions/devnet.ts
@@ -14,6 +14,7 @@ const DEVNET_CONSENSUS: ConsensusParameters = {
   enableAssetOwnership: 1,
   enforceSequentialBlockTime: 1,
   enableFishHash: null,
+  enableIncreasedDifficultyChange: null,
 }
 
 export const DEVNET_GENESIS = {

--- a/ironfish/src/networks/definitions/mainnet.ts
+++ b/ironfish/src/networks/definitions/mainnet.ts
@@ -15,6 +15,7 @@ const MAINNET_CONSENSUS: ConsensusParameters = {
   enableAssetOwnership: 9999999,
   enforceSequentialBlockTime: null,
   enableFishHash: null,
+  enableIncreasedDifficultyChange: null,
 }
 
 export const MAINNET_GENESIS = {

--- a/ironfish/src/networks/definitions/testnet.ts
+++ b/ironfish/src/networks/definitions/testnet.ts
@@ -15,6 +15,7 @@ const TESTNET_CONSENSUS: ConsensusParameters = {
   enableAssetOwnership: 9999999,
   enforceSequentialBlockTime: null,
   enableFishHash: null,
+  enableIncreasedDifficultyChange: null,
 }
 
 export const TESTNET_GENESIS = {

--- a/ironfish/src/networks/networkDefinition.ts
+++ b/ironfish/src/networks/networkDefinition.ts
@@ -52,6 +52,7 @@ export const networkDefinitionSchema: yup.ObjectSchema<NetworkDefinition> = yup
         enableAssetOwnership: yup.mixed<ActivationSequence>().defined(),
         enforceSequentialBlockTime: yup.mixed<ActivationSequence>().defined(),
         enableFishHash: yup.mixed<ActivationSequence>().defined(),
+        enableIncreasedDifficultyChange: yup.mixed<ActivationSequence>().defined(),
       })
       .defined(),
   })

--- a/ironfish/src/primitives/target.ts
+++ b/ironfish/src/primitives/target.ts
@@ -66,6 +66,7 @@ export class Target {
     previousBlockTarget: Target,
     targetBlockTimeInSeconds: number,
     targetBucketTimeInSeconds: number,
+    maxBuckets: number,
   ): Target {
     const parentDifficulty = previousBlockTarget.toDifficulty()
 
@@ -75,6 +76,7 @@ export class Target {
       parentDifficulty,
       targetBlockTimeInSeconds,
       targetBucketTimeInSeconds,
+      maxBuckets,
     )
 
     return Target.fromDifficulty(difficulty)
@@ -107,6 +109,7 @@ export class Target {
     previousBlockDifficulty: bigint,
     targetBlockTimeInSeconds: number,
     targetBucketTimeInSeconds: number,
+    maxBuckets: number,
   ): bigint {
     const diffInSeconds = (time.getTime() - previousBlockTimestamp.getTime()) / 1000
 
@@ -115,8 +118,8 @@ export class Target {
         targetBucketTimeInSeconds,
     )
 
-    // Should not change difficulty by more than 99 buckets from last block's difficulty
-    bucket = Math.min(bucket, 99)
+    // Should not change difficulty by more than `maxBuckets` buckets from last block's difficulty
+    bucket = Math.min(bucket, maxBuckets)
 
     const difficulty =
       previousBlockDifficulty - (previousBlockDifficulty / 2048n) * BigInt(bucket)

--- a/ironfish/src/rpc/routes/chain/getConsensusParameters.ts
+++ b/ironfish/src/rpc/routes/chain/getConsensusParameters.ts
@@ -26,6 +26,7 @@ export const GetConsensusParametersResponseSchema: yup.ObjectSchema<GetConsensus
       enableAssetOwnership: yup.number().nullable().defined(),
       enforceSequentialBlockTime: yup.number().nullable().defined(),
       enableFishHash: yup.number().nullable().defined(),
+      enableIncreasedDifficultyChange: yup.number().nullable().defined(),
     })
     .defined()
 


### PR DESCRIPTION
## Summary

- Modifies the `Target` class to allow for different max buckets, instead of the previous hard-coded 99 max buckets.
- Introduces a consensus parameter to allow a switch to a larger max buckets value (200) at a hard-fork sequence.

Previously, with 99 buckets, the maximum downward difficulty shift per block was around 4.83%., taking about 16.5 minutes. Once this sequence is activated, the max buckets value will change to 200, allowing a maximum shift downward of around 9.77%, taking roughly 33 minutes to reach this maximum.

This does not affect upward difficulty change.

The goal here is to allow a network to adjust difficulty easier in the event of a large amount of hashrate being removed from the network to maintain stability. The biggest gain here is that Testnet will get stuck less often, requiring less manual intervention. The secondary goal is to allow Mainnet to transition to the much-lower FishHash hashrate easier, and in the event of a large pool going offline, the network will adjust quicker.

**Breaking change and Documentation change will be followed up after the 2nd difficulty PR so I don't have to duplicate work**

## Testing Plan

Unit tests, manual testing

## Documentation

https://github.com/iron-fish/website/pull/607

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[x] Yes
```
