### PR TITLE
Allow user to input a new name if duplicate

### DIFF
--- a/ironfish/src/rpc/adapters/errors.ts
+++ b/ironfish/src/rpc/adapters/errors.ts
@@ -11,6 +11,7 @@ export enum RPC_ERROR_CODES {
   INSUFFICIENT_BALANCE = 'insufficient-balance',
   UNAUTHENTICATED = 'unauthenticated',
   NOT_FOUND = 'not-found',
+  DUPLICATE_ACCOUNT_NAME = 'duplicate-account-name',
 }
 
 /**

--- a/ironfish/src/wallet/errors.ts
+++ b/ironfish/src/wallet/errors.ts
@@ -18,3 +18,12 @@ export class NotEnoughFundsError extends Error {
     )} available to spend. Please fund your account and/or wait for any pending transactions to be confirmed.'`
   }
 }
+
+export class DuplicateAccountNameError extends Error {
+  name = this.constructor.name
+
+  constructor(name: string) {
+    super()
+    this.message = `Account already exists with the name ${name}`
+  }
+}

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -42,7 +42,7 @@ import { WorkerPool } from '../workerPool'
 import { DecryptedNote, DecryptNoteOptions } from '../workerPool/tasks/decryptNotes'
 import { Account, ACCOUNT_SCHEMA_VERSION } from './account/account'
 import { AssetBalances } from './assetBalances'
-import { NotEnoughFundsError } from './errors'
+import { DuplicateAccountNameError, NotEnoughFundsError } from './errors'
 import { MintAssetOptions } from './interfaces/mintAssetOptions'
 import {
   RemoteChainProcessor,
@@ -1449,7 +1449,7 @@ export class Wallet {
     },
   ): Promise<Account> {
     if (this.getAccountByName(name)) {
-      throw new Error(`Account already exists with the name ${name}`)
+      throw new DuplicateAccountNameError(name)
     }
 
     const key = generateKey()
@@ -1510,7 +1510,7 @@ export class Wallet {
 
   async importAccount(accountValue: AccountValue): Promise<Account> {
     if (accountValue.name && this.getAccountByName(accountValue.name)) {
-      throw new Error(`Account already exists with the name ${accountValue.name}`)
+      throw new DuplicateAccountNameError(accountValue.name)
     }
     const accounts = this.listAccounts()
     if (


### PR DESCRIPTION
## Summary

This fixes a bug where you are not prompted to enter a new name for the account in the case that the import is decoded in the server side.

## Testing Plan
1. Create an account with name `default`
2. Create a second account with name `default`
3. Import `default #2` into node with `default #1`
4. You are not prompted to enter a new name

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
