### PR TITLE
Add a one-time difficulty adjustment when FishHash activates

### DIFF
--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -920,14 +920,11 @@ export class Blockchain {
         timestamp = new Date(Math.max(currentTime, heaviestHead.timestamp.getTime() + 1))
 
         target = Target.calculateTarget(
+          this.consensus,
+          previousSequence + 1,
           timestamp,
           heaviestHead.timestamp,
           heaviestHead.target,
-          this.consensus.parameters.targetBlockTimeInSeconds,
-          this.consensus.parameters.targetBucketTimeInSeconds,
-          this.consensus.getDifficultyBucketMax(previousSequence + 1),
-          this.consensus.parameters.enableFishHash,
-          previousSequence + 1,
         )
       }
 

--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -926,6 +926,8 @@ export class Blockchain {
           this.consensus.parameters.targetBlockTimeInSeconds,
           this.consensus.parameters.targetBucketTimeInSeconds,
           this.consensus.getDifficultyBucketMax(previousSequence + 1),
+          this.consensus.parameters.enableFishHash,
+          previousSequence + 1,
         )
       }
 

--- a/ironfish/src/consensus/verifier.ts
+++ b/ironfish/src/consensus/verifier.ts
@@ -388,6 +388,8 @@ export class Verifier {
       this.chain.consensus.parameters.targetBlockTimeInSeconds,
       this.chain.consensus.parameters.targetBucketTimeInSeconds,
       this.chain.consensus.getDifficultyBucketMax(header.sequence),
+      this.chain.consensus.parameters.enableFishHash,
+      header.sequence,
     )
 
     return header.target.targetValue === expectedTarget.targetValue

--- a/ironfish/src/consensus/verifier.ts
+++ b/ironfish/src/consensus/verifier.ts
@@ -382,14 +382,11 @@ export class Verifier {
     }
 
     const expectedTarget = Target.calculateTarget(
+      this.chain.consensus,
+      header.sequence,
       header.timestamp,
       previous.timestamp,
       previous.target,
-      this.chain.consensus.parameters.targetBlockTimeInSeconds,
-      this.chain.consensus.parameters.targetBucketTimeInSeconds,
-      this.chain.consensus.getDifficultyBucketMax(header.sequence),
-      this.chain.consensus.parameters.enableFishHash,
-      header.sequence,
     )
 
     return header.target.targetValue === expectedTarget.targetValue

--- a/ironfish/src/mining/soloMiner.ts
+++ b/ironfish/src/mining/soloMiner.ts
@@ -4,7 +4,7 @@
 import { ThreadPoolHandler } from '@ironfish/rust-nodejs'
 import { Assert } from '../assert'
 import { serializeHeaderBlake3, serializeHeaderFishHash } from '../blockHasher'
-import { ActivationSequence, Consensus } from '../consensus'
+import { Consensus } from '../consensus'
 import { Logger } from '../logger'
 import { Meter } from '../metrics/meter'
 import { Target } from '../primitives/target'
@@ -152,12 +152,7 @@ export class MiningSoloMiner {
       this.currentHeadDifficulty = currentHeadTarget.toDifficulty()
       this.currentHeadTimestamp = payload.previousBlockInfo.timestamp
 
-      this.restartCalculateTargetInterval(
-        this.consensus.parameters.targetBlockTimeInSeconds,
-        this.consensus.parameters.targetBucketTimeInSeconds,
-        this.consensus.getDifficultyBucketMax(payload.header.sequence),
-        this.consensus.parameters.enableFishHash,
-      )
+      this.restartCalculateTargetInterval()
       this.startNewWork(payload)
     }
   }
@@ -271,14 +266,10 @@ export class MiningSoloMiner {
     })
   }
 
