### PR TITLE
feat: large prompt signature share

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/create-signature-share.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/create-signature-share.ts
@@ -5,6 +5,7 @@
 import { Flags } from '@oclif/core'
 import { IronfishCommand } from '../../../command'
 import { RemoteFlags } from '../../../flags'
+import { largePrompt } from '../../../utils/longPrompt'
 
 export class CreateSignatureShareCommand extends IronfishCommand {
   static description = `Creates a signature share for a participant for a given transaction`
@@ -20,25 +21,35 @@ export class CreateSignatureShareCommand extends IronfishCommand {
     unsignedTransaction: Flags.string({
       char: 'u',
       description: 'The unsigned transaction for which the signature share will be created',
-      required: true,
+      required: false,
     }),
     signingPackage: Flags.string({
       char: 's',
       description: 'The signing package for which the signature share will be created',
-      required: true,
+      required: false,
     }),
   }
 
   async start(): Promise<void> {
     const { flags } = await this.parse(CreateSignatureShareCommand)
+    let unsignedTransaction = flags.unsignedTransaction?.trim()
+    let signingPackage = flags.signingPackage?.trim()
+
+    if (!unsignedTransaction) {
+      unsignedTransaction = await largePrompt('Enter the unsigned transaction: ')
+    }
+
+    if (!signingPackage) {
+      signingPackage = await largePrompt('Enter the signing package: ')
+    }
 
     const client = await this.sdk.connectRpc()
     // TODO(andrea): use flags.transaction to create commiment when we incorportate deterministic nonces
     // set required to true as well
     const signatureShareResponse = await client.wallet.multisig.createSignatureShare({
       account: flags.account,
-      unsignedTransaction: flags.unsignedTransaction,
-      signingPackage: flags.signingPackage,
+      unsignedTransaction,
+      signingPackage,
       seed: 0,
     })
 

--- a/ironfish-cli/src/utils/longPrompt.ts
+++ b/ironfish-cli/src/utils/longPrompt.ts
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import readline from 'readline'
+
+// Most effective way to take in a large textual prompt input without affecting UX
+export function largePrompt(question: string): Promise<string> {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  })
+
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => {
+      rl.close()
+      resolve(answer.trim())
+    })
+  })
+}

--- a/ironfish/src/rpc/routes/wallet/multisig/createSignatureShare.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/createSignatureShare.ts
@@ -23,7 +23,7 @@ export type CreateSignatureShareResponse = {
 export const CreateSignatureShareRequestSchema: yup.ObjectSchema<CreateSignatureShareRequest> =
   yup
     .object({
-      account: yup.string().defined(),
+      account: yup.string().optional(),
       signingPackage: yup.string().defined(),
       unsignedTransaction: yup.string().defined(),
       seed: yup.number().defined(),


### PR DESCRIPTION
## Summary
Prompting mechanism for long text input truncates with `Cli.ux.prompt` and is very laggy when using `inquirer` library. 
When using the `CliUx` of `oclif/core` I see truncation of input.

This creates a simple wrapper around the node native input system for prompting long text.

## Testing Plan

https://github.com/iron-fish/ironfish/assets/26990067/42d8b8c6-2e25-480b-a34c-fd3eea1bd64a

Tested on macOS and linux, same behavior exists on both systems.


## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
