### PR TITLE
Base64JsonEncoder: correctly strip the 'ifaccount' prefix

### DIFF
--- a/ironfish/src/wallet/account/encoder/base64json.ts
+++ b/ironfish/src/wallet/account/encoder/base64json.ts
@@ -18,12 +18,7 @@ export class Base64JsonEncoder implements AccountEncoder {
       throw new Error('Invalid prefix for base64 encoded account')
     }
 
-    const parts = value.split(BASE64_JSON_ACCOUNT_PREFIX)
-    if (parts.length !== 2) {
-      throw new Error('Invalid format for base64 encoded account')
-    }
-
-    const [_, encoded] = parts
+    const encoded = value.slice(BASE64_JSON_ACCOUNT_PREFIX.length)
     const encodedJson = Buffer.from(encoded, 'base64').toString()
     return new JsonEncoder().decode(encodedJson, options)
   }


### PR DESCRIPTION
## Summary

Do not use `split()` to remove the `ifaccount` prefix from the base64 blob, as `ifaccount` is a valid base64 string and so it may occur (theoretically) inside the base64 blob.

This can be verified with this simple example:

```
let s = 'eyJzb21ldGhpIjoiifaccountCJ9'
console.log(`s = ${JSON.stringify(s)}`)
let b = Buffer.from(s, 'base64').toString()
console.log(`b = ${JSON.stringify(b)}`)
console.log(JSON.parse(b))
```

which produces:

```
s = "eyJzb21ldGhpIjoiifaccountCJ9"
b = "{\"somethi\":\"���r���\"}"
{ somethi: '���r���' }
```

In practice, because `ifaccount` does not translate to ASCII characters, it's implausible that an account export will have those characters, so this is a very pedantic bug fix. (Unless maybe that string can be used as the account name.)

## Testing Plan

Unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
