### PR TITLE
removes duplicate check for duplicate name in createAccount

### DIFF
--- a/ironfish/src/rpc/routes/wallet/create.test.slow.ts
+++ b/ironfish/src/rpc/routes/wallet/create.test.slow.ts
@@ -65,7 +65,7 @@ describe('Route wallet/create', () => {
         throw e
       }
       expect(e.status).toBe(400)
-      expect(e.code).toBe(RPC_ERROR_CODES.ACCOUNT_EXISTS)
+      expect(e.code).toBe(RPC_ERROR_CODES.DUPLICATE_ACCOUNT_NAME)
     }
   })
 


### PR DESCRIPTION
## Summary

wallet.createAccount already checks for duplicate names

instead of checking in both RPC and wallet sdk, the RPC catches the error that the wallet sdk throws and handles it with the appropriate RPC response

## Testing Plan

- ran `wallet:create` to create accounts, verified that behaviour unchanged for duplicate and unique names

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
