### PR TITLE
Use NodeFileSystem for AssetVerifier

### DIFF
--- a/ironfish/src/assets/assetsVerificationApi.test.ts
+++ b/ironfish/src/assets/assetsVerificationApi.test.ts
@@ -1,11 +1,17 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import fs from 'fs'
 import nock from 'nock'
+import { NodeFileProvider } from '../fileSystems'
 import { AssetsVerificationApi } from './assetsVerificationApi'
 
 describe('Assets Verification API Client', () => {
+  const files = new NodeFileProvider()
+
+  beforeAll(async () => {
+    await files.init()
+  })
+
   beforeEach(() => {
     nock.cleanAll()
   })
@@ -24,6 +30,7 @@ describe('Assets Verification API Client', () => {
         })
 
       const api = new AssetsVerificationApi({
+        files,
         url: 'https://test/assets/verified',
       })
       const verifiedAssets = await api.getVerifiedAssets()
@@ -47,6 +54,7 @@ describe('Assets Verification API Client', () => {
         })
 
       const api = new AssetsVerificationApi({
+        files,
         url: 'https://test/assets/verified',
       })
       const verifiedAssets = await api.getVerifiedAssets()
@@ -66,6 +74,7 @@ describe('Assets Verification API Client', () => {
         })
 
       const api = new AssetsVerificationApi({
+        files,
         url: 'https://test/assets/verified',
       })
       const verifiedAssets = await api.getVerifiedAssets()
@@ -96,6 +105,7 @@ describe('Assets Verification API Client', () => {
         .reply(304)
 
       const api = new AssetsVerificationApi({
+        files,
         url: 'https://test/assets/verified',
       })
       const verifiedAssets = await api.getVerifiedAssets()
@@ -111,6 +121,7 @@ describe('Assets Verification API Client', () => {
       nock('https://test').get('/assets/verified').reply(500)
 
       const api = new AssetsVerificationApi({
+        files,
         url: 'https://test/assets/verified',
       })
       await expect(api.getVerifiedAssets()).rejects.toThrow(
@@ -127,6 +138,7 @@ describe('Assets Verification API Client', () => {
         })
 
       const api = new AssetsVerificationApi({
+        files,
         url: 'https://test/assets/verified',
         timeout: 1000,
       })
@@ -142,6 +154,7 @@ describe('Assets Verification API Client', () => {
         })
 
       const api = new AssetsVerificationApi({
+        files,
         url: 'https://test/assets/verified',
         timeout: 1000,
       })
@@ -152,15 +165,16 @@ describe('Assets Verification API Client', () => {
       const contents = JSON.stringify({
         assets: [{ identifier: '0123' }, { identifier: 'abcd' }],
       })
-      const readFileSpy = jest.spyOn(fs.promises, 'readFile').mockResolvedValue(contents)
+      const readFileSpy = jest.spyOn(files, 'readFile').mockResolvedValue(contents)
 
       const api = new AssetsVerificationApi({
+        files,
         url: 'file:///some/where',
       })
       const verifiedAssets = await api.getVerifiedAssets()
 
       expect(verifiedAssets['assetIds']).toStrictEqual(new Set(['0123', 'abcd']))
-      expect(readFileSpy).toHaveBeenCalledWith('/some/where', { encoding: 'utf8' })
+      expect(readFileSpy).toHaveBeenCalledWith('/some/where')
     })
   })
 })

--- a/ironfish/src/assets/assetsVerifier.test.ts
+++ b/ironfish/src/assets/assetsVerifier.test.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import nock from 'nock'
 import { VerifiedAssetsCacheStore } from '../fileStores/verifiedAssets'
+import { NodeFileProvider } from '../fileSystems'
 import { AssetsVerifier } from './assetsVerifier'
 
 /* eslint-disable jest/no-standalone-expect */
@@ -17,6 +18,12 @@ describe('AssetsVerifier', () => {
     }
   }
 
+  const files = new NodeFileProvider()
+
+  beforeAll(async () => {
+    await files.init()
+  })
+
   beforeEach(() => {
     nock.cleanAll()
     jest.clearAllTimers()
@@ -27,7 +34,7 @@ describe('AssetsVerifier', () => {
   })
 
   it('does not refresh when not started', () => {
-    const assetsVerifier = new AssetsVerifier()
+    const assetsVerifier = new AssetsVerifier({ files })
     const refresh = jest.spyOn(assetsVerifier as any, 'refresh')
 
     jest.runOnlyPendingTimers()
@@ -50,6 +57,7 @@ describe('AssetsVerifier', () => {
       })
 
     const assetsVerifier = new AssetsVerifier({
+      files,
       apiUrl: 'https://test/assets/verified',
     })
     const refresh = jest.spyOn(assetsVerifier as any, 'refresh')
@@ -91,6 +99,7 @@ describe('AssetsVerifier', () => {
       })
 
     const assetsVerifier = new AssetsVerifier({
+      files,
       apiUrl: 'https://test/assets/verified',
     })
     const refresh = jest.spyOn(assetsVerifier as any, 'refresh')
@@ -120,6 +129,7 @@ describe('AssetsVerifier', () => {
       .reply(304)
 
     const assetsVerifier = new AssetsVerifier({
+      files,
       apiUrl: 'https://test/assets/verified',
     })
     const refresh = jest.spyOn(assetsVerifier as any, 'refresh')
@@ -139,7 +149,7 @@ describe('AssetsVerifier', () => {
 
   describe('verify', () => {
     it("returns 'unknown' when not started", () => {
-      const assetsVerifier = new AssetsVerifier()
+      const assetsVerifier = new AssetsVerifier({ files })
 
       expect(assetsVerifier.verify('0123')).toStrictEqual({ status: 'unknown' })
       expect(assetsVerifier.verify('4567')).toStrictEqual({ status: 'unknown' })
@@ -149,6 +159,7 @@ describe('AssetsVerifier', () => {
       nock('https://test').get('/assets/verified').reply(500)
 
       const assetsVerifier = new AssetsVerifier({
+        files,
         apiUrl: 'https://test/assets/verified',
       })
       const refresh = jest.spyOn(assetsVerifier as any, 'refresh')
@@ -172,6 +183,7 @@ describe('AssetsVerifier', () => {
         })
 
       const assetsVerifier = new AssetsVerifier({
+        files,
         apiUrl: 'https://test/assets/verified',
       })
       const refresh = jest.spyOn(assetsVerifier as any, 'refresh')
@@ -190,6 +202,7 @@ describe('AssetsVerifier', () => {
         })
 
       const assetsVerifier = new AssetsVerifier({
+        files,
         apiUrl: 'https://test/assets/verified',
       })
       const refresh = jest.spyOn(assetsVerifier as any, 'refresh')
@@ -210,6 +223,7 @@ describe('AssetsVerifier', () => {
         .reply(500)
 
       const assetsVerifier = new AssetsVerifier({
+        files,
         apiUrl: 'https://test/assets/verified',
       })
       const refresh = jest.spyOn(assetsVerifier as any, 'refresh')
@@ -240,6 +254,7 @@ describe('AssetsVerifier', () => {
         })
 
       const assetsVerifier = new AssetsVerifier({
+        files,
         apiUrl: 'https://test/assets/verified',
       })
       const refresh = jest.spyOn(assetsVerifier as any, 'refresh')
@@ -276,6 +291,7 @@ describe('AssetsVerifier', () => {
         })
 
       const assetsVerifier = new AssetsVerifier({
+        files,
         apiUrl: 'https://test/assets/verified',
         cache: cache,
       })
@@ -307,6 +323,7 @@ describe('AssetsVerifier', () => {
         })
 
       const assetsVerifier = new AssetsVerifier({
+        files,
         apiUrl: 'https://bar.test/assets/verified',
         cache: cache,
       })
@@ -343,6 +360,7 @@ describe('AssetsVerifier', () => {
         )
 
       const assetsVerifier = new AssetsVerifier({
+        files,
         apiUrl: 'https://test/assets/verified',
         cache: cache,
       })
@@ -387,6 +405,7 @@ describe('AssetsVerifier', () => {
         .reply(304)
 
       const assetsVerifier = new AssetsVerifier({
+        files,
         apiUrl: 'https://test/assets/verified',
         cache: cache,
       })

--- a/ironfish/src/assets/assetsVerifier.ts
+++ b/ironfish/src/assets/assetsVerifier.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { VerifiedAssetsCacheStore } from '../fileStores/verifiedAssets'
+import { FileSystem } from '../fileSystems'
 import { createRootLogger, Logger } from '../logger'
 import { ErrorUtils } from '../utils'
 import { SetIntervalToken } from '../utils'
@@ -28,13 +29,14 @@ export class AssetsVerifier {
   private refreshToken?: SetIntervalToken
   private verifiedAssets?: VerifiedAssets
 
-  constructor(options?: {
+  constructor(options: {
+    files: FileSystem
     apiUrl?: string
     cache?: VerifiedAssetsCacheStore
     logger?: Logger
   }) {
     this.logger = options?.logger ?? createRootLogger()
-    this.api = new AssetsVerificationApi({ url: options?.apiUrl })
+    this.api = new AssetsVerificationApi({ url: options?.apiUrl, files: options.files })
     this.cache = options?.cache
     this.started = false
 

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -230,6 +230,7 @@ export class FullNode {
     await verifiedAssetsCache.load()
 
     const assetsVerifier = new AssetsVerifier({
+      files,
       apiUrl: config.get('assetVerificationApi'),
       cache: verifiedAssetsCache,
       logger,


### PR DESCRIPTION
## Summary
Use the abstracted file system so that asset verification can work in other contexts besides NodeJS

## Testing Plan
Unit tests + running node locally

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[X] Yes
```
SDK breaking change. Need to pass file system into asset verfier classes
