### PR TITLE
Add `useAccountAndAddFundsFixture` to simplify tests

### DIFF
--- a/ironfish/src/rpc/routes/wallet/multisig/createSigningPackage.test.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/createSigningPackage.test.ts
@@ -4,8 +4,7 @@
 import { ParticipantSecret } from '@ironfish/rust-nodejs'
 import {
   createNodeTest,
-  useAccountFixture,
-  useMinerBlockFixture,
+  useAccountAndAddFundsFixture,
   useUnsignedTxFixture,
 } from '../../../../testUtilities'
 import { createRouteTest } from '../../../../testUtilities/routeTest'
@@ -64,18 +63,7 @@ describe('Route multisig/createSigningPackage', () => {
       commitments.push(signingCommitment.content.commitment)
     }
 
-    const account = await useAccountFixture(nodeTest.wallet)
-
-    // fund account
-    const block = await useMinerBlockFixture(
-      nodeTest.chain,
-      undefined,
-      account,
-      nodeTest.wallet,
-    )
-    await nodeTest.chain.addBlock(block)
-    await nodeTest.wallet.updateHead()
-
+    const account = await useAccountAndAddFundsFixture(nodeTest.wallet, nodeTest.chain)
     const unsignedTransaction = await useUnsignedTxFixture(nodeTest.wallet, account, account)
     const unsignedString = unsignedTransaction.serialize().toString('hex')
     const responseSigningPackage = await routeTest.client.wallet.multisig.createSigningPackage({

--- a/ironfish/src/testUtilities/fixtures/account.ts
+++ b/ironfish/src/testUtilities/fixtures/account.ts
@@ -1,7 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Blockchain } from '../../blockchain'
 import { AccountValue, AssertSpending, SpendingAccount, Wallet } from '../../wallet'
+import { useMinerBlockFixture } from './blocks'
 import { FixtureGenerate, useFixture } from './fixture'
 
 export function useAccountFixture(
@@ -42,4 +44,17 @@ export function useAccountFixture(
       return account
     },
   })
+}
+
+export async function useAccountAndAddFundsFixture(
+  wallet: Wallet,
+  chain: Blockchain,
+  generate: FixtureGenerate<SpendingAccount> | string = 'test',
+  options?: { setCreatedAt?: boolean; setDefault?: boolean },
+): Promise<SpendingAccount> {
+  const account = await useAccountFixture(wallet, generate, options)
+  const block = await useMinerBlockFixture(chain, undefined, account)
+  await expect(chain).toAddBlock(block)
+  await wallet.updateHead()
+  return account
 }


### PR DESCRIPTION
## Summary

The tests that I've written for deterministic nonces need to create new accounts and add funds to them every time, so having an utility function helps saving some repeated lines of code.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
