### PR TITLE
supports json file input to multisig transaction commands

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/commitment/aggregate.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/commitment/aggregate.ts
@@ -47,7 +47,7 @@ export class CreateSigningPackage extends IronfishCommand {
       })
     }
 
-    let commitments = options.commitments
+    let commitments = options.commitment
     if (!commitments) {
       const input = await longPrompt('Enter the signing commitments separated by commas', {
         required: true,

--- a/ironfish-cli/src/commands/wallet/multisig/commitment/aggregate.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/commitment/aggregate.ts
@@ -6,6 +6,7 @@ import { Flags } from '@oclif/core'
 import { IronfishCommand } from '../../../../command'
 import { RemoteFlags } from '../../../../flags'
 import { longPrompt } from '../../../../utils/longPrompt'
+import { MultisigTransactionJson } from '../../../../utils/multisig'
 
 export class CreateSigningPackage extends IronfishCommand {
   static description = `Creates a signing package for a given transaction for a multisig account`
@@ -28,20 +29,25 @@ export class CreateSigningPackage extends IronfishCommand {
         'The signing commitments from participants to be used for creating the signing package',
       multiple: true,
     }),
+    path: Flags.string({
+      description: 'Path to a JSON file containing multisig transaction data',
+    }),
   }
 
   async start(): Promise<void> {
     const { flags } = await this.parse(CreateSigningPackage)
 
-    let unsignedTransaction = flags.unsignedTransaction?.trim()
+    const loaded = await MultisigTransactionJson.load(this.sdk.fileSystem, flags.path)
+    const options = MultisigTransactionJson.resolveFlags(flags, loaded)
 
+    let unsignedTransaction = options.unsignedTransaction
     if (!unsignedTransaction) {
       unsignedTransaction = await longPrompt('Enter the unsigned transaction', {
         required: true,
       })
     }
 
-    let commitments = flags.commitment
+    let commitments = options.commitments
     if (!commitments) {
       const input = await longPrompt('Enter the signing commitments separated by commas', {
         required: true,

--- a/ironfish-cli/src/commands/wallet/multisig/commitment/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/commitment/create.ts
@@ -46,7 +46,7 @@ export class CreateSigningCommitmentCommand extends IronfishCommand {
     const loaded = await MultisigTransactionJson.load(this.sdk.fileSystem, flags.path)
     const options = MultisigTransactionJson.resolveFlags(flags, loaded)
 
-    let identities = options.signers
+    let identities = options.identity
     if (!identities || identities.length < 2) {
       const input = await longPrompt('Enter the identities separated by commas', {
         required: true,

--- a/ironfish-cli/src/commands/wallet/multisig/signature/aggregate.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/signature/aggregate.ts
@@ -54,7 +54,7 @@ export class MultisigSign extends IronfishCommand {
       signingPackage = await longPrompt('Enter the signing package', { required: true })
     }
 
-    let signatureShares = options.signatureShares
+    let signatureShares = options.signatureShare
     if (!signatureShares) {
       const input = await longPrompt('Enter the signature shares separated by commas', {
         required: true,

--- a/ironfish-cli/src/commands/wallet/multisig/signature/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/signature/create.ts
@@ -7,6 +7,7 @@ import { CliUx, Flags } from '@oclif/core'
 import { IronfishCommand } from '../../../../command'
 import { RemoteFlags } from '../../../../flags'
 import { longPrompt } from '../../../../utils/longPrompt'
+import { MultisigTransactionJson } from '../../../../utils/multisig'
 import { renderUnsignedTransactionDetails } from '../../../../utils/transaction'
 
 export class CreateSignatureShareCommand extends IronfishCommand {
@@ -29,12 +30,18 @@ export class CreateSignatureShareCommand extends IronfishCommand {
       default: false,
       description: 'Confirm creating signature share without confirming',
     }),
+    path: Flags.string({
+      description: 'Path to a JSON file containing multisig transaction data',
+    }),
   }
 
   async start(): Promise<void> {
     const { flags } = await this.parse(CreateSignatureShareCommand)
-    let signingPackageString = flags.signingPackage?.trim()
 
+    const loaded = await MultisigTransactionJson.load(this.sdk.fileSystem, flags.path)
+    const options = MultisigTransactionJson.resolveFlags(flags, loaded)
+
+    let signingPackageString = options.signingPackage
     if (!signingPackageString) {
       signingPackageString = await longPrompt('Enter the signing package')
     }

--- a/ironfish-cli/src/utils/multisig.ts
+++ b/ironfish-cli/src/utils/multisig.ts
@@ -5,22 +5,22 @@ import { FileSystem, YupUtils } from '@ironfish/sdk'
 import * as yup from 'yup'
 
 export type MultisigTransactionOptions = {
-  signers: string[]
+  identity: string[]
   unsignedTransaction: string
-  commitments: string[]
+  commitment: string[]
   signingPackage: string
-  signatureShares: string[]
+  signatureShare: string[]
 }
 
 export const MultisigTransactionOptionsSchema: yup.ObjectSchema<
   Partial<MultisigTransactionOptions>
 > = yup
   .object({
-    signers: yup.array().of(yup.string().defined()),
+    identity: yup.array().of(yup.string().defined()),
     unsignedTransaction: yup.string(),
-    commitments: yup.array().of(yup.string().defined()),
+    commitment: yup.array().of(yup.string().defined()),
     signingPackage: yup.string(),
-    signatureShares: yup.array().of(yup.string().defined()),
+    signatureShare: yup.array().of(yup.string().defined()),
   })
   .defined()
 
@@ -56,11 +56,11 @@ function resolveFlags(
   json: Partial<MultisigTransactionOptions>,
 ): Partial<MultisigTransactionOptions> {
   return {
-    signers: flags.identity ?? json.signers,
+    identity: flags.identity ?? json.identity,
     unsignedTransaction: flags.unsignedTransaction?.trim() ?? json.unsignedTransaction,
-    commitments: flags.commitment ?? json.commitments,
+    commitment: flags.commitment ?? json.commitment,
     signingPackage: flags.signingPackage?.trim() ?? json.signingPackage,
-    signatureShares: flags.signatureShare ?? json.signatureShares,
+    signatureShare: flags.signatureShare ?? json.signatureShare,
   }
 }
 

--- a/ironfish-cli/src/utils/multisig.ts
+++ b/ironfish-cli/src/utils/multisig.ts
@@ -1,0 +1,70 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { FileSystem, YupUtils } from '@ironfish/sdk'
+import * as yup from 'yup'
+
+export type MultisigTransactionOptions = {
+  signers: string[]
+  unsignedTransaction: string
+  commitments: string[]
+  signingPackage: string
+  signatureShares: string[]
+}
+
+export const MultisigTransactionOptionsSchema: yup.ObjectSchema<
+  Partial<MultisigTransactionOptions>
+> = yup
+  .object({
+    signers: yup.array().of(yup.string().defined()),
+    unsignedTransaction: yup.string(),
+    commitments: yup.array().of(yup.string().defined()),
+    signingPackage: yup.string(),
+    signatureShares: yup.array().of(yup.string().defined()),
+  })
+  .defined()
+
+async function load(
+  files: FileSystem,
+  path?: string,
+): Promise<Partial<MultisigTransactionOptions>> {
+  if (path === undefined) {
+    return {}
+  }
+
+  const data = (await files.readFile(files.resolve(path))).trim()
+
+  const { error, result } = await YupUtils.tryValidate(MultisigTransactionOptionsSchema, data)
+
+  if (error) {
+    throw error
+  }
+
+  return result
+}
+
+type MultisigTransactionFlags = {
+  identity?: string[]
+  unsignedTransaction?: string
+  commitment?: string[]
+  signingPackage?: string
+  signatureShare?: string[]
+}
+
+function resolveFlags(
+  flags: MultisigTransactionFlags,
+  json: Partial<MultisigTransactionOptions>,
+): Partial<MultisigTransactionOptions> {
+  return {
+    signers: flags.identity ?? json.signers,
+    unsignedTransaction: flags.unsignedTransaction?.trim() ?? json.unsignedTransaction,
+    commitments: flags.commitment ?? json.commitments,
+    signingPackage: flags.signingPackage?.trim() ?? json.signingPackage,
+    signatureShares: flags.signatureShare ?? json.signatureShares,
+  }
+}
+
+export const MultisigTransactionJson = {
+  load,
+  resolveFlags,
+}


### PR DESCRIPTION
## Summary

some of the multisig commands have very long inputs. it would be nice to be able to pass in a file instead

defines a single schema for a JSON file containing any inputs to a command in the multisig transaction signing flow

adds util functions for loading multisig JSON file and resolving input options with any flags. uses flags over json settings if both are set

adds path flag to each command in multisig signing flow: 'commitment:create', 'commitment:aggregate', 'signature:create', 'signature:aggregate'

## Testing Plan

manual testing

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
