### PR TITLE
feat(ironfish): Check for duplicate account name when creating secret

### DIFF
--- a/ironfish/src/rpc/routes/wallet/multisig/createIdentity.test.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/createIdentity.test.ts
@@ -1,0 +1,54 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Assert } from '../../../../assert'
+import { createRouteTest } from '../../../../testUtilities/routeTest'
+
+describe('Route wallet/multisig/createIdentity', () => {
+  const routeTest = createRouteTest()
+
+  it('should fail for a secret name that exists', async () => {
+    const name = 'name'
+    await routeTest.client.wallet.multisig.createIdentity({ name })
+
+    await expect(
+      routeTest.client.wallet.multisig.createIdentity({
+        name,
+      }),
+    ).rejects.toThrow(
+      expect.objectContaining({
+        message: expect.stringContaining(
+          `Multisig secret already exists with the name ${name}`,
+        ),
+        status: 400,
+      }),
+    )
+  })
+
+  it('should fail for an account name that exists', async () => {
+    const name = 'existing-account'
+    await routeTest.client.wallet.createAccount({ name })
+
+    await expect(
+      routeTest.client.wallet.multisig.createIdentity({
+        name,
+      }),
+    ).rejects.toThrow(
+      expect.objectContaining({
+        message: expect.stringContaining(`Account already exists with the name ${name}`),
+        status: 400,
+      }),
+    )
+  })
+
+  it('should create a secret for a new identity', async () => {
+    const name = 'identity'
+    const response = await routeTest.client.wallet.multisig.createIdentity({ name })
+
+    const secretValue = await routeTest.node.wallet.walletDb.getMultisigSecret(
+      Buffer.from(response.content.identity, 'hex'),
+    )
+    Assert.isNotUndefined(secretValue)
+    expect(secretValue.name).toEqual(name)
+  })
+})

--- a/ironfish/src/wallet/errors.ts
+++ b/ironfish/src/wallet/errors.ts
@@ -39,3 +39,12 @@ export class DuplicateAccountNameError extends Error {
     this.message = `Account already exists with the name ${name}`
   }
 }
+
+export class DuplicateMultisigSecretNameError extends Error {
+  name = this.constructor.name
+
+  constructor(name: string) {
+    super()
+    this.message = `Multisig secret already exists with the name ${name}`
+  }
+}


### PR DESCRIPTION
## Summary

Check if there is an existing account name before creating a secret

## Testing Plan

Unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