-  private recalculateTarget(
-    targetBlockTimeInSeconds: number,
-    targetBucketTimeInSeconds: number,
-    maxBuckets: number,
-    enableFishHashSequence: ActivationSequence,
-  ) {
+  private recalculateTarget() {
     Assert.isNotNull(this.currentHeadTimestamp)
     Assert.isNotNull(this.currentHeadDifficulty)
+    Assert.isNotNull(this.consensus)
 
     const latestBlock = this.miningRequestBlocks.get(this.nextMiningRequestId - 1)
     Assert.isNotUndefined(latestBlock)
@@ -286,14 +277,11 @@ export class MiningSoloMiner {
     const newTime = new Date()
     const newTarget = Target.fromDifficulty(
       Target.calculateDifficulty(
+        this.consensus,
+        latestBlock.header.sequence,
         newTime,
         new Date(this.currentHeadTimestamp),
         this.currentHeadDifficulty,
-        targetBlockTimeInSeconds,
-        targetBucketTimeInSeconds,
-        maxBuckets,
-        enableFishHashSequence,
-        latestBlock.header.sequence,
       ),
     )
 
@@ -303,23 +291,13 @@ export class MiningSoloMiner {
     this.startNewWork(latestBlock)
   }
 
-  private restartCalculateTargetInterval(
-    targetBlockTimeInSeconds: number,
-    targetBucketTimeInSeconds: number,
-    maxBuckets: number,
-    enableFishHashSequence: ActivationSequence,
-  ) {
+  private restartCalculateTargetInterval() {
     if (this.recalculateTargetInterval) {
       clearInterval(this.recalculateTargetInterval)
     }
 
     this.recalculateTargetInterval = setInterval(() => {
-      this.recalculateTarget(
-        targetBlockTimeInSeconds,
-        targetBucketTimeInSeconds,
-        maxBuckets,
-        enableFishHashSequence,
-      )
+      this.recalculateTarget()
     }, RECALCULATE_TARGET_TIMEOUT)
   }
 }

--- a/ironfish/src/mining/soloMiner.ts
+++ b/ironfish/src/mining/soloMiner.ts
@@ -4,7 +4,7 @@
 import { ThreadPoolHandler } from '@ironfish/rust-nodejs'
 import { Assert } from '../assert'
 import { serializeHeaderBlake3, serializeHeaderFishHash } from '../blockHasher'
-import { Consensus } from '../consensus'
+import { ActivationSequence, Consensus } from '../consensus'
 import { Logger } from '../logger'
 import { Meter } from '../metrics/meter'
 import { Target } from '../primitives/target'
@@ -156,6 +156,7 @@ export class MiningSoloMiner {
         this.consensus.parameters.targetBlockTimeInSeconds,
         this.consensus.parameters.targetBucketTimeInSeconds,
         this.consensus.getDifficultyBucketMax(payload.header.sequence),
+        this.consensus.parameters.enableFishHash,
       )
       this.startNewWork(payload)
     }
@@ -274,6 +275,7 @@ export class MiningSoloMiner {
     targetBlockTimeInSeconds: number,
     targetBucketTimeInSeconds: number,
     maxBuckets: number,
+    enableFishHashSequence: ActivationSequence,
   ) {
     Assert.isNotNull(this.currentHeadTimestamp)
     Assert.isNotNull(this.currentHeadDifficulty)
@@ -290,6 +292,8 @@ export class MiningSoloMiner {
         targetBlockTimeInSeconds,
         targetBucketTimeInSeconds,
         maxBuckets,
+        enableFishHashSequence,
+        latestBlock.header.sequence,
       ),
     )
 
@@ -303,13 +307,19 @@ export class MiningSoloMiner {
     targetBlockTimeInSeconds: number,
     targetBucketTimeInSeconds: number,
     maxBuckets: number,
+    enableFishHashSequence: ActivationSequence,
   ) {
     if (this.recalculateTargetInterval) {
       clearInterval(this.recalculateTargetInterval)
     }
 
     this.recalculateTargetInterval = setInterval(() => {
-      this.recalculateTarget(targetBlockTimeInSeconds, targetBucketTimeInSeconds, maxBuckets)
+      this.recalculateTarget(
+        targetBlockTimeInSeconds,
+        targetBucketTimeInSeconds,
+        maxBuckets,
+        enableFishHashSequence,
+      )
     }, RECALCULATE_TARGET_TIMEOUT)
   }
 }

--- a/ironfish/src/primitives/target.test.ts
+++ b/ironfish/src/primitives/target.test.ts
@@ -7,6 +7,8 @@ import { Target } from './target'
 const TARGET_BLOCK_TIME_IN_SECONDS = 60
 const TARGET_BUCKET_TIME_IN_SECONDS = 10
 const MAX_BUCKETS = 99
+const FISH_HASH_ACTIVATION_SEQUENCE = 999
+const SEQUENCE = 5
 
 describe('Target', () => {
   it('constructs targets', () => {
@@ -97,6 +99,8 @@ describe('Calculate target', () => {
         TARGET_BLOCK_TIME_IN_SECONDS,
         TARGET_BUCKET_TIME_IN_SECONDS,
         MAX_BUCKETS,
+        FISH_HASH_ACTIVATION_SEQUENCE,
+        SEQUENCE,
       )
       const newTarget = Target.calculateTarget(
         time,
@@ -105,6 +109,8 @@ describe('Calculate target', () => {
         TARGET_BLOCK_TIME_IN_SECONDS,
         TARGET_BUCKET_TIME_IN_SECONDS,
         MAX_BUCKETS,
+        FISH_HASH_ACTIVATION_SEQUENCE,
+        SEQUENCE,
       )
 
       expect(newDifficulty).toBeGreaterThan(difficulty)
@@ -129,6 +135,8 @@ describe('Calculate target', () => {
         TARGET_BLOCK_TIME_IN_SECONDS,
         TARGET_BUCKET_TIME_IN_SECONDS,
         MAX_BUCKETS,
+        FISH_HASH_ACTIVATION_SEQUENCE,
+        SEQUENCE,
       )
       const newTarget = Target.calculateTarget(
         time,
@@ -137,6 +145,8 @@ describe('Calculate target', () => {
         TARGET_BLOCK_TIME_IN_SECONDS,
         TARGET_BUCKET_TIME_IN_SECONDS,
         MAX_BUCKETS,
+        FISH_HASH_ACTIVATION_SEQUENCE,
+        SEQUENCE,
       )
 
       const diffInDifficulty = BigInt(newDifficulty) - difficulty
@@ -175,6 +185,8 @@ describe('Calculate target', () => {
         TARGET_BLOCK_TIME_IN_SECONDS,
         TARGET_BUCKET_TIME_IN_SECONDS,
         MAX_BUCKETS,
+        FISH_HASH_ACTIVATION_SEQUENCE,
+        SEQUENCE,
       )
       const newTarget = Target.calculateTarget(
         time,
@@ -183,12 +195,59 @@ describe('Calculate target', () => {
         TARGET_BLOCK_TIME_IN_SECONDS,
         TARGET_BUCKET_TIME_IN_SECONDS,
         MAX_BUCKETS,
+        FISH_HASH_ACTIVATION_SEQUENCE,
+        SEQUENCE,
       )
       expect(newDifficulty).toBeLessThan(difficulty)
       expect(BigInt(newDifficulty) + diffInDifficulty).toEqual(difficulty)
 
       expect(newTarget.asBigInt()).toBeGreaterThan(target.asBigInt())
     }
+  })
+
+  it('adjusts difficulty only if the given sequence is the fish hash activation sequence', () => {
+    const now = new Date()
+    const difficulty = BigInt(231072000)
+    const previousBlockTarget = Target.fromDifficulty(difficulty)
+
+    const nonActivationSequence = Target.calculateTarget(
+      new Date(now.getTime() + 60 * 1000),
+      now,
+      previousBlockTarget,
+      TARGET_BLOCK_TIME_IN_SECONDS,
+      TARGET_BUCKET_TIME_IN_SECONDS,
+      MAX_BUCKETS,
+      FISH_HASH_ACTIVATION_SEQUENCE,
+      FISH_HASH_ACTIVATION_SEQUENCE - 1,
+    )
+
+    expect(nonActivationSequence.toDifficulty()).toEqual(difficulty)
+
+    const activationSequence = Target.calculateTarget(
+      new Date(now.getTime() + 60 * 1000),
+      now,
+      previousBlockTarget,
+      TARGET_BLOCK_TIME_IN_SECONDS,
+      TARGET_BUCKET_TIME_IN_SECONDS,
+      MAX_BUCKETS,
+      FISH_HASH_ACTIVATION_SEQUENCE,
+      FISH_HASH_ACTIVATION_SEQUENCE,
+    )
+
+    expect(activationSequence.toDifficulty()).toEqual(difficulty / 100n)
+
+    const postActivationSequence = Target.calculateTarget(
+      new Date(now.getTime() + 60 * 1000),
+      now,
+      previousBlockTarget,
+      TARGET_BLOCK_TIME_IN_SECONDS,
+      TARGET_BUCKET_TIME_IN_SECONDS,
+      MAX_BUCKETS,
+      FISH_HASH_ACTIVATION_SEQUENCE,
+      FISH_HASH_ACTIVATION_SEQUENCE + 1,
+    )
+
+    expect(postActivationSequence.toDifficulty()).toEqual(difficulty)
   })
 
   describe('max buckets', () => {
@@ -204,6 +263,8 @@ describe('Calculate target', () => {
         TARGET_BLOCK_TIME_IN_SECONDS,
         TARGET_BUCKET_TIME_IN_SECONDS,
         MAX_BUCKETS,
+        FISH_HASH_ACTIVATION_SEQUENCE,
+        SEQUENCE,
       )
 
       // Sanity check that difficulty is different in the bucket prior
@@ -214,6 +275,8 @@ describe('Calculate target', () => {
         TARGET_BLOCK_TIME_IN_SECONDS,
         TARGET_BUCKET_TIME_IN_SECONDS,
         MAX_BUCKETS,
+        FISH_HASH_ACTIVATION_SEQUENCE,
+        SEQUENCE,
       )
       expect(almostMaxTarget.asBigInt()).toBeLessThan(maximallyDifferentTarget.asBigInt())
 
@@ -229,6 +292,8 @@ describe('Calculate target', () => {
           TARGET_BLOCK_TIME_IN_SECONDS,
           TARGET_BUCKET_TIME_IN_SECONDS,
           MAX_BUCKETS,
+          FISH_HASH_ACTIVATION_SEQUENCE,
+          SEQUENCE,
         )
 
         expect(newTarget).toEqual(maximallyDifferentTarget)
@@ -248,6 +313,8 @@ describe('Calculate target', () => {
         TARGET_BLOCK_TIME_IN_SECONDS,
         TARGET_BUCKET_TIME_IN_SECONDS,
         otherMaxBuckets,
+        FISH_HASH_ACTIVATION_SEQUENCE,
+        SEQUENCE,
       )
 
       // Sanity check that difficulty is different in the bucket prior
@@ -258,6 +325,8 @@ describe('Calculate target', () => {
         TARGET_BLOCK_TIME_IN_SECONDS,
         TARGET_BUCKET_TIME_IN_SECONDS,
         otherMaxBuckets,
+        FISH_HASH_ACTIVATION_SEQUENCE,
+        SEQUENCE,
       )
       expect(almostMaxTarget.asBigInt()).toBeLessThan(maximallyDifferentTarget.asBigInt())
 
@@ -273,6 +342,8 @@ describe('Calculate target', () => {
           TARGET_BLOCK_TIME_IN_SECONDS,
           TARGET_BUCKET_TIME_IN_SECONDS,
           otherMaxBuckets,
+          FISH_HASH_ACTIVATION_SEQUENCE,
+          SEQUENCE,
         )
 
         expect(newTarget).toEqual(maximallyDifferentTarget)

--- a/ironfish/src/primitives/target.ts
+++ b/ironfish/src/primitives/target.ts
@@ -22,6 +22,12 @@ const MAX_TARGET = 8834235323891921647916487503714592579137419484378094790608031
 const MAX_256_BIT_NUM =
   115792089237316195423570985008687907853269984665640564039457584007913129639935n
 
+/**
+ * The number to divide the difficulty by when FishHash is activated. This is
+ * due to the FishHash hash rate being much lower than Blake3
+ */
+const FISH_HASH_DIFFICULTY_ADJUSTMENT = 100n
+
 export class Target {
   targetValue: bigint
   constructor(targetValue: bigint | Buffer | string | number) {
@@ -127,9 +133,9 @@ export class Target {
       previousBlockDifficulty - (previousBlockDifficulty / 2048n) * BigInt(bucket)
 
     // A one-time difficulty adjustment when the mining algorithm changes from
-    // blake3 to fishhash, since the fishhash hashrate is much lower than blake3
+    // blake3 to FishHash, since the FishHash hash rate is much lower than Blake3
     if (sequence === enableFishHashSequence) {
-      difficulty /= 100n
+      difficulty /= FISH_HASH_DIFFICULTY_ADJUSTMENT
     }
 
     return BigIntUtils.max(difficulty, Target.minDifficulty())


### PR DESCRIPTION
## Summary

Introduces a one-time difficulty adjustment of `(difficulty / 100)` at the sequence that FishHash activates. The reasoning here is that FishHash has dramatically lower hashrate than the current blake3 algorithm. Initial testing shows a slowdown of 250-500x on GPUs. The reasoning for only adjusting by 100 is because we don't want to overshoot and make things too easy, but this still keeps the blocktime in the realm of usable.

If we say the current blake3 hashrate is 1,000,000, and the FishHash hashrate is 250x lower, that's 4,000. If it's 500x, it's 2,000.

Based on that blake3 hashrate, and a 60 second blocktime, the given difficulty would be 60,000,000. Given these FIshHash hashrates, we would see blocktimes in the 4-8 hour range. This is not good. If we simply divide by 100, we land on a new difficulty of 600,000. This gives us blocktimes in the 2.5 to 5 minute range. This would naturally adjust to the 60 second blocktime quite quickly, leading to a smooth transition. 

## Testing Plan

Unit testing, manual testing

## Documentation

N/A

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[x] Yes
```
