### PR TITLE
fix(cli): Remove signerIdentity from create-signature-share

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/create-signature-share.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/create-signature-share.ts
@@ -23,13 +23,6 @@ export class CreateSignatureShareCommand extends IronfishCommand {
       description: 'The signing package for which the signature share will be created',
       required: false,
     }),
-    signerIdentity: Flags.string({
-      char: 'i',
-      description:
-        'The identity of the participants that will sign the transaction (may be specified multiple times to add multiple signers)',
-      required: true,
-      multiple: true,
-    }),
     confirm: Flags.boolean({
       default: false,
       description: 'Confirm creating signature share without confirming',


### PR DESCRIPTION
## Summary

The command does not use signerIdentity and does not start properly. I think we can remove this flag.

```sh
❯ f wallet:multisig:create-signature-share --datadir=~/.ironfish-test
yarn run v1.22.21
$ yarn build && yarn start:js wallet:multisig:create-signature-share '--datadir=~/.ironfish-test'
$ tsc -b
$ cross-env OCLIF_TS_NODE=0 IRONFISH_DEBUG=1 node --expose-gc --inspect=:0 --inspect-publish-uid=http --enable-source-maps bin/run wallet:multisig:create-signature-share '--datadir=~/.ironfish-test'
 ›   Error: The following error occurred:
 ›     Missing required flag signerIdentity
 ›   See more help with --help
```

## Testing Plan

Ran the command.

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
