### PR TITLE
Decrypt notes in parallel

### DIFF
--- a/ironfish/src/rpc/routes/wallet/utils.ts
+++ b/ironfish/src/rpc/routes/wallet/utils.ts
@@ -176,6 +176,7 @@ export async function getTransactionNotes(
     }
 
     decryptNotesPayloads.push({
+      accountId: account.id,
       serializedNote: note.serialize(),
       incomingViewKey: account.incomingViewKey,
       outgoingViewKey: account.outgoingViewKey,

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -403,11 +403,10 @@ export class Wallet {
         async (a) => await this.isAccountUpToDate(a),
       ))
 
-    const decryptedNotesByAccountId = new Map<string, Array<DecryptedNote>>()
-
     const batchSize = 20
+    const notePromisesByAccountId: Map<string, Array<Promise<Array<DecryptedNote>>>> = new Map()
     for (const account of accountsToCheck) {
-      const decryptedNotes = []
+      const notePromises = []
       let decryptNotesPayloads = []
       let currentNoteIndex = initialNoteIndex
 
@@ -426,21 +425,23 @@ export class Wallet {
         }
 
         if (decryptNotesPayloads.length >= batchSize) {
-          const decryptedNotesBatch = await this.decryptNotesFromTransaction(
-            decryptNotesPayloads,
-          )
-          decryptedNotes.push(...decryptedNotesBatch)
+          notePromises.push(this.decryptNotesFromTransaction(decryptNotesPayloads))
           decryptNotesPayloads = []
         }
       }
 
       if (decryptNotesPayloads.length) {
-        const decryptedNotesBatch = await this.decryptNotesFromTransaction(decryptNotesPayloads)
-        decryptedNotes.push(...decryptedNotesBatch)
+        notePromises.push(this.decryptNotesFromTransaction(decryptNotesPayloads))
       }
 
+      notePromisesByAccountId.set(account.id, notePromises)
+    }
+
+    const decryptedNotesByAccountId = new Map<string, Array<DecryptedNote>>()
+    for (const [key, value] of notePromisesByAccountId) {
+      const decryptedNotes = (await Promise.all(value ?? [])).flat()
       if (decryptedNotes.length) {
-        decryptedNotesByAccountId.set(account.id, decryptedNotes)
+        decryptedNotesByAccountId.set(key, decryptedNotes)
       }
     }
 
@@ -476,9 +477,40 @@ export class Wallet {
       }
     })
 
