### PR TITLE
feat(ironfish): Add base64json encoder

### DIFF
--- a/ironfish/src/wallet/account/encoder/base64.json.test.ts
+++ b/ironfish/src/wallet/account/encoder/base64.json.test.ts
@@ -1,0 +1,158 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { generateKey } from '@ironfish/rust-nodejs'
+import { AccountImport } from '../../walletdb/accountValue'
+import { ACCOUNT_SCHEMA_VERSION } from '../account'
+import { BASE64_JSON_ACCOUNT_PREFIX, Base64JsonEncoder } from './base64json'
+
+describe('Base64JsonEncoder', () => {
+  const key = generateKey()
+  const encoder = new Base64JsonEncoder()
+
+  it('encodes the account as a base64 string and decodes the string', () => {
+    const accountImport: AccountImport = {
+      version: ACCOUNT_SCHEMA_VERSION,
+      name: 'test',
+      spendingKey: key.spendingKey,
+      viewKey: key.viewKey,
+      incomingViewKey: key.incomingViewKey,
+      outgoingViewKey: key.outgoingViewKey,
+      publicAddress: key.publicAddress,
+      createdAt: null,
+      proofAuthorizingKey: key.proofAuthorizingKey,
+    }
+
+    const encoded = encoder.encode(accountImport)
+    expect(encoded.startsWith(BASE64_JSON_ACCOUNT_PREFIX)).toBe(true)
+
+    const decoded = encoder.decode(encoded)
+    expect(decoded).toMatchObject(accountImport)
+  })
+
+  it('encodes and decodes accounts with non-null createdAt', () => {
+    const accountImport: AccountImport = {
+      version: ACCOUNT_SCHEMA_VERSION,
+      name: 'test',
+      spendingKey: key.spendingKey,
+      viewKey: key.viewKey,
+      incomingViewKey: key.incomingViewKey,
+      outgoingViewKey: key.outgoingViewKey,
+      publicAddress: key.publicAddress,
+      createdAt: {
+        hash: Buffer.from(
+          '0000000000000000000000000000000000000000000000000000000000000000',
+          'hex',
+        ),
+        sequence: 1,
+      },
+      proofAuthorizingKey: key.proofAuthorizingKey,
+    }
+
+    const encoded = encoder.encode(accountImport)
+    expect(encoded.startsWith(BASE64_JSON_ACCOUNT_PREFIX)).toBe(true)
+
+    const decoded = encoder.decode(encoded)
+    expect(decoded).toMatchObject(accountImport)
+  })
+
+  it('encodes and decodes accounts with proofAuthorizingKey', () => {
+    const accountImport: AccountImport = {
+      version: ACCOUNT_SCHEMA_VERSION,
+      name: 'test',
+      spendingKey: null,
+      viewKey: key.viewKey,
+      incomingViewKey: key.incomingViewKey,
+      outgoingViewKey: key.outgoingViewKey,
+      publicAddress: key.publicAddress,
+      createdAt: null,
+      proofAuthorizingKey: key.proofAuthorizingKey,
+    }
+
+    const encoded = encoder.encode(accountImport)
+    expect(encoded.startsWith(BASE64_JSON_ACCOUNT_PREFIX)).toBe(true)
+
+    const decoded = encoder.decode(encoded)
+    expect(decoded).toMatchObject(accountImport)
+  })
+
+  it('encodes and decodes accounts with multisig coordinator keys', () => {
+    const accountImport: AccountImport = {
+      version: ACCOUNT_SCHEMA_VERSION,
+      name: 'test',
+      spendingKey: null,
+      viewKey: key.viewKey,
+      incomingViewKey: key.incomingViewKey,
+      outgoingViewKey: key.outgoingViewKey,
+      publicAddress: key.publicAddress,
+      createdAt: null,
+      multiSigKeys: {
+        publicKeyPackage: 'abcdef0000',
+      },
+      proofAuthorizingKey: key.proofAuthorizingKey,
+    }
+
+    const encoded = encoder.encode(accountImport)
+    expect(encoded.startsWith(BASE64_JSON_ACCOUNT_PREFIX)).toBe(true)
+
+    const decoded = encoder.decode(encoded)
+    expect(decoded).toMatchObject(accountImport)
+  })
+
+  it('encodes and decodes accounts with multisig signer keys', () => {
+    const accountImport: AccountImport = {
+      version: ACCOUNT_SCHEMA_VERSION,
+      name: 'test',
+      spendingKey: null,
+      viewKey: key.viewKey,
+      incomingViewKey: key.incomingViewKey,
+      outgoingViewKey: key.outgoingViewKey,
+      publicAddress: key.publicAddress,
+      createdAt: null,
+      multiSigKeys: {
+        publicKeyPackage: 'cccc',
+        identifier: 'aaaa',
+        keyPackage: 'bbbb',
+      },
+      proofAuthorizingKey: null,
+    }
+
+    const encoded = encoder.encode(accountImport)
+    expect(encoded.startsWith(BASE64_JSON_ACCOUNT_PREFIX)).toBe(true)
+
+    const decoded = encoder.decode(encoded)
+    expect(decoded).toMatchObject(accountImport)
+  })
+
+  it('encodes and decodes view-only accounts', () => {
+    const accountImport: AccountImport = {
+      version: ACCOUNT_SCHEMA_VERSION,
+      name: 'test',
+      spendingKey: null,
+      viewKey: key.viewKey,
+      incomingViewKey: key.incomingViewKey,
+      outgoingViewKey: key.outgoingViewKey,
+      publicAddress: key.publicAddress,
+      createdAt: null,
+      proofAuthorizingKey: null,
+    }
+
+    const encoded = encoder.encode(accountImport)
+    expect(encoded.startsWith(BASE64_JSON_ACCOUNT_PREFIX)).toBe(true)
+
+    const decoded = encoder.decode(encoded)
+    expect(decoded).toMatchObject(accountImport)
+  })
+
+  it('throws an error when decoding strings without the prefix', () => {
+    const encoded = 'not base64'
+
+    expect(() => encoder.decode(encoded)).toThrow()
+  })
+
+  it('throws an error when decoding non-base64 strings', () => {
+    const encoded = 'ifaccountnot base64'
+
+    expect(() => encoder.decode(encoded)).toThrow()
+  })
+})

