### PR TITLE
Fix multiple display_trace definitions on android build

### DIFF
--- a/ironfish-rust/src/signal_catcher.rs
+++ b/ironfish-rust/src/signal_catcher.rs
@@ -16,7 +16,7 @@ unsafe fn display_trace() {
 
 /// # Safety
 /// This is unsafe, it calls libc functions
-#[cfg(all(unix, not(target_env = "musl")))]
+#[cfg(all(unix, not(target_env = "musl"), not(target_os = "android")))]
 unsafe fn display_trace() {
     const MAX_FRAMES: usize = 256;
     static mut STACK_TRACE: [*mut libc::c_void; MAX_FRAMES] = [std::ptr::null_mut(); MAX_FRAMES];


### PR DESCRIPTION
## Summary

When building ironfish-rust for Android, I got a build error around multiple definitions of display_trace.

We could probably consider pulling the trace library out of ironfish-rust, but for now I fixed to not include one of the functions.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
