### PR TITLE
fixes BuildTransaction worker task

### DIFF
--- a/ironfish/src/workerPool/pool.ts
+++ b/ironfish/src/workerPool/pool.ts
@@ -142,13 +142,13 @@ export class WorkerPool {
 
   async buildTransaction(
     transaction: RawTransaction,
-    proofGenerationKey: string,
+    proofAuthorizingKey: string,
     viewKey: string,
     outgoingViewKey: string,
   ): Promise<UnsignedTransaction> {
     const request = new BuildTransactionRequest(
       transaction,
-      proofGenerationKey,
+      proofAuthorizingKey,
       viewKey,
       outgoingViewKey,
     )

--- a/ironfish/src/workerPool/tasks/buildTransaction.test.ts
+++ b/ironfish/src/workerPool/tasks/buildTransaction.test.ts
@@ -44,7 +44,7 @@ describe('BuildTransactionRequest', () => {
 
     const request = new BuildTransactionRequest(
       raw,
-      key.proofGenerationKey,
+      key.proofAuthorizingKey,
       account.viewKey,
       account.outgoingViewKey,
     )
@@ -110,7 +110,7 @@ describe('BuildTransactionTask', () => {
 
     const request = new BuildTransactionRequest(
       raw,
-      key.proofGenerationKey,
+      key.proofAuthorizingKey,
       account.viewKey,
       account.outgoingViewKey,
     )


### PR DESCRIPTION
## Summary

uses proofAuthorizingKey instead of proofGenerationKey as input to build

changes sizes of serialization for key change

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
