### PR TITLE
uses long prompt for fetching identities when creating a commitment

### DIFF
--- a/ironfish-cli/src/commands/wallet/import.ts
+++ b/ironfish-cli/src/commands/wallet/import.ts
@@ -157,7 +157,7 @@ export class ImportCommand extends IronfishCommand {
   }
 
   async importTTY(): Promise<string> {
-    return await longPrompt('Paste the output of wallet:export, or your spending key: ', {
+    return await longPrompt('Paste the output of wallet:export, or your spending key', {
       required: true,
     })
   }

--- a/ironfish-cli/src/commands/wallet/multisig/commitment/aggregate.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/commitment/aggregate.ts
@@ -36,14 +36,14 @@ export class CreateSigningPackage extends IronfishCommand {
     let unsignedTransaction = flags.unsignedTransaction?.trim()
 
     if (!unsignedTransaction) {
-      unsignedTransaction = await longPrompt('Enter the unsigned transaction: ', {
+      unsignedTransaction = await longPrompt('Enter the unsigned transaction', {
         required: true,
       })
     }
 
     let commitments = flags.commitment
     if (!commitments) {
-      const input = await longPrompt('Enter the signing commitments separated by commas: ', {
+      const input = await longPrompt('Enter the signing commitments separated by commas', {
         required: true,
       })
       commitments = input.split(',')

--- a/ironfish-cli/src/commands/wallet/multisig/commitment/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/commitment/create.ts
@@ -41,7 +41,7 @@ export class CreateSigningCommitmentCommand extends IronfishCommand {
 
     let identities = flags.identity
     if (!identities || identities.length < 2) {
-      const input = await CliUx.ux.prompt('Enter the identities separated by commas', {
+      const input = await longPrompt('Enter the identities separated by commas', {
         required: true,
       })
       identities = input.split(',')
@@ -54,7 +54,7 @@ export class CreateSigningCommitmentCommand extends IronfishCommand {
 
     let unsignedTransactionInput = flags.unsignedTransaction?.trim()
     if (!unsignedTransactionInput) {
-      unsignedTransactionInput = await longPrompt('Enter the unsigned transaction: ', {
+      unsignedTransactionInput = await longPrompt('Enter the unsigned transaction', {
         required: true,
       })
     }

--- a/ironfish-cli/src/commands/wallet/multisig/signature/aggregate.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/signature/aggregate.ts
@@ -39,11 +39,11 @@ export class MultisigSign extends IronfishCommand {
 
     const signingPackage =
       flags.signingPackage?.trim() ??
-      (await longPrompt('Enter the signing package: ', { required: true }))
+      (await longPrompt('Enter the signing package', { required: true }))
 
     let signatureShares = flags.signatureShare
     if (!signatureShares) {
-      const input = await longPrompt('Enter the signature shares separated by commas: ', {
+      const input = await longPrompt('Enter the signature shares separated by commas', {
         required: true,
       })
       signatureShares = input.split(',')

--- a/ironfish-cli/src/commands/wallet/multisig/signature/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/signature/create.ts
@@ -35,7 +35,7 @@ export class CreateSignatureShareCommand extends IronfishCommand {
     let signingPackage = flags.signingPackage?.trim()
 
     if (!signingPackage) {
-      signingPackage = await longPrompt('Enter the signing package: ')
+      signingPackage = await longPrompt('Enter the signing package')
     }
 
     const client = await this.sdk.connectRpc()

--- a/ironfish-cli/src/utils/longPrompt.ts
+++ b/ironfish-cli/src/utils/longPrompt.ts
@@ -19,7 +19,7 @@ export async function longPrompt(
     })
 
   const userInput = await new Promise<string>((resolve) => {
-    rl.question(question, (answer) => {
+    rl.question(question + ': ', (answer) => {
       resolve(answer.trim())
     })
   })


### PR DESCRIPTION
## Summary

Long prompt for identities when creating commitment 
Added some additional formatting to long prompt

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
