### PR TITLE
Rahul/ifl 2178 remove max signers input from split spender key

### DIFF
--- a/ironfish-rust-nodejs/index.d.ts
+++ b/ironfish-rust-nodejs/index.d.ts
@@ -13,7 +13,7 @@ export interface IdentifierCommitment {
 }
 export function createSigningCommitment(keyPackage: string, seed: number): Commitment
 export function createSigningShare(signingPackage: string, keyPackage: string, publicKeyRandomness: string, seed: number): string
-export function splitSecret(coordinatorSaplingKey: string, minSigners: number, maxSigners: number, identifiers: Array<string>): TrustedDealerKeyPackages
+export function splitSecret(coordinatorSaplingKey: string, minSigners: number, identifiers: Array<string>): TrustedDealerKeyPackages
 export function contribute(inputPath: string, outputPath: string, seed?: string | undefined | null): Promise<string>
 export function verifyTransform(paramsPath: string, newParamsPath: string): Promise<string>
 export const KEY_LENGTH: number

--- a/ironfish-rust-nodejs/src/frost.rs
+++ b/ironfish-rust-nodejs/src/frost.rs
@@ -146,7 +146,6 @@ impl ParticipantIdentity {
 pub fn split_secret(
     coordinator_sapling_key: String,
     min_signers: u16,
-    max_signers: u16,
     identifiers: Vec<String>,
 ) -> Result<TrustedDealerKeyPackages> {
     let coordinator_key =
@@ -161,8 +160,7 @@ pub fn split_secret(
         converted.push(deserialized);
     }
 
-    let t = split_spender_key(&coordinator_key, min_signers, max_signers, converted)
-        .map_err(to_napi_err)?;
+    let t = split_spender_key(&coordinator_key, min_signers, converted).map_err(to_napi_err)?;
 
     let mut key_packages_serialized = Vec::new();
     for (k, v) in t.key_packages.iter() {

--- a/ironfish-rust/src/frost_utils/signing_commitment.rs
+++ b/ironfish-rust/src/frost_utils/signing_commitment.rs
@@ -21,7 +21,6 @@ pub fn create_signing_commitment(
 #[cfg(test)]
 mod test {
     use ff::Field;
-    use ironfish_frost::frost::keys::IdentifierList;
     use jubjub::Fr;
     use rand::rngs::ThreadRng;
 
@@ -32,10 +31,12 @@ mod test {
         let seed = 100;
         let key = Fr::random(&mut rand::thread_rng());
 
+        let identifiers = create_identifiers();
+
         let mut rng = ThreadRng::default();
         let key_packages = split_secret(
             &SecretShareConfig {
-                identifiers: IdentifierList::Default,
+                identifiers,
                 min_signers: 2,
                 secret: key.to_bytes().to_vec(),
             },

--- a/ironfish-rust/src/frost_utils/signing_commitment.rs
+++ b/ironfish-rust/src/frost_utils/signing_commitment.rs
@@ -35,11 +35,10 @@ mod test {
         let mut rng = ThreadRng::default();
         let key_packages = split_secret(
             &SecretShareConfig {
-                max_signers: 3,
+                identifiers: IdentifierList::Default,
                 min_signers: 2,
                 secret: key.to_bytes().to_vec(),
             },
-            IdentifierList::Default,
             &mut rng,
         )
         .expect("key shares to be created");

--- a/ironfish-rust/src/frost_utils/signing_commitment.rs
+++ b/ironfish-rust/src/frost_utils/signing_commitment.rs
@@ -20,18 +20,18 @@ pub fn create_signing_commitment(
 
 #[cfg(test)]
 mod test {
+    use crate::frost_utils::split_secret::{split_secret, SecretShareConfig};
+    use crate::test_util::create_identifiers;
     use ff::Field;
     use jubjub::Fr;
     use rand::rngs::ThreadRng;
-
-    use crate::frost_utils::split_secret::{split_secret, SecretShareConfig};
 
     #[test]
     pub fn test_seed_provides_same_result() {
         let seed = 100;
         let key = Fr::random(&mut rand::thread_rng());
 
-        let identifiers = create_identifiers();
+        let identifiers = create_identifiers(10);
 
         let mut rng = ThreadRng::default();
         let key_packages = split_secret(

--- a/ironfish-rust/src/frost_utils/split_secret.rs
+++ b/ironfish-rust/src/frost_utils/split_secret.rs
@@ -62,7 +62,7 @@ mod test {
 
     #[test]
     fn test_invalid_secret() {
-        let mut identifiers = create_identifiers(10);
+        let identifiers = create_identifiers(10);
 
         let vec = vec![1; 31];
         let config = SecretShareConfig {
@@ -82,7 +82,8 @@ mod test {
 
     #[test]
     fn test_split_secret() {
-        let mut identifiers = create_identifiers(10);
+        let identifiers = create_identifiers(10);
+        let identifiers_length = identifiers.len();
 
         let mut rng = rand::thread_rng();
 
@@ -90,12 +91,12 @@ mod test {
 
         let config = SecretShareConfig {
             min_signers: 2,
-            identifiers: identifiers,
+            identifiers,
             secret: key.to_vec(),
         };
 
         let (key_packages, _) = split_secret(&config, &mut rng).unwrap();
-        assert_eq!(key_packages.len(), 3);
+        assert_eq!(key_packages.len(), identifiers_length);
 
         let key_parts: Vec<_> = key_packages.values().cloned().collect();
 

--- a/ironfish-rust/src/frost_utils/split_secret.rs
+++ b/ironfish-rust/src/frost_utils/split_secret.rs
@@ -57,24 +57,12 @@ pub(crate) fn split_secret(
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::keys::SaplingKey;
-    use ironfish_frost::{
-        frost::{frost::keys::reconstruct, JubjubBlake2b512},
-        participant::Secret,
-    };
-    use rand::thread_rng;
+    use crate::{keys::SaplingKey, test_util::create_identifiers};
+    use ironfish_frost::frost::{frost::keys::reconstruct, JubjubBlake2b512};
 
     #[test]
     fn test_invalid_secret() {
-        let mut identifiers = Vec::new();
-
-        for _ in 0..10 {
-            identifiers.push(
-                Secret::random(thread_rng())
-                    .to_identity()
-                    .to_frost_identifier(),
-            );
-        }
+        let mut identifiers = create_identifiers(10);
 
         let vec = vec![1; 31];
         let config = SecretShareConfig {
@@ -94,15 +82,7 @@ mod test {
 
     #[test]
     fn test_split_secret() {
-        let mut identifiers = Vec::new();
-
-        for _ in 0..10 {
-            identifiers.push(
-                Secret::random(thread_rng())
-                    .to_identity()
-                    .to_frost_identifier(),
-            );
-        }
+        let mut identifiers = create_identifiers(10);
 
         let mut rng = rand::thread_rng();
 

--- a/ironfish-rust/src/frost_utils/split_spender_key.rs
+++ b/ironfish-rust/src/frost_utils/split_spender_key.rs
@@ -87,23 +87,15 @@ pub fn split_spender_key(
 
 #[cfg(test)]
 mod test {
+    use crate::test_util::create_identifiers;
+
     use super::*;
-    use ironfish_frost::{
-        frost::{frost::keys::reconstruct, JubjubBlake2b512},
-        participant::Secret,
-    };
+    use ironfish_frost::frost::{frost::keys::reconstruct, JubjubBlake2b512};
 
     #[test]
     fn test_split_spender_key_success() {
-        let mut identifiers = Vec::new();
+        let mut identifiers = create_identifiers(10);
 
-        for _ in 0..10 {
-            identifiers.push(
-                Secret::random(thread_rng())
-                    .to_identity()
-                    .to_frost_identifier(),
-            );
-        }
         let mut cloned_identifiers = identifiers.clone();
         cloned_identifiers.sort();
 

--- a/ironfish-rust/src/frost_utils/split_spender_key.rs
+++ b/ironfish-rust/src/frost_utils/split_spender_key.rs
@@ -4,7 +4,7 @@
 
 use group::GroupEncoding;
 use ironfish_frost::frost::{
-    keys::{IdentifierList, KeyPackage, PublicKeyPackage},
+    keys::{KeyPackage, PublicKeyPackage},
     Identifier,
 };
 use ironfish_zkp::constants::PROOF_GENERATION_KEY_GENERATOR;
@@ -35,7 +35,6 @@ pub struct TrustedDealerKeyPackages {
 pub fn split_spender_key(
     coordinator_sapling_key: &SaplingKey,
     min_signers: u16,
-    max_signers: u16,
     identifiers: Vec<Identifier>,
 ) -> Result<TrustedDealerKeyPackages, IronfishError> {
     let secret = coordinator_sapling_key
@@ -45,16 +44,13 @@ pub fn split_spender_key(
 
     let secret_config = SecretShareConfig {
         min_signers,
-        max_signers,
+        identifiers,
         secret,
     };
 
-    let identifier_list = IdentifierList::Custom(&identifiers);
-
     let mut rng: rand::prelude::ThreadRng = thread_rng();
 
-    let (key_packages, public_key_package) =
-        split_secret(&secret_config, identifier_list, &mut rng)?;
+    let (key_packages, public_key_package) = split_secret(&secret_config, &mut rng)?;
 
     let authorizing_key_bytes = public_key_package.verifying_key().serialize();
 
@@ -98,35 +94,6 @@ mod test {
     };
 
     #[test]
-    fn test_throws_error_with_mismatch_signer_and_identifiers_lengths() {
-        let mut identifiers = Vec::new();
-
-        for _ in 0..10 {
-            identifiers.push(
-                Secret::random(thread_rng())
-                    .to_identity()
-                    .to_frost_identifier(),
-            );
-        }
-
-        let sapling_key = SaplingKey::generate_key();
-        // max signers > identifiers length
-        let result = split_spender_key(&sapling_key, 5, 11, identifiers.clone());
-        assert!(result.is_err());
-        let err = result.err().unwrap();
-        assert_eq!(err.kind, IronfishErrorKind::FrostLibError);
-        assert!(err.to_string().contains("Incorrect number of identifiers."));
-
-        // max signers < identifiers length
-        let result = split_spender_key(&sapling_key, 5, 9, identifiers.clone());
-
-        assert!(result.is_err());
-        let err = result.err().unwrap();
-        assert_eq!(err.kind, IronfishErrorKind::FrostLibError);
-        assert!(err.to_string().contains("Incorrect number of identifiers."));
-    }
-
-    #[test]
     fn test_split_spender_key_success() {
         let mut identifiers = Vec::new();
 
@@ -143,7 +110,7 @@ mod test {
         let sapling_key = SaplingKey::generate_key();
 
         let trusted_dealer_key_packages =
-            split_spender_key(&sapling_key, 5, 10, identifiers).expect("spender key split failed");
+            split_spender_key(&sapling_key, 5, identifiers).expect("spender key split failed");
 
         assert_eq!(
             trusted_dealer_key_packages.key_packages.len(),

--- a/ironfish-rust/src/frost_utils/split_spender_key.rs
+++ b/ironfish-rust/src/frost_utils/split_spender_key.rs
@@ -94,7 +94,7 @@ mod test {
 
     #[test]
     fn test_split_spender_key_success() {
-        let mut identifiers = create_identifiers(10);
+        let identifiers = create_identifiers(10);
 
         let mut cloned_identifiers = identifiers.clone();
         cloned_identifiers.sort();

--- a/ironfish-rust/src/test_util.rs
+++ b/ironfish-rust/src/test_util.rs
@@ -8,6 +8,7 @@ use super::{
     MerkleNoteHash,
 };
 use blstrs::Scalar;
+use ironfish_frost::{frost::Identifier, participant::Secret};
 use ironfish_zkp::constants::TREE_DEPTH;
 use rand::{thread_rng, Rng};
 
@@ -57,4 +58,19 @@ pub(crate) fn auth_path_to_root_hash(
     }
 
     cur
+}
+
+// Helper function to create a list of random identifiers
+pub fn create_identifiers(num_identifiers: usize) -> Vec<Identifier> {
+    let mut identifiers = Vec::new();
+
+    for _ in 0..num_identifiers {
+        identifiers.push(
+            Secret::random(thread_rng())
+                .to_identity()
+                .to_frost_identifier(),
+        );
+    }
+
+    identifiers
 }

--- a/ironfish-rust/src/test_util.rs
+++ b/ironfish-rust/src/test_util.rs
@@ -60,7 +60,7 @@ pub(crate) fn auth_path_to_root_hash(
     cur
 }
 
-// Helper function to create a list of random identifiers
+// Helper function to create a list of random identifiers for multisig participants.
 pub fn create_identifiers(num_identifiers: usize) -> Vec<Identifier> {
     let mut identifiers = Vec::new();
 

--- a/ironfish-rust/src/transaction/tests.rs
+++ b/ironfish-rust/src/transaction/tests.rs
@@ -707,7 +707,7 @@ fn test_sign_frost() {
     let spender_key = SaplingKey::generate_key();
 
     // create fake participants in multisig
-    let mut identifiers = create_identifiers(10);
+    let identifiers = create_identifiers(10);
 
     // key package generation by trusted dealer
     let key_packages = split_spender_key(&spender_key, 2, identifiers)

--- a/ironfish-rust/src/transaction/tests.rs
+++ b/ironfish-rust/src/transaction/tests.rs
@@ -10,6 +10,7 @@ use super::{ProposedTransaction, Transaction};
 use crate::frost_utils::{
     signing_commitment::create_signing_commitment, signing_share::create_signing_share,
 };
+use crate::test_util::create_identifiers;
 use crate::transaction::tests::split_spender_key::split_spender_key;
 use crate::{
     assets::{asset::Asset, asset_identifier::NATIVE_ASSET},
@@ -29,7 +30,6 @@ use crate::{
 use ff::Field;
 use ironfish_frost::frost::round2::{Randomizer, SignatureShare};
 use ironfish_frost::frost::Identifier;
-use ironfish_frost::participant::Secret;
 use ironfish_zkp::{
     constants::{ASSET_ID_LENGTH, SPENDING_KEY_GENERATOR, TREE_DEPTH},
     proofs::{MintAsset, Output, Spend},
@@ -707,17 +707,10 @@ fn test_sign_frost() {
     let spender_key = SaplingKey::generate_key();
 
     // create fake participants in multisig
-    let mut identifiers = Vec::new();
-    for _ in 0..3 {
-        identifiers.push(
-            Secret::random(thread_rng())
-                .to_identity()
-                .to_frost_identifier(),
-        );
-    }
+    let mut identifiers = create_identifiers(10);
 
     // key package generation by trusted dealer
-    let key_packages = split_spender_key(&spender_key, 2, 3, identifiers)
+    let key_packages = split_spender_key(&spender_key, 2, identifiers)
         .expect("should be able to split spender key");
 
     // create raw/proposed transaction

--- a/ironfish-rust/src/transaction/tests.rs
+++ b/ironfish-rust/src/transaction/tests.rs
@@ -706,7 +706,6 @@ fn test_sign_simple() {
 fn test_sign_frost() {
     let spender_key = SaplingKey::generate_key();
 
-    // create fake participants in multisig
     let identifiers = create_identifiers(10);
 
     // key package generation by trusted dealer

--- a/ironfish/src/rpc/routes/multisig/createTrustedDealerKeyPackage.ts
+++ b/ironfish/src/rpc/routes/multisig/createTrustedDealerKeyPackage.ts
@@ -72,14 +72,10 @@ routes.register<
   CreateTrustedDealerKeyPackageRequestSchema,
   (request, _context): void => {
     const key = generateKey()
-    const { minSigners, maxSigners, participants } = request.data
+    // todo(rahul): remove max signers from request import
+    const { minSigners, maxSigners: _, participants } = request.data
     const identifiers = participants.map((p) => p.identifier)
-    const trustedDealerPackage = splitSecret(
-      key.spendingKey,
-      minSigners,
-      maxSigners,
-      identifiers,
-    )
+    const trustedDealerPackage = splitSecret(key.spendingKey, minSigners, identifiers)
 
     request.end(trustedDealerPackage)
   },

--- a/ironfish/src/wallet/wallet.test.slow.ts
+++ b/ironfish/src/wallet/wallet.test.slow.ts
@@ -1160,7 +1160,6 @@ describe('Wallet', () => {
       const trustedDealerPackage: TrustedDealerKeyPackages = splitSecret(
         coordinatorSaplingKey.spendingKey,
         minSigners,
-        maxSigners,
         identifiers,
       )
 


### PR DESCRIPTION
## Summary

Max signers is always the number of identifiers. There is even a check in frost that confirms this. I believe removing it would be a better user experience and less confusing for the user. 

## Testing Plan

Updated unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
