### PR TITLE
Allow custom network definitions in testing setup

### DIFF
--- a/ironfish-cli/src/commands/start.ts
+++ b/ironfish-cli/src/commands/start.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { Assert, FullNode, NodeUtils, PromiseUtils } from '@ironfish/sdk'
+import { Assert, FullNode, loadNetworkDefinition, NodeUtils, PromiseUtils } from '@ironfish/sdk'
 import { Flags } from '@oclif/core'
 import inspector from 'node:inspector'
 import { v4 as uuid } from 'uuid'
@@ -207,8 +207,12 @@ export default class Start extends IronfishCommand {
       await this.sdk.internal.save()
     }
 
+    const customNetworkDefinition = customNetwork
+      ? await loadNetworkDefinition(this.sdk.fileSystem, customNetwork)
+      : undefined
+
     const node = await this.sdk.node({
-      customNetworkPath: customNetwork,
+      customNetworkDefinition,
       networkId,
     })
 

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -23,7 +23,7 @@ import { MiningManager } from './mining'
 import { PeerNetwork, PrivateIdentity, privateIdentityToIdentity } from './network'
 import { isHexSecretKey } from './network/identity'
 import { IsomorphicWebSocketConstructor, NodeDataChannelType } from './network/types'
-import { getNetworkDefinition } from './networks'
+import { getNetworkDefinition, NetworkDefinition } from './networks'
 import { Network } from './networks/network'
 import { Package } from './package'
 import { Platform } from './platform'
@@ -193,7 +193,7 @@ export class FullNode {
     webSocket,
     privateIdentity,
     fishHashContext,
-    customNetworkPath,
+    customNetworkDefinition,
     networkId,
   }: {
     pkg: Package
@@ -207,7 +207,7 @@ export class FullNode {
     webSocket: IsomorphicWebSocketConstructor
     privateIdentity?: PrivateIdentity
     fishHashContext?: FishHashContext
-    customNetworkPath?: string
+    customNetworkDefinition?: NetworkDefinition
     networkId?: number
   }): Promise<FullNode> {
     logger = logger.withTag('ironfishnode')
@@ -245,7 +245,7 @@ export class FullNode {
       config,
       internal,
       files,
-      customNetworkPath,
+      customNetworkDefinition,
       networkId,
     )
 

--- a/ironfish/src/sdk.ts
+++ b/ironfish/src/sdk.ts
@@ -23,6 +23,7 @@ import { MetricsMonitor } from './metrics'
 import { isHexSecretKey, PrivateIdentity } from './network/identity'
 import { IsomorphicWebSocketConstructor } from './network/types'
 import { WebSocketClient } from './network/webSocketClient'
+import { NetworkDefinition } from './networks'
 import { FullNode } from './node'
 import { IronfishPKG, Package } from './package'
 import { Platform } from './platform'
@@ -174,13 +175,13 @@ export class IronfishSdk {
   async node({
     autoSeed,
     privateIdentity,
-    customNetworkPath,
+    customNetworkDefinition,
     networkId,
   }: {
     autoSeed?: boolean
     privateIdentity?: PrivateIdentity
     fishHashContext?: FishHashContext
-    customNetworkPath?: string
+    customNetworkDefinition?: NetworkDefinition
     networkId?: number
   } = {}): Promise<FullNode> {
     const webSocket = WebSocketClient as IsomorphicWebSocketConstructor
@@ -196,7 +197,7 @@ export class IronfishSdk {
       webSocket: webSocket,
       privateIdentity: privateIdentity,
       dataDir: this.dataDir,
-      customNetworkPath,
+      customNetworkDefinition,
       networkId,
     })
 

--- a/ironfish/src/testUtilities/nodeTest.ts
+++ b/ironfish/src/testUtilities/nodeTest.ts
@@ -7,7 +7,7 @@ import { Blockchain } from '../blockchain'
 import { Verifier } from '../consensus/verifier'
 import { ConfigOptions } from '../fileStores/config'
 import { PeerNetwork } from '../network'
-import { Network } from '../networks'
+import { Network, NetworkDefinition } from '../networks'
 import { FullNode } from '../node'
 import { IronfishSdk } from '../sdk'
 import { Syncer } from '../syncer'
@@ -19,6 +19,7 @@ export type NodeTestOptions =
   | {
       config?: Partial<ConfigOptions>
       autoSeed?: boolean
+      customNetworkDefinition?: NetworkDefinition
     }
   | undefined
 
@@ -92,10 +93,14 @@ export class NodeTest {
       }
     }
 
+    const networkOptions = options?.customNetworkDefinition
+      ? { customNetworkDefinition: options.customNetworkDefinition }
+      : { networkId: 2 }
+
     const node = await sdk.node({
       autoSeed: this.options?.autoSeed,
       fishHashContext: FISH_HASH_CONTEXT,
-      networkId: 2,
+      ...networkOptions,
     })
 
     const network = node.network


### PR DESCRIPTION
## Summary
Allow custom network definitions in node setup to enbale testing starting up the blockchain db on a custom network

## Testing Plan
Unit tests, starting a node locally on testnet, devnet, mainnet and a custom network definition

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[X] Yes
```
This changes the `sdk.node()` function to take a `NetworkDefinition` instead of the path the the network definition file (if starting on a custom network)
