### PR TITLE
Support V1 miner by default

### DIFF
--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -480,7 +480,7 @@ export class Config<
       poolMaxConnectionsPerIp: 0,
       poolLarkWebhook: '',
       poolXnSize: 2,
-      poolSupportedVersions: [2, 3],
+      poolSupportedVersions: [1, 2, 3],
       jsonLogs: false,
       feeEstimatorMaxBlockHistory: DEFAULT_FEE_ESTIMATOR_MAX_BLOCK_HISTORY,
       feeEstimatorPercentileSlow: DEFAULT_FEE_ESTIMATOR_PERCENTILE_SLOW,


### PR DESCRIPTION
## Summary
The reference pool miner is still on V1 and doesn't work with the pool unless you update the config. Making it easier for development until the pool miner is updated to V3

## Testing Plan
Locally tested pool + miner on V1

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
