### PR TITLE
adds wallet:multisig:identity:create

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/identity/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/identity/create.ts
@@ -6,6 +6,7 @@ import { IronfishCommand } from '../../../../command'
 
 export class MultisigIdentityCreate extends IronfishCommand {
   static description = `Create a multisig identity`
+  static hidden = true
 
   start(): void {
     // TODO: generate secret over RPC, persist in walletDb

--- a/ironfish-cli/src/commands/wallet/multisig/identity/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/identity/create.ts
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { ParticipantSecret } from '@ironfish/rust-nodejs'
+import { IronfishCommand } from '../../../../command'
+
+export class MultisigIdentityCreate extends IronfishCommand {
+  static description = `Create a multisig identity`
+
+  start(): void {
+    // TODO: generate secret over RPC, persist in walletDb
+    const secret = ParticipantSecret.random()
+
+    const identity = secret.toIdentity()
+    this.log('Identity:')
+    this.log(identity.serialize().toString('hex'))
+
+    this.log()
+
+    // TODO: remove when other multisig CLI commands use identity as inputs
+    const identifier = identity.toFrostIdentifier()
+    this.log('Identifier:')
+    this.log(identifier)
+  }
+}


### PR DESCRIPTION
## Summary

adds a cli command that generates a random secret and outputs the identity and identifier for that secret

useful for creating identifiers for testing for now, but doesn't interact with any RPC or persist any data

## Testing Plan

```
> fish wallet:multisig:identity:create

Identity:
721710619274d7f93e147cef1332f3aa54352d0b20c26eef086e6bfdfded532c60ad497130bbf0f037f22fb6f218923b8d5130afab326577e983d13dd89f100568a7bf61b2f8335c623b6a42fac96a00b539be0ffece7f3ee53ba656e63c0975415f79f9053918a3be7536f85d84422d827eb9673089eaafa9768fd59890e5710a

Identifier:
b53d7eb64e152844bec434d9d26bd9014b52ad763f13cb130bb06ae1e7cbae02
```

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
