### PR TITLE
adds function to assert that an account is a multisig account

### DIFF
--- a/ironfish/src/utils/types.ts
+++ b/ironfish/src/utils/types.ts
@@ -56,3 +56,6 @@ export function HasOwnProperty<X extends {}, Y extends PropertyKey>(obj: X, prop
 // ie Account.spendingKey = string | null
 // with WithNonNull<Account, 'spendingKey'>, the return type has Account.spendingKey = string
 export type WithNonNull<T, K extends keyof T> = T & { [P in K]: NonNullable<T[P]> }
+
+// When used requires that an optional property K be defined in type T
+export type WithRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] }

--- a/ironfish/src/wallet/account/account.ts
+++ b/ironfish/src/wallet/account/account.ts
@@ -10,7 +10,7 @@ import { GENESIS_BLOCK_SEQUENCE } from '../../primitives/block'
 import { Note } from '../../primitives/note'
 import { DatabaseKeyRange, IDatabaseTransaction } from '../../storage'
 import { StorageUtils } from '../../storage/database/utils'
-import { WithNonNull } from '../../utils'
+import { WithNonNull, WithRequired } from '../../utils'
 import { DecryptedNote } from '../../workerPool/tasks/decryptNotes'
 import { AssetBalances } from '../assetBalances'
 import { MultiSigKeys } from '../interfaces/multiSigKeys'
@@ -31,6 +31,15 @@ export type SpendingAccount = WithNonNull<Account, 'spendingKey'>
 
 export function AssertSpending(account: Account): asserts account is SpendingAccount {
   Assert.isTrue(account.isSpendingAccount())
+}
+
+export type MultiSigAccount = WithRequired<Account, 'multiSigKeys'>
+
+export function AssertMultiSig(account: Account): asserts account is MultiSigAccount {
+  Assert.isNotUndefined(
+    account.multiSigKeys,
+    `Account ${account.name} is not a multisig account`,
+  )
 }
 
 export class Account {


### PR DESCRIPTION
## Summary

we are changing a number of multisig RPCs to accept an 'account' parameter in requests

we will need to assert that the account passed to each one is a multisig account

adds an assertion for convenience that asserts that an account is a multisig account

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
