### PR TITLE
Rahul/ifl 2349 add watch to signatureaggregate

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/signature/aggregate.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/signature/aggregate.ts
@@ -6,6 +6,7 @@ import { CliUx, Flags } from '@oclif/core'
 import { IronfishCommand } from '../../../../command'
 import { RemoteFlags } from '../../../../flags'
 import { longPrompt } from '../../../../utils/longPrompt'
+import { watchTransaction } from '../../../../utils/transaction'
 
 export class MultisigSign extends IronfishCommand {
   static description = 'Aggregate signature shares from participants to sign a transaction'
@@ -31,6 +32,10 @@ export class MultisigSign extends IronfishCommand {
       default: true,
       allowNo: true,
       description: 'Broadcast the transaction to the network after signing',
+    }),
+    watch: Flags.boolean({
+      default: false,
+      description: 'Wait for the transaction to be confirmed',
     }),
   }
 
@@ -79,5 +84,16 @@ export class MultisigSign extends IronfishCommand {
     this.log(`Transaction: ${response.content.transaction}`)
     this.log(`Hash: ${transaction.hash().toString('hex')}`)
     this.log(`Fee: ${CurrencyUtils.renderIron(transaction.fee(), true)}`)
+
+    if (flags.watch) {
+      this.log('')
+
+      await watchTransaction({
+        client,
+        logger: this.logger,
+        account: flags.account,
+        hash: transaction.hash().toString('hex'),
+      })
+    }
   }
 }

--- a/ironfish/src/rpc/routes/wallet/multisig/aggregateSignatureShares.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/aggregateSignatureShares.ts
@@ -62,6 +62,7 @@ routes.register<typeof AggregateSignatureSharesRequestSchema, AggregateSignature
     let broadcasted = false
 
     if (request.data.broadcast) {
+      await node.wallet.addPendingTransaction(transaction)
       const result = await node.wallet.broadcastTransaction(transaction)
       accepted = result.accepted
       broadcasted = result.broadcasted


### PR DESCRIPTION
## Summary

Adds `--watch` flag for signature aggregate

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
