### PR TITLE
make account param optional for createSignatureShare

### DIFF
--- a/ironfish/src/rpc/routes/wallet/multisig/createSignatureShare.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/createSignatureShare.ts
@@ -23,7 +23,7 @@ export type CreateSignatureShareResponse = {
 export const CreateSignatureShareRequestSchema: yup.ObjectSchema<CreateSignatureShareRequest> =
   yup
     .object({
-      account: yup.string().defined(),
+      account: yup.string().optional(),
       signingPackage: yup.string().defined(),
       unsignedTransaction: yup.string().defined(),
       seed: yup.number().defined(),


### PR DESCRIPTION
## Summary

This was the cause of the issue during our multi sig testing 

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
