### PR TITLE
Multisig: add encryption/decryption primitives to ParticipantIdentity and ParticipantSecret

### DIFF
--- a/ironfish-rust-nodejs/index.d.ts
+++ b/ironfish-rust-nodejs/index.d.ts
@@ -101,10 +101,12 @@ export class ParticipantSecret {
   serialize(): Buffer
   static random(): ParticipantSecret
   toIdentity(): ParticipantIdentity
+  decryptData(jsBytes: Buffer): Buffer
 }
 export class ParticipantIdentity {
   constructor(jsBytes: Buffer)
   serialize(): Buffer
+  encryptData(jsBytes: Buffer): Buffer
 }
 export type NativePublicKeyPackage = PublicKeyPackage
 export class PublicKeyPackage {


### PR DESCRIPTION
## Summary

This allows NodeJS code to encrypt/decrypt arbitrary data to a multisig participant.

## Testing Plan

Tests will be written in a future PR that adds multisig account encryption.

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
