### PR TITLE
feat(ironfish,rust,rust-nodejs): Return descriptions from unsigned transaction

### DIFF
--- a/ironfish-rust-nodejs/index.d.ts
+++ b/ironfish-rust-nodejs/index.d.ts
@@ -52,6 +52,19 @@ export const TRANSACTION_EXPIRATION_LENGTH: number
 export const TRANSACTION_FEE_LENGTH: number
 export const LATEST_TRANSACTION_VERSION: number
 export function verifyTransactions(serializedTransactions: Array<Buffer>): boolean
+export interface NativeMintDescription {
+  assetId: string
+  value: bigint
+}
+export interface NativeBurnDescription {
+  assetId: string
+  value: bigint
+}
+export interface NativeUnsignedTransactionNotes {
+  outputs: Array<Buffer>
+  mints: Array<NativeMintDescription>
+  burns: Array<NativeBurnDescription>
+}
 export function aggregateSignatureShares(publicKeyPackageStr: string, signingPackageStr: string, signatureSharesArr: Array<string>): Buffer
 export interface IdentityKeyPackage {
   identity: string
@@ -245,6 +258,7 @@ export class UnsignedTransaction {
   hash(): Buffer
   signingPackage(nativeIdentiferCommitments: Array<string>): string
   sign(spenderHexKey: string): Buffer
+  descriptions(): NativeUnsignedTransactionNotes
 }
 export class FoundBlockResult {
   randomness: string

--- a/ironfish-rust-nodejs/src/structs/transaction.rs
+++ b/ironfish-rust-nodejs/src/structs/transaction.rs
@@ -386,6 +386,29 @@ pub struct NativeUnsignedTransaction {
     transaction: UnsignedTransaction,
 }
 
+#[napi(object)]
+pub struct NativeMintDescription {
+    pub asset_id: String,
+
+    pub value: BigInt,
+}
+
+#[napi(object)]
+pub struct NativeBurnDescription {
+    pub asset_id: String,
+
+    pub value: BigInt,
+}
+
+#[napi(object)]
+pub struct NativeUnsignedTransactionNotes {
+    pub outputs: Vec<Buffer>,
+
+    pub mints: Vec<NativeMintDescription>,
+
+    pub burns: Vec<NativeBurnDescription>,
+}
+
 #[napi]
 impl NativeUnsignedTransaction {
     #[napi(constructor)]
@@ -456,6 +479,39 @@ impl NativeUnsignedTransaction {
         posted_transaction.write(&mut vec).map_err(to_napi_err)?;
 
         Ok(Buffer::from(vec))
+    }
+
+    #[napi]
+    pub fn descriptions(&mut self) -> Result<NativeUnsignedTransactionNotes> {
+        let mut mints = Vec::new();
+        for mint in self.transaction.mints().iter() {
+            mints.push(NativeMintDescription {
+                asset_id: bytes_to_hex(mint.description().asset.id().as_bytes()),
+                value: mint.description().value.into(),
+            });
+        }
+
+        let mut burns = Vec::new();
+        for burn in self.transaction.burns().iter() {
+            burns.push(NativeBurnDescription {
+                asset_id: bytes_to_hex(burn.asset_id.as_bytes()),
+                value: burn.value.into(),
+            });
+        }
+
+        let mut outputs = Vec::new();
+        for output in self.transaction.outputs().iter() {
+            let mut vec: Vec<u8> = vec![];
+            output.merkle_note().write(&mut vec).map_err(to_napi_err)?;
+
+            outputs.push(Buffer::from(vec));
+        }
+
+        Ok(NativeUnsignedTransactionNotes{
+            mints,
+            burns,
+            outputs,
+        })
     }
 }
 

--- a/ironfish-rust-nodejs/src/structs/transaction.rs
+++ b/ironfish-rust-nodejs/src/structs/transaction.rs
@@ -507,7 +507,7 @@ impl NativeUnsignedTransaction {
             outputs.push(Buffer::from(vec));
         }
 
-        Ok(NativeUnsignedTransactionNotes{
+        Ok(NativeUnsignedTransactionNotes {
             mints,
             burns,
             outputs,

--- a/ironfish-rust/src/transaction/mints.rs
+++ b/ironfish-rust/src/transaction/mints.rs
@@ -177,6 +177,10 @@ impl UnsignedMintDescription {
 
         Ok(())
     }
+
+    pub fn description(&self) -> &MintDescription {
+        &self.description
+    }
 }
 
 /// This description represents an action to increase the supply of an existing

--- a/ironfish-rust/src/transaction/unsigned.rs
+++ b/ironfish-rust/src/transaction/unsigned.rs
@@ -312,4 +312,16 @@ impl UnsignedTransaction {
     pub fn public_key_randomness(&self) -> jubjub::Fr {
         self.public_key_randomness
     }
+
+    pub fn outputs(&self) -> &Vec<OutputDescription> {
+        &self.outputs
+    }
+
+    pub fn mints(&self) -> &Vec<UnsignedMintDescription> {
+        &self.mints
+    }
+
+    pub fn burns(&self) -> &Vec<BurnDescription> {
+        &self.burns
+    }
 }

--- a/ironfish/src/primitives/__fixtures__/unsignedTransaction.test.ts.fixture
+++ b/ironfish/src/primitives/__fixtures__/unsignedTransaction.test.ts.fixture
@@ -1,0 +1,66 @@
+{
+  "UnsignedTransaction should return descriptions": [
+    {
+      "version": 4,
+      "id": "56b437b2-46e5-42f3-86b7-3dd62929adc4",
+      "name": "test",
+      "spendingKey": "fa6bf81b751072e50434e34aabc578ebd2547fe9c57bc459143ee81864b2d265",
+      "viewKey": "b77d2ec7dffd9c745be68707bdfe1f641b0794d75f893c7347f8e397c10b755592ae8ee11de65a753b0916c00c88c32bad71a2ca06e74b9e65aa198c895adec3",
+      "incomingViewKey": "002153c2c15b1664432c133b60911599cf0101f3bacdc0dd72d07db58ba09e00",
+      "outgoingViewKey": "40118f234ebcba4e7632630d8313727ed1e07f38cbccc6ff9b78ba86a0592357",
+      "publicAddress": "f75878f1459ca846e4ad887df3c183c02f0ff9c74a080896cf79ca19772c392d",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+        },
+        "sequence": 1
+      },
+      "proofAuthorizingKey": "14609df16d30c618185a4fd3442c76c79a6c6a3fee6f0ff46c4ae7c16da5620d"
+    },
+    {
+      "version": 4,
+      "id": "b6cabe53-7633-4fa8-ac6f-a584b634c697",
+      "name": "recipient",
+      "spendingKey": "2e65b01b783e8970cd40dc34e79919e1bdf52507df4af34ca815789f8a5c73f9",
+      "viewKey": "c2c5a6061d5370b4eabada59de3314701520e5f1d536b02318ae1c5ec7fd9a981fd7f6b6dfe6636c8ea6176c366f54640b913f4fafa4eea92a60c0dabf50d86b",
+      "incomingViewKey": "a3798180664444d3504ea8efc76ac7d1f689134a1f27d55e7cc156685d1e5805",
+      "outgoingViewKey": "dfee9e1ee34594afbaf6e3625085178a271946de18d1892ea563c01c0d7fc24f",
+      "publicAddress": "ab6425e6f39541f7becbc3178428ee69ba4a7afbd26e9d2f8be968809977c980",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+        },
+        "sequence": 1
+      },
+      "proofAuthorizingKey": "09364f9b085e93d4c53589f7fd3487a8f8ff58c2ac5f3ccb616922c052843900"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "4791D7AE9F97DF100EF1558E84772D6A09B43762388283F75C6F20A32A88AA86",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:bCbDrqrcUbT8cdpkuVl4qOKGoznMaw1f+aXTDzg0GWk="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:ho6ebX8fDaMFEW/6RrUuc7nfFqivuME4uHPlTWammvY="
+        },
+        "target": "9282972777491357380673661573939192202192629606981189395159182914949423",
+        "randomness": "0",
+        "timestamp": 1708106718922,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AgAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAZ+vKo4pkg2/RZdjaro/lqqZZcPNEvAbuzCUsdR7CmpiSM8Z+PzQzct6386TbBO6R+2cQj0XNyI3Zy5VUzZjzOzW8ZVwCHsPWztSK9jnNcxSI8ccf0gsGKmv7XpvfJyqtiew1x7em0Ytbun+xqCmNmSriIi8CgthIPA2xqoNF2oUBsqJpt5YfZSbazkEbzBRFMnrFydi9+2WMZvKBOiCNz/Yf4w+ZGy436bm8u0qsLYSX5/9Lu9IsArUIJX+0w+UZboO2CUb6+9voiFeG7HOg3fXeURoDL5Rx3tXnHy5J4vgYkh6SfJUO0yUbrkxaUfuOcaBRTG1yr7SUDd16WzLU7SP2PW1CJkTQXFU3xYRlLe1qhXHyHl4k/W1mFZWtWSZmgEZz/+oufZ9FfJrY0PT7SG2riDKheC1ZLpgfzwvUmfODwEGhTC8Enu1BR+kGFQfLFUNg1+uINXu1q7a1+nXEDROvLGLRgPcs1PEzXpbm0WhBHpgueIiNpscxtgK29jCO9fDYxwHAhHcDqDhAcDT5eYdk2Aul6JrH85rlvKQK8tuL/y9ly8oA6ryDJ+pbxbNeqkxPOO5iQ2qTtFgMXLuQy+6tPbrOL9TQygM5tDrm28z04KG82JmUCklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw9esWZfmSuC0jyhLr+dgUfwpx4Z154z7+QSCT8evpy9Z1i9sxXLfQOXKWLUXNv4r3wXAXVEPvL0Gbyt5E3oxaAg=="
+        }
+      ]
+    }
+  ]
+}

