### PR TITLE
uses AssertMultiSig in aggregateSignatureShares

### DIFF
--- a/ironfish/src/rpc/routes/wallet/multisig/aggregateSignatureShares.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/aggregateSignatureShares.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { UnsignedTransaction } from '@ironfish/rust-nodejs'
 import * as yup from 'yup'
-import { Assert } from '../../../../assert'
+import { AssertMultisig } from '../../../../wallet'
 import { ApiNamespace } from '../../namespaces'
 import { routes } from '../../router'
 import { AssertHasRpcContext } from '../../rpcContext'
@@ -43,8 +43,7 @@ routes.register<typeof AggregateSignatureSharesRequestSchema, AggregateSignature
   (request, node): void => {
     AssertHasRpcContext(request, node, 'wallet')
     const account = getAccount(node.wallet, request.data.account)
-    // TODO(hughy): change this to use assertion instead of not undefined
-    Assert.isNotUndefined(account.multisigKeys, 'Account is not a multisig account')
+    AssertMultisig(account)
 
     const unsigned = new UnsignedTransaction(
       Buffer.from(request.data.unsignedTransaction, 'hex'),


### PR DESCRIPTION
## Summary

we have a custom assertion to assert that an account has multisigKeys

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
