### PR TITLE
Fix flaky fileStore test

### DIFF
--- a/ironfish/src/fileStores/fileStore.test.ts
+++ b/ironfish/src/fileStores/fileStore.test.ts
@@ -42,10 +42,8 @@ describe('FileStore', () => {
     await files.init()
     const store = new FileStore<{ foo: string }>(files, 'test', dir)
 
-    const [promise1, resolve1] = PromiseUtils.split<void>()
-    const [promise2, resolve2] = PromiseUtils.split<void>()
-    writeFileSpy.mockReturnValueOnce(promise1)
-    writeFileSpy.mockReturnValueOnce(promise2)
+    const [promiseFirstWrite, resolveFirstWrite] = PromiseUtils.split<void>()
+    writeFileSpy.mockReturnValueOnce(promiseFirstWrite)
 
     const save1 = store.save({ foo: 'hello' })
     const save2 = store.save({ foo: 'hello' })
@@ -58,19 +56,9 @@ describe('FileStore', () => {
     await flushTimeout()
     expect(writeFileSpy).toHaveBeenCalledTimes(1)
 
-    resolve1()
-    // Resolve the first promise, freeing the mutex and allowing save2 to
-    // execute
-    await flushTimeout()
-    await flushTimeout()
-    await flushTimeout()
-    await flushTimeout()
-    expect(writeFileSpy).toHaveBeenCalledTimes(2)
-
+    resolveFirstWrite()
     await save1
-    resolve2()
     await save2
-
     expect(writeFileSpy).toHaveBeenCalledTimes(2)
   })
 })


### PR DESCRIPTION
## Summary
This test is sometimes failing on the second expect `expect(writeFileSpy).toHaveBeenCalledTimes(2)`. Changing this to wait for everything to execute until checking that the file is saved for a second time. This still tests the desired functionality because the test is testing that "The 2nd save IS NOT called until the first save resolves". That is still being tested with these changes and we can make the test less flaky without reducing coverage.

## Testing Plan
Unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