--- a/ironfish/src/primitives/unsignedTransaction.test.ts
+++ b/ironfish/src/primitives/unsignedTransaction.test.ts
@@ -1,0 +1,81 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Asset } from '@ironfish/rust-nodejs'
+import { Assert } from '../assert'
+import { useAccountFixture, useMinerBlockFixture } from '../testUtilities/fixtures'
+import { createRawTransaction } from '../testUtilities/helpers/transaction'
+import { createNodeTest } from '../testUtilities/nodeTest'
+import { MintData } from './rawTransaction'
+import { UnsignedTransaction } from './unsignedTransaction'
+
+describe('UnsignedTransaction', () => {
+  const nodeTest = createNodeTest()
+
+  it('should return descriptions', async () => {
+    const account = await useAccountFixture(nodeTest.wallet)
+    const recipient = await useAccountFixture(nodeTest.wallet, 'recipient')
+    const asset = new Asset(account.publicAddress, 'test', '')
+
+    const block = await useMinerBlockFixture(
+      nodeTest.chain,
+      undefined,
+      account,
+      nodeTest.wallet,
+    )
+    await expect(nodeTest.chain).toAddBlock(block)
+    await nodeTest.wallet.updateHead()
+
+    const burnValue = 2n
+    const burn = {
+      assetId: Asset.nativeId(),
+      value: burnValue,
+    }
+
+    const mintValue = 1337n
+    const mint: MintData = {
+      creator: asset.creator().toString('hex'),
+      name: asset.name().toString('utf8'),
+      metadata: asset.metadata().toString('utf8'),
+      value: mintValue,
+    }
+
+    const raw = await createRawTransaction({
+      wallet: nodeTest.wallet,
+      from: account,
+      to: recipient,
+      amount: 1n,
+      fee: 0n,
+      expiration: 10,
+      burns: [burn],
+      mints: [mint],
+    })
+
+    Assert.isNotNull(account.proofAuthorizingKey)
+    const builtTx = raw.build(
+      account.proofAuthorizingKey,
+      account.viewKey,
+      account.outgoingViewKey,
+    )
+    const unsigned = new UnsignedTransaction(builtTx.serialize())
+
+    const descriptions = unsigned.descriptions(account.incomingViewKey, account.outgoingViewKey)
+
+    const mintOutput = descriptions.receivedNotes.filter((n) => n.assetId().equals(asset.id()))
+    expect(mintOutput).toHaveLength(1)
+    expect(mintOutput[0].value()).toEqual(mintValue)
+
+    expect(descriptions.mints).toEqual([
+      {
+        assetId: asset.id().toString('hex'),
+        value: mintValue,
+      },
+    ])
+    expect(descriptions.burns).toEqual([
+      {
+        assetId: Asset.nativeId().toString('hex'),
+        value: burnValue,
+      },
+    ])
+  })
+})

