### PR TITLE
Add Ironfish Stratum V3 (post-fishhash) to reference pool

### DIFF
--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -480,7 +480,7 @@ export class Config<
       poolMaxConnectionsPerIp: 0,
       poolLarkWebhook: '',
       poolXnSize: 2,
-      poolSupportedVersions: [1, 2],
+      poolSupportedVersions: [2, 3],
       jsonLogs: false,
       feeEstimatorMaxBlockHistory: DEFAULT_FEE_ESTIMATOR_MAX_BLOCK_HISTORY,
       feeEstimatorPercentileSlow: DEFAULT_FEE_ESTIMATOR_PERCENTILE_SLOW,

--- a/ironfish/src/mining/stratum/messages.ts
+++ b/ironfish/src/mining/stratum/messages.ts
@@ -58,7 +58,12 @@ export type MiningSubscribedMessageV2 = {
   xn: string
 }
 
-export type MiningSubmittedMessageV2 = {
+export type MiningSubscribedMessageV3 = {
+  clientId: number
+  xn: string
+}
+
+export type MiningSubmittedMessage = {
   id: number
   result: boolean
   message?: string
@@ -133,7 +138,14 @@ export const MiningSubscribedMessageSchemaV1: yup.ObjectSchema<MiningSubscribedM
   })
   .required()
 
-export const MiningSubscribedMessageV2Schema: yup.ObjectSchema<MiningSubscribedMessageV2> = yup
+export const MiningSubscribedMessageSchemaV2: yup.ObjectSchema<MiningSubscribedMessageV2> = yup
+  .object({
+    clientId: yup.number().required(),
+    xn: yup.string().required(),
+  })
+  .required()
+
+export const MiningSubscribedMessageSchemaV3: yup.ObjectSchema<MiningSubscribedMessageV3> = yup
   .object({
     clientId: yup.number().required(),
     xn: yup.string().required(),
@@ -146,7 +158,7 @@ export const MiningSetTargetSchema: yup.ObjectSchema<MiningSetTargetMessage> = y
   })
   .required()
 
-export const MiningSubmittedSchemaV2: yup.ObjectSchema<MiningSubmittedMessageV2> = yup
+export const MiningSubmittedSchema: yup.ObjectSchema<MiningSubmittedMessage> = yup
   .object({
     id: yup.number().required(),
     result: yup.bool().required(),

--- a/ironfish/src/mining/stratum/messages.ts
+++ b/ironfish/src/mining/stratum/messages.ts
@@ -43,6 +43,11 @@ export type MiningSubmitMessageV2 = {
   graffiti: string
 }
 
+export type MiningSubmitMessageV3 = {
+  miningRequestId: number
+  randomness: string
+}
+
 export type MiningSubscribedMessageV1 = {
   clientId: number
   graffiti: string
@@ -181,6 +186,13 @@ export const MiningSubmitSchemaV2: yup.ObjectSchema<MiningSubmitMessageV2> = yup
     miningRequestId: yup.number().required(),
     randomness: yup.string().required(),
     graffiti: yup.string().required(),
+  })
+  .required()
+
+export const MiningSubmitSchemaV3: yup.ObjectSchema<MiningSubmitMessageV3> = yup
+  .object({
+    miningRequestId: yup.number().required(),
+    randomness: yup.string().required(),
   })
   .required()
 

--- a/ironfish/src/mining/stratum/stratumServer.ts
+++ b/ironfish/src/mining/stratum/stratumServer.ts
@@ -23,7 +23,7 @@ import {
   MiningSubmitSchemaV1,
   MiningSubmitSchemaV2,
   MiningSubmitSchemaV3,
-  MiningSubmittedMessageV2,
+  MiningSubmittedMessage,
   MiningSubscribedMessageV1,
   MiningSubscribedMessageV2,
   MiningSubscribeSchema,
@@ -33,8 +33,6 @@ import {
 } from './messages'
 import { StratumPeers } from './stratumPeers'
 import { StratumServerClient } from './stratumServerClient'
-
-const SUPPORTED_VERSIONS = [1, 2]
 
 export class StratumServer {
   readonly pool: MiningPool
@@ -65,7 +63,7 @@ export class StratumServer {
     this.config = options.config
     this.logger = options.logger
 
-    this.supportedVersions = SUPPORTED_VERSIONS
+    this.supportedVersions = options.config.get('poolSupportedVersions')
 
     this.clients = new Map()
     this.nextMinerId = 1
@@ -538,7 +536,7 @@ export class StratumServer {
   send(socket: net.Socket, method: 'mining.set_target', body: MiningSetTargetMessage): void
   send(socket: net.Socket, method: 'mining.subscribed', body: MiningSubscribedMessageV1): void
   send(socket: net.Socket, method: 'mining.subscribed', body: MiningSubscribedMessageV2): void
-  send(socket: net.Socket, method: 'mining.submitted', body: MiningSubmittedMessageV2): void
+  send(socket: net.Socket, method: 'mining.submitted', body: MiningSubmittedMessage): void
   send(socket: net.Socket, method: 'mining.wait_for_work'): void
   send(socket: net.Socket, method: 'mining.status', body: MiningStatusMessage): void
   send(socket: net.Socket, method: string, body?: unknown): void {

--- a/ironfish/src/mining/stratum/stratumServerClient.ts
+++ b/ironfish/src/mining/stratum/stratumServerClient.ts
@@ -21,12 +21,20 @@ type V2Subscription = {
   xn: string
 }
 
+type V3Subscription = {
+  version: 3
+  publicAddress: string
+  name?: string
+  agent?: string
+  xn: string
+}
+
 export class StratumServerClient {
   id: number
   socket: net.Socket
   connected: boolean
   remoteAddress: string
-  subscription: V1Subscription | V2Subscription | null = null
+  subscription: V1Subscription | V2Subscription | V3Subscription | null = null
   messageBuffer: MessageBuffer
 
   private constructor(options: { socket: net.Socket; id: number }) {


### PR DESCRIPTION
## Summary
Add a new version of stratum for post FishHash pools. This change allows mining pools to set the graffiti as opposed to miners setting the graffiti with current TRM stratum protocol. Pools will send `xn`/extra nonce field to miners to distinguish miner search space 

## Testing Plan
Locally testing running pool against reference miner

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
