### PR TITLE
removing unsigned transaction from aggregate signature share

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/sign.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/sign.ts
@@ -18,10 +18,6 @@ export class MultisigSign extends IronfishCommand {
       description: 'Account to use when aggregating signature shares',
       required: false,
     }),
-    unsignedTransaction: Flags.string({
-      char: 'u',
-      description: 'Unsigned transaction',
-    }),
     signingPackage: Flags.string({
       char: 'p',
       description: 'Signing package',
@@ -40,10 +36,6 @@ export class MultisigSign extends IronfishCommand {
 
   async start(): Promise<void> {
     const { flags } = await this.parse(MultisigSign)
-
-    const unsignedTransaction =
-      flags.unsignedTransaction?.trim() ??
-      (await longPrompt('Enter the unsigned transaction: ', { required: true }))
 
     const signingPackage =
       flags.signingPackage?.trim() ??
@@ -65,7 +57,6 @@ export class MultisigSign extends IronfishCommand {
     const response = await client.wallet.multisig.aggregateSignatureShares({
       account: flags.account,
       broadcast: flags.broadcast,
-      unsignedTransaction,
       signingPackage,
       signatureShares,
     })

--- a/ironfish-rust-nodejs/index.d.ts
+++ b/ironfish-rust-nodejs/index.d.ts
@@ -52,6 +52,7 @@ export const TRANSACTION_EXPIRATION_LENGTH: number
 export const TRANSACTION_FEE_LENGTH: number
 export const LATEST_TRANSACTION_VERSION: number
 export function verifyTransactions(serializedTransactions: Array<Buffer>): boolean
+export function aggregateSignatureShares(publicKeyPackageStr: string, signingPackageStr: string, signatureSharesArr: Array<string>): Buffer
 export interface IdentityKeyPackage {
   identity: string
   keyPackage: string
@@ -244,7 +245,6 @@ export class UnsignedTransaction {
   hash(): Buffer
   signingPackage(nativeIdentiferCommitments: Array<string>): string
   sign(spenderHexKey: string): Buffer
-  aggregateSignatureShares(publicKeyPackageStr: string, signingPackageStr: string, signatureSharesArr: Array<string>): Buffer
 }
 export class FoundBlockResult {
   randomness: string

--- a/ironfish-rust-nodejs/index.js
+++ b/ironfish-rust-nodejs/index.js
@@ -252,7 +252,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { FishHashContext, createSigningCommitment, createSignatureShare, ParticipantSecret, ParticipantIdentity, splitSecret, contribute, verifyTransform, KEY_LENGTH, NONCE_LENGTH, BoxKeyPair, randomBytes, boxMessage, unboxMessage, RollingFilter, initSignalHandler, triggerSegfault, ASSET_ID_LENGTH, ASSET_METADATA_LENGTH, ASSET_NAME_LENGTH, ASSET_LENGTH, Asset, NOTE_ENCRYPTION_KEY_LENGTH, MAC_LENGTH, ENCRYPTED_NOTE_PLAINTEXT_LENGTH, ENCRYPTED_NOTE_LENGTH, NoteEncrypted, PUBLIC_ADDRESS_LENGTH, RANDOMNESS_LENGTH, MEMO_LENGTH, AMOUNT_VALUE_LENGTH, DECRYPTED_NOTE_LENGTH, Note, PROOF_LENGTH, TRANSACTION_SIGNATURE_LENGTH, TRANSACTION_PUBLIC_KEY_RANDOMNESS_LENGTH, TRANSACTION_EXPIRATION_LENGTH, TRANSACTION_FEE_LENGTH, LATEST_TRANSACTION_VERSION, TransactionPosted, Transaction, verifyTransactions, UnsignedTransaction, LanguageCode, generateKey, spendingKeyToWords, wordsToSpendingKey, generateKeyFromPrivateKey, initializeSapling, FoundBlockResult, ThreadPoolHandler, isValidPublicAddress } = nativeBinding
+const { FishHashContext, createSigningCommitment, createSignatureShare, ParticipantSecret, ParticipantIdentity, splitSecret, contribute, verifyTransform, KEY_LENGTH, NONCE_LENGTH, BoxKeyPair, randomBytes, boxMessage, unboxMessage, RollingFilter, initSignalHandler, triggerSegfault, ASSET_ID_LENGTH, ASSET_METADATA_LENGTH, ASSET_NAME_LENGTH, ASSET_LENGTH, Asset, NOTE_ENCRYPTION_KEY_LENGTH, MAC_LENGTH, ENCRYPTED_NOTE_PLAINTEXT_LENGTH, ENCRYPTED_NOTE_LENGTH, NoteEncrypted, PUBLIC_ADDRESS_LENGTH, RANDOMNESS_LENGTH, MEMO_LENGTH, AMOUNT_VALUE_LENGTH, DECRYPTED_NOTE_LENGTH, Note, PROOF_LENGTH, TRANSACTION_SIGNATURE_LENGTH, TRANSACTION_PUBLIC_KEY_RANDOMNESS_LENGTH, TRANSACTION_EXPIRATION_LENGTH, TRANSACTION_FEE_LENGTH, LATEST_TRANSACTION_VERSION, TransactionPosted, Transaction, verifyTransactions, UnsignedTransaction, aggregateSignatureShares, LanguageCode, generateKey, spendingKeyToWords, wordsToSpendingKey, generateKeyFromPrivateKey, initializeSapling, FoundBlockResult, ThreadPoolHandler, isValidPublicAddress } = nativeBinding
 
 module.exports.FishHashContext = FishHashContext
 module.exports.createSigningCommitment = createSigningCommitment
@@ -297,6 +297,7 @@ module.exports.TransactionPosted = TransactionPosted
 module.exports.Transaction = Transaction
 module.exports.verifyTransactions = verifyTransactions
 module.exports.UnsignedTransaction = UnsignedTransaction
+module.exports.aggregateSignatureShares = aggregateSignatureShares
 module.exports.LanguageCode = LanguageCode
 module.exports.generateKey = generateKey
 module.exports.spendingKeyToWords = spendingKeyToWords

--- a/ironfish-rust/src/transaction/tests.rs
+++ b/ironfish-rust/src/transaction/tests.rs
@@ -829,7 +829,7 @@ fn test_aggregate_signature_shares() {
     let signed_transaction = unsigned_transaction
         .aggregate_signature_shares(
             &key_packages.public_key_package,
-            &signing_package,
+            &signing_package.frost_signing_package,
             signature_shares,
         )
         .expect("should be able to sign transaction");

--- a/ironfish-rust/src/transaction/unsigned.rs
+++ b/ironfish-rust/src/transaction/unsigned.rs
@@ -209,7 +209,7 @@ impl UnsignedTransaction {
             RandomizedParams::from_randomizer(public_key_package.verifying_key(), randomizer);
 
         let authorizing_group_signature = aggregate(
-            &authorizing_signing_package,
+            authorizing_signing_package,
             &authorizing_signature_shares,
             public_key_package,
             &randomized_params,

--- a/ironfish-rust/src/transaction/unsigned.rs
+++ b/ironfish-rust/src/transaction/unsigned.rs
@@ -197,7 +197,7 @@ impl UnsignedTransaction {
     pub fn aggregate_signature_shares(
         &mut self,
         public_key_package: &PublicKeyPackage,
-        authorizing_signing_package: &SigningPackage,
+        authorizing_signing_package: &FrostSigningPackage,
         authorizing_signature_shares: BTreeMap<Identifier, SignatureShare>,
     ) -> Result<Transaction, IronfishError> {
         // Create the transaction signature hash
@@ -209,7 +209,7 @@ impl UnsignedTransaction {
             RandomizedParams::from_randomizer(public_key_package.verifying_key(), randomizer);
 
         let authorizing_group_signature = aggregate(
-            &authorizing_signing_package.frost_signing_package,
+            &authorizing_signing_package,
             &authorizing_signature_shares,
             public_key_package,
             &randomized_params,

--- a/ironfish/src/rpc/routes/wallet/multisig/integration.test.slow.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/integration.test.slow.ts
@@ -141,7 +141,6 @@ describe('multisig RPC integration', () => {
     // aggregate signing shares
     const aggregateResponse = await routeTest.client.wallet.multisig.aggregateSignatureShares({
       account: coordinatorAccount.name,
-      unsignedTransaction,
       signingPackage,
       signatureShares,
     })

--- a/ironfish/src/wallet/wallet.test.slow.ts
+++ b/ironfish/src/wallet/wallet.test.slow.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import {
+  aggregateSignatureShares,
   Asset,
   ASSET_ID_LENGTH,
   createSignatureShare,
@@ -1307,7 +1308,7 @@ describe('Wallet', () => {
       }
 
       Assert.isNotUndefined(coordinator.multisigKeys)
-      const serializedFrostTransaction = unsignedTransaction.aggregateSignatureShares(
+      const serializedFrostTransaction = aggregateSignatureShares(
         coordinator.multisigKeys.publicKeyPackage,
         signingPackage,
         signatureShares,


### PR DESCRIPTION
## Summary

Removes unsigned transaction from aggregate signature share. 

This is continuation of the work that was started here #4734 

## Testing Plan

Update tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
