### PR TITLE
adds walletdb multisigSecrets

### DIFF
--- a/ironfish/src/wallet/walletdb/walletdb.test.ts
+++ b/ironfish/src/wallet/walletdb/walletdb.test.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { Asset } from '@ironfish/rust-nodejs'
+import { Asset, ParticipantSecret } from '@ironfish/rust-nodejs'
 import { Assert } from '../../assert'
 import {
   createNodeTest,
@@ -388,6 +388,23 @@ describe('WalletDB', () => {
       expect(transactions.length).toEqual(transactionHashes.length - 2)
       expect(transactions[0].transaction.hash()).toEqual(transactionHashes[1])
       expect(transactions[1].transaction.hash()).toEqual(transactionHashes[2])
+    })
+  })
+
+  describe('multisigSecrets', () => {
+    it('should store named ParticipantSecret as buffer', async () => {
+      const node = (await nodeTest.createSetup()).node
+      const walletDb = node.wallet.walletDb
+
+      const name = 'test'
+      const secret = ParticipantSecret.random()
+      const serializedSecret = secret.serialize()
+
+      await walletDb.putMultisigSecret(name, serializedSecret)
+
+      const storedSecret = await walletDb.getMultisigSecret(name)
+
+      expect(storedSecret).toEqualBuffer(serializedSecret)
     })
   })
 })

--- a/ironfish/src/wallet/walletdb/walletdb.ts
+++ b/ironfish/src/wallet/walletdb/walletdb.ts
@@ -134,6 +134,11 @@ export class WalletDB {
     value: null
   }>
 
+  multisigSecrets: IDatabaseStore<{
+    key: string
+    value: Buffer
+  }>
+
   cacheStores: Array<IDatabaseStore<DatabaseSchema>>
 
   constructor({
@@ -280,6 +285,12 @@ export class WalletDB {
         [new BufferEncoding(), 32], // note hash
       ]),
       valueEncoding: NULL_ENCODING,
+    })
+
+    this.multisigSecrets = this.db.addStore({
+      name: 'ms',
+      keyEncoding: new StringEncoding(),
+      valueEncoding: new BufferEncoding(),
     })
 
     // IDatabaseStores that cache and index decrypted chain data
@@ -1241,5 +1252,24 @@ export class WalletDB {
     tx?: IDatabaseTransaction,
   ): Promise<void> {
     await this.nullifierToTransactionHash.del([account.prefix, nullifier], tx)
+  }
+
+  async putMultisigSecret(
+    name: string,
+    secret: Buffer,
+    tx?: IDatabaseTransaction,
+  ): Promise<void> {
+    await this.multisigSecrets.put(name, secret, tx)
+  }
+
+  async getMultisigSecret(
+    name: string,
+    tx?: IDatabaseTransaction,
+  ): Promise<Buffer | undefined> {
+    return this.multisigSecrets.get(name, tx)
+  }
+
+  async deleteMultisigSecret(name: string, tx?: IDatabaseTransaction): Promise<void> {
+    await this.multisigSecrets.del(name, tx)
   }
 }


### PR DESCRIPTION
## Summary

adds a datastore to the walletDb to store each 'ParticipantSecret' that a multisig user generates

uses a string 'name' as the key and stores the secret as a buffer as the datastore value

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