-    for (const account of accounts) {
-      const shouldDecrypt = await this.shouldDecryptForAccount(blockHeader, account)
+    const decryptAccounts = (
+      await Promise.all(
+        accounts.map((a) =>
+          this.shouldDecryptForAccount(blockHeader, a).then(
+            (shouldDecrypt): [Account, boolean] => [a, shouldDecrypt],
+          ),
+        ),
+      )
+    )
+      .filter((v) => v[1])
+      .map((v) => v[0])
+    const decryptedTransactions = await Promise.all(
+      transactions.map(({ transaction, initialNoteIndex }) =>
+        this.decryptNotes(transaction, initialNoteIndex, false, decryptAccounts).then((r) => ({
+          result: r,
+          transaction,
+        })),
+      ),
+    )
 
+    const m: Map<string, [Transaction, DecryptedNote[]][]> = new Map()
+    for (const { transaction, result } of decryptedTransactions) {
+      for (const [id, v] of result) {
+        if (!v.length) {
+          continue
+        }
+
+        const arr = m.get(id) ?? []
+        arr.push([transaction, v])
+        m.set(id, arr)
+      }
+    }
+
+    for (const account of accounts) {
       if (scan && scan.isAborted) {
         scan.signalComplete()
         this.scan = null
@@ -487,11 +519,12 @@ export class Wallet {
 
       await this.walletDb.db.transaction(async (tx) => {
         let assetBalanceDeltas = new AssetBalances()
+        const txns = m.get(account.id)
 
-        if (shouldDecrypt) {
+        if (txns) {
           assetBalanceDeltas = await this.connectBlockTransactions(
             blockHeader,
-            transactions,
+            txns,
             account,
             scan,
             tx,
@@ -548,26 +581,17 @@ export class Wallet {
 
   private async connectBlockTransactions(
     blockHeader: WalletBlockHeader,
-    transactions: WalletBlockTransaction[],
+    transactions: Array<[Transaction, DecryptedNote[]]>,
     account: Account,
     scan?: ScanState,
     tx?: IDatabaseTransaction,
   ): Promise<AssetBalances> {
     const assetBalanceDeltas = new AssetBalances()
 
-    for (const { transaction, initialNoteIndex } of transactions) {
+    for (const [transaction, decryptedNotes] of transactions) {
       if (scan && scan.isAborted) {
         return assetBalanceDeltas
       }
-
-      const decryptedNotesByAccountId = await this.decryptNotes(
-        transaction,
-        initialNoteIndex,
-        false,
-        [account],
-      )
-
-      const decryptedNotes = decryptedNotesByAccountId.get(account.id) ?? []
 
       const transactionDeltas = await account.connectTransaction(
         blockHeader,

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -404,14 +404,14 @@ export class Wallet {
       ))
 
     const batchSize = 20
-    const notePromisesByAccountId: Map<string, Array<Promise<Array<DecryptedNote>>>> = new Map()
+    const notePromises: Array<Promise<Array<DecryptedNote>>> = []
+    let decryptNotesPayloads = []
     for (const account of accountsToCheck) {
-      const notePromises = []
-      let decryptNotesPayloads = []
       let currentNoteIndex = initialNoteIndex
 
       for (const note of transaction.notes) {
         decryptNotesPayloads.push({
+          accountId: account.id,
           serializedNote: note.serialize(),
           incomingViewKey: account.incomingViewKey,
           outgoingViewKey: account.outgoingViewKey,
@@ -429,20 +429,18 @@ export class Wallet {
           decryptNotesPayloads = []
         }
       }
+    }
 
-      if (decryptNotesPayloads.length) {
-        notePromises.push(this.decryptNotesFromTransaction(decryptNotesPayloads))
-      }
-
-      notePromisesByAccountId.set(account.id, notePromises)
+    if (decryptNotesPayloads.length) {
+      notePromises.push(this.decryptNotesFromTransaction(decryptNotesPayloads))
     }
 
     const decryptedNotesByAccountId = new Map<string, Array<DecryptedNote>>()
-    for (const [key, value] of notePromisesByAccountId) {
-      const decryptedNotes = (await Promise.all(value ?? [])).flat()
-      if (decryptedNotes.length) {
-        decryptedNotesByAccountId.set(key, decryptedNotes)
-      }
+    const flatPromises = (await Promise.all(notePromises)).flat()
+    for (const decryptedNote of flatPromises) {
+      const accountNotes = decryptedNotesByAccountId.get(decryptedNote.accountId) ?? []
+      accountNotes.push(decryptedNote)
+      decryptedNotesByAccountId.set(decryptedNote.accountId, accountNotes)
     }
 
     return decryptedNotesByAccountId


### PR DESCRIPTION

## Summary

Scanning 40+ accounts on one node right now is almost impossible due to only executing one decryptNotes batch at a time, and splitting up the decryptNotes batches per transaction and per account. In the past, this was more of a concern that the worker pool job queue would get blocked, but now that we process tasks round robin from every task queue, we should be able to keep the queue full.

With nodeWorkersMax and nodeWorkers set to 12, this increases decryption time from about 1 block per second to about 10, depending on the number of notes per block. A secondary benefit is the decryption no longer happens inside the DB lock -- the account status seems to update more frequently on this branch, but it could be due to the scan speed.

This is still WIP, I don't have time to clean up the code and tests right now, and also needs testing to make sure P2P and syncing performance aren't affected. I ran a perf test to verify that the main thread isn't blocked.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
