### PR TITLE
Verify mint ownership on block connect instead of on add

### DIFF
--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -615,7 +615,7 @@ export class Blockchain {
     prev: BlockHeader | null,
     tx: IDatabaseTransaction,
   ): Promise<void> {
-    const verifyBlockAdd = this.verifier.verifyBlockAdd(block, prev, tx).catch((_) => {
+    const verifyBlockAdd = this.verifier.verifyBlockAdd(block, prev).catch((_) => {
       return { valid: false, reason: VerificationResultReason.ERROR }
     })
 
@@ -676,13 +676,13 @@ export class Blockchain {
       await this.reorganizeChain(prev, tx)
     }
 
-    const verifyBlock = this.verifier.verifyBlockAdd(block, prev, tx).catch((_) => {
+    const verifyBlockAdd = this.verifier.verifyBlockAdd(block, prev).catch((_) => {
       return { valid: false, reason: VerificationResultReason.ERROR }
     })
 
     await this.saveBlock(block, prev, false, tx)
 
-    const { valid, reason } = await verifyBlock
+    const { valid, reason } = await verifyBlockAdd
     if (!valid) {
       Assert.isNotUndefined(reason)
 
@@ -959,7 +959,7 @@ export class Blockchain {
       if (verifyBlock && !previousBlockHash.equals(GENESIS_BLOCK_PREVIOUS)) {
         // since we're creating a block that hasn't been mined yet, don't
         // verify target because it'll always fail target check here
-        const verification = await this.verifier.verifyBlock(block, { verifyTarget: false }, tx)
+        const verification = await this.verifier.verifyBlock(block, { verifyTarget: false })
 
         if (!verification.valid) {
           throw new Error(verification.reason)

--- a/ironfish/src/consensus/verifier.test.ts
+++ b/ironfish/src/consensus/verifier.test.ts
@@ -422,7 +422,7 @@ describe('Verifier', () => {
 
       block.transactions[1].mints[0].owner = Buffer.from(accountB.publicAddress, 'hex')
 
-      expect(await nodeTest.verifier.verifyBlock(block)).toMatchObject({
+      expect(await nodeTest.verifier.verifyBlockConnect(block)).toMatchObject({
         reason: VerificationResultReason.INVALID_MINT_OWNER,
         valid: false,
       })

--- a/ironfish/src/consensus/verifier.ts
+++ b/ironfish/src/consensus/verifier.ts
@@ -47,7 +47,6 @@ export class Verifier {
   async verifyBlock(
     block: Block,
     options: { verifyTarget?: boolean } = { verifyTarget: true },
-    tx?: IDatabaseTransaction,
   ): Promise<VerificationResult> {
     if (getBlockSize(block) > this.chain.consensus.parameters.maxBlockSizeBytes) {
       return { valid: false, reason: VerificationResultReason.MAX_BLOCK_SIZE_EXCEEDED }
@@ -69,11 +68,6 @@ export class Verifier {
     // Require the miner's fee transaction
     if (!minersFeeTransaction || !minersFeeTransaction.isMinersFee()) {
       return { valid: false, reason: VerificationResultReason.MINERS_FEE_EXPECTED }
-    }
-
-    const mintOwnersValid = await this.verifyMintOwners(block.mints(), tx)
-    if (!mintOwnersValid.valid) {
-      return mintOwnersValid
     }
 
     // Verify the transactions
@@ -399,11 +393,7 @@ export class Verifier {
   }
 
   // TODO: Rename to verifyBlock but merge verifyBlock into this
-  async verifyBlockAdd(
-    block: Block,
-    prev: BlockHeader | null,
-    tx?: IDatabaseTransaction,
-  ): Promise<VerificationResult> {
+  async verifyBlockAdd(block: Block, prev: BlockHeader | null): Promise<VerificationResult> {
     if (block.header.sequence === GENESIS_BLOCK_SEQUENCE) {
       return { valid: true }
     }
@@ -417,7 +407,7 @@ export class Verifier {
       return verification
     }
 
-    verification = await this.verifyBlock(block, {}, tx)
+    verification = await this.verifyBlock(block, {})
     if (!verification.valid) {
       return verification
     }
@@ -456,6 +446,11 @@ export class Verifier {
     block: Block,
     tx?: IDatabaseTransaction,
   ): Promise<VerificationResult> {
+    const mintOwnersValid = await this.verifyMintOwners(block.mints(), tx)
+    if (!mintOwnersValid.valid) {
+      return mintOwnersValid
+    }
+
     const result = Verifier.verifyInternalNullifiers(block.spends())
     if (!result.valid) {
       return result


### PR DESCRIPTION
## Summary
Asset ownership changes through mints can only be verified for blocks being added to the main chain. We only store the asset owner at the current head so verifying asset ownership on a fork would not work

## Testing Plan
Unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
