### PR TITLE
Improve the terminology used around multisig

### DIFF
--- a/ironfish-rust-nodejs/index.d.ts
+++ b/ironfish-rust-nodejs/index.d.ts
@@ -6,7 +6,7 @@
 export const IDENTITY_LEN: number
 export function createSigningCommitment(identity: string, keyPackage: string, transactionHash: Buffer, signers: Array<string>): string
 export function createSignatureShare(identity: string, keyPackage: string, signingPackage: string): string
-export function splitSecret(coordinatorSaplingKey: string, minSigners: number, identities: Array<string>): TrustedDealerKeyPackages
+export function splitSecret(spendingKey: string, minSigners: number, identities: Array<string>): TrustedDealerKeyPackages
 export function contribute(inputPath: string, outputPath: string, seed?: string | undefined | null): Promise<string>
 export function verifyTransform(paramsPath: string, newParamsPath: string): Promise<string>
 export const KEY_LENGTH: number
@@ -59,7 +59,6 @@ export interface IdentityKeyPackage {
   keyPackage: string
 }
 export interface TrustedDealerKeyPackages {
-  verifyingKey: string
   proofAuthorizingKey: string
   viewKey: string
   incomingViewKey: string

--- a/ironfish-rust-nodejs/src/structs/key_packages.rs
+++ b/ironfish-rust-nodejs/src/structs/key_packages.rs
@@ -9,10 +9,9 @@ pub struct IdentityKeyPackage {
     pub identity: String,
     pub key_package: String,
 }
-#[napi(object)]
 
+#[napi(object)]
 pub struct TrustedDealerKeyPackages {
-    pub verifying_key: String,
     pub proof_authorizing_key: String,
     pub view_key: String,
     pub incoming_view_key: String,

--- a/ironfish/src/rpc/routes/wallet/multisig/createTrustedDealerKeyPackage.test.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/createTrustedDealerKeyPackage.test.ts
@@ -17,7 +17,12 @@ describe('Route multisig/createTrustedDealerKeyPackage', () => {
       .waitForEnd()
 
     expect(response.content).toMatchObject({
+      publicAddress: expect.any(String),
+      publicKeyPackage: expect.any(String),
+      proofAuthorizingKey: expect.any(String),
+      viewKey: expect.any(String),
       incomingViewKey: expect.any(String),
+      outgoingViewKey: expect.any(String),
       keyPackages: expect.arrayContaining([
         {
           identity: participants[0].identity,
@@ -32,12 +37,6 @@ describe('Route multisig/createTrustedDealerKeyPackage', () => {
           keyPackage: expect.any(String),
         },
       ]),
-      outgoingViewKey: expect.any(String),
-      proofAuthorizingKey: expect.any(String),
-      publicAddress: expect.any(String),
-      publicKeyPackage: expect.any(String),
-      verifyingKey: expect.any(String),
-      viewKey: expect.any(String),
     })
   })
 })

--- a/ironfish/src/rpc/routes/wallet/multisig/createTrustedDealerKeyPackage.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/createTrustedDealerKeyPackage.ts
@@ -13,7 +13,6 @@ export type CreateTrustedDealerKeyPackageRequest = {
   }>
 }
 export type CreateTrustedDealerKeyPackageResponse = {
-  verifyingKey: string
   proofAuthorizingKey: string
   viewKey: string
   incomingViewKey: string
@@ -42,7 +41,6 @@ export const CreateTrustedDealerKeyPackageRequestSchema: yup.ObjectSchema<Create
 export const CreateTrustedDealerKeyPackageResponseSchema: yup.ObjectSchema<CreateTrustedDealerKeyPackageResponse> =
   yup
     .object({
-      verifyingKey: yup.string().defined(),
       proofAuthorizingKey: yup.string().defined(),
       viewKey: yup.string().defined(),
       incomingViewKey: yup.string().defined(),


### PR DESCRIPTION
## Summary

- Rename `verifying_key` (used by FROST) to `authorizing_key` (used by Iron Fish)
- Drop `verifyingKey`/`authorizingKey` from the output of `createTrustedDealerKeyPackage` as it is not needed
- Remove the term "coordinator" in places where it should actually be "trusted dealer"
- Rename 1-letter variables

## Testing Plan

Unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
