### PR TITLE
Add SDK exports to repl

### DIFF
--- a/ironfish-cli/src/commands/repl.ts
+++ b/ironfish-cli/src/commands/repl.ts
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import * as IronfishSDK from '@ironfish/sdk'
 import { ALL_API_NAMESPACES, NodeUtils, RpcMemoryClient } from '@ironfish/sdk'
 import { Flags } from '@oclif/core'
 import fs from 'fs/promises'
@@ -54,6 +55,9 @@ export default class Repl extends IronfishCommand {
     this.log(`\n  Use the RPC node/getStatus`)
     this.log(`  > (await client.status()).content`)
     this.log('')
+    this.log(`\n  Use an exported function or constructor from the SDK`)
+    this.log(`  > const tx = new IronfishSDK.Transaction(Buffer.from('dsf3...', 'hex'))`)
+    this.log('')
 
     const historyPath = path.join(node.config.tempDir, 'repl_history.txt')
     await fs.mkdir(node.config.tempDir, { recursive: true })
@@ -61,6 +65,7 @@ export default class Repl extends IronfishCommand {
     this.log('Type .exit or press CTRL+C to quit')
 
     const server = repl.start('> ')
+    server.context.IronfishSDK = IronfishSDK
     server.context.sdk = this.sdk
     server.context.client = client
     server.context.node = node


### PR DESCRIPTION
## Summary
For faster debugging in the repl command expose all the SDK exported functions

## Testing Plan
Tested running repl locally

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
