### PR TITLE
allows minting asset with 0 supply

### DIFF
--- a/ironfish-cli/src/commands/wallet/mint.ts
+++ b/ironfish-cli/src/commands/wallet/mint.ts
@@ -193,7 +193,7 @@ export class Mint extends IronfishCommand {
         client: client,
         required: true,
         text: 'Enter the amount',
-        minimum: 1n,
+        minimum: 0n,
         logger: this.logger,
       })
     }

--- a/ironfish/src/rpc/routes/wallet/createTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/createTransaction.ts
@@ -72,7 +72,7 @@ export const CreateTransactionRequestSchema: yup.ObjectSchema<CreateTransactionR
             assetId: yup.string().optional(),
             name: yup.string().optional().max(ASSET_NAME_LENGTH),
             metadata: yup.string().optional().max(ASSET_METADATA_LENGTH),
-            value: YupUtils.currency({ min: 1n }).defined(),
+            value: YupUtils.currency({ min: 0n }).defined(),
             transferOwnershipTo: yup.string().optional(),
           })
           .defined(),

--- a/ironfish/src/rpc/routes/wallet/mintAsset.test.ts
+++ b/ironfish/src/rpc/routes/wallet/mintAsset.test.ts
@@ -42,7 +42,7 @@ describe('Route wallet/mintAsset', () => {
           value: '-1',
         }),
       ).rejects.toThrow(
-        'Request failed (400) validation: value must be equal to or greater than 1',
+        'Request failed (400) validation: value must be equal to or greater than 0',
       )
     })
   })

--- a/ironfish/src/rpc/routes/wallet/mintAsset.ts
+++ b/ironfish/src/rpc/routes/wallet/mintAsset.ts
@@ -36,7 +36,7 @@ export const MintAssetRequestSchema: yup.ObjectSchema<MintAssetRequest> = yup
   .object({
     account: yup.string().required(),
     fee: YupUtils.currency({ min: 1n }).defined(),
-    value: YupUtils.currency({ min: 1n }).defined(),
+    value: YupUtils.currency({ min: 0n }).defined(),
     assetId: yup.string().optional(),
     expiration: yup.number().optional(),
     expirationDelta: yup.number().optional(),


### PR DESCRIPTION
## Summary

removes minimum mint amount from cli, rpc endpoints

it is useful to be able to mint an asset with 0 supply. for example, create an asset before minting tokens corresponding to deposits

## Testing Plan

- manually created asset with 0 supply, asset displayed in `wallet:assets` command

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
