### PR TITLE
Cleanup/remove hashing header function

### DIFF
--- a/ironfish/src/primitives/blockheader.ts
+++ b/ironfish/src/primitives/blockheader.ts
@@ -14,10 +14,6 @@ import { Transaction } from './transaction'
 
 export type BlockHash = Buffer
 
-export function hashBlockHeader(serializedHeader: Buffer): BlockHash {
-  return blake3(serializedHeader)
-}
-
 export function isBlockLater(a: BlockHeader, b: BlockHeader): boolean {
   if (a.sequence !== b.sequence) {
     return a.sequence > b.sequence


### PR DESCRIPTION
## Summary
Removing unused function to hash the header with blake3. With move to FishHash that is now handled by the BlockHasher class

## Testing Plan
Unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```

