### PR TITLE
Add mainnet hardfork sequence for hardfork 1

### DIFF
--- a/ironfish/src/networks/definitions/mainnet.ts
+++ b/ironfish/src/networks/definitions/mainnet.ts
@@ -5,6 +5,8 @@
 import type { NetworkDefinition } from '../networkDefinition'
 import { ConsensusParameters } from '../../consensus'
 
+const HARDFORK_1_ACTIVATION_MAINNET = 503_338
+
 const MAINNET_CONSENSUS: ConsensusParameters = {
   allowedBlockFutureSeconds: 15,
   genesisSupplyInIron: 42000000,
@@ -13,9 +15,9 @@ const MAINNET_CONSENSUS: ConsensusParameters = {
   maxBlockSizeBytes: 524288,
   minFee: 1,
   enableAssetOwnership: null,
-  enforceSequentialBlockTime: null,
-  enableFishHash: null,
-  enableIncreasedDifficultyChange: null,
+  enforceSequentialBlockTime: HARDFORK_1_ACTIVATION_MAINNET,
+  enableFishHash: HARDFORK_1_ACTIVATION_MAINNET,
+  enableIncreasedDifficultyChange: HARDFORK_1_ACTIVATION_MAINNET,
   checkpoints: [],
 }
 
@@ -67,10 +69,6 @@ export const MAINNET_GENESIS = {
   ],
 }
 
-// TODO(IFL-1523): Update proper activation sequence for enableAssetOwnership
-// enforceSequentialBlockTime activation date is approximately 26-07-2024 00:50. This is not the
-// actual date, it's an placeholder for the next hardfork.
-// TODO: @ygao76 update this once the hard fork date is finalized.
 export const MAINNET: NetworkDefinition = {
   id: 1,
   bootstrapNodes: ['1.main.bn.ironfish.network', '2.main.bn.ironfish.network'],


### PR DESCRIPTION
## Summary
Adding code to intitiate the first hardfork. Hardfork is described further in [FIP-10](https://fips.ironfish.network/fips/fip-10-hardfork-1)

## Testing Plan
Extensive testing has been done on the FishHash hardfork including excecuting the hardfork on testnet with the same parameters  

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[X] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[X] Yes
```
Once released this change will initiate a hardfork at the given block sequence
