### PR TITLE
Add testnet checkpoint for FishHash hardfork

### DIFF
--- a/ironfish/src/networks/definitions/testnet.ts
+++ b/ironfish/src/networks/definitions/testnet.ts
@@ -18,7 +18,12 @@ const TESTNET_CONSENSUS: ConsensusParameters = {
   enforceSequentialBlockTime: HARDFORK_1_ACTIVATION_TESTNET,
   enableFishHash: HARDFORK_1_ACTIVATION_TESTNET,
   enableIncreasedDifficultyChange: HARDFORK_1_ACTIVATION_TESTNET,
-  checkpoints: [],
+  checkpoints: [
+    {
+      sequence: 419193,
+      hash: '0000000002ee166a1ffe9ae5402ed7eae3be254f38f1d9f3d285b11007847d7d',
+    },
+  ],
 }
 
 export const TESTNET_GENESIS = {


### PR DESCRIPTION
## Summary
Testnet hardfork has been completed. Adding a checkpoint to point to the first FishHash block so that the chain cannot re-org previous to it

## Testing Plan
Running a node with the checkpoint on testnet

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
