### PR TITLE
Rahul/add unsigned transaction summary to create signing commitment

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/create-signature-share.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/create-signature-share.ts
@@ -2,11 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { CurrencyUtils, RpcClient, UnsignedTransaction } from '@ironfish/sdk'
+import { UnsignedTransaction } from '@ironfish/sdk'
 import { CliUx, Flags } from '@oclif/core'
 import { IronfishCommand } from '../../../command'
 import { RemoteFlags } from '../../../flags'
 import { longPrompt } from '../../../utils/longPrompt'
+import { renderUnsignedTransactionDetails } from '../../../utils/transaction'
 
 export class CreateSignatureShareCommand extends IronfishCommand {
   static description = `Creates a signature share for a participant for a given transaction`
@@ -41,7 +42,7 @@ export class CreateSignatureShareCommand extends IronfishCommand {
     const client = await this.sdk.connectRpc()
     const unsignedTransaction = UnsignedTransaction.fromSigningPackage(signingPackage)
 
-    await this.renderUnsignedTransactionDetails(client, unsignedTransaction, flags.account)
+    await renderUnsignedTransactionDetails(client, unsignedTransaction, flags.account)
 
     if (!flags.confirm) {
       const confirmed = await CliUx.ux.confirm('Confirm new signature share creation (Y/N)')
@@ -57,112 +58,5 @@ export class CreateSignatureShareCommand extends IronfishCommand {
 
     this.log('Signing Share:\n')
     this.log(signatureShareResponse.content.signatureShare)
-  }
-
-  private async renderUnsignedTransactionDetails(
-    client: RpcClient,
-    unsignedTransaction: UnsignedTransaction,
-    account?: string,
-  ): Promise<void> {
-    if (unsignedTransaction.mints.length > 0) {
-      this.log()
-      this.log('==================')
-      this.log('Transaction Mints:')
-      this.log('==================')
-
-      for (const [i, mint] of unsignedTransaction.mints.entries()) {
-        if (i !== 0) {
-          this.log('------------------')
-        }
-        this.log()
-
-        this.log(`Asset ID:      ${mint.asset.id().toString('hex')}`)
-        this.log(`Name:          ${mint.asset.name().toString('utf8')}`)
-        this.log(`Amount:        ${CurrencyUtils.renderIron(mint.value, false)}`)
-
-        if (mint.transferOwnershipTo) {
-          this.log(
-            `Ownership of this asset will be transferred to ${mint.transferOwnershipTo.toString(
-              'hex',
-            )}. The current account will no longer have any permission to mint or modify this asset. This cannot be undone.`,
-          )
-        }
-        this.log()
-      }
-    }
-
-    if (unsignedTransaction.burns.length > 0) {
-      this.log()
-      this.log('==================')
-      this.log('Transaction Burns:')
-      this.log('==================')
-
-      for (const [i, burn] of unsignedTransaction.burns.entries()) {
-        if (i !== 0) {
-          this.log('------------------')
-        }
-        this.log()
-
-        this.log(`Asset ID:      ${burn.assetId.toString('hex')}`)
-        this.log(`Amount:        ${CurrencyUtils.renderIron(burn.value, false)}`)
-        this.log()
-      }
-    }
-
-    if (unsignedTransaction.notes.length > 0) {
-      const response = await client.wallet.getUnsignedTransactionNotes({
-        account,
-        unsignedTransaction: unsignedTransaction.serialize().toString('hex'),
-      })
-
-      if (response.content.sentNotes.length > 0) {
-        this.log()
-        this.log('==================')
-        this.log('Notes sent:')
-        this.log('==================')
-
-        let logged = false
-        for (const note of response.content.sentNotes) {
-          // Skip this since we'll re-render for received notes
-          if (note.owner === note.sender) {
-            continue
-          }
-
-          if (logged) {
-            this.log('------------------')
-          }
-          logged = true
-          this.log()
-
-          this.log(`Amount:        ${CurrencyUtils.renderIron(note.value, true, note.assetId)}`)
-          this.log(`Memo:          ${note.memo}`)
-          this.log(`Recipient:     ${note.owner}`)
-          this.log(`Sender:        ${note.sender}`)
-          this.log()
-        }
-      }
-
-      if (response.content.sentNotes.length > 0) {
-        this.log()
-        this.log('==================')
-        this.log('Notes received:')
-        this.log('==================')
-
-        for (const [i, note] of response.content.receivedNotes.entries()) {
-          if (i !== 0) {
-            this.log('------------------')
-          }
-          this.log()
-
-          this.log(`Amount:        ${CurrencyUtils.renderIron(note.value, true, note.assetId)}`)
-          this.log(`Memo:          ${note.memo}`)
-          this.log(`Recipient:     ${note.owner}`)
-          this.log(`Sender:        ${note.sender}`)
-          this.log()
-        }
-      }
-    }
-
-    this.log()
   }
 }

--- a/ironfish-cli/src/commands/wallet/multisig/create-signature-share.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/create-signature-share.ts
@@ -42,7 +42,12 @@ export class CreateSignatureShareCommand extends IronfishCommand {
     const client = await this.sdk.connectRpc()
     const unsignedTransaction = UnsignedTransaction.fromSigningPackage(signingPackage)
 
-    await renderUnsignedTransactionDetails(client, unsignedTransaction, flags.account)
+    await renderUnsignedTransactionDetails(
+      client,
+      unsignedTransaction,
+      flags.account,
+      this.logger,
+    )
 
     if (!flags.confirm) {
       const confirmed = await CliUx.ux.confirm('Confirm new signature share creation (Y/N)')

--- a/ironfish-cli/src/commands/wallet/multisig/create-signing-commitment.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/create-signing-commitment.ts
@@ -1,9 +1,11 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { UnsignedTransaction } from '@ironfish/sdk'
 import { Flags } from '@oclif/core'
 import { IronfishCommand } from '../../../command'
 import { RemoteFlags } from '../../../flags'
+import { renderUnsignedTransactionDetails } from '../../../utils/transaction'
 
 export class CreateSigningCommitmentCommand extends IronfishCommand {
   static description = 'Create a signing commitment from a participant for a given transaction'
@@ -29,12 +31,21 @@ export class CreateSigningCommitmentCommand extends IronfishCommand {
       required: true,
       multiple: true,
     }),
+    confirm: Flags.boolean({
+      default: false,
+      description: 'Confirm creating signature share without confirming',
+    }),
   }
 
   async start(): Promise<void> {
     const { flags } = await this.parse(CreateSigningCommitmentCommand)
 
     const client = await this.sdk.connectRpc()
+
+    const unsignedTransaction = new UnsignedTransaction(Buffer.from(flags.unsignedTransaction))
+
+    await renderUnsignedTransactionDetails(client, unsignedTransaction, flags.account)
+
     const response = await client.wallet.multisig.createSigningCommitment({
       account: flags.account,
       unsignedTransaction: flags.unsignedTransaction,

--- a/ironfish-cli/src/utils/transaction.ts
+++ b/ironfish-cli/src/utils/transaction.ts
@@ -101,7 +101,7 @@ export async function renderUnsignedTransactionDetails(
       }
     }
 
-    if (response.content.sentNotes.length > 0) {
+    if (response.content.receivedNotes.length > 0) {
       logger.log('')
       logger.log('==================')
       logger.log('Notes received:')

--- a/ironfish-cli/src/utils/transaction.ts
+++ b/ironfish-cli/src/utils/transaction.ts
@@ -11,8 +11,119 @@ import {
   RpcClient,
   TimeUtils,
   TransactionStatus,
+  UnsignedTransaction,
 } from '@ironfish/sdk'
 import { CliUx } from '@oclif/core'
+
+export async function renderUnsignedTransactionDetails(
+  client: RpcClient,
+  unsignedTransaction: UnsignedTransaction,
+  account?: string,
+  logger?: Logger,
+): Promise<void> {
+  logger = logger ?? createRootLogger()
+
+  if (unsignedTransaction.mints.length > 0) {
+    logger.log('')
+    logger.log('==================')
+    logger.log('Transaction Mints:')
+    logger.log('==================')
+
+    for (const [i, mint] of unsignedTransaction.mints.entries()) {
+      if (i !== 0) {
+        logger.log('------------------')
+      }
+      logger.log('')
+
+      logger.log(`Asset ID:      ${mint.asset.id().toString('hex')}`)
+      logger.log(`Name:          ${mint.asset.name().toString('utf8')}`)
+      logger.log(`Amount:        ${CurrencyUtils.renderIron(mint.value, false)}`)
+
+      if (mint.transferOwnershipTo) {
+        logger.log(
+          `Ownership of logger asset will be transferred to ${mint.transferOwnershipTo.toString(
+            'hex',
+          )}. The current account will no longer have any permission to mint or modify logger asset. logger cannot be undone.`,
+        )
+      }
+      logger.log('')
+    }
+  }
+
+  if (unsignedTransaction.burns.length > 0) {
+    logger.log('')
+    logger.log('==================')
+    logger.log('Transaction Burns:')
+    logger.log('==================')
+
+    for (const [i, burn] of unsignedTransaction.burns.entries()) {
+      if (i !== 0) {
+        logger.log('------------------')
+      }
+      logger.log('')
+
+      logger.log(`Asset ID:      ${burn.assetId.toString('hex')}`)
+      logger.log(`Amount:        ${CurrencyUtils.renderIron(burn.value, false)}`)
+      logger.log('')
+    }
+  }
+
+  if (unsignedTransaction.notes.length > 0) {
+    const response = await client.wallet.getUnsignedTransactionNotes({
+      account,
+      unsignedTransaction: unsignedTransaction.serialize().toString('hex'),
+    })
+
+    if (response.content.sentNotes.length > 0) {
+      logger.log('')
+      logger.log('==================')
+      logger.log('Notes sent:')
+      logger.log('==================')
+
+      let logged = false
+      for (const note of response.content.sentNotes) {
+        // Skip logger since we'll re-render for received notes
+        if (note.owner === note.sender) {
+          continue
+        }
+
+        if (logged) {
+          logger.log('------------------')
+        }
+        logged = true
+        logger.log('')
+
+        logger.log(`Amount:        ${CurrencyUtils.renderIron(note.value, true, note.assetId)}`)
+        logger.log(`Memo:          ${note.memo}`)
+        logger.log(`Recipient:     ${note.owner}`)
+        logger.log(`Sender:        ${note.sender}`)
+        logger.log('')
+      }
+    }
+
+    if (response.content.sentNotes.length > 0) {
+      logger.log('')
+      logger.log('==================')
+      logger.log('Notes received:')
+      logger.log('==================')
+
+      for (const [i, note] of response.content.receivedNotes.entries()) {
+        if (i !== 0) {
+          logger.log('------------------')
+        }
+        logger.log('')
+
+        logger.log(`Amount:        ${CurrencyUtils.renderIron(note.value, true, note.assetId)}`)
+        logger.log(`Memo:          ${note.memo}`)
+        logger.log(`Recipient:     ${note.owner}`)
+        logger.log(`Sender:        ${note.sender}`)
+        logger.log('')
+      }
+    }
+  }
+
+  logger.log('')
+}
 
 export function displayTransactionSummary(
   transaction: RawTransaction,


### PR DESCRIPTION
## Summary

1. moves `renderUnsignedTransactionDetails` to utils
2. uses `renderUnsignedTransactionDetails` when creating signing commitment
3. prompts user for unsigned transaction if not provided 
4. prompts user for identities if not provided 
5. prompts user to confirm the creating of the signing commitment

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
