### PR TITLE
name flag optional for multisig identity create

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/identity/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/identity/create.ts
@@ -20,9 +20,9 @@ export class MultisigIdentityCreate extends IronfishCommand {
 
   async start(): Promise<void> {
     const { flags } = await this.parse(MultisigIdentityCreate)
-
-    if (!flags.name) {
-      flags.name = await CliUx.ux.prompt('Enter a name for the identity', {
+    let name = flags.name
+    if (!name) {
+      name = await CliUx.ux.prompt('Enter a name for the identity', {
         required: true,
       })
     }
@@ -31,7 +31,7 @@ export class MultisigIdentityCreate extends IronfishCommand {
     let response
     while (!response) {
       try {
-        response = await client.wallet.multisig.createIdentity({ name: flags.name })
+        response = await client.wallet.multisig.createIdentity({ name })
       } catch (e) {
         if (
           e instanceof RpcRequestError &&
@@ -41,7 +41,7 @@ export class MultisigIdentityCreate extends IronfishCommand {
           this.log(e.codeMessage)
         }
 
-        flags.name = await CliUx.ux.prompt('Enter a new name for the identity', {
+        name = await CliUx.ux.prompt('Enter a new name for the identity', {
           required: true,
         })
       }

--- a/ironfish-cli/src/commands/wallet/multisig/identity/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/identity/create.ts
@@ -15,12 +15,17 @@ export class MultisigIdentityCreate extends IronfishCommand {
     name: Flags.string({
       char: 'n',
       description: 'Name to associate with the identity',
-      required: true,
     }),
   }
 
   async start(): Promise<void> {
     const { flags } = await this.parse(MultisigIdentityCreate)
+
+    if (!flags.name) {
+      flags.name = await CliUx.ux.prompt('Enter a name for the identity', {
+        required: true,
+      })
+    }
 
     const client = await this.sdk.connectRpc()
     let response


### PR DESCRIPTION
## Summary

Slight convenience/ UX improvement. 

If the name flag is not passed in ask the user for it

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
