### PR TITLE
fixes rendering of notes in wallet:transaction

### DIFF
--- a/ironfish-cli/src/commands/wallet/transaction/index.ts
+++ b/ironfish-cli/src/commands/wallet/transaction/index.ts
@@ -101,6 +101,7 @@ export class TransactionCommand extends IronfishCommand {
         },
         assetId: {
           header: 'Asset Id',
+          get: ({ note }) => note.assetId,
         },
         isSpent: {
           header: 'Spent',
@@ -108,6 +109,7 @@ export class TransactionCommand extends IronfishCommand {
         },
         memo: {
           header: 'Memo',
+          get: ({ note }) => note.memo,
         },
         owner: {
           header: 'Owner Address',


### PR DESCRIPTION
## Summary

defines getter functions to extract assetId, memo from each note displayed in the table

notes are paired with asset information, so the default getter doesn't work to extract fields from the nested note object

## Testing Plan

Before:
```
$ fish wallet:transaction 62f9886197898988da46f23c3034b4c0a2836c73934107aab5526bbc6ec00f2a -d ~/.if.dev

Transaction: 62f9886197898988da46f23c3034b4c0a2836c73934107aab5526bbc6ec00f2a
Account: test
Status: confirmed
Type: receive
Timestamp: 2/21/2024 1:54:54 PM PST
Fee: $IRON 0.00000001
Block Hash: 00000002078575e210c512a5ca8cff2c431ccb4ffbe7ebd6bf981dff59ab8f7b
Block Sequence: 192882
Notes Count: 1
Spends Count: 1
Mints Count: 0
Burns Count: 0
Sender: 16ee4de18adff9aaf5519f63de91f594bc346b07f3981527899db073691a966c

---Notes---

 Amount     Asset Name Asset Id Spent Memo Owner Address                                                    
 ────────── ────────── ──────── ───── ──── ──────────────────────────────────────────────────────────────── 
 1.00000000 $IRON               x          ef15857dfd7526e5217d1f9af601719e7c9f25ac42fac51636ae9249663853f2
```

After:
```
$ fish wallet:transaction 62f9886197898988da46f23c3034b4c0a2836c73934107aab5526bbc6ec00f2a -d ~/.if.dev

Transaction: 62f9886197898988da46f23c3034b4c0a2836c73934107aab5526bbc6ec00f2a
Account: test
Status: confirmed
Type: receive
Timestamp: 2/21/2024 1:54:54 PM PST
Fee: $IRON 0.00000001
Block Hash: 00000002078575e210c512a5ca8cff2c431ccb4ffbe7ebd6bf981dff59ab8f7b
Block Sequence: 192882
Notes Count: 1
Spends Count: 1
Mints Count: 0
Burns Count: 0
Sender: 16ee4de18adff9aaf5519f63de91f594bc346b07f3981527899db073691a966c

---Notes---

 Amount     Asset Name Asset Id                                                         Spent Memo                     Owner Address                                                    
 ────────── ────────── ──────────────────────────────────────────────────────────────── ───── ──────────────────────── ──────────────────────────────────────────────────────────────── 
 1.00000000 $IRON      51f33a2f14f92735e562dc658a5639279ddca3d5079a6d1242b2a588a9cbf44c x     test memo, please ignore ef15857dfd7526e5217d1f9af601719e7c9f25ac42fac51636ae9249663853f2 
```

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
