### PR TITLE
Rahul/multisig prompt for inputs

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/create-signing-package.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/create-signing-package.ts
@@ -5,7 +5,7 @@
 import { Flags } from '@oclif/core'
 import { IronfishCommand } from '../../../command'
 import { RemoteFlags } from '../../../flags'
-import { largePrompt } from '../../../utils/longPrompt'
+import { longPrompt } from '../../../utils/longPrompt'
 
 export class CreateSigningPackage extends IronfishCommand {
   static description = `Creates a signing package for a given transaction for a multisig account`
@@ -31,14 +31,14 @@ export class CreateSigningPackage extends IronfishCommand {
     let unsignedTransaction = flags.unsignedTransaction?.trim()
 
     if (!unsignedTransaction) {
-      unsignedTransaction = await largePrompt('Enter the unsigned transaction: ', {
+      unsignedTransaction = await longPrompt('Enter the unsigned transaction: ', {
         required: true,
       })
     }
 
     let commitments = flags.commitment
     if (!commitments) {
-      const input = await largePrompt('Enter the signing commitments separated by commas', {
+      const input = await longPrompt('Enter the signing commitments separated by commas', {
         required: true,
       })
       commitments = input.split(',')

--- a/ironfish-cli/src/commands/wallet/multisig/sign.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/sign.ts
@@ -5,6 +5,7 @@ import { CurrencyUtils, Transaction } from '@ironfish/sdk'
 import { CliUx, Flags } from '@oclif/core'
 import { IronfishCommand } from '../../../command'
 import { RemoteFlags } from '../../../flags'
+import { largePrompt } from '../../../utils/longPrompt'
 
 export class MultisigSign extends IronfishCommand {
   static description = 'Aggregate signature shares from participants to sign a transaction'
@@ -42,15 +43,15 @@ export class MultisigSign extends IronfishCommand {
 
     const unsignedTransaction =
       flags.unsignedTransaction?.trim() ??
-      (await CliUx.ux.prompt('Enter the unsigned transaction', { required: true }))
+      (await largePrompt('Enter the unsigned transaction: ', { required: true }))
 
     const signingPackage =
       flags.signingPackage?.trim() ??
-      (await CliUx.ux.prompt('Enter the signing package', { required: true }))
+      (await largePrompt('Enter the signing package: ', { required: true }))
 
     let signatureShares = flags.signatureShare
     if (!signatureShares) {
-      const input = await CliUx.ux.prompt('Enter the signature shares separated by commas', {
+      const input = await largePrompt('Enter the signature shares separated by commas', {
         required: true,
       })
       signatureShares = input.split(',')

--- a/ironfish-cli/src/commands/wallet/multisig/sign.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/sign.ts
@@ -5,7 +5,7 @@ import { CurrencyUtils, Transaction } from '@ironfish/sdk'
 import { CliUx, Flags } from '@oclif/core'
 import { IronfishCommand } from '../../../command'
 import { RemoteFlags } from '../../../flags'
-import { largePrompt } from '../../../utils/longPrompt'
+import { longPrompt } from '../../../utils/longPrompt'
 
 export class MultisigSign extends IronfishCommand {
   static description = 'Aggregate signature shares from participants to sign a transaction'
@@ -43,15 +43,15 @@ export class MultisigSign extends IronfishCommand {
 
     const unsignedTransaction =
       flags.unsignedTransaction?.trim() ??
-      (await largePrompt('Enter the unsigned transaction: ', { required: true }))
+      (await longPrompt('Enter the unsigned transaction: ', { required: true }))
 
     const signingPackage =
       flags.signingPackage?.trim() ??
-      (await largePrompt('Enter the signing package: ', { required: true }))
+      (await longPrompt('Enter the signing package: ', { required: true }))
 
     let signatureShares = flags.signatureShare
     if (!signatureShares) {
-      const input = await largePrompt('Enter the signature shares separated by commas', {
+      const input = await longPrompt('Enter the signature shares separated by commas', {
         required: true,
       })
       signatureShares = input.split(',')


### PR DESCRIPTION
## Summary

Depends on #4721

1. Improving consistency by not requiring any inputs (if they don't exist prompt the user for it). 
2. If the user doesn't pass a valid input (empty string), ask them for it again 
3. Prompting user for list of commitments if not provided
4. Replacing `CliUx.ux.prompt` with `largePrompt` for unsigned transaction and signing package

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
