### PR TITLE
feat(cli): Use `longPrompt` when creating dealer

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/dealer/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dealer/create.ts
@@ -5,6 +5,7 @@ import { ACCOUNT_SCHEMA_VERSION } from '@ironfish/sdk'
 import { CliUx, Flags } from '@oclif/core'
 import { IronfishCommand } from '../../../../command'
 import { RemoteFlags } from '../../../../flags'
+import { longPrompt } from '../../../../utils/longPrompt'
 
 export class MultisigCreateDealer extends IronfishCommand {
   static description = `Create a set of multisig accounts from participant identities`
@@ -37,7 +38,7 @@ export class MultisigCreateDealer extends IronfishCommand {
 
     let identities = flags.identity
     if (!identities || identities.length < 2) {
-      const input = await CliUx.ux.prompt('Enter the identities separated by commas', {
+      const input = await longPrompt('Enter the identities separated by commas', {
         required: true,
       })
       identities = input.split(',')


### PR DESCRIPTION
## Summary

Update the prompt when creating the trusted dealer if we need to manually paste identities

## Testing Plan

Manual test

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
