### PR TITLE
displays signers during signature share creation

### DIFF
--- a/ironfish-rust-nodejs/index.d.ts
+++ b/ironfish-rust-nodejs/index.d.ts
@@ -119,6 +119,12 @@ export class SigningCommitment {
   constructor(jsBytes: Buffer)
   identity(): Buffer
 }
+export type NativeSigningPackage = SigningPackage
+export class SigningPackage {
+  constructor(jsBytes: Buffer)
+  unsignedTransaction(): NativeUnsignedTransaction
+  signers(): Array<Buffer>
+}
 export class BoxKeyPair {
   constructor()
   static fromHex(secretHex: string): BoxKeyPair
@@ -253,7 +259,6 @@ export class Transaction {
 export type NativeUnsignedTransaction = UnsignedTransaction
 export class UnsignedTransaction {
   constructor(jsBytes: Buffer)
-  static fromSigningPackage(signingPackageStr: string): NativeUnsignedTransaction
   serialize(): Buffer
   publicKeyRandomness(): string
   hash(): Buffer

--- a/ironfish-rust-nodejs/index.js
+++ b/ironfish-rust-nodejs/index.js
@@ -252,7 +252,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { FishHashContext, IDENTITY_LEN, SECRET_LEN, createSigningCommitment, createSignatureShare, ParticipantSecret, ParticipantIdentity, generateAndSplitKey, PublicKeyPackage, SigningCommitment, contribute, verifyTransform, KEY_LENGTH, NONCE_LENGTH, BoxKeyPair, randomBytes, boxMessage, unboxMessage, RollingFilter, initSignalHandler, triggerSegfault, ASSET_ID_LENGTH, ASSET_METADATA_LENGTH, ASSET_NAME_LENGTH, ASSET_LENGTH, Asset, NOTE_ENCRYPTION_KEY_LENGTH, MAC_LENGTH, ENCRYPTED_NOTE_PLAINTEXT_LENGTH, ENCRYPTED_NOTE_LENGTH, NoteEncrypted, PUBLIC_ADDRESS_LENGTH, RANDOMNESS_LENGTH, MEMO_LENGTH, AMOUNT_VALUE_LENGTH, DECRYPTED_NOTE_LENGTH, Note, PROOF_LENGTH, TRANSACTION_SIGNATURE_LENGTH, TRANSACTION_PUBLIC_KEY_RANDOMNESS_LENGTH, TRANSACTION_EXPIRATION_LENGTH, TRANSACTION_FEE_LENGTH, LATEST_TRANSACTION_VERSION, TransactionPosted, Transaction, verifyTransactions, UnsignedTransaction, aggregateSignatureShares, LanguageCode, generateKey, spendingKeyToWords, wordsToSpendingKey, generateKeyFromPrivateKey, initializeSapling, FoundBlockResult, ThreadPoolHandler, isValidPublicAddress } = nativeBinding
+const { FishHashContext, IDENTITY_LEN, SECRET_LEN, createSigningCommitment, createSignatureShare, ParticipantSecret, ParticipantIdentity, generateAndSplitKey, PublicKeyPackage, SigningCommitment, SigningPackage, contribute, verifyTransform, KEY_LENGTH, NONCE_LENGTH, BoxKeyPair, randomBytes, boxMessage, unboxMessage, RollingFilter, initSignalHandler, triggerSegfault, ASSET_ID_LENGTH, ASSET_METADATA_LENGTH, ASSET_NAME_LENGTH, ASSET_LENGTH, Asset, NOTE_ENCRYPTION_KEY_LENGTH, MAC_LENGTH, ENCRYPTED_NOTE_PLAINTEXT_LENGTH, ENCRYPTED_NOTE_LENGTH, NoteEncrypted, PUBLIC_ADDRESS_LENGTH, RANDOMNESS_LENGTH, MEMO_LENGTH, AMOUNT_VALUE_LENGTH, DECRYPTED_NOTE_LENGTH, Note, PROOF_LENGTH, TRANSACTION_SIGNATURE_LENGTH, TRANSACTION_PUBLIC_KEY_RANDOMNESS_LENGTH, TRANSACTION_EXPIRATION_LENGTH, TRANSACTION_FEE_LENGTH, LATEST_TRANSACTION_VERSION, TransactionPosted, Transaction, verifyTransactions, UnsignedTransaction, aggregateSignatureShares, LanguageCode, generateKey, spendingKeyToWords, wordsToSpendingKey, generateKeyFromPrivateKey, initializeSapling, FoundBlockResult, ThreadPoolHandler, isValidPublicAddress } = nativeBinding
 
 module.exports.FishHashContext = FishHashContext
 module.exports.IDENTITY_LEN = IDENTITY_LEN
@@ -264,6 +264,7 @@ module.exports.ParticipantIdentity = ParticipantIdentity
 module.exports.generateAndSplitKey = generateAndSplitKey
 module.exports.PublicKeyPackage = PublicKeyPackage
 module.exports.SigningCommitment = SigningCommitment
+module.exports.SigningPackage = SigningPackage
 module.exports.contribute = contribute
 module.exports.verifyTransform = verifyTransform
 module.exports.KEY_LENGTH = KEY_LENGTH

--- a/ironfish-rust-nodejs/src/structs/transaction.rs
+++ b/ironfish-rust-nodejs/src/structs/transaction.rs
@@ -383,7 +383,7 @@ pub fn verify_transactions(serialized_transactions: Vec<JsBuffer>) -> Result<boo
 
 #[napi(js_name = "UnsignedTransaction")]
 pub struct NativeUnsignedTransaction {
-    transaction: UnsignedTransaction,
+    pub(crate) transaction: UnsignedTransaction,
 }
 
 #[napi]
@@ -395,16 +395,6 @@ impl NativeUnsignedTransaction {
         let transaction = UnsignedTransaction::read(bytes.as_ref()).map_err(to_napi_err)?;
 
         Ok(NativeUnsignedTransaction { transaction })
-    }
-
-    #[napi(factory)]
-    pub fn from_signing_package(signing_package_str: String) -> Result<Self> {
-        let bytes = hex_to_vec_bytes(&signing_package_str).map_err(to_napi_err)?;
-        let signing_package = SigningPackage::read(&bytes[..]).map_err(to_napi_err)?;
-
-        Ok(NativeUnsignedTransaction {
-            transaction: signing_package.unsigned_transaction,
-        })
     }
 
     #[napi]

--- a/ironfish/src/primitives/unsignedTransaction.ts
+++ b/ironfish/src/primitives/unsignedTransaction.ts
@@ -122,11 +122,6 @@ export class UnsignedTransaction {
     reader.seek(TRANSACTION_SIGNATURE_LENGTH)
   }
 
-  static fromSigningPackage(signingPackage: string): UnsignedTransaction {
-    const unsigned = NativeUnsignedTransaction.fromSigningPackage(signingPackage)
-    return new UnsignedTransaction(unsigned.serialize())
-  }
-
   serialize(): Buffer {
     return this.unsignedTransactionSerialized
   }


### PR DESCRIPTION
## Summary

allows user to confirm list of signers from signing package before creating signature share

- adds NativeSigningPackage to napi layer, defines 'signers' and 'unsigned_transaction' methods
- removes 'from_signing_package' from UnsignedTransaction, NativeUnsignedTransaction in favor of constructing from NativeSigningPackage

## Testing Plan

<img width="756" alt="image" src="https://github.com/iron-fish/ironfish/assets/57735705/28e6c380-8a86-42b1-8c36-6147d9e76e9b">


## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
