### PR TITLE
Remove uses of `ThreadRng`

### DIFF
--- a/ironfish-rust/src/frost_utils/signing_commitment.rs
+++ b/ironfish-rust/src/frost_utils/signing_commitment.rs
@@ -76,7 +76,7 @@ mod test {
     use crate::test_util::create_identifiers;
     use ff::Field;
     use jubjub::Fr;
-    use rand::rngs::ThreadRng;
+    use rand::thread_rng;
 
     #[test]
     pub fn test_seed_provides_same_result() {
@@ -85,14 +85,13 @@ mod test {
 
         let identifiers = create_identifiers(10);
 
-        let mut rng = ThreadRng::default();
         let key_packages = split_secret(
             &SecretShareConfig {
                 identifiers,
                 min_signers: 2,
                 secret: key.to_bytes().to_vec(),
             },
-            &mut rng,
+            thread_rng(),
         )
         .expect("key shares to be created");
         let key_package = key_packages

--- a/ironfish-rust/src/frost_utils/split_spender_key.rs
+++ b/ironfish-rust/src/frost_utils/split_spender_key.rs
@@ -48,9 +48,9 @@ pub fn split_spender_key(
         secret,
     };
 
-    let mut rng: rand::prelude::ThreadRng = thread_rng();
+    let rng = thread_rng();
 
-    let (key_packages, public_key_package) = split_secret(&secret_config, &mut rng)?;
+    let (key_packages, public_key_package) = split_secret(&secret_config, rng)?;
 
     let authorizing_key_bytes = public_key_package.verifying_key().serialize();
 


### PR DESCRIPTION
## Summary

ThreadRng shouldn't be used directly as it restricts the kinds of random number generators that people can pass as an input

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
