### PR TITLE
refactor: serialization signature share

### DIFF
--- a/ironfish-rust-nodejs/index.d.ts
+++ b/ironfish-rust-nodejs/index.d.ts
@@ -9,7 +9,7 @@ export interface Commitment {
   binding: string
 }
 export function createSigningCommitment(keyPackage: string, seed: number): Commitment
-export function createSigningShare(signingPackage: string, keyPackage: string, publicKeyRandomness: string, seed: number): string
+export function createSigningShare(signingPackage: string, identifier: string, keyPackage: string, publicKeyRandomness: string, seed: number): string
 export function splitSecret(coordinatorSaplingKey: string, minSigners: number, identifiers: Array<string>): TrustedDealerKeyPackages
 export function contribute(inputPath: string, outputPath: string, seed?: string | undefined | null): Promise<string>
 export function verifyTransform(paramsPath: string, newParamsPath: string): Promise<string>
@@ -249,7 +249,7 @@ export class UnsignedTransaction {
   publicKeyRandomness(): string
   signingPackage(nativeIdentiferCommitments: Array<Commitment>): string
   sign(spenderHexKey: string): Buffer
-  signFrost(publicKeyPackageStr: string, signingPackageStr: string, signatureSharesMap: Record<string, string>): Buffer
+  signFrost(publicKeyPackageStr: string, signingPackageStr: string, signatureSharesArr: Array<string>): Buffer
 }
 export class FoundBlockResult {
   randomness: string

--- a/ironfish-rust-nodejs/src/frost.rs
+++ b/ironfish-rust-nodejs/src/frost.rs
@@ -8,10 +8,10 @@ use crate::{
 };
 use ironfish::{
     frost::{keys::KeyPackage, round2::Randomizer, Identifier, SigningPackage},
-    frost_utils::split_spender_key::split_spender_key,
     frost_utils::{
         signing_commitment::create_signing_commitment as create_signing_commitment_rust,
         signing_share::create_signing_share as create_signing_share_rust,
+        split_spender_key::split_spender_key,
     },
     participant::{Identity, Secret},
     serializing::{bytes_to_hex, fr::FrSerializable, hex_to_bytes, hex_to_vec_bytes},
@@ -44,10 +44,13 @@ pub fn create_signing_commitment(key_package: String, seed: u32) -> Result<Nativ
 #[napi]
 pub fn create_signing_share(
     signing_package: String,
+    identifier: String,
     key_package: String,
     public_key_randomness: String,
     seed: u32,
 ) -> Result<String> {
+    let identifier = Identifier::deserialize(&hex_to_bytes(&identifier).map_err(to_napi_err)?)
+        .map_err(to_napi_err)?;
     let key_package =
         KeyPackage::deserialize(&hex_to_vec_bytes(&key_package).map_err(to_napi_err)?[..])
             .map_err(to_napi_err)?;
@@ -58,9 +61,14 @@ pub fn create_signing_share(
         Randomizer::deserialize(&hex_to_bytes(&public_key_randomness).map_err(to_napi_err)?)
             .map_err(to_napi_err)?;
 
-    let signature_share =
-        create_signing_share_rust(signing_package, key_package, randomizer, seed as u64)
-            .map_err(to_napi_err)?;
+    let signature_share = create_signing_share_rust(
+        signing_package,
+        identifier,
+        key_package,
+        randomizer,
+        seed as u64,
+    )
+    .map_err(to_napi_err)?;
 
     Ok(bytes_to_hex(&signature_share.serialize()))
 }

--- a/ironfish-rust-nodejs/src/structs/transaction.rs
+++ b/ironfish-rust-nodejs/src/structs/transaction.rs
@@ -4,16 +4,17 @@
 
 use std::cell::RefCell;
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 use std::convert::TryInto;
 
 use ironfish::assets::asset_identifier::AssetIdentifier;
 use ironfish::frost::frost::round1::NonceCommitment;
 use ironfish::frost::keys::PublicKeyPackage;
 use ironfish::frost::round1::SigningCommitments;
-use ironfish::frost::round2::SignatureShare;
+use ironfish::frost::round2::SignatureShare as FrostSignatureShare;
 use ironfish::frost::Identifier;
 use ironfish::frost::SigningPackage;
+use ironfish::frost_utils::signing_share::SignatureShare;
 use ironfish::serializing::fr::FrSerializable;
 use ironfish::serializing::hex_to_vec_bytes;
 use ironfish::serializing::{bytes_to_hex, hex_to_bytes};
@@ -464,7 +465,7 @@ impl NativeUnsignedTransaction {
         &mut self,
         public_key_package_str: String,
         signing_package_str: String,
-        signature_shares_map: HashMap<String, String>,
+        signature_shares_arr: Vec<String>,
     ) -> Result<Buffer> {
         let public_key_package = PublicKeyPackage::deserialize(
             &hex_to_vec_bytes(&public_key_package_str).map_err(to_napi_err)?,
@@ -474,14 +475,12 @@ impl NativeUnsignedTransaction {
             &hex_to_vec_bytes(&signing_package_str).map_err(to_napi_err)?,
         )
         .map_err(to_napi_err)?;
-        let mut signature_shares = BTreeMap::<Identifier, SignatureShare>::new();
-        for (k, v) in signature_shares_map.iter() {
-            let identifier = Identifier::deserialize(&hex_to_bytes(k).map_err(to_napi_err)?)
-                .map_err(to_napi_err)?;
-            let signature_share =
-                SignatureShare::deserialize(hex_to_bytes(v).map_err(to_napi_err)?)
+        let mut signature_shares = BTreeMap::<Identifier, FrostSignatureShare>::new();
+        for signature_share in signature_shares_arr.iter() {
+            let iss =
+                SignatureShare::deserialize(&hex_to_bytes(signature_share).map_err(to_napi_err)?)
                     .map_err(to_napi_err)?;
-            signature_shares.insert(identifier, signature_share);
+            signature_shares.insert(iss.identifier, iss.signature_share);
         }
 
         let signed_transaction = self

--- a/ironfish-rust/src/errors.rs
+++ b/ironfish-rust/src/errors.rs
@@ -40,6 +40,8 @@ pub enum IronfishErrorKind {
     InvalidDiversificationPoint,
     InvalidEntropy,
     InvalidFr,
+    InvalidFrostIdentifier,
+    InvalidFrostSignatureShare,
     InvalidLanguageEncoding,
     InvalidMinersFeeTransaction,
     InvalidMintProof,

--- a/ironfish-rust/src/frost_utils/signing_share.rs
+++ b/ironfish-rust/src/frost_utils/signing_share.rs
@@ -6,22 +6,62 @@ use ironfish_frost::frost::{
     self,
     keys::KeyPackage,
     round1::SigningNonces,
-    round2::{Randomizer, SignatureShare},
-    SigningPackage,
+    round2::{Randomizer, SignatureShare as FrostSignatureShare},
+    Identifier, SigningPackage,
 };
 use rand::{rngs::StdRng, SeedableRng};
 
 use crate::errors::{IronfishError, IronfishErrorKind};
 
+pub struct SignatureShare {
+    pub identifier: Identifier,
+    pub signature_share: FrostSignatureShare,
+}
+
+impl SignatureShare {
+    pub fn serialize(&self) -> [u8; 64] {
+        let identifier_bytes = self.identifier.serialize();
+        let signature_share_bytes = self.signature_share.serialize();
+        let mut combined: [u8; 64] = [0; 64];
+        combined[..32].copy_from_slice(&identifier_bytes);
+        combined[32..].copy_from_slice(&signature_share_bytes);
+        combined
+    }
+
+    pub fn deserialize(bytes: &[u8; 64]) -> Result<SignatureShare, IronfishError> {
+        let mut identifier_bytes = [0u8; 32];
+        let mut signature_share_bytes = [0u8; 32];
+        identifier_bytes.copy_from_slice(&bytes[..32]);
+        signature_share_bytes.copy_from_slice(&bytes[32..]);
+
+        Ok(SignatureShare {
+            identifier: Identifier::deserialize(&identifier_bytes).map_err(|e| {
+                IronfishError::new_with_source(IronfishErrorKind::InvalidFrostIdentifier, e)
+            })?,
+            signature_share: FrostSignatureShare::deserialize(signature_share_bytes).map_err(
+                |e| {
+                    IronfishError::new_with_source(IronfishErrorKind::InvalidFrostSignatureShare, e)
+                },
+            )?,
+        })
+    }
+}
+
 // Wrapper around frost::round2::sign that provides a seedable rng from u64
 pub fn create_signing_share(
     signing_package: SigningPackage,
+    identifier: Identifier,
     key_package: KeyPackage,
     randomizer: Randomizer,
     seed: u64,
 ) -> Result<SignatureShare, IronfishError> {
     let mut rng = StdRng::seed_from_u64(seed);
     let signer_nonces = SigningNonces::new(key_package.signing_share(), &mut rng);
-    frost::round2::sign(&signing_package, &signer_nonces, &key_package, randomizer)
-        .map_err(|_| IronfishError::new(IronfishErrorKind::RoundTwoSigningFailure))
+    let signature_share =
+        frost::round2::sign(&signing_package, &signer_nonces, &key_package, randomizer)
+            .map_err(|_| IronfishError::new(IronfishErrorKind::RoundTwoSigningFailure))?;
+    Ok(SignatureShare {
+        identifier,
+        signature_share,
+    })
 }

--- a/ironfish-rust/src/transaction/tests.rs
+++ b/ironfish-rust/src/transaction/tests.rs
@@ -801,12 +801,13 @@ fn test_sign_frost() {
     for key_package in key_packages.key_packages.iter() {
         let signature_share = create_signing_share(
             signing_package.clone(),
+            *key_package.0,
             key_package.1.clone(),
             randomizer,
             0,
         )
         .expect("should be able to create signature share");
-        signing_shares.insert(*key_package.0, signature_share);
+        signing_shares.insert(signature_share.identifier, signature_share.signature_share);
     }
 
     // coordinator creates signed transaction

--- a/ironfish/src/rpc/routes/wallet/multisig/aggregateSigningShares.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/aggregateSigningShares.ts
@@ -13,10 +13,7 @@ export type AggregateSigningSharesRequest = {
   account: string
   unsignedTransaction: string
   signingPackage: string
-  signingShares: Array<{
-    identifier: string
-    signingShare: string
-  }>
+  signingShares: Array<string>
 }
 
 export type AggregateSigningSharesResponse = {
@@ -29,16 +26,7 @@ export const AggregateSigningSharesRequestSchema: yup.ObjectSchema<AggregateSign
       account: yup.string().defined(),
       unsignedTransaction: yup.string().defined(),
       signingPackage: yup.string().defined(),
-      signingShares: yup
-        .array(
-          yup
-            .object({
-              identifier: yup.string().defined(),
-              signingShare: yup.string().defined(),
-            })
-            .defined(),
-        )
-        .defined(),
+      signingShares: yup.array(yup.string().defined()).defined(),
     })
     .defined()
 
@@ -61,17 +49,10 @@ routes.register<typeof AggregateSigningSharesRequestSchema, AggregateSigningShar
     const unsigned = new UnsignedTransaction(
       Buffer.from(request.data.unsignedTransaction, 'hex'),
     )
-
-    // TODO(hughy): change interface of signFrost to take Array of shares instead of Record
-    const signingShares: Record<string, string> = {}
-    for (const { identifier, signingShare } of request.data.signingShares) {
-      signingShares[identifier] = signingShare
-    }
-
     const transaction = unsigned.signFrost(
       account.multiSigKeys.publicKeyPackage,
       request.data.signingPackage,
-      signingShares,
+      request.data.signingShares,
     )
 
     request.end({

--- a/ironfish/src/rpc/routes/wallet/multisig/createSigningShare.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/createSigningShare.ts
@@ -52,6 +52,7 @@ routes.register<typeof CreateSigningShareRequestSchema, CreateSigningShareRespon
     )
     const result = createSigningShare(
       request.data.signingPackage,
+      account.multiSigKeys.identifier,
       account.multiSigKeys.keyPackage,
       unsigned.publicKeyRandomness(),
       request.data.seed,

--- a/ironfish/src/wallet/wallet.test.slow.ts
+++ b/ironfish/src/wallet/wallet.test.slow.ts
@@ -1285,16 +1285,19 @@ describe('Wallet', () => {
       const signingPackage = unsignedTransaction.signingPackage(signingCommitments)
       const publicKeyRandomness = unsignedTransaction.publicKeyRandomness()
 
-      const signatureShares: Record<string, string> = {}
+      const signatureShares: Array<string> = []
 
       for (const participant of participants) {
         Assert.isNotUndefined(participant.multiSigKeys)
         AssertIsSignerMultiSig(participant.multiSigKeys)
-        signatureShares[participant.multiSigKeys.identifier] = createSigningShare(
-          signingPackage,
-          participant.multiSigKeys.keyPackage,
-          publicKeyRandomness,
-          seed,
+        signatureShares.push(
+          createSigningShare(
+            signingPackage,
+            participant.multiSigKeys.identifier,
+            participant.multiSigKeys.keyPackage,
+            publicKeyRandomness,
+            seed,
+          ),
         )
       }
 


### PR DESCRIPTION
## Summary
Updates serialization of signature share to include identifier. This allows us to have a single string output for the identifier/signingShare.

Note: We now have to pass in identifier to this method just so the serialization can include identifier in the hex string.
## Testing Plan

Tests pass

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
