### PR TITLE
feat(cli,ironfish): Throw error for multisig secret during import

### DIFF
--- a/ironfish-cli/src/commands/wallet/import.ts
+++ b/ironfish-cli/src/commands/wallet/import.ts
@@ -92,14 +92,21 @@ export class ImportCommand extends IronfishCommand {
         if (
           e instanceof RpcRequestError &&
           (e.code === RPC_ERROR_CODES.DUPLICATE_ACCOUNT_NAME.toString() ||
-            e.code === RPC_ERROR_CODES.IMPORT_ACCOUNT_NAME_REQUIRED.toString())
+            e.code === RPC_ERROR_CODES.IMPORT_ACCOUNT_NAME_REQUIRED.toString() ||
+            e.code === RPC_ERROR_CODES.MULTISIG_SECRET_NAME_REQUIRED.toString())
         ) {
+          let message = 'Enter a name for the account'
+
           if (e.code === RPC_ERROR_CODES.DUPLICATE_ACCOUNT_NAME.toString()) {
             this.log()
             this.log(e.codeMessage)
           }
 
-          const name = await CliUx.ux.prompt('Enter a name for the account', {
+          if (e.code === RPC_ERROR_CODES.MULTISIG_SECRET_NAME_REQUIRED.toString()) {
+            message = 'Enter the name of the multisig secret'
+          }
+
+          const name = await CliUx.ux.prompt(message, {
             required: true,
           })
           if (name === flags.name) {

--- a/ironfish/src/rpc/adapters/errors.ts
+++ b/ironfish/src/rpc/adapters/errors.ts
@@ -13,6 +13,7 @@ export enum RPC_ERROR_CODES {
   NOT_FOUND = 'not-found',
   DUPLICATE_ACCOUNT_NAME = 'duplicate-account-name',
   IMPORT_ACCOUNT_NAME_REQUIRED = 'import-account-name-required',
+  MULTISIG_SECRET_NAME_REQUIRED = 'multisig-secret-name-required',
 }
 
 /**

--- a/ironfish/src/rpc/routes/wallet/importAccount.ts
+++ b/ironfish/src/rpc/routes/wallet/importAccount.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
-import { DecodeInvalidName } from '../../../wallet'
+import { DecodeInvalidName, MultisigMissingSecretName } from '../../../wallet'
 import { decodeAccount } from '../../../wallet/account/encoder/account'
 import { DuplicateAccountNameError } from '../../../wallet/errors'
 import { RPC_ERROR_CODES, RpcValidationError } from '../../adapters'
@@ -69,6 +69,12 @@ routes.register<typeof ImportAccountRequestSchema, ImportResponse>(
           e.message,
           400,
           RPC_ERROR_CODES.IMPORT_ACCOUNT_NAME_REQUIRED,
+        )
+      } else if (e instanceof MultisigMissingSecretName) {
+        throw new RpcValidationError(
+          e.message,
+          400,
+          RPC_ERROR_CODES.MULTISIG_SECRET_NAME_REQUIRED,
         )
       }
       throw e

--- a/ironfish/src/wallet/account/encoder/encoder.ts
+++ b/ironfish/src/wallet/account/encoder/encoder.ts
@@ -20,6 +20,10 @@ export class DecodeFailed extends Error {
   }
 }
 
+export class MultisigMissingSecretName extends DecodeInvalid {
+  name = this.constructor.name
+}
+
 export enum AccountFormat {
   Base64Json = 'Base64Json',
   JSON = 'JSON',

--- a/ironfish/src/wallet/account/encoder/multisig.ts
+++ b/ironfish/src/wallet/account/encoder/multisig.ts
@@ -2,7 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { ParticipantIdentity, ParticipantSecret } from '@ironfish/rust-nodejs'
-import { AccountDecodingOptions, MultisigIdentityEncryption } from './encoder'
+import {
+  AccountDecodingOptions,
+  MultisigIdentityEncryption,
+  MultisigMissingSecretName,
+} from './encoder'
 
 export function encodeEncryptedMultisigAccount(
   value: Buffer,
@@ -19,7 +23,9 @@ export function decodeEncryptedMultisigAccount(
   options?: AccountDecodingOptions,
 ): Buffer {
   if (!options?.multisigSecret) {
-    throw new Error('Encrypted multisig account cannot be decrypted without a multisig secret')
+    throw new MultisigMissingSecretName(
+      'Encrypted multisig account cannot be decrypted without a multisig secret',
+    )
   }
   const secret = Buffer.isBuffer(options.multisigSecret)
     ? new ParticipantSecret(options.multisigSecret)


### PR DESCRIPTION
## Summary

A multisig secret name is required when importing from the TDK. Improve the UX to prompt for the secret if the name isn't provided.

## Testing Plan

RPC is covered by existing tests.

Manually tested CLI

```sh
❯ f wallet:import -d ~/.ironfish-testnet ifmsaccount2AtiArQwrhmMtU...
Enter the name of the multisig secret: rj
```

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
