### PR TITLE
changes NativeNote napi to take memo as buffer

### DIFF
--- a/ironfish-rust-nodejs/index.d.ts
+++ b/ironfish-rust-nodejs/index.d.ts
@@ -151,7 +151,7 @@ export class NoteEncrypted {
 }
 export type NativeNote = Note
 export class Note {
-  constructor(owner: string, value: bigint, memo: string, assetId: Buffer, sender: string)
+  constructor(owner: string, value: bigint, memo: Buffer, assetId: Buffer, sender: string)
   static deserialize(jsBytes: Buffer): NativeNote
   serialize(): Buffer
   /**

--- a/ironfish-rust-nodejs/src/structs/note.rs
+++ b/ironfish-rust-nodejs/src/structs/note.rs
@@ -54,13 +54,16 @@ impl NativeNote {
     pub fn new(
         owner: String,
         value: BigInt,
-        memo: String,
+        memo: JsBuffer,
         asset_id: JsBuffer,
         sender: String,
     ) -> Result<Self> {
         let value_u64 = value.get_u64().1;
         let owner_address = ironfish::PublicAddress::from_hex(&owner).map_err(to_napi_err)?;
         let sender_address = ironfish::PublicAddress::from_hex(&sender).map_err(to_napi_err)?;
+
+        let memo_buffer = memo.into_value()?;
+        let memo_bytes = memo_buffer.as_ref();
 
         let buffer = asset_id.into_value()?;
         let asset_id_vec = buffer.as_ref();
@@ -69,7 +72,13 @@ impl NativeNote {
         let asset_id = asset_id_bytes.try_into().map_err(to_napi_err)?;
 
         Ok(NativeNote {
-            note: Note::new(owner_address, value_u64, memo, asset_id, sender_address),
+            note: Note::new(
+                owner_address,
+                value_u64,
+                memo_bytes,
+                asset_id,
+                sender_address,
+            ),
         })
     }
 

--- a/ironfish-rust-nodejs/src/structs/note.rs
+++ b/ironfish-rust-nodejs/src/structs/note.rs
@@ -63,7 +63,9 @@ impl NativeNote {
         let sender_address = ironfish::PublicAddress::from_hex(&sender).map_err(to_napi_err)?;
 
         let memo_buffer = memo.into_value()?;
-        let memo_bytes = memo_buffer.as_ref();
+        let memo_vec = memo_buffer.as_ref();
+        let mut memo_bytes = [0; MEMO_SIZE];
+        memo_bytes.clone_from_slice(&memo_vec[0..MEMO_SIZE]);
 
         let buffer = asset_id.into_value()?;
         let asset_id_vec = buffer.as_ref();

--- a/ironfish-rust/src/note.rs
+++ b/ironfish-rust/src/note.rs
@@ -26,7 +26,7 @@ use ironfish_zkp::{
 };
 use jubjub::SubgroupPoint;
 use rand::thread_rng;
-use std::{cmp, fmt, io, io::Read};
+use std::{fmt, io, io::Read};
 pub const ENCRYPTED_NOTE_SIZE: usize =
     SCALAR_SIZE + MEMO_SIZE + AMOUNT_VALUE_SIZE + ASSET_ID_LENGTH + PUBLIC_ADDRESS_SIZE;
 //   8  value
@@ -57,12 +57,9 @@ impl From<String> for Memo {
     }
 }
 
-impl From<&[u8]> for Memo {
-    fn from(value: &[u8]) -> Self {
-        let num_to_copy = cmp::min(value.len(), MEMO_SIZE);
-        let mut memo_bytes = [0u8; MEMO_SIZE];
-        memo_bytes[..num_to_copy].copy_from_slice(&value[..num_to_copy]);
-        Memo(memo_bytes)
+impl From<[u8; MEMO_SIZE]> for Memo {
+    fn from(value: [u8; MEMO_SIZE]) -> Self {
+        Memo(value)
     }
 }
 

--- a/ironfish-rust/src/note.rs
+++ b/ironfish-rust/src/note.rs
@@ -26,7 +26,7 @@ use ironfish_zkp::{
 };
 use jubjub::SubgroupPoint;
 use rand::thread_rng;
-use std::{fmt, io, io::Read};
+use std::{cmp, fmt, io, io::Read};
 pub const ENCRYPTED_NOTE_SIZE: usize =
     SCALAR_SIZE + MEMO_SIZE + AMOUNT_VALUE_SIZE + ASSET_ID_LENGTH + PUBLIC_ADDRESS_SIZE;
 //   8  value
@@ -54,6 +54,15 @@ impl From<&str> for Memo {
 impl From<String> for Memo {
     fn from(string: String) -> Self {
         Memo::from(string.as_str())
+    }
+}
+
+impl From<&[u8]> for Memo {
+    fn from(value: &[u8]) -> Self {
+        let num_to_copy = cmp::min(value.len(), MEMO_SIZE);
+        let mut memo_bytes = [0u8; MEMO_SIZE];
+        memo_bytes[..num_to_copy].copy_from_slice(&value[..num_to_copy]);
+        Memo(memo_bytes)
     }
 }
 

--- a/ironfish/src/genesis/addGenesisTransaction.ts
+++ b/ironfish/src/genesis/addGenesisTransaction.ts
@@ -101,7 +101,7 @@ export async function addGenesisTransaction(
     const note = new NativeNote(
       alloc.publicAddress,
       BigInt(alloc.amountInOre),
-      alloc.memo,
+      Buffer.from(alloc.memo, 'hex'),
       Asset.nativeId(),
       account.publicAddress,
     )

--- a/ironfish/src/genesis/makeGenesisBlock.ts
+++ b/ironfish/src/genesis/makeGenesisBlock.ts
@@ -56,7 +56,7 @@ export async function makeGenesisBlock(
   const genesisNote = new NativeNote(
     genesisKey.publicAddress,
     allocationSum,
-    '',
+    Buffer.alloc(0),
     Asset.nativeId(),
     genesisKey.publicAddress,
   )
@@ -72,7 +72,7 @@ export async function makeGenesisBlock(
   const note = new NativeNote(
     minersFeeKey.publicAddress,
     BigInt(0),
-    '',
+    Buffer.alloc(0),
     Asset.nativeId(),
     minersFeeKey.publicAddress,
   )
@@ -141,7 +141,7 @@ export async function makeGenesisBlock(
     const note = new NativeNote(
       alloc.publicAddress,
       BigInt(alloc.amountInOre),
-      alloc.memo,
+      Buffer.from(alloc.memo, 'hex'),
       Asset.nativeId(),
       genesisNote.owner(),
     )

--- a/ironfish/src/testUtilities/fixtures/blocks.ts
+++ b/ironfish/src/testUtilities/fixtures/blocks.ts
@@ -184,7 +184,7 @@ export async function useBlockWithRawTxFixture(
       const note = new NativeNote(
         output.publicAddress,
         output.amount,
-        output.memo,
+        Buffer.from(output.memo, 'hex'),
         output.assetId,
         sender.publicAddress,
       )

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -1022,7 +1022,7 @@ export class Wallet {
           const note = new NativeNote(
             output.publicAddress,
             output.amount,
-            output.memo,
+            Buffer.from(output.memo, 'hex'),
             output.assetId,
             options.account.publicAddress,
           )

--- a/ironfish/src/workerPool/tasks/createMinersFee.ts
+++ b/ironfish/src/workerPool/tasks/createMinersFee.ts
@@ -97,7 +97,7 @@ export class CreateMinersFeeTask extends WorkerTask {
     const minerNote = new Note(
       minerPublicAddress,
       amount,
-      memo,
+      Buffer.from(memo, 'hex'),
       Asset.nativeId(),
       minerPublicAddress,
     )


### PR DESCRIPTION
## Summary

the NativeNote napi constructor takes the memo to be a utf-8 string that is then converted to bytes when constructing a Memo

this prevents clients from easily constructing a memo from arbitrary bytes

changes constructor to take the memo as a JsBuffer

clients treating memos as strings should convert to buffers before constructing Notes

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
