### PR TITLE
changes createSigningShare RPC to take an account name

### DIFF
--- a/ironfish/src/rpc/routes/wallet/multisig/__fixtures__/createSigningShare.test.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/multisig/__fixtures__/createSigningShare.test.ts.fixture
@@ -1,0 +1,22 @@
+{
+  "Route multisig/createSigningShare should fail for an account that does not have multisig keys": [
+    {
+      "version": 4,
+      "id": "ef8a8d12-b4c2-48ba-952c-8cf7b398bd82",
+      "name": "test",
+      "spendingKey": "fe24aa5ec0df39f47a4a3a464ad7ccd6df7a94387a4becdcdc8273e7bd6f2775",
+      "viewKey": "2a4f6a8bdbd8ad56cb33b17481b75887131894ab0ad51418d66e7ba7483cb8ef1b0147cc4dec2daee8871072dce331fc2b94116fa31528ff0315c021c5696ece",
+      "incomingViewKey": "e692cb799f7711f460fcd167c5d9f15327aa7e5ee5dadca37ef9583812b73c01",
+      "outgoingViewKey": "d1a3d4d19b6ee59122e76e35ae93b0e240708971e90f1c3dbc55ac4b1d627e24",
+      "publicAddress": "238e1bfb3d867cb811346acb53832ab041ee1014862d10ae0ccbd03d6f357a2a",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+        },
+        "sequence": 1
+      },
+      "proofAuthorizingKey": "b8f276b6a86c3b5ff8e100a03d74cac15ff705aab41ff9577d1c88a57ac85909"
+    }
+  ]
+}

--- a/ironfish/src/rpc/routes/wallet/multisig/createSigningShare.test.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/createSigningShare.test.ts
@@ -1,0 +1,55 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { generateKey } from '@ironfish/rust-nodejs'
+import { createRouteTest } from '../../../../testUtilities/routeTest'
+import { ACCOUNT_SCHEMA_VERSION } from '../../../../wallet'
+
+describe('Route multisig/createSigningShare', () => {
+  const routeTest = createRouteTest()
+
+  it('should fail for an account that does not exist', async () => {
+    await expect(
+      routeTest.client.wallet.multisig.createSigningShare({
+        account: 'non-existent',
+        signingPackage: 'fake',
+        unsignedTransaction: 'deadbeef',
+        seed: 420,
+      }),
+    ).rejects.toThrow(
+      expect.objectContaining({
+        message: expect.stringContaining('No account with name'),
+        status: 400,
+      }),
+    )
+  })
+
+  it('should fail for an account that does not have multisig keys', async () => {
+    const key = generateKey()
+
+    const accountImport = {
+      ...key,
+      id: '1',
+      name: 'fake coordinator',
+      version: ACCOUNT_SCHEMA_VERSION,
+      spendingKey: null,
+      createdAt: null,
+      multiSigKeys: { publicKeyPackage: 'abcd' },
+    }
+
+    const account = await routeTest.wallet.importAccount(accountImport)
+
+    await expect(
+      routeTest.client.wallet.multisig.createSigningShare({
+        account: account.name,
+        signingPackage: 'fake',
+        unsignedTransaction: 'deadbeef',
+        seed: 420,
+      }),
+    ).rejects.toThrow(
+      expect.objectContaining({
+        status: 400,
+      }),
+    )
+  })
+})


### PR DESCRIPTION
## Summary

changes the RPC to take an account name as a request parameter instead of a serialized keyPackage

loads the account for the given name and asserts that it is a multisig signing account before using the keyPackage from that account

this avoids passing a keyPackage, which contains a sensitive secret, from being passed through an RPC request

## Testing Plan

- updates to follow in integration test (#4681)

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
