### PR TITLE
adds unsignedTransaction flag to send command

### DIFF
--- a/ironfish-cli/src/commands/wallet/send.ts
+++ b/ironfish-cli/src/commands/wallet/send.ts
@@ -87,6 +87,13 @@ export class Send extends IronfishCommand {
       description:
         'Return raw transaction. Use it to create a transaction but not post to the network',
     }),
+    unsignedTransaction: Flags.boolean({
+      hidden: true,
+      default: false,
+      description:
+        'Return a serialized UnsignedTransaction. Use it to create a transaction and build proofs but not post to the network',
+      exclusive: ['rawTransaction'],
+    }),
     offline: Flags.boolean({
       default: false,
       description: 'Allow offline transaction creation',
@@ -217,6 +224,15 @@ export class Send extends IronfishCommand {
       this.log('Raw Transaction')
       this.log(RawTransactionSerde.serialize(raw).toString('hex'))
       this.log(`Run "ironfish wallet:post" to post the raw transaction. `)
+      this.exit(0)
+    }
+
+    if (flags.unsignedTransaction) {
+      const response = await client.wallet.buildTransaction({
+        rawTransaction: RawTransactionSerde.serialize(raw).toString('hex'),
+      })
+      this.log('Unsigned Transaction')
+      this.log(response.content.unsignedTransaction)
       this.exit(0)
     }
 


### PR DESCRIPTION
## Summary

if flag is set uses the wallet/buildTransaction RPC to build the raw transaction to send

outputs unsigned transaction as hex string before exiting

flag is exclusive to the rawTransaction so that the command will output either a rawTransaction or an unsignedTransaction

flag is hidden

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
