### PR TITLE
automatically include account identity for commitment

### DIFF
--- a/ironfish/src/rpc/routes/wallet/multisig/createSigningCommitment.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/createSigningCommitment.ts
@@ -1,7 +1,11 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { createSigningCommitment, UnsignedTransaction } from '@ironfish/rust-nodejs'
+import {
+  createSigningCommitment,
+  ParticipantSecret,
+  UnsignedTransaction,
+} from '@ironfish/rust-nodejs'
 import * as yup from 'yup'
 import { AssertMultisigSigner } from '../../../../wallet/account/account'
 import { ApiNamespace } from '../../namespaces'
@@ -55,11 +59,19 @@ routes.register<typeof CreateSigningCommitmentRequestSchema, CreateSigningCommit
     const unsigned = new UnsignedTransaction(
       Buffer.from(request.data.unsignedTransaction, 'hex'),
     )
+
+    const signers = request.data.signers.map((signer) => signer.identity)
+
+    // always include account's own identity. ironfish-frost deduplicates identities
+    const accountSecret = new ParticipantSecret(Buffer.from(account.multisigKeys.secret, 'hex'))
+    const accountIdentity = accountSecret.toIdentity().serialize().toString('hex')
+    signers.push(accountIdentity)
+
     const commitment = createSigningCommitment(
       account.multisigKeys.secret,
       account.multisigKeys.keyPackage,
       unsigned.hash(),
-      request.data.signers.map((signer) => signer.identity),
+      signers,
     )
 
     request.end({ commitment })


### PR DESCRIPTION
## Summary

when a user creates a signing commitment using a multisig account their account identity must be included in the list of signers in order for the commitment to be valid

automatically includes the account's participant identity whether or not it was passed to wallet/multisig/createSigningCommitment. relies on ironfish-frost for deduplication when creating nonces

## Testing Plan

manual testing: created commitment without specifying own identity in CLI, commitment still valid, transaction sent

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