--- a/ironfish/src/wallet/account/encoder/base64json.ts
+++ b/ironfish/src/wallet/account/encoder/base64json.ts
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { AccountImport } from '../../walletdb/accountValue'
+import { AccountDecodingOptions, AccountEncoder } from './encoder'
+import { JsonEncoder } from './json'
+
+export const BASE64_JSON_ACCOUNT_PREFIX = 'ifaccount'
+
+export class Base64JsonEncoder implements AccountEncoder {
+  encode(value: AccountImport): string {
+    const encoded = Buffer.from(new JsonEncoder().encode(value)).toString('base64')
+    return `${BASE64_JSON_ACCOUNT_PREFIX}${encoded}`
+  }
+
+  decode(value: string, options?: AccountDecodingOptions): AccountImport {
+    if (!value.startsWith(BASE64_JSON_ACCOUNT_PREFIX)) {
+      throw new Error('Invalid prefix for base64 encoded account')
+    }
+
+    const parts = value.split(BASE64_JSON_ACCOUNT_PREFIX)
+    if (parts.length !== 2) {
+      throw new Error('Invalid format for base64 encoded account')
+    }
+
+    const [_, encoded] = parts
+    const encodedJson = Buffer.from(encoded, 'base64').toString()
+    return new JsonEncoder().decode(encodedJson, options)
+  }
+}


### PR DESCRIPTION
## Summary

Adds a new encoder that takes the output of the json encoder and base64 encodes it. We are using this due to length issues from bech32 with new FROST fields (the public key package is unbounded).

## Testing Plan

Unit test

Example encoded account:
```
ifaccounteyJ2ZXJzaW9uIjo0LCJuYW1lIjoidGVzdCIsInNwZW5kaW5nS2V5IjpudWxsLCJ2aWV3S2V5IjoiYjU5MzhjNGVmN2FhMWJiYzZiMmQzNmJjZmZlOWIxY2M2YWYwMjY4Zjg3OTVhNzE5YTI3MzVhZGRiMjdhMzYwMzEyOTJmMTRhM2IwZjBlZGE5NDdjZDNjMDBjMTljZGVjYzI1Zjg5YjE5NWMyOGU2MmRhZTgzMWU0NWExOGM0NTIiLCJpbmNvbWluZ1ZpZXdLZXkiOiJkZGEyOGQ5ZWYwNjZiMDQ1ZGE1NzQwNzc5MTI0ZTlhNmRkMDkzZjZhMDY1ZWI2ZDhkNjAzNzIyMmU4MDJkNzAwIiwib3V0Z29pbmdWaWV3S2V5IjoiOWY3ZGVkZjMyYTQ4ZmIxYmIxNmUyMmEzYzgyOTNmMjdkY2VmYmZjNmQ3MDkyYjVkODEwYmM4NjcxZmY1ODkyZiIsInB1YmxpY0FkZHJlc3MiOiJlZDIwOGRmNWJiZjE3MjY2Y2IyNzQxMmQ1YzFiYTQzOTE3ODAzYTQyMDQ2ZDM5YmRlMDU4NGUyNmI1Yzk3ZTI1IiwiY3JlYXRlZEF0IjpudWxsLCJwcm9vZkF1dGhvcml6aW5nS2V5IjoiZjBhYTQ5ZmJjMDU1YzQ0NmFlODBiN2Y3ZjVkZjJiZmY0YzJmOTFjNTMwZDE0ZDk2YzM0MzgyYzJkMzA4NjIwYyJ9
```

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
