### PR TITLE
adds multisig/aggregateSigningShares RPC

### DIFF
--- a/ironfish/src/rpc/clients/client.ts
+++ b/ironfish/src/rpc/clients/client.ts
@@ -823,7 +823,7 @@ export abstract class RpcClient {
     },
   }
   multisig = {
-    aggregateSignatureShares: (
+    aggregateSigningShares: (
       params: AggregateSigningSharesRequest,
     ): Promise<RpcResponseEnded<AggregateSigningSharesResponse>> => {
       return this.request<AggregateSigningSharesResponse>(

--- a/ironfish/src/rpc/clients/client.ts
+++ b/ironfish/src/rpc/clients/client.ts
@@ -827,7 +827,7 @@ export abstract class RpcClient {
       params: AggregateSigningSharesRequest,
     ): Promise<RpcResponseEnded<AggregateSigningSharesResponse>> => {
       return this.request<AggregateSigningSharesResponse>(
-        `${ApiNamespace.multisig}/aggregateSignatureShares`,
+        `${ApiNamespace.multisig}/aggregateSigningShares`,
         params,
       ).waitForEnd()
     },

--- a/ironfish/src/rpc/clients/client.ts
+++ b/ironfish/src/rpc/clients/client.ts
@@ -9,6 +9,8 @@ import type {
   AddPeerResponse,
   AddTransactionRequest,
   AddTransactionResponse,
+  AggregateSigningSharesRequest,
+  AggregateSigningSharesResponse,
   BlockTemplateStreamRequest,
   BlockTemplateStreamResponse,
   BroadcastTransactionRequest,
@@ -821,6 +823,15 @@ export abstract class RpcClient {
     },
   }
   multisig = {
+    aggregateSignatureShares: (
+      params: AggregateSigningSharesRequest,
+    ): Promise<RpcResponseEnded<AggregateSigningSharesResponse>> => {
+      return this.request<AggregateSigningSharesResponse>(
+        `${ApiNamespace.multisig}/aggregateSignatureShares`,
+        params,
+      ).waitForEnd()
+    },
+
     createTrustedDealerKeyPackage: (
       params: CreateTrustedDealerKeyPackageRequest,
     ): Promise<RpcResponseEnded<CreateTrustedDealerKeyPackageResponse>> => {

--- a/ironfish/src/rpc/routes/multisig/aggregateSigningShares.ts
+++ b/ironfish/src/rpc/routes/multisig/aggregateSigningShares.ts
@@ -1,0 +1,73 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { UnsignedTransaction } from '@ironfish/rust-nodejs'
+import * as yup from 'yup'
+import { ApiNamespace } from '../namespaces'
+import { routes } from '../router'
+
+export type AggregateSigningSharesRequest = {
+  publicKeyPackage: string
+  unsignedTransaction: string
+  signingPackage: string
+  signingShares: Array<{
+    identifier: string
+    signingShare: string
+  }>
+}
+
+export type AggregateSigningSharesResponse = {
+  transaction: string
+}
+
+export const AggregateSigningSharesRequestSchema: yup.ObjectSchema<AggregateSigningSharesRequest> =
+  yup
+    .object({
+      publicKeyPackage: yup.string().defined(),
+      unsignedTransaction: yup.string().defined(),
+      signingPackage: yup.string().defined(),
+      signingShares: yup
+        .array(
+          yup
+            .object({
+              identifier: yup.string().defined(),
+              signingShare: yup.string().defined(),
+            })
+            .defined(),
+        )
+        .defined(),
+    })
+    .defined()
+
+export const AggregateSigningSharesResponseSchema: yup.ObjectSchema<AggregateSigningSharesResponse> =
+  yup
+    .object({
+      transaction: yup.string().defined(),
+    })
+    .defined()
+
+routes.register<typeof AggregateSigningSharesRequestSchema, AggregateSigningSharesResponse>(
+  `${ApiNamespace.multisig}/aggregateSigningShares`,
+  AggregateSigningSharesRequestSchema,
+  (request, _context): void => {
+    const unsigned = new UnsignedTransaction(
+      Buffer.from(request.data.unsignedTransaction, 'hex'),
+    )
+
+    // TODO(hughy): change interface of signFrost to take Array of shares instead of Record
+    const signingShares: Record<string, string> = {}
+    for (const { identifier, signingShare } of request.data.signingShares) {
+      signingShares[identifier] = signingShare
+    }
+
+    const transaction = unsigned.signFrost(
+      request.data.publicKeyPackage,
+      request.data.signingPackage,
+      signingShares,
+    )
+
+    request.end({
+      transaction: transaction.toString('hex'),
+    })
+  },
+)

--- a/ironfish/src/rpc/routes/multisig/index.ts
+++ b/ironfish/src/rpc/routes/multisig/index.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+export * from './aggregateSigningShares'
 export * from './createSigningCommitment'
 export * from './createSigningPackage'
 export * from './createTrustedDealerKeyPackage'


### PR DESCRIPTION
## Summary

takes a publicKeyPackage, an unsignedTransaction, a signingPackage for that transaction, and a list of signatureShares for that signingPackage

uses UnsignedTransaction.signFrost to aggregate the signatureShares, sign the transaction, and produce a signed transaction

returns a signed transaction serialized as hex

## Testing Plan

RPC integration test will be added in a followup PR

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
