### PR TITLE
renames SigningShare to SignatureShare

### DIFF
--- a/ironfish-rust-nodejs/index.d.ts
+++ b/ironfish-rust-nodejs/index.d.ts
@@ -9,7 +9,7 @@ export interface Commitment {
   binding: string
 }
 export function createSigningCommitment(keyPackage: string, seed: number): Commitment
-export function createSigningShare(signingPackage: string, identifier: string, keyPackage: string, publicKeyRandomness: string, seed: number): string
+export function createSignatureShare(signingPackage: string, identifier: string, keyPackage: string, publicKeyRandomness: string, seed: number): string
 export function splitSecret(coordinatorSaplingKey: string, minSigners: number, identifiers: Array<string>): TrustedDealerKeyPackages
 export function contribute(inputPath: string, outputPath: string, seed?: string | undefined | null): Promise<string>
 export function verifyTransform(paramsPath: string, newParamsPath: string): Promise<string>

--- a/ironfish-rust-nodejs/index.js
+++ b/ironfish-rust-nodejs/index.js
@@ -252,11 +252,11 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { FishHashContext, createSigningCommitment, createSigningShare, ParticipantSecret, ParticipantIdentity, splitSecret, contribute, verifyTransform, KEY_LENGTH, NONCE_LENGTH, BoxKeyPair, randomBytes, boxMessage, unboxMessage, RollingFilter, initSignalHandler, triggerSegfault, ASSET_ID_LENGTH, ASSET_METADATA_LENGTH, ASSET_NAME_LENGTH, ASSET_LENGTH, Asset, NOTE_ENCRYPTION_KEY_LENGTH, MAC_LENGTH, ENCRYPTED_NOTE_PLAINTEXT_LENGTH, ENCRYPTED_NOTE_LENGTH, NoteEncrypted, PUBLIC_ADDRESS_LENGTH, RANDOMNESS_LENGTH, MEMO_LENGTH, AMOUNT_VALUE_LENGTH, DECRYPTED_NOTE_LENGTH, Note, PROOF_LENGTH, TRANSACTION_SIGNATURE_LENGTH, TRANSACTION_PUBLIC_KEY_RANDOMNESS_LENGTH, TRANSACTION_EXPIRATION_LENGTH, TRANSACTION_FEE_LENGTH, LATEST_TRANSACTION_VERSION, TransactionPosted, Transaction, verifyTransactions, UnsignedTransaction, LanguageCode, generateKey, spendingKeyToWords, wordsToSpendingKey, generateKeyFromPrivateKey, initializeSapling, FoundBlockResult, ThreadPoolHandler, isValidPublicAddress } = nativeBinding
+const { FishHashContext, createSigningCommitment, createSignatureShare, ParticipantSecret, ParticipantIdentity, splitSecret, contribute, verifyTransform, KEY_LENGTH, NONCE_LENGTH, BoxKeyPair, randomBytes, boxMessage, unboxMessage, RollingFilter, initSignalHandler, triggerSegfault, ASSET_ID_LENGTH, ASSET_METADATA_LENGTH, ASSET_NAME_LENGTH, ASSET_LENGTH, Asset, NOTE_ENCRYPTION_KEY_LENGTH, MAC_LENGTH, ENCRYPTED_NOTE_PLAINTEXT_LENGTH, ENCRYPTED_NOTE_LENGTH, NoteEncrypted, PUBLIC_ADDRESS_LENGTH, RANDOMNESS_LENGTH, MEMO_LENGTH, AMOUNT_VALUE_LENGTH, DECRYPTED_NOTE_LENGTH, Note, PROOF_LENGTH, TRANSACTION_SIGNATURE_LENGTH, TRANSACTION_PUBLIC_KEY_RANDOMNESS_LENGTH, TRANSACTION_EXPIRATION_LENGTH, TRANSACTION_FEE_LENGTH, LATEST_TRANSACTION_VERSION, TransactionPosted, Transaction, verifyTransactions, UnsignedTransaction, LanguageCode, generateKey, spendingKeyToWords, wordsToSpendingKey, generateKeyFromPrivateKey, initializeSapling, FoundBlockResult, ThreadPoolHandler, isValidPublicAddress } = nativeBinding
 
 module.exports.FishHashContext = FishHashContext
 module.exports.createSigningCommitment = createSigningCommitment
