### PR TITLE
checks coordinator name against accounts and identities

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/dealer/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dealer/create.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { ACCOUNT_SCHEMA_VERSION } from '@ironfish/sdk'
+import { ACCOUNT_SCHEMA_VERSION, RpcClient } from '@ironfish/sdk'
 import { CliUx, Flags } from '@oclif/core'
 import { IronfishCommand } from '../../../../command'
 import { RemoteFlags } from '../../../../flags'
@@ -60,11 +60,9 @@ export class MultisigCreateDealer extends IronfishCommand {
       }
     }
 
-    const name =
-      flags.name?.trim() ??
-      (await CliUx.ux.prompt('Enter the name for the coordinator', { required: true }))
-
     const client = await this.sdk.connectRpc()
+
+    const name = await this.getCoordinatorName(client, flags.name?.trim())
 
     const response = await client.wallet.multisig.createTrustedDealerKeyPackage({
       minSigners,
@@ -115,5 +113,31 @@ export class MultisigCreateDealer extends IronfishCommand {
     }
 
     this.log()
+  }
+
+  async getCoordinatorName(client: RpcClient, inputName?: string): Promise<string> {
+    const accountsResponse = await client.wallet.getAccounts()
+    const accountNames = new Set(accountsResponse.content.accounts)
+
+    const identitiesResponse = await client.wallet.multisig.getIdentities()
+    const secretNames = new Set(identitiesResponse.content.identities.map((i) => i.name))
+
+    let name = inputName
+    do {
+      name =
+        name ?? (await CliUx.ux.prompt('Enter a name for the coordinator', { required: true }))
+
+      if (accountNames.has(name)) {
+        this.log(`Account with name ${name} already exists`)
+        this.log('')
+        name = undefined
+      } else if (secretNames.has(name)) {
+        this.log(`Multisig identity with name ${name} already exists`)
+        this.log('')
+        name = undefined
+      }
+    } while (name === undefined)
+
+    return name
   }
 }

--- a/ironfish-cli/src/commands/wallet/multisig/participant/index.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/participant/index.ts
@@ -29,7 +29,7 @@ export class MultisigIdentity extends IronfishCommand {
       this.log('Identity:')
       this.log(response.content.identity)
     } else {
-      const response = await client.wallet.multisig.getIdentities(undefined)
+      const response = await client.wallet.multisig.getIdentities()
 
       const choices = []
       for (const { name, identity } of response.content.identities) {

--- a/ironfish/src/rpc/clients/client.ts
+++ b/ironfish/src/rpc/clients/client.ts
@@ -255,7 +255,7 @@ export abstract class RpcClient {
       },
 
       getIdentities: (
-        params: GetIdentitiesRequest,
+        params: GetIdentitiesRequest = undefined,
       ): Promise<RpcResponseEnded<GetIdentitiesResponse>> => {
         return this.request<GetIdentitiesResponse>(
           `${ApiNamespace.wallet}/multisig/getIdentities`,


### PR DESCRIPTION
## Summary

prompts for new name until the user inputs a unique name

checks names before trusted dealer so that import doesn't fail after accounts have been created

includes small fix to RPC method to provide default undefined params

## Testing Plan

<img width="579" alt="image" src="https://github.com/iron-fish/ironfish/assets/57735705/aac0cf95-4d9e-4fb9-873e-a1f4ccda81d4">


## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
