### PR TITLE
Multisig: move key generation to the Rust layer

### DIFF
--- a/ironfish-rust-nodejs/index.d.ts
+++ b/ironfish-rust-nodejs/index.d.ts
@@ -6,7 +6,7 @@
 export const IDENTITY_LEN: number
 export function createSigningCommitment(identity: string, keyPackage: string, transactionHash: Buffer, signers: Array<string>): string
 export function createSignatureShare(identity: string, keyPackage: string, signingPackage: string): string
-export function splitSecret(spendingKey: string, minSigners: number, identities: Array<string>): TrustedDealerKeyPackages
+export function generateAndSplitKey(minSigners: number, identities: Array<string>): TrustedDealerKeyPackages
 export interface ParticipantKeyPackage {
   identity: string
   keyPackage: string

--- a/ironfish-rust-nodejs/index.js
+++ b/ironfish-rust-nodejs/index.js
@@ -252,7 +252,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { FishHashContext, IDENTITY_LEN, createSigningCommitment, createSignatureShare, ParticipantSecret, ParticipantIdentity, splitSecret, PublicKeyPackage, contribute, verifyTransform, KEY_LENGTH, NONCE_LENGTH, BoxKeyPair, randomBytes, boxMessage, unboxMessage, RollingFilter, initSignalHandler, triggerSegfault, ASSET_ID_LENGTH, ASSET_METADATA_LENGTH, ASSET_NAME_LENGTH, ASSET_LENGTH, Asset, NOTE_ENCRYPTION_KEY_LENGTH, MAC_LENGTH, ENCRYPTED_NOTE_PLAINTEXT_LENGTH, ENCRYPTED_NOTE_LENGTH, NoteEncrypted, PUBLIC_ADDRESS_LENGTH, RANDOMNESS_LENGTH, MEMO_LENGTH, AMOUNT_VALUE_LENGTH, DECRYPTED_NOTE_LENGTH, Note, PROOF_LENGTH, TRANSACTION_SIGNATURE_LENGTH, TRANSACTION_PUBLIC_KEY_RANDOMNESS_LENGTH, TRANSACTION_EXPIRATION_LENGTH, TRANSACTION_FEE_LENGTH, LATEST_TRANSACTION_VERSION, TransactionPosted, Transaction, verifyTransactions, UnsignedTransaction, aggregateSignatureShares, LanguageCode, generateKey, spendingKeyToWords, wordsToSpendingKey, generateKeyFromPrivateKey, initializeSapling, FoundBlockResult, ThreadPoolHandler, isValidPublicAddress } = nativeBinding
+const { FishHashContext, IDENTITY_LEN, createSigningCommitment, createSignatureShare, ParticipantSecret, ParticipantIdentity, generateAndSplitKey, PublicKeyPackage, contribute, verifyTransform, KEY_LENGTH, NONCE_LENGTH, BoxKeyPair, randomBytes, boxMessage, unboxMessage, RollingFilter, initSignalHandler, triggerSegfault, ASSET_ID_LENGTH, ASSET_METADATA_LENGTH, ASSET_NAME_LENGTH, ASSET_LENGTH, Asset, NOTE_ENCRYPTION_KEY_LENGTH, MAC_LENGTH, ENCRYPTED_NOTE_PLAINTEXT_LENGTH, ENCRYPTED_NOTE_LENGTH, NoteEncrypted, PUBLIC_ADDRESS_LENGTH, RANDOMNESS_LENGTH, MEMO_LENGTH, AMOUNT_VALUE_LENGTH, DECRYPTED_NOTE_LENGTH, Note, PROOF_LENGTH, TRANSACTION_SIGNATURE_LENGTH, TRANSACTION_PUBLIC_KEY_RANDOMNESS_LENGTH, TRANSACTION_EXPIRATION_LENGTH, TRANSACTION_FEE_LENGTH, LATEST_TRANSACTION_VERSION, TransactionPosted, Transaction, verifyTransactions, UnsignedTransaction, aggregateSignatureShares, LanguageCode, generateKey, spendingKeyToWords, wordsToSpendingKey, generateKeyFromPrivateKey, initializeSapling, FoundBlockResult, ThreadPoolHandler, isValidPublicAddress } = nativeBinding
 
 module.exports.FishHashContext = FishHashContext
 module.exports.IDENTITY_LEN = IDENTITY_LEN
@@ -260,7 +260,7 @@ module.exports.createSigningCommitment = createSigningCommitment
 module.exports.createSignatureShare = createSignatureShare
 module.exports.ParticipantSecret = ParticipantSecret
 module.exports.ParticipantIdentity = ParticipantIdentity
-module.exports.splitSecret = splitSecret
+module.exports.generateAndSplitKey = generateAndSplitKey
 module.exports.PublicKeyPackage = PublicKeyPackage
 module.exports.contribute = contribute
 module.exports.verifyTransform = verifyTransform

--- a/ironfish-rust-nodejs/src/frost.rs
+++ b/ironfish-rust-nodejs/src/frost.rs
@@ -7,7 +7,7 @@ use ironfish::{
     frost::{keys::KeyPackage, round1::SigningCommitments, round2, Randomizer},
     frost_utils::{signing_package::SigningPackage, split_spender_key::split_spender_key},
     participant::{Identity, Secret},
-    serializing::{bytes_to_hex, fr::FrSerializable, hex_to_bytes, hex_to_vec_bytes},
+    serializing::{bytes_to_hex, fr::FrSerializable, hex_to_vec_bytes},
     SaplingKey,
 };
 use ironfish_frost::{
@@ -193,14 +193,11 @@ impl ParticipantIdentity {
 }
 
 #[napi]
-pub fn split_secret(
-    spending_key: String,
+pub fn generate_and_split_key(
     min_signers: u16,
     identities: Vec<String>,
 ) -> Result<TrustedDealerKeyPackages> {
-    let spending_key = hex_to_bytes(&spending_key)
-        .and_then(SaplingKey::new)
-        .map_err(to_napi_err)?;
+    let spending_key = SaplingKey::generate_key();
 
     let identities = try_deserialize_identities(identities)?;
 

--- a/ironfish/src/rpc/routes/wallet/multisig/createTrustedDealerKeyPackage.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/createTrustedDealerKeyPackage.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { generateKey, splitSecret } from '@ironfish/rust-nodejs'
+import { generateAndSplitKey } from '@ironfish/rust-nodejs'
 import * as yup from 'yup'
 import { Assert } from '../../../../assert'
 import { FullNode } from '../../../../node'
@@ -66,7 +66,6 @@ routes.register<
   (request, node): void => {
     Assert.isInstanceOf(node, FullNode)
 
-    const key = generateKey()
     const { minSigners, participants } = request.data
     const identities = participants.map((p) => p.identity)
     const {
@@ -77,7 +76,7 @@ routes.register<
       outgoingViewKey,
       proofAuthorizingKey,
       keyPackages,
-    } = splitSecret(key.spendingKey, minSigners, identities)
+    } = generateAndSplitKey(minSigners, identities)
 
     const latestHeader = node.chain.latest
     const createdAt = {

--- a/ironfish/src/testUtilities/keys.ts
+++ b/ironfish/src/testUtilities/keys.ts
@@ -3,9 +3,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import {
-  generateKey,
+  generateAndSplitKey,
   ParticipantSecret,
-  splitSecret,
   TrustedDealerKeyPackages,
 } from '@ironfish/rust-nodejs'
 
@@ -13,9 +12,8 @@ export function createTrustedDealerKeyPackages(
   minSigners: number = 2,
   maxSigners: number = 2,
 ): TrustedDealerKeyPackages {
-  const key = generateKey()
   const identities = Array.from({ length: maxSigners }, () =>
     ParticipantSecret.random().toIdentity().serialize().toString('hex'),
   )
-  return splitSecret(key.spendingKey, minSigners, identities)
+  return generateAndSplitKey(minSigners, identities)
 }

--- a/ironfish/src/wallet/wallet.test.slow.ts
+++ b/ironfish/src/wallet/wallet.test.slow.ts
@@ -7,10 +7,9 @@ import {
   ASSET_ID_LENGTH,
   createSignatureShare,
   createSigningCommitment,
+  generateAndSplitKey,
   generateKey,
   ParticipantSecret,
-  splitSecret,
-  TrustedDealerKeyPackages,
 } from '@ironfish/rust-nodejs'
 import { v4 as uuid } from 'uuid'
 import { Assert } from '../assert'
@@ -1145,8 +1144,6 @@ describe('Wallet', () => {
       const { node } = await nodeTest.createSetup()
       const recipient = await useAccountFixture(node.wallet, 'recipient')
 
-      const coordinatorSaplingKey = generateKey()
-
       const identities = Array.from({ length: 3 }, () =>
         ParticipantSecret.random().toIdentity().serialize().toString('hex'),
       )
@@ -1154,11 +1151,7 @@ describe('Wallet', () => {
       // construct 3 separate secrets for the participants
       // take the secrets and get identities back (get identity first then identifier)
 
-      const trustedDealerPackage: TrustedDealerKeyPackages = splitSecret(
-        coordinatorSaplingKey.spendingKey,
-        minSigners,
-        identities,
-      )
+      const trustedDealerPackage = generateAndSplitKey(minSigners, identities)
 
       const getMultisigKeys = (index: number) => {
         return {
@@ -1341,17 +1334,11 @@ describe('Wallet', () => {
 
     const { node } = await nodeTest.createSetup()
 
-    const coordinatorSaplingKey = generateKey()
-
     const identities = Array.from({ length: 3 }, () =>
       ParticipantSecret.random().toIdentity().serialize().toString('hex'),
     )
 
-    const trustedDealerPackage: TrustedDealerKeyPackages = splitSecret(
-      coordinatorSaplingKey.spendingKey,
-      minSigners,
-      identities,
-    )
+    const trustedDealerPackage = generateAndSplitKey(minSigners, identities)
 
     const account = await node.wallet.importAccount({
       version: 2,


### PR DESCRIPTION
## Summary

Avoid generating the key in Rust, then moving it to TypeScript, and then moving it back to Rust. Generate the key directly in Rust. This avoids copies that leave secrets in memory, reducing the attack surface.

## Testing Plan

Unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