-module.exports.createSigningShare = createSigningShare
+module.exports.createSignatureShare = createSignatureShare
 module.exports.ParticipantSecret = ParticipantSecret
 module.exports.ParticipantIdentity = ParticipantIdentity
 module.exports.splitSecret = splitSecret

--- a/ironfish-rust-nodejs/src/frost.rs
+++ b/ironfish-rust-nodejs/src/frost.rs
@@ -9,8 +9,8 @@ use crate::{
 use ironfish::{
     frost::{keys::KeyPackage, round2::Randomizer, Identifier, SigningPackage},
     frost_utils::{
+        signature_share::create_signature_share as create_signature_share_rust,
         signing_commitment::create_signing_commitment as create_signing_commitment_rust,
-        signing_share::create_signing_share as create_signing_share_rust,
         split_spender_key::split_spender_key,
     },
     participant::{Identity, Secret},
@@ -42,7 +42,7 @@ pub fn create_signing_commitment(key_package: String, seed: u32) -> Result<Nativ
 }
 
 #[napi]
-pub fn create_signing_share(
+pub fn create_signature_share(
     signing_package: String,
     identifier: String,
     key_package: String,
@@ -61,7 +61,7 @@ pub fn create_signing_share(
         Randomizer::deserialize(&hex_to_bytes(&public_key_randomness).map_err(to_napi_err)?)
             .map_err(to_napi_err)?;
 
-    let signature_share = create_signing_share_rust(
+    let signature_share = create_signature_share_rust(
         signing_package,
         identifier,
         key_package,

--- a/ironfish-rust-nodejs/src/structs/transaction.rs
+++ b/ironfish-rust-nodejs/src/structs/transaction.rs
@@ -14,7 +14,7 @@ use ironfish::frost::round1::SigningCommitments;
 use ironfish::frost::round2::SignatureShare as FrostSignatureShare;
 use ironfish::frost::Identifier;
 use ironfish::frost::SigningPackage;
-use ironfish::frost_utils::signing_share::SignatureShare;
+use ironfish::frost_utils::signature_share::SignatureShare;
 use ironfish::serializing::fr::FrSerializable;
 use ironfish::serializing::hex_to_vec_bytes;
 use ironfish::serializing::{bytes_to_hex, hex_to_bytes};

--- a/ironfish-rust/src/frost_utils/mod.rs
+++ b/ironfish-rust/src/frost_utils/mod.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+pub mod signature_share;
 pub mod signing_commitment;
-pub mod signing_share;
 pub mod split_secret;
 pub mod split_spender_key;

--- a/ironfish-rust/src/frost_utils/signature_share.rs
+++ b/ironfish-rust/src/frost_utils/signature_share.rs
@@ -48,7 +48,7 @@ impl SignatureShare {
 }
 
 // Wrapper around frost::round2::sign that provides a seedable rng from u64
-pub fn create_signing_share(
+pub fn create_signature_share(
     signing_package: SigningPackage,
     identifier: Identifier,
     key_package: KeyPackage,

--- a/ironfish-rust/src/transaction/tests.rs
+++ b/ironfish-rust/src/transaction/tests.rs
@@ -8,7 +8,7 @@ use std::collections::BTreeMap;
 use super::internal_batch_verify_transactions;
 use super::{ProposedTransaction, Transaction};
 use crate::frost_utils::{
-    signing_commitment::create_signing_commitment, signing_share::create_signing_share,
+    signature_share::create_signature_share, signing_commitment::create_signing_commitment,
 };
 use crate::test_util::create_identifiers;
 use crate::transaction::tests::split_spender_key::split_spender_key;
@@ -793,13 +793,13 @@ fn test_aggregate_signature_shares() {
         .expect("should be able to create signing package");
 
     // simulate round 2
-    let mut signing_shares: BTreeMap<Identifier, SignatureShare> = BTreeMap::new();
+    let mut signature_shares: BTreeMap<Identifier, SignatureShare> = BTreeMap::new();
     let randomizer =
         Randomizer::deserialize(&unsigned_transaction.public_key_randomness.to_bytes())
             .expect("should be able to deserialize randomizer");
 
     for key_package in key_packages.key_packages.iter() {
-        let signature_share = create_signing_share(
+        let signature_share = create_signature_share(
             signing_package.clone(),
             *key_package.0,
             key_package.1.clone(),
@@ -807,7 +807,7 @@ fn test_aggregate_signature_shares() {
             0,
         )
         .expect("should be able to create signature share");
-        signing_shares.insert(signature_share.identifier, signature_share.signature_share);
+        signature_shares.insert(signature_share.identifier, signature_share.signature_share);
     }
 
     // coordinator creates signed transaction
@@ -815,7 +815,7 @@ fn test_aggregate_signature_shares() {
         .aggregate_signature_shares(
             &key_packages.public_key_package,
             &signing_package,
-            signing_shares,
+            signature_shares,
         )
         .expect("should be able to sign transaction");
 

--- a/ironfish/src/rpc/clients/client.ts
+++ b/ironfish/src/rpc/clients/client.ts
@@ -9,8 +9,8 @@ import type {
   AddPeerResponse,
   AddTransactionRequest,
   AddTransactionResponse,
-  AggregateSigningSharesRequest,
-  AggregateSigningSharesResponse,
+  AggregateSignatureSharesRequest,
+  AggregateSignatureSharesResponse,
   BlockTemplateStreamRequest,
   BlockTemplateStreamResponse,
   BroadcastTransactionRequest,
@@ -21,12 +21,12 @@ import type {
   BurnAssetResponse,
   CreateAccountRequest,
   CreateAccountResponse,
+  CreateSignatureShareRequest,
+  CreateSignatureShareResponse,
   CreateSigningCommitmentRequest,
   CreateSigningCommitmentResponse,
   CreateSigningPackageRequest,
   CreateSigningPackageResponse,
-  CreateSigningShareRequest,
-  CreateSigningShareResponse,
   CreateTransactionRequest,
   CreateTransactionResponse,
   CreateTrustedDealerKeyPackageRequest,
@@ -181,11 +181,11 @@ export abstract class RpcClient {
 
   wallet = {
     multisig: {
-      aggregateSigningShares: (
-        params: AggregateSigningSharesRequest,
-      ): Promise<RpcResponseEnded<AggregateSigningSharesResponse>> => {
-        return this.request<AggregateSigningSharesResponse>(
-          `${ApiNamespace.wallet}/multisig/aggregateSigningShares`,
+      aggregateSignatureShares: (
+        params: AggregateSignatureSharesRequest,
+      ): Promise<RpcResponseEnded<AggregateSignatureSharesResponse>> => {
+        return this.request<AggregateSignatureSharesResponse>(
+          `${ApiNamespace.wallet}/multisig/aggregateSignatureShares`,
           params,
         ).waitForEnd()
       },
@@ -217,11 +217,11 @@ export abstract class RpcClient {
         ).waitForEnd()
       },
 
-      createSigningShare: (
-        params: CreateSigningShareRequest,
-      ): Promise<RpcResponseEnded<CreateSigningShareResponse>> => {
-        return this.request<CreateSigningShareResponse>(
-          `${ApiNamespace.wallet}/multisig/createSigningShare`,
+      createSignatureShare: (
+        params: CreateSignatureShareRequest,
+      ): Promise<RpcResponseEnded<CreateSignatureShareResponse>> => {
+        return this.request<CreateSignatureShareResponse>(
+          `${ApiNamespace.wallet}/multisig/createSignatureShare`,
           params,
         ).waitForEnd()
       },

--- a/ironfish/src/rpc/routes/wallet/multisig/__fixtures__/createSignatureShare.test.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/multisig/__fixtures__/createSignatureShare.test.ts.fixture
@@ -1,5 +1,5 @@
 {
-  "Route multisig/createSigningShare should fail for an account that does not have multisig keys": [
+  "Route multisig/createSignatureShare should fail for an account that does not have multisig keys": [
     {
       "version": 4,
       "id": "ef8a8d12-b4c2-48ba-952c-8cf7b398bd82",

--- a/ironfish/src/rpc/routes/wallet/multisig/__fixtures__/createSignatureShare.test.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/multisig/__fixtures__/createSignatureShare.test.ts.fixture
@@ -1,5 +1,5 @@
 {
-  "Route multisig/createSignatureShare should fail for an account that does not have multisig keys": [
+  "Route wallet/multisig/createSignatureShare should fail for an account that does not have multisig keys": [
     {
       "version": 4,
       "id": "ef8a8d12-b4c2-48ba-952c-8cf7b398bd82",

--- a/ironfish/src/rpc/routes/wallet/multisig/aggregateSignatureShares.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/aggregateSignatureShares.ts
@@ -9,37 +9,37 @@ import { routes } from '../../router'
 import { AssertHasRpcContext } from '../../rpcContext'
 import { getAccount } from '../utils'
 
-export type AggregateSigningSharesRequest = {
+export type AggregateSignatureSharesRequest = {
   account: string
   unsignedTransaction: string
   signingPackage: string
-  signingShares: Array<string>
+  signatureShares: Array<string>
 }
 
-export type AggregateSigningSharesResponse = {
+export type AggregateSignatureSharesResponse = {
   transaction: string
 }
 
-export const AggregateSigningSharesRequestSchema: yup.ObjectSchema<AggregateSigningSharesRequest> =
+export const AggregateSignatureSharesRequestSchema: yup.ObjectSchema<AggregateSignatureSharesRequest> =
   yup
     .object({
       account: yup.string().defined(),
       unsignedTransaction: yup.string().defined(),
       signingPackage: yup.string().defined(),
-      signingShares: yup.array(yup.string().defined()).defined(),
+      signatureShares: yup.array(yup.string().defined()).defined(),
     })
     .defined()
 
-export const AggregateSigningSharesResponseSchema: yup.ObjectSchema<AggregateSigningSharesResponse> =
+export const AggregateSignatureSharesResponseSchema: yup.ObjectSchema<AggregateSignatureSharesResponse> =
   yup
     .object({
       transaction: yup.string().defined(),
     })
     .defined()
 
-routes.register<typeof AggregateSigningSharesRequestSchema, AggregateSigningSharesResponse>(
-  `${ApiNamespace.wallet}/multisig/aggregateSigningShares`,
-  AggregateSigningSharesRequestSchema,
+routes.register<typeof AggregateSignatureSharesRequestSchema, AggregateSignatureSharesResponse>(
+  `${ApiNamespace.wallet}/multisig/aggregateSignatureShares`,
+  AggregateSignatureSharesRequestSchema,
   (request, node): void => {
     AssertHasRpcContext(request, node, 'wallet')
     const account = getAccount(node.wallet, request.data.account)
@@ -52,7 +52,7 @@ routes.register<typeof AggregateSigningSharesRequestSchema, AggregateSigningShar
     const transaction = unsigned.aggregateSignatureShares(
       account.multiSigKeys.publicKeyPackage,
       request.data.signingPackage,
-      request.data.signingShares,
+      request.data.signatureShares,
     )
 
     request.end({

--- a/ironfish/src/rpc/routes/wallet/multisig/createSignatureShare.test.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/createSignatureShare.test.ts
@@ -5,12 +5,12 @@ import { generateKey } from '@ironfish/rust-nodejs'
 import { createRouteTest } from '../../../../testUtilities/routeTest'
 import { ACCOUNT_SCHEMA_VERSION } from '../../../../wallet'
 
-describe('Route multisig/createSigningShare', () => {
+describe('Route multisig/createSignatureShare', () => {
   const routeTest = createRouteTest()
 
   it('should fail for an account that does not exist', async () => {
     await expect(
-      routeTest.client.wallet.multisig.createSigningShare({
+      routeTest.client.wallet.multisig.createSignatureShare({
         account: 'non-existent',
         signingPackage: 'fake',
         unsignedTransaction: 'deadbeef',
@@ -40,7 +40,7 @@ describe('Route multisig/createSigningShare', () => {
     const account = await routeTest.wallet.importAccount(accountImport)
 
     await expect(
-      routeTest.client.wallet.multisig.createSigningShare({
+      routeTest.client.wallet.multisig.createSignatureShare({
         account: account.name,
         signingPackage: 'fake',
         unsignedTransaction: 'deadbeef',

--- a/ironfish/src/rpc/routes/wallet/multisig/createSignatureShare.test.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/createSignatureShare.test.ts
@@ -5,7 +5,7 @@ import { generateKey } from '@ironfish/rust-nodejs'
 import { createRouteTest } from '../../../../testUtilities/routeTest'
 import { ACCOUNT_SCHEMA_VERSION } from '../../../../wallet'
 
-describe('Route multisig/createSignatureShare', () => {
+describe('Route wallt/multisig/createSignatureShare', () => {
   const routeTest = createRouteTest()
 
   it('should fail for an account that does not exist', async () => {

--- a/ironfish/src/rpc/routes/wallet/multisig/createSignatureShare.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/createSignatureShare.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { createSigningShare, UnsignedTransaction } from '@ironfish/rust-nodejs'
+import { createSignatureShare, UnsignedTransaction } from '@ironfish/rust-nodejs'
 import * as yup from 'yup'
 import { AssertMultiSigSigner } from '../../../../wallet'
 import { ApiNamespace } from '../../namespaces'
@@ -9,36 +9,37 @@ import { routes } from '../../router'
 import { AssertHasRpcContext } from '../../rpcContext'
 import { getAccount } from '../utils'
 
-export type CreateSigningShareRequest = {
+export type CreateSignatureShareRequest = {
   account: string
   signingPackage: string
   unsignedTransaction: string
   seed: number //  TODO: remove when we have deterministic nonces
 }
 
-export type CreateSigningShareResponse = {
-  signingShare: string
+export type CreateSignatureShareResponse = {
+  signatureShare: string
 }
 
-export const CreateSigningShareRequestSchema: yup.ObjectSchema<CreateSigningShareRequest> = yup
-  .object({
-    account: yup.string().defined(),
-    signingPackage: yup.string().defined(),
-    unsignedTransaction: yup.string().defined(),
-    seed: yup.number().defined(),
-  })
-  .defined()
-
-export const CreateSigningShareResponseSchema: yup.ObjectSchema<CreateSigningShareResponse> =
+export const CreateSignatureShareRequestSchema: yup.ObjectSchema<CreateSignatureShareRequest> =
   yup
     .object({
-      signingShare: yup.string().defined(),
+      account: yup.string().defined(),
+      signingPackage: yup.string().defined(),
+      unsignedTransaction: yup.string().defined(),
+      seed: yup.number().defined(),
     })
     .defined()
 
-routes.register<typeof CreateSigningShareRequestSchema, CreateSigningShareResponse>(
-  `${ApiNamespace.wallet}/multisig/createSigningShare`,
-  CreateSigningShareRequestSchema,
+export const CreateSignatureShareResponseSchema: yup.ObjectSchema<CreateSignatureShareResponse> =
+  yup
+    .object({
+      signatureShare: yup.string().defined(),
+    })
+    .defined()
+
+routes.register<typeof CreateSignatureShareRequestSchema, CreateSignatureShareResponse>(
+  `${ApiNamespace.wallet}/multisig/createSignatureShare`,
+  CreateSignatureShareRequestSchema,
   (request, node): void => {
     AssertHasRpcContext(request, node, 'wallet')
 
@@ -48,7 +49,7 @@ routes.register<typeof CreateSigningShareRequestSchema, CreateSigningShareRespon
     const unsigned = new UnsignedTransaction(
       Buffer.from(request.data.unsignedTransaction, 'hex'),
     )
-    const result = createSigningShare(
+    const result = createSignatureShare(
       request.data.signingPackage,
       account.multiSigKeys.identifier,
       account.multiSigKeys.keyPackage,
@@ -57,7 +58,7 @@ routes.register<typeof CreateSigningShareRequestSchema, CreateSigningShareRespon
     )
 
     request.end({
-      signingShare: result,
+      signatureShare: result,
     })
   },
 )

--- a/ironfish/src/rpc/routes/wallet/multisig/index.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/index.ts
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-export * from './aggregateSigningShares'
+export * from './aggregateSignatureShares'
 export * from './createSigningCommitment'
 export * from './createSigningPackage'
 export * from './createTrustedDealerKeyPackage'
-export * from './createSigningShare'
+export * from './createSignatureShare'

--- a/ironfish/src/wallet/wallet.test.slow.ts
+++ b/ironfish/src/wallet/wallet.test.slow.ts
@@ -5,8 +5,8 @@ import {
   Asset,
   ASSET_ID_LENGTH,
   Commitment,
+  createSignatureShare,
   createSigningCommitment,
-  createSigningShare,
   generateKey,
   ParticipantSecret,
   splitSecret,
@@ -1289,7 +1289,7 @@ describe('Wallet', () => {
       for (const participant of participants) {
         AssertMultiSigSigner(participant)
         signatureShares.push(
-          createSigningShare(
+          createSignatureShare(
             signingPackage,
             participant.multiSigKeys.identifier,
             participant.multiSigKeys.keyPackage,


### PR DESCRIPTION
## Summary

the frost crates use the term SignatureShare to refer to a part of a signature, but we have used the term SigningShare

the term 'SigningShare' can be confused with the 'signing_share' part of a key package, used to create signing commitments and signature shares

renames SigningShare to SignatureShare in rust types, napi bindings, and multisig RPCs

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
