### PR TITLE
chore: refactor sign frost naming

### DIFF
--- a/ironfish-rust-nodejs/index.d.ts
+++ b/ironfish-rust-nodejs/index.d.ts
@@ -249,7 +249,7 @@ export class UnsignedTransaction {
   publicKeyRandomness(): string
   signingPackage(nativeIdentiferCommitments: Array<Commitment>): string
   sign(spenderHexKey: string): Buffer
-  signFrost(publicKeyPackageStr: string, signingPackageStr: string, signatureSharesArr: Array<string>): Buffer
+  aggregateSignatureShares(publicKeyPackageStr: string, signingPackageStr: string, signatureSharesArr: Array<string>): Buffer
 }
 export class FoundBlockResult {
   randomness: string

--- a/ironfish-rust-nodejs/src/structs/transaction.rs
+++ b/ironfish-rust-nodejs/src/structs/transaction.rs
@@ -461,7 +461,7 @@ impl NativeUnsignedTransaction {
     }
 
     #[napi]
-    pub fn sign_frost(
+    pub fn aggregate_signature_shares(
         &mut self,
         public_key_package_str: String,
         signing_package_str: String,
@@ -485,7 +485,7 @@ impl NativeUnsignedTransaction {
 
         let signed_transaction = self
             .transaction
-            .sign_frost(&public_key_package, &signing_package, signature_shares)
+            .aggregate_signature_shares(&public_key_package, &signing_package, signature_shares)
             .map_err(to_napi_err)?;
 
         let mut vec: Vec<u8> = vec![];

--- a/ironfish-rust/src/transaction/tests.rs
+++ b/ironfish-rust/src/transaction/tests.rs
@@ -703,7 +703,7 @@ fn test_sign_simple() {
 }
 
 #[test]
-fn test_sign_frost() {
+fn test_aggregate_signature_shares() {
     let spender_key = SaplingKey::generate_key();
 
     let identifiers = create_identifiers(10);
@@ -812,7 +812,7 @@ fn test_sign_frost() {
 
     // coordinator creates signed transaction
     let signed_transaction = unsigned_transaction
-        .sign_frost(
+        .aggregate_signature_shares(
             &key_packages.public_key_package,
             &signing_package,
             signing_shares,

--- a/ironfish-rust/src/transaction/unsigned.rs
+++ b/ironfish-rust/src/transaction/unsigned.rs
@@ -193,7 +193,7 @@ impl UnsignedTransaction {
         Ok(hash_result)
     }
 
-    pub fn sign_frost(
+    pub fn aggregate_signature_shares(
         &mut self,
         public_key_package: &PublicKeyPackage,
         authorizing_signing_package: &SigningPackage,

--- a/ironfish/src/rpc/routes/wallet/multisig/aggregateSigningShares.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/aggregateSigningShares.ts
@@ -49,7 +49,7 @@ routes.register<typeof AggregateSigningSharesRequestSchema, AggregateSigningShar
     const unsigned = new UnsignedTransaction(
       Buffer.from(request.data.unsignedTransaction, 'hex'),
     )
-    const transaction = unsigned.signFrost(
+    const transaction = unsigned.aggregateSignatureShares(
       account.multiSigKeys.publicKeyPackage,
       request.data.signingPackage,
       request.data.signingShares,

--- a/ironfish/src/wallet/wallet.test.slow.ts
+++ b/ironfish/src/wallet/wallet.test.slow.ts
@@ -1302,7 +1302,7 @@ describe('Wallet', () => {
       }
 
       Assert.isNotUndefined(coordinator.multiSigKeys)
-      const serializedFrostTransaction = unsignedTransaction.signFrost(
+      const serializedFrostTransaction = unsignedTransaction.aggregateSignatureShares(
         coordinator.multiSigKeys.publicKeyPackage,
         signingPackage,
         signatureShares,


### PR DESCRIPTION
## Summary
Renames `signFrost` to be consistent with `aggregateSignatureShares` RPC.
## Testing Plan
Tests pass
## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
