### PR TITLE
using proof authorizing key in useUnsignedTxFixture

### DIFF
--- a/ironfish/src/testUtilities/fixtures/transactions.ts
+++ b/ironfish/src/testUtilities/fixtures/transactions.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { Asset, generateKeyFromPrivateKey } from '@ironfish/rust-nodejs'
+import { Asset } from '@ironfish/rust-nodejs'
 import { Assert } from '../../assert'
 import { FullNode } from '../../node'
 import { BurnDescription } from '../../primitives/burnDescription'
@@ -125,10 +125,9 @@ export async function useUnsignedTxFixture(
         expiration: expiration ?? 0,
         expirationDelta: 0,
       })
-      Assert.isNotNull(from.spendingKey)
-      const key = generateKeyFromPrivateKey(from.spendingKey)
+      Assert.isNotNull(from.proofAuthorizingKey)
       const unsignedBuffer = raw
-        .build(key.proofAuthorizingKey, key.viewKey, key.outgoingViewKey)
+        .build(from.proofAuthorizingKey, from.viewKey, from.outgoingViewKey)
         .serialize()
       return new UnsignedTransaction(unsignedBuffer)
     })


### PR DESCRIPTION
## Summary

Now that the account schema contains proof authorizing key we can use it directly instead of generating the signing key

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
