### PR TITLE
standardizing how the account flag is used in our CLI

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/create-signature-share.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/create-signature-share.ts
@@ -14,7 +14,7 @@ export class CreateSignatureShareCommand extends IronfishCommand {
   static flags = {
     ...RemoteFlags,
     account: Flags.string({
-      char: 'f',
+      char: 'a',
       description: 'The account from which the signature share will be created',
       required: false,
     }),

--- a/ironfish-cli/src/commands/wallet/multisig/create-signing-commitment.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/create-signing-commitment.ts
@@ -12,7 +12,7 @@ export class CreateSigningCommitmentCommand extends IronfishCommand {
   static flags = {
     ...RemoteFlags,
     account: Flags.string({
-      char: 'f',
+      char: 'a',
       description:
         'The account to use for generating the commitment, must be a multisig participant account',
       required: false,

--- a/ironfish-cli/src/commands/wallet/multisig/sign.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/sign.ts
@@ -14,7 +14,7 @@ export class MultisigSign extends IronfishCommand {
   static flags = {
     ...RemoteFlags,
     account: Flags.string({
-      char: 'f',
+      char: 'a',
       description: 'Account to use when aggregating signature shares',
       required: false,
     }),

--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -61,14 +61,23 @@ export class CombineNotesCommand extends IronfishCommand {
       description: 'The public address of the recipient',
     }),
     account: Flags.string({
-      char: 'f',
-      description: 'The account to send money from',
+      char: 'a',
+      aliases: ['f'],
+      description: 'The account to combine notes for',
     }),
     benchmark: Flags.boolean({
       hidden: true,
       default: false,
       description: 'Force run the benchmark to measure the time to combine 1 note',
     }),
+  }
+
+  warnIfFlagDeprecated(flags: Record<string, unknown>) {
+    if (flags.account) {
+      this.warn(
+        `Warning: The "-f" is going away in version 1.22.0. Use "--account" or "-a" instead.`,
+      )
+    }
   }
 
   private async getSpendPostTimeInMs(

--- a/ironfish-cli/src/commands/wallet/notes/index.ts
+++ b/ironfish-cli/src/commands/wallet/notes/index.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { CurrencyUtils } from '@ironfish/sdk'
-import { CliUx } from '@oclif/core'
+import { CliUx, Flags } from '@oclif/core'
 import { IronfishCommand } from '../../../command'
 import { RemoteFlags } from '../../../flags'
 import { TableCols } from '../../../utils/table'
@@ -14,23 +14,18 @@ export class NotesCommand extends IronfishCommand {
   static flags = {
     ...RemoteFlags,
     ...tableFlags,
+    account: Flags.string({
+      char: 'a',
+      deprecateAliases: true,
+    }),
   }
 
-  static args = [
-    {
-      name: 'account',
-      required: false,
-      description: 'Name of the account to get notes for',
-    },
-  ]
-
   async start(): Promise<void> {
-    const { flags, args } = await this.parse(NotesCommand)
-    const account = args.account as string | undefined
+    const { flags } = await this.parse(NotesCommand)
 
     const client = await this.sdk.connectRpc()
 
-    const response = client.wallet.getAccountNotesStream({ account })
+    const response = client.wallet.getAccountNotesStream({ account: flags.account })
 
     let showHeader = !flags['no-header']
 

--- a/ironfish-cli/src/commands/wallet/post.ts
+++ b/ironfish-cli/src/commands/wallet/post.ts
@@ -25,8 +25,8 @@ export class PostCommand extends IronfishCommand {
   static flags = {
     ...RemoteFlags,
     account: Flags.string({
+      char: 'a',
       description: 'The account that created the raw transaction',
-      required: false,
     }),
     confirm: Flags.boolean({
       default: false,

--- a/ironfish-cli/src/commands/wallet/transaction/index.ts
+++ b/ironfish-cli/src/commands/wallet/transaction/index.ts
@@ -9,7 +9,7 @@ import {
   RpcWalletNote,
   TimeUtils,
 } from '@ironfish/sdk'
-import { CliUx } from '@oclif/core'
+import { CliUx, Flags } from '@oclif/core'
 import { IronfishCommand } from '../../../command'
 import { RemoteFlags } from '../../../flags'
 
@@ -18,6 +18,10 @@ export class TransactionCommand extends IronfishCommand {
 
   static flags = {
     ...RemoteFlags,
+    account: Flags.string({
+      char: 'a',
+      description: 'The account from which the transaction was sent',
+    }),
   }
 
   static args = [
@@ -27,17 +31,12 @@ export class TransactionCommand extends IronfishCommand {
       required: true,
       description: 'Hash of the transaction',
     },
-    {
-      name: 'account',
-      required: false,
-      description: 'Name of the account',
-    },
   ]
 
   async start(): Promise<void> {
-    const { args } = await this.parse(TransactionCommand)
+    const { flags, args } = await this.parse(TransactionCommand)
     const hash = args.hash as string
-    const account = args.account as string | undefined
+    const account = flags.account
 
     const client = await this.sdk.connectRpc()
 

--- a/ironfish-cli/src/commands/wallet/transaction/watch.ts
+++ b/ironfish-cli/src/commands/wallet/transaction/watch.ts
@@ -15,6 +15,10 @@ export class WatchTxCommand extends IronfishCommand {
       required: false,
       description: 'Minimum number of blocks confirmations for a transaction',
     }),
+    account: Flags.string({
+      char: 'a',
+      description: 'The account from which the transaction was sent',
+    }),
   }
 
   static args = [
@@ -24,24 +28,18 @@ export class WatchTxCommand extends IronfishCommand {
       required: true,
       description: 'Hash of the transaction',
     },
-    {
-      name: 'account',
-      required: false,
-      description: 'Name of the account',
-    },
   ]
 
   async start(): Promise<void> {
     const { flags, args } = await this.parse(WatchTxCommand)
     const hash = args.hash as string
-    const account = args.account as string | undefined
 
     const client = await this.sdk.connectRpc()
 
     await watchTransaction({
       client,
       logger: this.logger,
-      account,
+      account: flags.account,
       hash,
       confirmations: flags.confirmations,
     })

--- a/ironfish-cli/src/commands/wallet/transactions.ts
+++ b/ironfish-cli/src/commands/wallet/transactions.ts
@@ -23,6 +23,10 @@ export class TransactionsCommand extends IronfishCommand {
   static flags = {
     ...RemoteFlags,
     ...tableFlags,
+    account: Flags.string({
+      char: 'a',
+      description: 'The account to view transactions for',
+    }),
     hash: Flags.string({
       char: 't',
       description: 'Transaction hash to get details for',
@@ -46,17 +50,9 @@ export class TransactionsCommand extends IronfishCommand {
     }),
   }
 
-  static args = [
-    {
-      name: 'account',
-      required: false,
-      description: 'Name of the account',
-    },
-  ]
-
   async start(): Promise<void> {
-    const { flags, args } = await this.parse(TransactionsCommand)
-    const account = args.account as string | undefined
+    const { flags } = await this.parse(TransactionsCommand)
+    const account = flags.account
 
     const format: Format =
       flags.csv || flags.output === 'csv'


### PR DESCRIPTION
## Summary

These are the ways we enter the account in our CLI: 

1. (most common) Using the `-f` flag
2. As an argument (has it's place, for example when creating an account or changing the name of an account)
3. `-a` 
4. `--account`

As a user want the experience to be as consistent as possible. Provide the account with the same flag. If the account is not provided, use the default account.

This change goes through our CLI commands and attempts to make the way we enter the account consistent. 

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
