### PR TITLE
updates unsigned tx details to always show output for notes

### DIFF
--- a/ironfish-cli/src/utils/transaction.ts
+++ b/ironfish-cli/src/utils/transaction.ts
@@ -74,51 +74,52 @@ export async function renderUnsignedTransactionDetails(
       unsignedTransaction: unsignedTransaction.serialize().toString('hex'),
     })
 
-    if (response.content.sentNotes.length > 0) {
-      logger.log('')
-      logger.log('==================')
-      logger.log('Notes sent:')
-      logger.log('==================')
+    logger.log('')
+    logger.log('==================')
+    logger.log('Notes sent:')
+    logger.log('==================')
 
-      let logged = false
-      for (const note of response.content.sentNotes) {
-        // Skip logger since we'll re-render for received notes
-        if (note.owner === note.sender) {
-          continue
-        }
-
-        if (logged) {
-          logger.log('------------------')
-        }
-        logged = true
-        logger.log('')
-
-        logger.log(`Amount:        ${CurrencyUtils.renderIron(note.value, true, note.assetId)}`)
-        logger.log(`Memo:          ${note.memo}`)
-        logger.log(`Recipient:     ${note.owner}`)
-        logger.log(`Sender:        ${note.sender}`)
-        logger.log('')
+    for (const [i, note] of response.content.sentNotes.entries()) {
+      // Skip logger since we'll re-render for received notes
+      if (note.owner === note.sender) {
+        continue
       }
+
+      if (i !== 0) {
+        logger.log('------------------')
+      }
+      logger.log('')
+
+      logger.log(`Amount:        ${CurrencyUtils.renderIron(note.value, true, note.assetId)}`)
+      logger.log(`Memo:          ${note.memo}`)
+      logger.log(`Recipient:     ${note.owner}`)
+      logger.log(`Sender:        ${note.sender}`)
+      logger.log('')
     }
 
-    if (response.content.receivedNotes.length > 0) {
-      logger.log('')
-      logger.log('==================')
-      logger.log('Notes received:')
-      logger.log('==================')
+    logger.log('')
+    logger.log('==================')
+    logger.log('Notes received:')
+    logger.log('==================')
 
-      for (const [i, note] of response.content.receivedNotes.entries()) {
-        if (i !== 0) {
-          logger.log('------------------')
-        }
-        logger.log('')
-
-        logger.log(`Amount:        ${CurrencyUtils.renderIron(note.value, true, note.assetId)}`)
-        logger.log(`Memo:          ${note.memo}`)
-        logger.log(`Recipient:     ${note.owner}`)
-        logger.log(`Sender:        ${note.sender}`)
-        logger.log('')
+    for (const [i, note] of response.content.receivedNotes.entries()) {
+      if (i !== 0) {
+        logger.log('------------------')
       }
+      logger.log('')
+
+      logger.log(`Amount:        ${CurrencyUtils.renderIron(note.value, true, note.assetId)}`)
+      logger.log(`Memo:          ${note.memo}`)
+      logger.log(`Recipient:     ${note.owner}`)
+      logger.log(`Sender:        ${note.sender}`)
+      logger.log('')
+    }
+
+    if (!response.content.sentNotes.length && !response.content.receivedNotes.length) {
+      logger.log('')
+      logger.log('------------------')
+      logger.log('Account unable to decrypt any notes in this transaction')
+      logger.log('------------------')
     }
   }
 


### PR DESCRIPTION
## Summary

if a user tries to view details of an unsigned transaction that their account isn't involved in then there may be no output for the transaction details. this may be confusing when multisig commands prompt them to confirm, but there are no details visible to confirm

always renders the 'Notes sent' and 'Notes received' headings if the transaction has output notes

outputs a message that no notes could be decrypted if no sent or received notes decryptable

## Testing Plan

manual testing: create a commitment with the wrong account.

before:
<img width="446" alt="image" src="https://github.com/iron-fish/ironfish/assets/57735705/a0afaf9d-8230-40fa-8c69-bf09053d3651">

after:
<img width="413" alt="image" src="https://github.com/iron-fish/ironfish/assets/57735705/2ed9fbe0-91ea-4148-b653-b0ca37cce8c3">


## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
