### PR TITLE
handles errors in participant creation

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/participant/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/participant/create.ts
@@ -39,11 +39,12 @@ export class MultisigIdentityCreate extends IronfishCommand {
         ) {
           this.log()
           this.log(e.codeMessage)
+          name = await CliUx.ux.prompt('Enter a new name for the identity', {
+            required: true,
+          })
+        } else {
+          throw e
         }
-
-        name = await CliUx.ux.prompt('Enter a new name for the identity', {
-          required: true,
-        })
       }
     }
 

--- a/ironfish/src/rpc/routes/wallet/multisig/createParticipant.test.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/createParticipant.test.ts
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { RPC_ERROR_CODES } from '@ironfish/sdk'
 import { Assert } from '../../../../assert'
 import { createRouteTest } from '../../../../testUtilities/routeTest'
 
@@ -22,7 +21,6 @@ describe('Route wallet/multisig/createParticipant', () => {
           `Multisig secret already exists with the name ${name}`,
         ),
         status: 400,
-        code: RPC_ERROR_CODES.DUPLICATE_ACCOUNT_NAME,
       }),
     )
   })

--- a/ironfish/src/rpc/routes/wallet/multisig/createParticipant.test.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/createParticipant.test.ts
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { RPC_ERROR_CODES } from '@ironfish/sdk'
 import { Assert } from '../../../../assert'
 import { createRouteTest } from '../../../../testUtilities/routeTest'
 
@@ -21,6 +22,7 @@ describe('Route wallet/multisig/createParticipant', () => {
           `Multisig secret already exists with the name ${name}`,
         ),
         status: 400,
+        code: RPC_ERROR_CODES.DUPLICATE_ACCOUNT_NAME,
       }),
     )
   })


### PR DESCRIPTION
## Summary

wallet/multisig/createParticipant returns DUPLICATE_ACCOUNT_NAME error code if account name or multisig secret name already exists

only prompts for new name if the error was from a duplicate name

## Testing Plan

<img width="614" alt="image" src="https://github.com/iron-fish/ironfish/assets/57735705/962ce030-a2ed-48e0-bcb7-fb7eca27ff3d">


## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
