### PR TITLE
Rahul/use public key package with identities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1543,7 +1543,7 @@ dependencies = [
 [[package]]
 name = "ironfish-frost"
 version = "0.1.0"
-source = "git+https://github.com/iron-fish/ironfish-frost.git?branch=main#2097825398c6a5ab0469058c52c2c2ed5842a3f0"
+source = "git+https://github.com/iron-fish/ironfish-frost.git?branch=main#3363ff1ce322ad195cdad50ac76e05dc6353a919"
 dependencies = [
  "blake3",
  "chacha20 0.9.1",

--- a/ironfish-rust-nodejs/src/frost.rs
+++ b/ironfish-rust-nodejs/src/frost.rs
@@ -216,7 +216,10 @@ pub fn split_secret(
         });
     }
 
-    let public_key_package = t.public_key_package.serialize().map_err(to_napi_err)?;
+    let mut public_key_package_vec: Vec<u8> = vec![];
+    t.public_key_package
+        .write(&mut public_key_package_vec)
+        .map_err(to_napi_err)?;
 
     Ok(TrustedDealerKeyPackages {
         verifying_key: bytes_to_hex(&t.verifying_key),
@@ -226,6 +229,6 @@ pub fn split_secret(
         outgoing_view_key: t.outgoing_view_key.hex_key(),
         public_address: t.public_address.hex_public_address(),
         key_packages: key_packages_serialized,
-        public_key_package: bytes_to_hex(&public_key_package),
+        public_key_package: bytes_to_hex(&public_key_package_vec),
     })
 }

--- a/ironfish-rust-nodejs/src/structs/transaction.rs
+++ b/ironfish-rust-nodejs/src/structs/transaction.rs
@@ -8,7 +8,6 @@ use std::collections::BTreeMap;
 use std::convert::TryInto;
 
 use ironfish::assets::asset_identifier::AssetIdentifier;
-use ironfish::frost::keys::PublicKeyPackage;
 use ironfish::frost::round1::SigningCommitments;
 use ironfish::frost::round2::SignatureShare as FrostSignatureShare;
 use ironfish::frost::Identifier;
@@ -27,6 +26,7 @@ use ironfish::{
     MerkleNoteHash, OutgoingViewKey, ProposedTransaction, PublicAddress, SaplingKey, Transaction,
     ViewKey,
 };
+use ironfish_frost::keys::PublicKeyPackage;
 use napi::{
     bindgen_prelude::{i64n, BigInt, Buffer, Env, Object, Result, Undefined},
     JsBuffer,
@@ -521,8 +521,8 @@ pub fn aggregate_signature_shares(
     signing_package_str: String,
     signature_shares_arr: Vec<String>,
 ) -> Result<Buffer> {
-    let public_key_package = PublicKeyPackage::deserialize(
-        &hex_to_vec_bytes(&public_key_package_str).map_err(to_napi_err)?,
+    let public_key_package = PublicKeyPackage::read(
+        &hex_to_vec_bytes(&public_key_package_str).map_err(to_napi_err)?[..],
     )
     .map_err(to_napi_err)?;
 

--- a/ironfish-rust/src/frost_utils/split_secret.rs
+++ b/ironfish-rust/src/frost_utils/split_secret.rs
@@ -2,12 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use ironfish_frost::frost::{
-    frost::keys::split,
-    keys::{IdentifierList, KeyPackage, PublicKeyPackage},
-    SigningKey,
-};
 use ironfish_frost::participant::Identity;
+use ironfish_frost::{
+    frost::{
+        frost::keys::split,
+        keys::{IdentifierList, KeyPackage},
+        SigningKey,
+    },
+    keys::PublicKeyPackage,
+};
 use rand::{CryptoRng, RngCore};
 use std::collections::HashMap;
 
@@ -62,7 +65,12 @@ pub(crate) fn split_secret<R: RngCore + CryptoRng>(
         key_packages.insert(identity, key_package);
     }
 
-    Ok((key_packages, pubkeys))
+    let public_key_package = PublicKeyPackage {
+        frost_public_key_package: pubkeys,
+        identities: config.identities.clone(),
+    };
+
+    Ok((key_packages, public_key_package))
 }
 
 #[cfg(test)]

--- a/ironfish-rust/src/frost_utils/split_spender_key.rs
+++ b/ironfish-rust/src/frost_utils/split_spender_key.rs
@@ -3,8 +3,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use group::GroupEncoding;
-use ironfish_frost::frost::keys::{KeyPackage, PublicKeyPackage};
 use ironfish_frost::participant::Identity;
+use ironfish_frost::{frost::keys::KeyPackage, keys::PublicKeyPackage};
 use ironfish_zkp::constants::PROOF_GENERATION_KEY_GENERATOR;
 use jubjub::SubgroupPoint;
 use rand::thread_rng;
@@ -50,7 +50,10 @@ pub fn split_spender_key(
 
     let (key_packages, public_key_package) = split_secret(&secret_config, rng)?;
 
-    let authorizing_key_bytes = public_key_package.verifying_key().serialize();
+    let authorizing_key_bytes = public_key_package
+        .frost_public_key_package
+        .verifying_key()
+        .serialize();
 
     let authorizing_key = Option::from(SubgroupPoint::from_bytes(&authorizing_key_bytes))
         .ok_or_else(|| IronfishError::new(IronfishErrorKind::InvalidAuthorizingKey))?;


### PR DESCRIPTION
## Summary

Uses the public key package in the ironfish-frost library instead of the one provided by frost. 
This new public key package contains the identities + frost public key package

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
