### PR TITLE
preserves order of identities when returning key packages

### DIFF
--- a/ironfish-rust-nodejs/src/frost.rs
+++ b/ironfish-rust-nodejs/src/frost.rs
@@ -203,13 +203,19 @@ pub fn generate_and_split_key(
     let identities = try_deserialize_identities(identities)?;
 
     let packages =
-        split_spender_key(&spending_key, min_signers, identities).map_err(to_napi_err)?;
+        split_spender_key(&spending_key, min_signers, identities.clone()).map_err(to_napi_err)?;
 
     let mut key_packages = Vec::with_capacity(packages.key_packages.len());
-    for (identity, key_package) in packages.key_packages.iter() {
+
+    // preserves the order of the identities
+    for identity in identities {
         key_packages.push(ParticipantKeyPackage {
             identity: bytes_to_hex(&identity.serialize()),
-            key_package: bytes_to_hex(&key_package.serialize().map_err(to_napi_err)?),
+            key_package: bytes_to_hex(
+                &packages.key_packages[&identity]
+                    .serialize()
+                    .map_err(to_napi_err)?,
+            ),
         });
     }
 

--- a/ironfish-rust-nodejs/src/frost.rs
+++ b/ironfish-rust-nodejs/src/frost.rs
@@ -212,7 +212,7 @@ pub fn generate_and_split_key(
         let key_package = packages
             .key_packages
             .get(&identity)
-            .ok_or_else(|| to_napi_err("Key package not found for identity".to_string()))?
+            .ok_or_else(|| to_napi_err("Key package not found for identity"))?
             .serialize()
             .map_err(to_napi_err)?;
 

--- a/ironfish-rust-nodejs/src/frost.rs
+++ b/ironfish-rust-nodejs/src/frost.rs
@@ -209,13 +209,16 @@ pub fn generate_and_split_key(
 
     // preserves the order of the identities
     for identity in identities {
+        let key_package = packages
+            .key_packages
+            .get(&identity)
+            .ok_or_else(|| to_napi_err("Key package not found for identity".to_string()))?
+            .serialize()
+            .map_err(to_napi_err)?;
+
         key_packages.push(ParticipantKeyPackage {
             identity: bytes_to_hex(&identity.serialize()),
-            key_package: bytes_to_hex(
-                &packages.key_packages[&identity]
-                    .serialize()
-                    .map_err(to_napi_err)?,
-            ),
+            key_package: bytes_to_hex(&key_package),
         });
     }
 


### PR DESCRIPTION
## Summary

Preserves order of identities when returning key packages for each identity

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
