### PR TITLE
Multisig wallet: generate TDK accounts on the server side

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/account/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/account/create.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { ACCOUNT_SCHEMA_VERSION, Base64JsonEncoder } from '@ironfish/sdk'
+import { ACCOUNT_SCHEMA_VERSION } from '@ironfish/sdk'
 import { CliUx, Flags } from '@oclif/core'
 import { IronfishCommand } from '../../../../command'
 import { RemoteFlags } from '../../../../flags'
@@ -105,30 +105,12 @@ export class MultisigCreate extends IronfishCommand {
       CliUx.ux.action.stop()
     }
 
-    const encoder = new Base64JsonEncoder()
-
-    for (const [i, keyPackage] of response.content.keyPackages.entries()) {
+    for (const [i, { identity, account }] of response.content.participantAccounts.entries()) {
       this.log('\n')
       this.log(`Account ${i + 1}`)
-      this.log(`Identity ${keyPackage.identity}`)
+      this.log(`Identity ${identity}`)
       this.log('----------------')
-      const accountStr = encoder.encode({
-        name: `${name}-${i}`,
-        version: ACCOUNT_SCHEMA_VERSION,
-        createdAt,
-        spendingKey: null,
-        viewKey: response.content.viewKey,
-        incomingViewKey: response.content.incomingViewKey,
-        outgoingViewKey: response.content.outgoingViewKey,
-        publicAddress: response.content.publicAddress,
-        proofAuthorizingKey: response.content.proofAuthorizingKey,
-        multisigKeys: {
-          identity: keyPackage.identity,
-          keyPackage: keyPackage.keyPackage,
-          publicKeyPackage: response.content.publicKeyPackage,
-        },
-      })
-      this.log(accountStr)
+      this.log(account)
     }
 
     this.log()

--- a/ironfish/src/rpc/routes/wallet/multisig/createSigningCommitment.test.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/createSigningCommitment.test.ts
@@ -97,22 +97,7 @@ describe('Route wallet/multisig/createSigningCommitment', () => {
 
     const importAccountRequest = {
       name: 'participant1',
-      account: {
-        name: 'participant1',
-        version: ACCOUNT_SCHEMA_VERSION,
-        viewKey: trustedDealerPackage.viewKey,
-        incomingViewKey: trustedDealerPackage.incomingViewKey,
-        outgoingViewKey: trustedDealerPackage.outgoingViewKey,
-        publicAddress: trustedDealerPackage.publicAddress,
-        spendingKey: null,
-        createdAt: null,
-        multisigKeys: {
-          keyPackage: trustedDealerPackage.keyPackages[0].keyPackage,
-          identity: trustedDealerPackage.keyPackages[0].identity,
-          publicKeyPackage: trustedDealerPackage.publicKeyPackage,
-        },
-        proofAuthorizingKey: null,
-      },
+      account: trustedDealerPackage.participantAccounts[0].account,
     }
 
     const importAccountResponse = await routeTest.client.wallet.importAccount(

--- a/ironfish/src/rpc/routes/wallet/multisig/createTrustedDealerKeyPackage.test.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/createTrustedDealerKeyPackage.test.ts
@@ -23,18 +23,18 @@ describe('Route multisig/createTrustedDealerKeyPackage', () => {
       viewKey: expect.any(String),
       incomingViewKey: expect.any(String),
       outgoingViewKey: expect.any(String),
-      keyPackages: expect.arrayContaining([
+      participantAccounts: expect.arrayContaining([
         {
           identity: participants[0].identity,
-          keyPackage: expect.any(String),
+          account: expect.any(String),
         },
         {
           identity: participants[1].identity,
-          keyPackage: expect.any(String),
+          account: expect.any(String),
         },
         {
           identity: participants[2].identity,
-          keyPackage: expect.any(String),
+          account: expect.any(String),
         },
       ]),
     })

--- a/ironfish/src/rpc/routes/wallet/multisig/createTrustedDealerKeyPackage.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/createTrustedDealerKeyPackage.ts
@@ -3,6 +3,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { generateKey, splitSecret } from '@ironfish/rust-nodejs'
 import * as yup from 'yup'
+import { Assert } from '../../../../assert'
+import { FullNode } from '../../../../node'
+import { ACCOUNT_SCHEMA_VERSION, Base64JsonEncoder } from '../../../../wallet'
 import { ApiNamespace } from '../../namespaces'
 import { routes } from '../../router'
 
@@ -12,28 +15,24 @@ export type CreateTrustedDealerKeyPackageRequest = {
     identity: string
   }>
 }
+
 export type CreateTrustedDealerKeyPackageResponse = {
-  proofAuthorizingKey: string
+  publicAddress: string
+  publicKeyPackage: string
   viewKey: string
   incomingViewKey: string
   outgoingViewKey: string
-  publicAddress: string
-  keyPackages: Array<{ identity: string; keyPackage: string }>
-  publicKeyPackage: string
+  proofAuthorizingKey: string
+  participantAccounts: Array<{ identity: string; account: string }>
 }
+
 export const CreateTrustedDealerKeyPackageRequestSchema: yup.ObjectSchema<CreateTrustedDealerKeyPackageRequest> =
   yup
     .object({
       minSigners: yup.number().defined(),
       participants: yup
         .array()
-        .of(
-          yup
-            .object({
-              identity: yup.string().defined(),
-            })
-            .defined(),
-        )
+        .of(yup.object({ identity: yup.string().defined() }).defined())
         .defined(),
     })
     .defined()
@@ -41,22 +40,22 @@ export const CreateTrustedDealerKeyPackageRequestSchema: yup.ObjectSchema<Create
 export const CreateTrustedDealerKeyPackageResponseSchema: yup.ObjectSchema<CreateTrustedDealerKeyPackageResponse> =
   yup
     .object({
-      proofAuthorizingKey: yup.string().defined(),
+      publicAddress: yup.string().defined(),
+      publicKeyPackage: yup.string().defined(),
       viewKey: yup.string().defined(),
       incomingViewKey: yup.string().defined(),
       outgoingViewKey: yup.string().defined(),
-      publicAddress: yup.string().defined(),
-      keyPackages: yup
+      proofAuthorizingKey: yup.string().defined(),
+      participantAccounts: yup
         .array(
           yup
             .object({
               identity: yup.string().defined(),
-              keyPackage: yup.string().defined(),
+              account: yup.string().defined(),
             })
             .defined(),
         )
         .defined(),
-      publicKeyPackage: yup.string().defined(),
     })
     .defined()
 
@@ -66,12 +65,57 @@ routes.register<
 >(
   `${ApiNamespace.wallet}/multisig/createTrustedDealerKeyPackage`,
   CreateTrustedDealerKeyPackageRequestSchema,
-  (request, _context): void => {
+  (request, node): void => {
+    Assert.isInstanceOf(node, FullNode)
+
     const key = generateKey()
     const { minSigners, participants } = request.data
     const identities = participants.map((p) => p.identity)
-    const trustedDealerPackage = splitSecret(key.spendingKey, minSigners, identities)
+    const {
+      publicAddress,
+      publicKeyPackage,
+      viewKey,
+      incomingViewKey,
+      outgoingViewKey,
+      proofAuthorizingKey,
+      keyPackages,
+    } = splitSecret(key.spendingKey, minSigners, identities)
 
-    request.end(trustedDealerPackage)
+    const latestHeader = node.chain.latest
+    const createdAt = {
+      hash: latestHeader.hash,
+      sequence: latestHeader.sequence,
+    }
+
+    const encoder = new Base64JsonEncoder()
+    const participantAccounts = keyPackages.map(({ identity, keyPackage }) => ({
+      identity,
+      account: encoder.encode({
+        name: identity,
+        version: ACCOUNT_SCHEMA_VERSION,
+        createdAt,
+        spendingKey: null,
+        viewKey,
+        incomingViewKey,
+        outgoingViewKey,
+        publicAddress,
+        proofAuthorizingKey,
+        multisigKeys: {
+          identity,
+          keyPackage,
+          publicKeyPackage,
+        },
+      }),
+    }))
+
+    request.end({
+      publicAddress,
+      publicKeyPackage,
+      viewKey,
+      incomingViewKey,
+      outgoingViewKey,
+      proofAuthorizingKey,
+      participantAccounts,
+    })
   },
 )

--- a/ironfish/src/rpc/routes/wallet/multisig/integration.test.slow.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/integration.test.slow.ts
@@ -28,22 +28,8 @@ describe('multisig RPC integration', () => {
     for (let i = 0; i < participants.length; i++) {
       const accountName = `participant${i}`
       await routeTest.client.wallet.importAccount({
-        account: {
-          name: accountName,
-          version: ACCOUNT_SCHEMA_VERSION,
-          viewKey: trustedDealerPackage.viewKey,
-          incomingViewKey: trustedDealerPackage.incomingViewKey,
-          outgoingViewKey: trustedDealerPackage.outgoingViewKey,
-          publicAddress: trustedDealerPackage.publicAddress,
-          spendingKey: null,
-          createdAt: null,
-          multisigKeys: {
-            keyPackage: trustedDealerPackage.keyPackages[i].keyPackage,
-            identity: trustedDealerPackage.keyPackages[i].identity,
-            publicKeyPackage: trustedDealerPackage.publicKeyPackage,
-          },
-          proofAuthorizingKey: null,
-        },
+        name: accountName,
+        account: trustedDealerPackage.participantAccounts[i].account,
         rescan: false,
       })
 


### PR DESCRIPTION
## Summary

The `wallet/multisig/createTrustedDealerKeyPackage` RPC now creates base64 accounts directly, instead of delegating this operation to the CLI. This change is a pre-requisite for multisig account encryption.

## Testing Plan

Unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
