### PR TITLE
wallet/multisig/createTrustedDealerKeyPackage now returns encrypted accounts

### DIFF
--- a/ironfish/src/rpc/routes/wallet/multisig/createSigningCommitment.test.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/createSigningCommitment.test.ts
@@ -5,6 +5,7 @@ import { ParticipantSecret } from '@ironfish/rust-nodejs'
 import { useAccountAndAddFundsFixture, useUnsignedTxFixture } from '../../../../testUtilities'
 import { createRouteTest } from '../../../../testUtilities/routeTest'
 import { ACCOUNT_SCHEMA_VERSION } from '../../../../wallet'
+import { CreateIdentityResponse } from './createIdentity'
 
 describe('Route wallet/multisig/createSigningCommitment', () => {
   const routeTest = createRouteTest()
@@ -85,25 +86,36 @@ describe('Route wallet/multisig/createSigningCommitment', () => {
   })
 
   it('should create signing commitment', async () => {
-    const participants = Array.from({ length: 3 }, () => ({
-      identity: ParticipantSecret.random().toIdentity().serialize().toString('hex'),
-    }))
-
-    const request = { minSigners: 2, participants }
-
-    const trustedDealerPackage = (
-      await routeTest.client.wallet.multisig.createTrustedDealerKeyPackage(request)
-    ).content
-
-    const importAccountRequest = {
-      name: 'participant1',
-      account: trustedDealerPackage.participantAccounts[0].account,
-    }
-
-    const importAccountResponse = await routeTest.client.wallet.importAccount(
-      importAccountRequest,
+    // Create a bunch of multisig identities
+    const accountNames = Array.from({ length: 3 }, (_, index) => `test-account-${index}`)
+    const participants = await Promise.all(
+      accountNames.map(
+        async (name) =>
+          (
+            await routeTest.client
+              .request<CreateIdentityResponse>('wallet/multisig/createIdentity', { name })
+              .waitForEnd()
+          ).content,
+      ),
     )
 
+    // Initialize the group though TDK and import one of the accounts generated
+    const trustedDealerPackage = (
+      await routeTest.client.wallet.multisig.createTrustedDealerKeyPackage({
+        minSigners: 2,
+        participants,
+      })
+    ).content
+    const importAccount = trustedDealerPackage.participantAccounts.find(
+      ({ identity }) => identity === participants[0].identity,
+    )
+    expect(importAccount).not.toBeUndefined()
+    await routeTest.client.wallet.importAccount({
+      name: accountNames[0],
+      account: importAccount!.account,
+    })
+
+    // Create an unsigned transaction
     const txAccount = await useAccountAndAddFundsFixture(routeTest.wallet, routeTest.chain)
     const unsignedTransaction = (
       await useUnsignedTxFixture(routeTest.wallet, txAccount, txAccount)
@@ -111,8 +123,9 @@ describe('Route wallet/multisig/createSigningCommitment', () => {
       .serialize()
       .toString('hex')
 
+    // Create the signing commitment
     const response = await routeTest.client.wallet.multisig.createSigningCommitment({
-      account: importAccountResponse.content.name,
+      account: accountNames[0],
       unsignedTransaction,
       signers: participants,
     })

--- a/ironfish/src/rpc/routes/wallet/multisig/createTrustedDealerKeyPackage.test.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/createTrustedDealerKeyPackage.test.ts
@@ -19,10 +19,10 @@ describe('Route multisig/createTrustedDealerKeyPackage', () => {
     expect(response.content).toMatchObject({
       publicAddress: expect.any(String),
       publicKeyPackage: expect.any(String),
-      proofAuthorizingKey: expect.any(String),
       viewKey: expect.any(String),
       incomingViewKey: expect.any(String),
       outgoingViewKey: expect.any(String),
+      proofAuthorizingKey: expect.any(String),
       participantAccounts: expect.arrayContaining([
         {
           identity: participants[0].identity,

--- a/ironfish/src/rpc/routes/wallet/multisig/createTrustedDealerKeyPackage.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/createTrustedDealerKeyPackage.ts
@@ -11,9 +11,7 @@ import { routes } from '../../router'
 
 export type CreateTrustedDealerKeyPackageRequest = {
   minSigners: number
-  participants: Array<{
-    identity: string
-  }>
+  participants: Array<{ identity: string }>
 }
 
 export type CreateTrustedDealerKeyPackageResponse = {
@@ -90,22 +88,30 @@ routes.register<
     const encoder = new Base64JsonEncoder()
     const participantAccounts = keyPackages.map(({ identity, keyPackage }) => ({
       identity,
-      account: encoder.encode({
-        name: identity,
-        version: ACCOUNT_SCHEMA_VERSION,
-        createdAt,
-        spendingKey: null,
-        viewKey,
-        incomingViewKey,
-        outgoingViewKey,
-        publicAddress,
-        proofAuthorizingKey,
-        multisigKeys: {
-          identity,
-          keyPackage,
-          publicKeyPackage,
+      account: encoder.encode(
+        {
+          name: identity,
+          version: ACCOUNT_SCHEMA_VERSION,
+          createdAt,
+          spendingKey: null,
+          viewKey,
+          incomingViewKey,
+          outgoingViewKey,
+          publicAddress,
+          proofAuthorizingKey,
+          multisigKeys: {
+            identity,
+            keyPackage,
+            publicKeyPackage,
+          },
         },
-      }),
+        {
+          encryptWith: {
+            kind: 'MultisigIdentity',
+            identity: Buffer.from(identity, 'hex'),
+          },
+        },
+      ),
     }))
 
     request.end({


### PR DESCRIPTION
## Summary

The accounts returned by `createTrustedDealerKeyPackage` are now encrypted.

## Testing Plan

Unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
