### PR TITLE
Move pool miner to V3

### DIFF
--- a/ironfish-cli/src/commands/miners/start.ts
+++ b/ironfish-cli/src/commands/miners/start.ts
@@ -57,6 +57,10 @@ export class Miner extends IronfishCommand {
       default: false,
       allowNo: true,
     }),
+    blake3: Flags.boolean({
+      description: 'Mine with the blake3 algorithm instead of fish hash',
+      default: false,
+    }),
   }
 
   async start(): Promise<void> {
@@ -124,6 +128,8 @@ export class Miner extends IronfishCommand {
         batchSize,
         stratum,
         name: flags.name,
+        blake3: flags.blake3,
+        fishHashFullContext: flags.fishHashFull,
       })
 
       miner.start()

--- a/ironfish-rust-nodejs/index.d.ts
+++ b/ironfish-rust-nodejs/index.d.ts
@@ -260,7 +260,7 @@ export class FoundBlockResult {
 }
 export class ThreadPoolHandler {
   constructor(threadCount: number, batchSize: number, pauseOnSuccess: boolean, useFishHash: boolean, fishHashFullContext: boolean)
-  newWork(headerBytes: Buffer, target: Buffer, miningRequestId: number, fishHash: boolean): void
+  newWork(headerBytes: Buffer, target: Buffer, miningRequestId: number, fishHash: boolean, xnLength: number): void
   stop(): void
   pause(): void
   getFoundBlock(): FoundBlockResult | null

--- a/ironfish-rust-nodejs/src/lib.rs
+++ b/ironfish-rust-nodejs/src/lib.rs
@@ -156,9 +156,15 @@ impl ThreadPoolHandler {
         target: Buffer,
         mining_request_id: u32,
         fish_hash: bool,
+        xn_length: u8,
     ) {
-        self.threadpool
-            .new_work(&header_bytes, &target, mining_request_id, fish_hash)
+        self.threadpool.new_work(
+            &header_bytes,
+            &target,
+            mining_request_id,
+            fish_hash,
+            xn_length,
+        )
     }
 
     #[napi]

--- a/ironfish-rust/src/mining/threadpool.rs
+++ b/ironfish-rust/src/mining/threadpool.rs
@@ -56,6 +56,7 @@ impl ThreadPool {
         target: &[u8],
         mining_request_id: u32,
         fish_hash: bool,
+        xn_length: u8,
     ) {
         self.mining_request_id = mining_request_id;
 
@@ -66,6 +67,7 @@ impl ThreadPool {
                     target.to_vec(),
                     mining_request_id,
                     fish_hash,
+                    xn_length,
                 )
                 .unwrap();
         }

--- a/ironfish/src/mining/pool.ts
+++ b/ironfish/src/mining/pool.ts
@@ -15,6 +15,7 @@ import { RawBlockTemplateSerde, SerializedBlockTemplate } from '../serde/BlockTe
 import { BigIntUtils } from '../utils/bigint'
 import { ErrorUtils } from '../utils/error'
 import { FileUtils } from '../utils/file'
+import { GraffitiUtils } from '../utils/graffiti'
 import { SetIntervalToken, SetTimeoutToken } from '../utils/types'
 import { TransactionStatus } from '../wallet'
 import { MiningPoolShares } from './poolShares'
@@ -457,6 +458,10 @@ export class MiningPool {
     this.logger.debug('target recalculated', { prevHash: latestBlock.header.previousBlockHash })
   }
 
+  graffiti(): Buffer {
+    return GraffitiUtils.fromString(this.name)
+  }
+
   private distributeNewBlock(newBlock: SerializedBlockTemplate) {
     Assert.isNotNull(this.currentHeadTimestamp)
     Assert.isNotNull(this.currentHeadDifficulty)
@@ -467,6 +472,7 @@ export class MiningPool {
     this.recentSubmissions.clear()
 
     const rawBlock = RawBlockTemplateSerde.deserialize(newBlock)
+    rawBlock.header.graffiti = this.graffiti()
     const newWork = this.blockHasher.serializeHeader(rawBlock.header)
 
     this.stratum.newWork(miningRequestId, newWork)

--- a/ironfish/src/mining/soloMiner.ts
+++ b/ironfish/src/mining/soloMiner.ts
@@ -183,7 +183,7 @@ export class MiningSoloMiner {
     )
 
     this.waiting = false
-    this.threadPool.newWork(headerBytes, this.target, miningRequestId, fishHashBlock)
+    this.threadPool.newWork(headerBytes, this.target, miningRequestId, fishHashBlock, 0)
   }
 
   private async mine(): Promise<void> {


### PR DESCRIPTION
## Summary
Move the CPU pool miner to use V3 of ironfish stratum

## Testing Plan
Tested running against local pool on fishhash and blake3

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
