### PR TITLE
Prompt user to enter a name for nameless account

### DIFF
--- a/ironfish-cli/src/commands/wallet/import.ts
+++ b/ironfish-cli/src/commands/wallet/import.ts
@@ -90,12 +90,15 @@ export class ImportCommand extends IronfishCommand {
       } catch (e) {
         if (
           e instanceof RpcRequestError &&
-          e.code === RPC_ERROR_CODES.DUPLICATE_ACCOUNT_NAME.toString()
+          (e.code === RPC_ERROR_CODES.DUPLICATE_ACCOUNT_NAME.toString() ||
+            e.code === RPC_ERROR_CODES.IMPORT_ACCOUNT_NAME_REQUIRED.toString())
         ) {
-          this.log()
-          this.log(e.codeMessage)
+          if (e.code === RPC_ERROR_CODES.DUPLICATE_ACCOUNT_NAME.toString()) {
+            this.log()
+            this.log(e.codeMessage)
+          }
 
-          const name = await CliUx.ux.prompt('Enter a different name for the account', {
+          const name = await CliUx.ux.prompt('Enter a name for the account', {
             required: true,
           })
           if (name === flags.name) {

--- a/ironfish/src/rpc/adapters/errors.ts
+++ b/ironfish/src/rpc/adapters/errors.ts
@@ -12,6 +12,7 @@ export enum RPC_ERROR_CODES {
   UNAUTHENTICATED = 'unauthenticated',
   NOT_FOUND = 'not-found',
   DUPLICATE_ACCOUNT_NAME = 'duplicate-account-name',
+  IMPORT_ACCOUNT_NAME_REQUIRED = 'import-account-name-required',
 }
 
 /**

--- a/ironfish/src/wallet/account/encoder/encoder.ts
+++ b/ironfish/src/wallet/account/encoder/encoder.ts
@@ -6,6 +6,10 @@ import { AccountImport } from '../../walletdb/accountValue'
 
 export class DecodeInvalid extends Error {}
 
+export class DecodeInvalidName extends DecodeInvalid {
+  name = this.constructor.name
+}
+
 export class DecodeFailed extends Error {
   decoder: string
 

--- a/ironfish/src/wallet/account/encoder/mnemonic.ts
+++ b/ironfish/src/wallet/account/encoder/mnemonic.ts
@@ -16,6 +16,7 @@ import {
   AccountEncodingOptions,
   DecodeFailed,
   DecodeInvalid,
+  DecodeInvalidName,
 } from './encoder'
 
 export class MnemonicEncoder implements AccountEncoder {
@@ -47,8 +48,9 @@ export class MnemonicEncoder implements AccountEncoder {
       throw new DecodeFailed('Invalid mnemonic', this.constructor.name)
     }
     if (!options.name) {
-      throw new DecodeInvalid('Name option is required for mnemonic key encoder')
+      throw new DecodeInvalidName('Name option is required for mnemonic key encoder')
     }
+
     const key = generateKeyFromPrivateKey(spendingKey)
     return {
       name: options.name,

--- a/ironfish/src/wallet/account/encoder/mnemonic.ts
+++ b/ironfish/src/wallet/account/encoder/mnemonic.ts
@@ -15,7 +15,6 @@ import {
   AccountEncoder,
   AccountEncodingOptions,
   DecodeFailed,
-  DecodeInvalid,
   DecodeInvalidName,
 } from './encoder'
 

--- a/ironfish/src/wallet/account/encoder/spendingKey.ts
+++ b/ironfish/src/wallet/account/encoder/spendingKey.ts
@@ -4,7 +4,12 @@
 import { generateKeyFromPrivateKey, Key } from '@ironfish/rust-nodejs'
 import { AccountImport } from '../../walletdb/accountValue'
 import { ACCOUNT_SCHEMA_VERSION } from '../account'
-import { AccountDecodingOptions, AccountEncoder, DecodeFailed, DecodeInvalid, DecodeInvalidName } from './encoder'
+import {
+  AccountDecodingOptions,
+  AccountEncoder,
+  DecodeFailed,
+  DecodeInvalidName,
+} from './encoder'
 
 export class SpendingKeyEncoder implements AccountEncoder {
   encode(value: AccountImport): string {

--- a/ironfish/src/wallet/account/encoder/spendingKey.ts
+++ b/ironfish/src/wallet/account/encoder/spendingKey.ts
@@ -4,7 +4,7 @@
 import { generateKeyFromPrivateKey, Key } from '@ironfish/rust-nodejs'
 import { AccountImport } from '../../walletdb/accountValue'
 import { ACCOUNT_SCHEMA_VERSION } from '../account'
-import { AccountDecodingOptions, AccountEncoder, DecodeFailed, DecodeInvalid } from './encoder'
+import { AccountDecodingOptions, AccountEncoder, DecodeFailed, DecodeInvalid, DecodeInvalidName } from './encoder'
 
 export class SpendingKeyEncoder implements AccountEncoder {
   encode(value: AccountImport): string {
@@ -26,8 +26,9 @@ export class SpendingKeyEncoder implements AccountEncoder {
     }
 
     if (!options.name) {
-      throw new DecodeInvalid('Name option is required for spending key encoder')
+      throw new DecodeInvalidName('Name option is required for spending key encoder')
     }
+
     return {
       name: options.name,
       spendingKey: spendingKey,


### PR DESCRIPTION
## Summary

This fix will now prompt the user to enter a name in the case that an encoder throws an error because an account name was not provided. This gest caught and forwarded to the front end so they can prompt the user for a name to then try the import again.


## Testing Plan

1. Create an account
2. Get the mnemonic
3. Delete the account
4. Import the account by mnemonic
5. See you are now prompted for a name

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
