### PR TITLE
feat(cli): Ask for confirmation when creating signature share

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/create-signature-share.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/create-signature-share.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { Flags } from '@oclif/core'
+import { CliUx, Flags } from '@oclif/core'
 import { IronfishCommand } from '../../../command'
 import { RemoteFlags } from '../../../flags'
 import { longPrompt } from '../../../utils/longPrompt'
@@ -28,6 +28,10 @@ export class CreateSignatureShareCommand extends IronfishCommand {
       description: 'The signing package for which the signature share will be created',
       required: false,
     }),
+    confirm: Flags.boolean({
+      default: false,
+      description: 'Confirm creating signature share without confirming',
+    }),
   }
 
   async start(): Promise<void> {
@@ -41,6 +45,13 @@ export class CreateSignatureShareCommand extends IronfishCommand {
 
     if (!signingPackage) {
       signingPackage = await longPrompt('Enter the signing package: ')
+    }
+
+    if (!flags.confirm) {
+      const confirmed = await CliUx.ux.confirm('Confirm new signature share creation (Y/N)')
+      if (!confirmed) {
+        this.error('Creating signature share aborted')
+      }
     }
 
     const client = await this.sdk.connectRpc()


### PR DESCRIPTION
## Summary

Small UX improvement to ask for user confirmation before creating signature share

## Testing Plan

Ran the command

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