--- a/ironfish/src/primitives/unsignedTransaction.ts
+++ b/ironfish/src/primitives/unsignedTransaction.ts
@@ -2,7 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { UnsignedTransaction as NativeUnsignedTransaction } from '@ironfish/rust-nodejs'
+import {
+  NativeBurnDescription,
+  NativeMintDescription,
+  UnsignedTransaction as NativeUnsignedTransaction,
+} from '@ironfish/rust-nodejs'
+import { Note } from './note'
+import { NoteEncrypted } from './noteEncrypted'
 
 export class UnsignedTransaction {
   private readonly unsignedTransactionSerialized: Buffer
@@ -54,5 +60,41 @@ export class UnsignedTransaction {
     })
 
     return result
+  }
+
+  descriptions(
+    incomingViewKey: string,
+    outgoingViewKey: string,
+  ): {
+    receivedNotes: Note[]
+    spentNotes: Note[]
+    mints: NativeMintDescription[]
+    burns: NativeBurnDescription[]
+  } {
+    const descriptions = this.takeReference().descriptions()
+    this.returnReference()
+
+    const receivedNotes = []
+    const spentNotes = []
+    for (const serializedOutput of descriptions.outputs) {
+      const note = new NoteEncrypted(serializedOutput)
+
+      const receivedNote = note.decryptNoteForOwner(incomingViewKey)
+      if (receivedNote) {
+        receivedNotes.push(receivedNote)
+      }
+
+      const spentNote = note.decryptNoteForSpender(outgoingViewKey)
+      if (spentNote) {
+        spentNotes.push(spentNote)
+      }
+    }
+
+    return {
+      receivedNotes,
+      spentNotes,
+      mints: descriptions.mints,
+      burns: descriptions.burns,
+    }
   }
 }

