### PR TITLE
Rahul/ifl 2187 replace keypackage with account name input for

### DIFF
--- a/ironfish/src/rpc/routes/wallet/multisig/createSigningCommitment.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/createSigningCommitment.ts
@@ -4,6 +4,7 @@
 import { createSigningCommitment } from '@ironfish/rust-nodejs'
 import * as yup from 'yup'
 import { Assert } from '../../../../assert'
+import { AssertMultiSig } from '../../../../wallet/account/account'
 import { AssertIsSignerMultiSig } from '../../../../wallet/account/encoder/multiSigKeys'
 import { ApiNamespace } from '../../namespaces'
 import { routes } from '../../router'
@@ -38,8 +39,7 @@ routes.register<typeof CreateSigningCommitmentRequestSchema, CreateSigningCommit
 
     const account = getAccount(context.wallet, request.data.account)
 
-    // todo: update this with an assertion for account being a multiSig account
-    Assert.isNotUndefined(account.multiSigKeys)
+    AssertMultiSig(account)
     AssertIsSignerMultiSig(account.multiSigKeys)
 
     const result = createSigningCommitment(account.multiSigKeys.keyPackage, request.data.seed)

--- a/ironfish/src/rpc/routes/wallet/multisig/createSigningCommitment.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/createSigningCommitment.ts
@@ -3,7 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { createSigningCommitment } from '@ironfish/rust-nodejs'
 import * as yup from 'yup'
-import { Assert } from '../../../../assert'
 import { AssertMultiSig } from '../../../../wallet/account/account'
 import { AssertIsSignerMultiSig } from '../../../../wallet/account/encoder/multiSigKeys'
 import { ApiNamespace } from '../../namespaces'
@@ -35,7 +34,6 @@ routes.register<typeof CreateSigningCommitmentRequestSchema, CreateSigningCommit
   CreateSigningCommitmentRequestSchema,
   (request, context): void => {
     AssertHasRpcContext(request, context, 'wallet')
-    Assert.isNotNull(context.wallet.nodeClient)
 
     const account = getAccount(context.wallet, request.data.account)
 

--- a/ironfish/src/rpc/routes/wallet/types.ts
+++ b/ironfish/src/rpc/routes/wallet/types.ts
@@ -147,7 +147,6 @@ export type RpcAccountImport = {
   outgoingViewKey: string
   publicAddress: string
   spendingKey: string | null
-
   createdAt: { hash: string; sequence: number } | null
   multiSigKeys?: RpcMultiSigKeys
   proofAuthorizingKey: string | null


### PR DESCRIPTION
## Summary

Changes create signing commitment RPC to accept account name as input instead of the keyPackage

## Testing Plan

Unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
