### PR TITLE
Change consensus params type to nullable

### DIFF
--- a/ironfish/src/consensus/consensus.test.ts
+++ b/ironfish/src/consensus/consensus.test.ts
@@ -20,11 +20,11 @@ describe('Consensus', () => {
 
   const consensus = new Consensus(params)
 
-  const consensusWithNevers = new Consensus({
+  const consensusWithInactives = new Consensus({
     ...params,
-    enableAssetOwnership: 'never',
-    enforceSequentialBlockTime: 'never',
-    enableFishHash: 'never',
+    enableAssetOwnership: null,
+    enforceSequentialBlockTime: null,
+    enableFishHash: null,
   })
 
   describe('isActive', () => {
@@ -68,17 +68,17 @@ describe('Consensus', () => {
     })
 
     it('returns false if flag activation is never', () => {
-      expect(consensusWithNevers.isActive('enableAssetOwnership', 3)).toBe(false)
-      expect(consensusWithNevers.isActive('enforceSequentialBlockTime', 3)).toBe(false)
-      expect(consensusWithNevers.isActive('enableFishHash', 3)).toBe(false)
+      expect(consensusWithInactives.isActive('enableAssetOwnership', 3)).toBe(false)
+      expect(consensusWithInactives.isActive('enforceSequentialBlockTime', 3)).toBe(false)
+      expect(consensusWithInactives.isActive('enableFishHash', 3)).toBe(false)
     })
   })
 
   describe('isNeverActive', () => {
     it('returns true if flag activation is never', () => {
-      expect(consensusWithNevers.isNeverActive('enableAssetOwnership')).toBe(true)
-      expect(consensusWithNevers.isNeverActive('enforceSequentialBlockTime')).toBe(true)
-      expect(consensusWithNevers.isNeverActive('enableFishHash')).toBe(true)
+      expect(consensusWithInactives.isNeverActive('enableAssetOwnership')).toBe(true)
+      expect(consensusWithInactives.isNeverActive('enforceSequentialBlockTime')).toBe(true)
+      expect(consensusWithInactives.isNeverActive('enableFishHash')).toBe(true)
     })
 
     it('returns false if flag has activation sequence', () => {
@@ -97,7 +97,9 @@ describe('Consensus', () => {
     })
 
     it('returns V1 transaction when activation flag is never', () => {
-      expect(consensusWithNevers.getActiveTransactionVersion(5)).toEqual(TransactionVersion.V1)
+      expect(consensusWithInactives.getActiveTransactionVersion(5)).toEqual(
+        TransactionVersion.V1,
+      )
     })
   })
 })

--- a/ironfish/src/consensus/consensus.ts
+++ b/ironfish/src/consensus/consensus.ts
@@ -4,7 +4,7 @@
 
 import { TransactionVersion } from '../primitives/transaction'
 
-export type ActivationSequence = number | 'never'
+export type ActivationSequence = number | null
 
 export type ConsensusParameters = {
   /**
@@ -66,7 +66,7 @@ export class Consensus {
 
   isActive(upgrade: keyof ConsensusParameters, sequence: number): boolean {
     const upgradeSequence = this.parameters[upgrade]
-    if (upgradeSequence === 'never') {
+    if (upgradeSequence === null) {
       return false
     }
     return Math.max(1, sequence) >= upgradeSequence
@@ -76,7 +76,7 @@ export class Consensus {
    * Returns true if the upgrade can never activate on the network
    */
   isNeverActive(upgrade: keyof ConsensusParameters): boolean {
-    return this.parameters[upgrade] === 'never'
+    return this.parameters[upgrade] === null
   }
 
   getActiveTransactionVersion(sequence: number): TransactionVersion {

--- a/ironfish/src/mining/pool.ts
+++ b/ironfish/src/mining/pool.ts
@@ -361,12 +361,7 @@ export class MiningPool {
     this.webhooks.map((w) => w.poolConnected(explorer ?? undefined))
 
     const consensusResponse = (await this.rpc.chain.getConsensusParameters()).content
-    this.consensusParameters = {
-      ...consensusResponse,
-      enableFishHash: consensusResponse.enableFishHash || 'never',
-      enableAssetOwnership: consensusResponse.enableAssetOwnership || 'never',
-      enforceSequentialBlockTime: consensusResponse.enforceSequentialBlockTime || 'never',
-    }
+    this.consensusParameters = consensusResponse
 
     // TODO: Add option for full cache FishHash verification
     this.blockHasher = new BlockHasher({

--- a/ironfish/src/mining/soloMiner.ts
+++ b/ironfish/src/mining/soloMiner.ts
@@ -256,12 +256,7 @@ export class MiningSoloMiner {
     }
 
     const consensusResponse = (await this.rpc.chain.getConsensusParameters()).content
-    this.consensus = new Consensus({
-      ...consensusResponse,
-      enableFishHash: consensusResponse.enableFishHash || 'never',
-      enableAssetOwnership: consensusResponse.enableAssetOwnership || 'never',
-      enforceSequentialBlockTime: consensusResponse.enforceSequentialBlockTime || 'never',
-    })
+    this.consensus = new Consensus(consensusResponse)
 
     this.connectWarned = false
     this.logger.info('Successfully connected to node')

--- a/ironfish/src/networks/definitions/devnet.ts
+++ b/ironfish/src/networks/definitions/devnet.ts
@@ -13,7 +13,7 @@ const DEVNET_CONSENSUS: ConsensusParameters = {
   minFee: 0,
   enableAssetOwnership: 1,
   enforceSequentialBlockTime: 1,
-  enableFishHash: 'never',
+  enableFishHash: null,
 }
 
 export const DEVNET_GENESIS = {

--- a/ironfish/src/networks/definitions/mainnet.ts
+++ b/ironfish/src/networks/definitions/mainnet.ts
@@ -13,8 +13,8 @@ const MAINNET_CONSENSUS: ConsensusParameters = {
   maxBlockSizeBytes: 524288,
   minFee: 1,
   enableAssetOwnership: 9999999,
-  enforceSequentialBlockTime: 'never',
-  enableFishHash: 'never',
+  enforceSequentialBlockTime: null,
+  enableFishHash: null,
 }
 
 export const MAINNET_GENESIS = {

--- a/ironfish/src/networks/definitions/testnet.ts
+++ b/ironfish/src/networks/definitions/testnet.ts
@@ -13,8 +13,8 @@ const TESTNET_CONSENSUS: ConsensusParameters = {
   maxBlockSizeBytes: 524288,
   minFee: 1,
   enableAssetOwnership: 9999999,
-  enforceSequentialBlockTime: 'never',
-  enableFishHash: 'never',
+  enforceSequentialBlockTime: null,
+  enableFishHash: null,
 }
 
 export const TESTNET_GENESIS = {

--- a/ironfish/src/rpc/routes/chain/getConsensusParameters.test.ts
+++ b/ironfish/src/rpc/routes/chain/getConsensusParameters.test.ts
@@ -14,12 +14,6 @@ describe('Route chain.getConsensusParameters', () => {
       .waitForEnd()
 
     const chainParams = routeTest.chain.consensus.parameters
-    const expectedResponseParams = Object.fromEntries(
-      Object.entries(chainParams).map(([k, v]) => {
-        return [k, v === 'never' ? null : v]
-      }),
-    )
-
-    expect(response.content).toEqual(expectedResponseParams)
+    expect(response.content).toEqual(chainParams)
   })
 })

--- a/ironfish/src/rpc/routes/chain/getConsensusParameters.ts
+++ b/ironfish/src/rpc/routes/chain/getConsensusParameters.ts
@@ -3,17 +3,13 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
-import { ActivationSequence, ConsensusParameters } from '../../../consensus/consensus'
+import { ConsensusParameters } from '../../../consensus/consensus'
 import { FullNode } from '../../../node'
 import { ApiNamespace } from '../namespaces'
 import { routes } from '../router'
 
 export type GetConsensusParametersRequest = Record<string, never> | undefined
-export type GetConsensusParametersResponse = {
-  [K in keyof ConsensusParameters]: ConsensusParameters[K] extends number
-    ? ConsensusParameters[K]
-    : number | null
-}
+export type GetConsensusParametersResponse = ConsensusParameters
 
 export const GetConsensusParametersRequestSchema: yup.MixedSchema<GetConsensusParametersRequest> =
   yup.mixed().oneOf([undefined] as const)
@@ -41,15 +37,6 @@ routes.register<typeof GetConsensusParametersRequestSchema, GetConsensusParamete
 
     const consensusParameters = node.chain.consensus.parameters
 
-    const neverToNull = (value: ActivationSequence): number | null => {
-      return value === 'never' ? null : value
-    }
-
-    request.end({
-      ...consensusParameters,
-      enableAssetOwnership: neverToNull(consensusParameters.enableAssetOwnership),
-      enforceSequentialBlockTime: neverToNull(consensusParameters.enforceSequentialBlockTime),
-      enableFishHash: neverToNull(consensusParameters.enableFishHash),
-    })
+    request.end(consensusParameters)
   },
 )


### PR DESCRIPTION
## Summary
Nullable types work much better in many contexts. The make the return types for RPC endpoints specifically much easier

## Testing Plan
Unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[X] Yes
```
This changes the type of `ConsensusParameters` exported from the SDK. It also changes the type of network definition files for anyone running on a custom network
