### PR TITLE
Update frost-related Cargo dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1092,9 +1092,9 @@ dependencies = [
 
 [[package]]
 name = "frost-core"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae732628620e7e52b3146df2eef3636f321b63dfba6e92b3b67147e0c5b2bb2"
+checksum = "45d6280625f1603d160df24b23e4984a6a7286f41455ae606823d0104c32e834"
 dependencies = [
  "byteorder",
  "const-crc32",
@@ -1114,9 +1114,9 @@ dependencies = [
 
 [[package]]
 name = "frost-rerandomized"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abc9f0445f27262bd1e1d4754ad8ce7ac03c8d079704e6c696f5e40bab85d1e2"
+checksum = "52c58f58ea009000db490efd9a3936d0035647a2b00c7ba8f3868c2ed0306b0b"
 dependencies = [
  "derive-getters",
  "document-features",
@@ -1543,7 +1543,7 @@ dependencies = [
 [[package]]
 name = "ironfish-frost"
 version = "0.1.0"
-source = "git+https://github.com/iron-fish/ironfish-frost.git?branch=main#9f2f785cc8e4c32078fbb6f1403a60e2dd4eb6d9"
+source = "git+https://github.com/iron-fish/ironfish-frost.git?branch=main#2097825398c6a5ab0469058c52c2c2ed5842a3f0"
 dependencies = [
  "blake3",
  "chacha20 0.9.1",
@@ -2375,7 +2375,7 @@ dependencies = [
 [[package]]
 name = "reddsa"
 version = "0.5.1"
-source = "git+https://github.com/ZcashFoundation/reddsa.git#36cb6b8226e2315c6cb753b5852a824fd53d3598"
+source = "git+https://github.com/ZcashFoundation/reddsa.git?rev=311baf8865f6e21527d1f20750d8f2cf5c9e531a#311baf8865f6e21527d1f20750d8f2cf5c9e531a"
 dependencies = [
  "blake2b_simd",
  "byteorder",

--- a/ironfish-rust-nodejs/src/frost.rs
+++ b/ironfish-rust-nodejs/src/frost.rs
@@ -7,11 +7,7 @@ use crate::{
     to_napi_err,
 };
 use ironfish::{
-    frost::{
-        keys::KeyPackage,
-        round1::SigningCommitments,
-        round2::{self, Randomizer},
-    },
+    frost::{keys::KeyPackage, round1::SigningCommitments, round2, Randomizer},
     frost_utils::{
         signature_share::SignatureShare, signing_commitment::SigningCommitment,
         signing_package::SigningPackage, split_spender_key::split_spender_key,

--- a/ironfish-rust/src/transaction/tests.rs
+++ b/ironfish-rust/src/transaction/tests.rs
@@ -26,11 +26,7 @@ use crate::{
 
 use ff::Field;
 use ironfish_frost::{
-    frost::{
-        round2,
-        round2::{Randomizer, SignatureShare},
-        Identifier,
-    },
+    frost::{round2, round2::SignatureShare, Identifier, Randomizer},
     nonces::deterministic_signing_nonces,
 };
 use ironfish_zkp::{

--- a/ironfish-rust/src/transaction/unsigned.rs
+++ b/ironfish-rust/src/transaction/unsigned.rs
@@ -6,11 +6,8 @@ use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use group::GroupEncoding;
 use ironfish_frost::{
     frost::{
-        aggregate,
-        keys::PublicKeyPackage,
-        round1::SigningCommitments,
-        round2::{Randomizer, SignatureShare},
-        Identifier, RandomizedParams, SigningPackage as FrostSigningPackage,
+        aggregate, keys::PublicKeyPackage, round1::SigningCommitments, round2::SignatureShare,
+        Identifier, RandomizedParams, Randomizer, SigningPackage as FrostSigningPackage,
     },
     participant::Identity,
 };


### PR DESCRIPTION
## Summary

Updating Cargo dependencies related to frost, in particular `frost-rerandomized`, which went from 1.0.0-rc.0 to 1.0.0 and introduced a backward-incompatible change (`Randomizer` moved to the crate root).

## Testing Plan

Unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
