### PR TITLE
Add functionality to Base64JsonEncoder to encrypt multisig accounts

### DIFF
--- a/ironfish/src/wallet/account/encoder/base64json.test.ts
+++ b/ironfish/src/wallet/account/encoder/base64json.test.ts
@@ -1,14 +1,41 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { generateKey } from '@ironfish/rust-nodejs'
+import { generateKey, ParticipantSecret } from '@ironfish/rust-nodejs'
 import { AccountImport } from '../../walletdb/accountValue'
 import { ACCOUNT_SCHEMA_VERSION } from '../account'
-import { BASE64_JSON_ACCOUNT_PREFIX, Base64JsonEncoder } from './base64json'
+import {
+  BASE64_JSON_ACCOUNT_PREFIX,
+  BASE64_JSON_MULTISIG_ENCRYPTED_ACCOUNT_PREFIX,
+  Base64JsonEncoder,
+} from './base64json'
+
+const isBase64 = (s: string): boolean => {
+  const rebuilt = Buffer.from(s, 'base64').toString('base64')
+  return s === rebuilt
+}
 
 describe('Base64JsonEncoder', () => {
   const key = generateKey()
   const encoder = new Base64JsonEncoder()
+
+  it(`produces a base64 blob with the ${BASE64_JSON_ACCOUNT_PREFIX} prefix`, () => {
+    const accountImport: AccountImport = {
+      version: ACCOUNT_SCHEMA_VERSION,
+      name: 'test',
+      spendingKey: key.spendingKey,
+      viewKey: key.viewKey,
+      incomingViewKey: key.incomingViewKey,
+      outgoingViewKey: key.outgoingViewKey,
+      publicAddress: key.publicAddress,
+      createdAt: null,
+      proofAuthorizingKey: key.proofAuthorizingKey,
+    }
+
+    const encoded = encoder.encode(accountImport)
+    expect(encoded.startsWith(BASE64_JSON_ACCOUNT_PREFIX)).toBe(true)
+    expect(isBase64(encoded.slice(BASE64_JSON_ACCOUNT_PREFIX.length))).toBe(true)
+  })
 
   it('encodes the account as a base64 string and decodes the string', () => {
     const accountImport: AccountImport = {
@@ -154,5 +181,126 @@ describe('Base64JsonEncoder', () => {
     const encoded = 'ifaccountnot base64'
 
     expect(() => encoder.decode(encoded)).toThrow()
+  })
+
+  describe('with multisig encryption', () => {
+    const multisigSecret = ParticipantSecret.random()
+    const identity = multisigSecret.toIdentity()
+
+    it(`produces a base64 blob with the ${BASE64_JSON_MULTISIG_ENCRYPTED_ACCOUNT_PREFIX} prefix`, () => {
+      const accountImport: AccountImport = {
+        version: ACCOUNT_SCHEMA_VERSION,
+        name: 'test',
+        spendingKey: key.spendingKey,
+        viewKey: key.viewKey,
+        incomingViewKey: key.incomingViewKey,
+        outgoingViewKey: key.outgoingViewKey,
+        publicAddress: key.publicAddress,
+        createdAt: null,
+        proofAuthorizingKey: key.proofAuthorizingKey,
+      }
+
+      const encoded = encoder.encode(accountImport, {
+        encryptWith: { kind: 'MultisigIdentity', identity },
+      })
+      expect(encoded.startsWith(BASE64_JSON_MULTISIG_ENCRYPTED_ACCOUNT_PREFIX)).toBe(true)
+      expect(
+        isBase64(encoded.slice(BASE64_JSON_MULTISIG_ENCRYPTED_ACCOUNT_PREFIX.length)),
+      ).toBe(true)
+    })
+
+    it('encodes an account and decodes the string', () => {
+      const accountImport: AccountImport = {
+        version: ACCOUNT_SCHEMA_VERSION,
+        name: 'test',
+        spendingKey: key.spendingKey,
+        viewKey: key.viewKey,
+        incomingViewKey: key.incomingViewKey,
+        outgoingViewKey: key.outgoingViewKey,
+        publicAddress: key.publicAddress,
+        createdAt: null,
+        proofAuthorizingKey: key.proofAuthorizingKey,
+      }
+
+      const encoded = encoder.encode(accountImport, {
+        encryptWith: { kind: 'MultisigIdentity', identity },
+      })
+      expect(encoded.startsWith(BASE64_JSON_MULTISIG_ENCRYPTED_ACCOUNT_PREFIX)).toBe(true)
+
+      const decoded = encoder.decode(encoded, { multisigSecret })
+      expect(decoded).toMatchObject(accountImport)
+    })
+
+    it('throws an error when decoding without a secret', () => {
+      const accountImport: AccountImport = {
+        version: ACCOUNT_SCHEMA_VERSION,
+        name: 'test',
+        spendingKey: key.spendingKey,
+        viewKey: key.viewKey,
+        incomingViewKey: key.incomingViewKey,
+        outgoingViewKey: key.outgoingViewKey,
+        publicAddress: key.publicAddress,
+        createdAt: null,
+        proofAuthorizingKey: key.proofAuthorizingKey,
+      }
+
+      const encoded = encoder.encode(accountImport, {
+        encryptWith: { kind: 'MultisigIdentity', identity },
+      })
+      expect(() => encoder.decode(encoded)).toThrow()
+    })
+
+    it('throws an error when decoding with the wrong secret', () => {
+      const accountImport: AccountImport = {
+        version: ACCOUNT_SCHEMA_VERSION,
+        name: 'test',
+        spendingKey: key.spendingKey,
+        viewKey: key.viewKey,
+        incomingViewKey: key.incomingViewKey,
+        outgoingViewKey: key.outgoingViewKey,
+        publicAddress: key.publicAddress,
+        createdAt: null,
+        proofAuthorizingKey: key.proofAuthorizingKey,
+      }
+
+      const encoded = encoder.encode(accountImport, {
+        encryptWith: { kind: 'MultisigIdentity', identity },
+      })
+      const wrongSecret = ParticipantSecret.random()
+      expect(() => encoder.decode(encoded, { multisigSecret: wrongSecret })).toThrow()
+    })
+
+    it('does not expose account information in cleartext', () => {
+      const accountImport: AccountImport = {
+        version: ACCOUNT_SCHEMA_VERSION,
+        name: 'test',
+        spendingKey: key.spendingKey,
+        viewKey: key.viewKey,
+        incomingViewKey: key.incomingViewKey,
+        outgoingViewKey: key.outgoingViewKey,
+        publicAddress: key.publicAddress,
+        createdAt: null,
+        proofAuthorizingKey: key.proofAuthorizingKey,
+      }
+
+      const encoded = encoder.encode(accountImport, {
+        encryptWith: { kind: 'MultisigIdentity', identity },
+      })
+      expect(encoded.startsWith(BASE64_JSON_MULTISIG_ENCRYPTED_ACCOUNT_PREFIX)).toBe(true)
+      expect(
+        isBase64(encoded.slice(BASE64_JSON_MULTISIG_ENCRYPTED_ACCOUNT_PREFIX.length)),
+      ).toBe(true)
+
+      const binary = Buffer.from(
+        encoded.slice(BASE64_JSON_MULTISIG_ENCRYPTED_ACCOUNT_PREFIX.length),
+        'base64',
+      )
+
+      for (const [_key, value] of Object.entries(accountImport)) {
+        if (typeof value === 'string') {
+          expect(binary.includes(value)).toBe(false)
+        }
+      }
+    })
   })
 })

--- a/ironfish/src/wallet/account/encoder/base64json.ts
+++ b/ironfish/src/wallet/account/encoder/base64json.ts
@@ -2,24 +2,48 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { AccountImport } from '../../walletdb/accountValue'
-import { AccountDecodingOptions, AccountEncoder } from './encoder'
+import {
+  AccountDecodingOptions,
+  AccountEncoder,
+  AccountEncodingOptions,
+  isMultisigIdentityEncryption,
+} from './encoder'
 import { JsonEncoder } from './json'
+import { decodeEncryptedMultisigAccount, encodeEncryptedMultisigAccount } from './multisig'
 
 export const BASE64_JSON_ACCOUNT_PREFIX = 'ifaccount'
 
+export const BASE64_JSON_MULTISIG_ENCRYPTED_ACCOUNT_PREFIX = 'ifmsaccount'
+
 export class Base64JsonEncoder implements AccountEncoder {
-  encode(value: AccountImport): string {
-    const encoded = Buffer.from(new JsonEncoder().encode(value)).toString('base64')
-    return `${BASE64_JSON_ACCOUNT_PREFIX}${encoded}`
+  encode(value: AccountImport, options?: AccountEncodingOptions): string {
+    const binary = Buffer.from(new JsonEncoder().encode(value))
+
+    if (!options?.encryptWith) {
+      const encoded = binary.toString('base64')
+      return `${BASE64_JSON_ACCOUNT_PREFIX}${encoded}`
+    } else if (isMultisigIdentityEncryption(options.encryptWith)) {
+      const encrypted = encodeEncryptedMultisigAccount(binary, options.encryptWith)
+      const encoded = encrypted.toString('base64')
+      return `${BASE64_JSON_MULTISIG_ENCRYPTED_ACCOUNT_PREFIX}${encoded}`
+    } else {
+      throw new Error('Unknown encryption method requested')
+    }
   }
 
   decode(value: string, options?: AccountDecodingOptions): AccountImport {
-    if (!value.startsWith(BASE64_JSON_ACCOUNT_PREFIX)) {
+    let json
+    if (value.startsWith(BASE64_JSON_ACCOUNT_PREFIX)) {
+      const encoded = value.slice(BASE64_JSON_ACCOUNT_PREFIX.length)
+      json = Buffer.from(encoded, 'base64').toString()
+    } else if (value.startsWith(BASE64_JSON_MULTISIG_ENCRYPTED_ACCOUNT_PREFIX)) {
+      const encoded = value.slice(BASE64_JSON_MULTISIG_ENCRYPTED_ACCOUNT_PREFIX.length)
+      const encrypted = Buffer.from(encoded, 'base64')
+      json = decodeEncryptedMultisigAccount(encrypted, options).toString()
+    } else {
       throw new Error('Invalid prefix for base64 encoded account')
     }
 
-    const encoded = value.slice(BASE64_JSON_ACCOUNT_PREFIX.length)
-    const encodedJson = Buffer.from(encoded, 'base64').toString()
-    return new JsonEncoder().decode(encodedJson, options)
+    return new JsonEncoder().decode(json, options)
   }
 }

--- a/ironfish/src/wallet/account/encoder/encoder.ts
+++ b/ironfish/src/wallet/account/encoder/encoder.ts
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { ParticipantIdentity, ParticipantSecret } from '@ironfish/rust-nodejs'
 import { LanguageKey } from '../../../utils'
 import { AccountImport } from '../../walletdb/accountValue'
 
@@ -26,12 +27,32 @@ export enum AccountFormat {
   SpendingKey = 'SpendingKey',
 }
 
+export interface MultisigIdentityEncryption {
+  kind: 'MultisigIdentity'
+  identity: ParticipantIdentity | Buffer
+}
+
+// This is meant to be a tagged union type: `AccountEncryptionMethod = Method1 | Method2 | Method3 | ...`
+export type AccountEncryptionMethod = MultisigIdentityEncryption
+
+export function isMultisigIdentityEncryption(
+  method: AccountEncryptionMethod,
+): method is MultisigIdentityEncryption {
+  return 'kind' in method && method.kind === 'MultisigIdentity'
+}
+
 export type AccountEncodingOptions = {
   language?: LanguageKey
+  encryptWith?: AccountEncryptionMethod
 }
 
 export type AccountDecodingOptions = {
   name?: string
+  // It would have been nice to have a `wallet?: Wallet` field and let the
+  // encoders extract all the decryption information they needed from it, but
+  // sadly interacting with the wallet DB is an asynchronous operation, and
+  // decoders are all synchronous
+  multisigSecret?: ParticipantSecret | Buffer
 }
 
 export type AccountEncoder = {

--- a/ironfish/src/wallet/account/encoder/multisig.ts
+++ b/ironfish/src/wallet/account/encoder/multisig.ts
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { ParticipantIdentity, ParticipantSecret } from '@ironfish/rust-nodejs'
+import { AccountDecodingOptions, MultisigIdentityEncryption } from './encoder'
+
+export function encodeEncryptedMultisigAccount(
+  value: Buffer,
+  options: MultisigIdentityEncryption,
+): Buffer {
+  const identity = Buffer.isBuffer(options.identity)
+    ? new ParticipantIdentity(options.identity)
+    : options.identity
+  return identity.encryptData(value)
+}
+
+export function decodeEncryptedMultisigAccount(
+  value: Buffer,
+  options?: AccountDecodingOptions,
+): Buffer {
+  if (!options?.multisigSecret) {
+    throw new Error('Encrypted multisig account cannot be decrypted without a multisig secret')
+  }
+  const secret = Buffer.isBuffer(options.multisigSecret)
+    ? new ParticipantSecret(options.multisigSecret)
+    : options.multisigSecret
+  return secret.decryptData(value)
+}


### PR DESCRIPTION
## Summary

Multisig accounts can be encrypted as follows:

```ts
const encoder = new Base64JsonEncoder()
encoder.encode(account, {
  encryptWith: { kind: 'MultisigIdentity', identity: ... })
```

and decrypted as follows:

```ts
decodeAccount(encodedAccount, { multisigSecret: ... })
```

Base64 multisig encrypted accounts differ from regular base64 encoded accounts from the prefix: `ifaccount` vs `ifmsaccount`.

## Testing Plan

Unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
