### PR TITLE
Fix route and node test cleanups

### DIFF
--- a/ironfish/src/testUtilities/nodeTest.ts
+++ b/ironfish/src/testUtilities/nodeTest.ts
@@ -178,8 +178,10 @@ export function createNodeTest(preserveState = false, options: NodeTestOptions =
     afterAll(() => nodeTest.teardownAll())
   } else {
     beforeEach(() => nodeTest.setup(), 10000)
-    afterEach(() => nodeTest.teardownEach())
-    afterEach(() => nodeTest.teardownAll())
+    afterEach(async () => {
+      await nodeTest.teardownEach()
+      await nodeTest.teardownAll()
+    })
   }
 
   return nodeTest

--- a/ironfish/src/testUtilities/routeTest.ts
+++ b/ironfish/src/testUtilities/routeTest.ts
@@ -73,8 +73,10 @@ export function createRouteTest(preserveState = false): RouteTest {
     afterAll(() => routeTest.teardownAll())
   } else {
     beforeEach(() => routeTest.setup(), 10000)
-    afterEach(() => routeTest.teardownEach())
-    afterEach(() => routeTest.teardownAll())
+    afterEach(async () => {
+      await routeTest.teardownEach()
+      await routeTest.teardownAll()
+    })
   }
 
   return routeTest


### PR DESCRIPTION
## Summary

These afterEach would execute in parallel causing the DB to close before the node shuts down. This causes any code still running that's not aborted to cause a crash.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