--- a/ironfish/src/primitives/unsignedTransaction.ts
+++ b/ironfish/src/primitives/unsignedTransaction.ts
@@ -67,7 +67,7 @@ export class UnsignedTransaction {
     outgoingViewKey: string,
   ): {
     receivedNotes: Note[]
-    spentNotes: Note[]
+    sentNotes: Note[]
     mints: NativeMintDescription[]
     burns: NativeBurnDescription[]
   } {
@@ -75,7 +75,7 @@ export class UnsignedTransaction {
     this.returnReference()
 
     const receivedNotes = []
-    const spentNotes = []
+    const sentNotes = []
     for (const serializedOutput of descriptions.outputs) {
       const note = new NoteEncrypted(serializedOutput)
 
@@ -84,15 +84,15 @@ export class UnsignedTransaction {
         receivedNotes.push(receivedNote)
       }
 
-      const spentNote = note.decryptNoteForSpender(outgoingViewKey)
-      if (spentNote) {
-        spentNotes.push(spentNote)
+      const sentNote = note.decryptNoteForSpender(outgoingViewKey)
+      if (sentNote) {
+        sentNotes.push(sentNote)
       }
     }
 
     return {
       receivedNotes,
-      spentNotes,
+      sentNotes,
       mints: descriptions.mints,
       burns: descriptions.burns,
     }


### PR DESCRIPTION
## Summary

* Adds getter methods to the unsigned transaction struct
* Adds a `descriptions` method on the Napi layer to fetch parts of an unsigned transaction
* Adds a method to the JS primitive to fetch descriptions

## Testing Plan

Unit test

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
