### PR TITLE
fixes description for confirm flag in commitment:create

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/commitment/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/commitment/create.ts
@@ -32,7 +32,7 @@ export class CreateSigningCommitmentCommand extends IronfishCommand {
     }),
     confirm: Flags.boolean({
       default: false,
-      description: 'Confirm creating signature share without confirming',
+      description: 'Confirm creating signing commitment without confirming',
     }),
   }
 


### PR DESCRIPTION
## Summary

refers to creating a signing commitment instead of a signature share

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
