### PR TITLE
Replace uses of `request<T>(...)` in tests with the appropriate method from `RpcClient`

### DIFF
--- a/ironfish/src/rpc/routes/chain/getChainInfo.test.ts
+++ b/ironfish/src/rpc/routes/chain/getChainInfo.test.ts
@@ -1,17 +1,13 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-
 import { createRouteTest } from '../../../testUtilities/routeTest'
-import { GetChainInfoResponse } from './getChainInfo'
 
 describe('Route chain.getChainInfo', () => {
   const routeTest = createRouteTest()
 
   it('returns the right object with hash', async () => {
-    const response = await routeTest.client
-      .request<GetChainInfoResponse>('chain/getChainInfo')
-      .waitForEnd()
+    const response = await routeTest.client.chain.getChainInfo()
 
     expect(response.content.currentBlockIdentifier.index).toEqual(
       routeTest.chain.latest.sequence.toString(),

--- a/ironfish/src/rpc/routes/chain/getConsensusParameters.test.ts
+++ b/ironfish/src/rpc/routes/chain/getConsensusParameters.test.ts
@@ -1,17 +1,13 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-
 import { createRouteTest } from '../../../testUtilities/routeTest'
-import { GetConsensusParametersResponse } from './getConsensusParameters'
 
 describe('Route chain.getConsensusParameters', () => {
   const routeTest = createRouteTest()
 
   it('returns the right parameters', async () => {
-    const response = await routeTest.client
-      .request<GetConsensusParametersResponse>('chain/getConsensusParameters')
-      .waitForEnd()
+    const response = await routeTest.client.chain.getConsensusParameters()
 
     const chainParams = routeTest.chain.consensus.parameters
     expect(response.content).toEqual(chainParams)

--- a/ironfish/src/rpc/routes/chain/getNetworkInfo.test.ts
+++ b/ironfish/src/rpc/routes/chain/getNetworkInfo.test.ts
@@ -1,17 +1,13 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-
 import { createRouteTest } from '../../../testUtilities/routeTest'
-import { GetNetworkInfoResponse } from './getNetworkInfo'
 
 describe('Route chain.getNetworkInfo', () => {
   const routeTest = createRouteTest()
 
   it('returns the network id', async () => {
-    const response = await routeTest.client
-      .request<GetNetworkInfoResponse>('chain/getNetworkInfo')
-      .waitForEnd()
+    const response = await routeTest.client.chain.getNetworkInfo()
 
     expect(response.content.networkId).toEqual(routeTest.node.internal.config.networkId)
   })

--- a/ironfish/src/rpc/routes/chain/getNoteWitness.test.ts
+++ b/ironfish/src/rpc/routes/chain/getNoteWitness.test.ts
@@ -6,7 +6,6 @@ import { Witness } from '../../../merkletree'
 import { NoteEncrypted } from '../../../primitives/noteEncrypted'
 import { useMinerBlockFixture } from '../../../testUtilities'
 import { createRouteTest } from '../../../testUtilities/routeTest'
-import { GetNoteWitnessResponse } from './getNoteWitness'
 
 describe('Route chain/getNoteWitness', () => {
   const routeTest = createRouteTest()
@@ -23,9 +22,7 @@ describe('Route chain/getNoteWitness', () => {
     const noteSize = await chain.notes.size()
 
     for (const index of Array.from(Array(noteSize).keys())) {
-      const response = await routeTest.client
-        .request<GetNoteWitnessResponse>('chain/getNoteWitness', { index })
-        .waitForEnd()
+      const response = await routeTest.client.chain.getNoteWitness({ index })
 
       const witness: Witness<NoteEncrypted, Buffer, Buffer, Buffer> | null =
         await chain.notes.witness(index)
@@ -61,9 +58,7 @@ describe('Route chain/getNoteWitness', () => {
     const confirmations = 1
 
     for (let index = 0; index < noteSize; index++) {
-      const response = await routeTest.client
-        .request<GetNoteWitnessResponse>('chain/getNoteWitness', { index, confirmations })
-        .waitForEnd()
+      const response = await routeTest.client.chain.getNoteWitness({ index, confirmations })
 
       const witness: Witness<NoteEncrypted, Buffer, Buffer, Buffer> | null =
         await chain.notes.witness(index, noteSize)
@@ -87,10 +82,8 @@ describe('Route chain/getNoteWitness', () => {
 
     // Notes on block2 are not confirmed
     for (let index = noteSize; index < block2NoteSize; index++) {
-      await expect(() =>
-        routeTest.client
-          .request<GetNoteWitnessResponse>('chain/getNoteWitness', { index, confirmations })
-          .waitForEnd(),
+      await expect(
+        routeTest.client.chain.getNoteWitness({ index, confirmations }),
       ).rejects.toThrow(`No confirmed notes exist with index ${index}`)
     }
   })

--- a/ironfish/src/rpc/routes/wallet/exportAccount.test.ts
+++ b/ironfish/src/rpc/routes/wallet/exportAccount.test.ts
@@ -10,8 +10,6 @@ import { AccountFormat } from '../../../wallet/account/encoder/encoder'
 import { JsonEncoder } from '../../../wallet/account/encoder/json'
 import { MnemonicEncoder } from '../../../wallet/account/encoder/mnemonic'
 import { SpendingKeyEncoder } from '../../../wallet/account/encoder/spendingKey'
-import { ExportAccountResponse } from './exportAccount'
-import { CreateParticipantResponse } from './multisig/createParticipant'
 
 describe('Route wallet/exportAccount', () => {
   const routeTest = createRouteTest(true)
@@ -23,12 +21,10 @@ describe('Route wallet/exportAccount', () => {
   })
 
   it('should export a default account', async () => {
-    const response = await routeTest.client
-      .request<ExportAccountResponse>('wallet/exportAccount', {
-        account: account.name,
-        viewOnly: false,
-      })
-      .waitForEnd()
+    const response = await routeTest.client.wallet.exportAccount({
+      account: account.name,
+      viewOnly: false,
+    })
 
     expect(response.status).toBe(200)
     expect(response.content).toMatchObject({
@@ -45,12 +41,10 @@ describe('Route wallet/exportAccount', () => {
   })
 
   it('should omit spending key when view only account is requested', async () => {
-    const response = await routeTest.client
-      .request<ExportAccountResponse>('wallet/exportAccount', {
-        account: account.name,
-        viewOnly: true,
-      })
-      .waitForEnd()
+    const response = await routeTest.client.wallet.exportAccount({
+      account: account.name,
+      viewOnly: true,
+    })
 
     expect(response.status).toBe(200)
     expect(response.content).toMatchObject({
@@ -67,12 +61,10 @@ describe('Route wallet/exportAccount', () => {
   })
 
   it('should export an account as a json string if requested', async () => {
-    const response = await routeTest.client
-      .request<ExportAccountResponse>('wallet/exportAccount', {
-        account: account.name,
-        format: AccountFormat.JSON,
-      })
-      .waitForEnd()
+    const response = await routeTest.client.wallet.exportAccount({
+      account: account.name,
+      format: AccountFormat.JSON,
+    })
 
     expect(response.status).toBe(200)
 
@@ -81,12 +73,10 @@ describe('Route wallet/exportAccount', () => {
   })
 
   it('should export an account as a base64 string if requested', async () => {
-    const response = await routeTest.client
-      .request<ExportAccountResponse>('wallet/exportAccount', {
-        account: account.name,
-        format: AccountFormat.Base64Json,
-      })
-      .waitForEnd()
+    const response = await routeTest.client.wallet.exportAccount({
+      account: account.name,
+      format: AccountFormat.Base64Json,
+    })
 
     const { id: _, ...accountImport } = account.serialize()
 
@@ -95,12 +85,10 @@ describe('Route wallet/exportAccount', () => {
   })
 
   it('should export an account as a spending key string if requested', async () => {
-    const response = await routeTest.client
-      .request<ExportAccountResponse>('wallet/exportAccount', {
-        account: account.name,
-        format: AccountFormat.SpendingKey,
-      })
-      .waitForEnd()
+    const response = await routeTest.client.wallet.exportAccount({
+      account: account.name,
+      format: AccountFormat.SpendingKey,
+    })
 
     expect(response.status).toBe(200)
     expect(response.content.account).toEqual(new SpendingKeyEncoder().encode(account))
@@ -108,23 +96,19 @@ describe('Route wallet/exportAccount', () => {
 
   it('should return an error when exporting a view only account in the spending key format', async () => {
     await expect(() =>
-      routeTest.client
-        .request<ExportAccountResponse>('wallet/exportAccount', {
-          account: account.name,
-          format: AccountFormat.SpendingKey,
-          viewOnly: true,
-        })
-        .waitForEnd(),
+      routeTest.client.wallet.exportAccount({
+        account: account.name,
+        format: AccountFormat.SpendingKey,
+        viewOnly: true,
+      }),
     ).rejects.toThrow()
   })
 
   it('should export an account as a mnemonic phrase string if requested', async () => {
-    const response = await routeTest.client
-      .request<ExportAccountResponse>('wallet/exportAccount', {
-        account: account.name,
-        format: AccountFormat.Mnemonic,
-      })
-      .waitForEnd()
+    const response = await routeTest.client.wallet.exportAccount({
+      account: account.name,
+      format: AccountFormat.Mnemonic,
+    })
 
     expect(response.status).toBe(200)
     expect(response.content.account).toEqual(new MnemonicEncoder().encode(account, {}))
@@ -132,13 +116,11 @@ describe('Route wallet/exportAccount', () => {
 
   it('should return an error when exporting a view only account in the mnemonic format', async () => {
     await expect(() =>
-      routeTest.client
-        .request<ExportAccountResponse>('wallet/exportAccount', {
-          account: account.name,
-          format: AccountFormat.Mnemonic,
-          viewOnly: true,
-        })
-        .waitForEnd(),
+      routeTest.client.wallet.exportAccount({
+        account: account.name,
+        format: AccountFormat.Mnemonic,
+        viewOnly: true,
+      }),
     ).rejects.toThrow()
   })
 
@@ -148,9 +130,7 @@ describe('Route wallet/exportAccount', () => {
       accountNames.map(
         async (name) =>
           (
-            await routeTest.client
-              .request<CreateParticipantResponse>('wallet/multisig/createParticipant', { name })
-              .waitForEnd()
+            await routeTest.client.wallet.multisig.createParticipant({ name })
           ).content,
       ),
     )
@@ -178,12 +158,10 @@ describe('Route wallet/exportAccount', () => {
       account: importAccount!.account,
     })
 
-    const response = await routeTest.client
-      .request<ExportAccountResponse>('wallet/exportAccount', {
-        account: accountNames[0],
-        viewOnly: false,
-      })
-      .waitForEnd()
+    const response = await routeTest.client.wallet.exportAccount({
+      account: accountNames[0],
+      viewOnly: false,
+    })
 
     expect(response.status).toBe(200)
     expect(response.content).toMatchObject({
@@ -211,9 +189,7 @@ describe('Route wallet/exportAccount', () => {
       accountNames.map(
         async (name) =>
           (
-            await routeTest.client
-              .request<CreateParticipantResponse>('wallet/multisig/createParticipant', { name })
-              .waitForEnd()
+            await routeTest.client.wallet.multisig.createParticipant({ name })
           ).content,
       ),
     )
@@ -241,12 +217,10 @@ describe('Route wallet/exportAccount', () => {
       account: importAccount!.account,
     })
 
-    const response = await routeTest.client
-      .request<ExportAccountResponse>('wallet/exportAccount', {
-        account: accountNames[0],
-        viewOnly: true,
-      })
-      .waitForEnd()
+    const response = await routeTest.client.wallet.exportAccount({
+      account: accountNames[0],
+      viewOnly: false,
+    })
 
     expect(response.status).toBe(200)
     expect(response.content).toMatchObject({

--- a/ironfish/src/rpc/routes/wallet/getAccountStatus.test.ts
+++ b/ironfish/src/rpc/routes/wallet/getAccountStatus.test.ts
@@ -16,11 +16,9 @@ describe('Route wallet/getAccountStatus', () => {
       setCreatedAt: true,
       setDefault: true,
     })
-    const response = await routeTest.client
-      .request<any>('wallet/getAccountStatus', {
-        account: account.name,
-      })
-      .waitForEnd()
+    const response = await routeTest.client.wallet.getAccountStatus({
+      account: account.name,
+    })
 
     expect(response.status).toBe(200)
     expect(response.content).toMatchObject({
@@ -38,12 +36,10 @@ describe('Route wallet/getAccountStatus', () => {
   })
 
   it('errors if no account exists', async () => {
-    await expect(() => {
-      return routeTest.client
-        .request<any>('wallet/getAccountStatus', {
-          account: 'asdf',
-        })
-        .waitForEnd()
-    }).rejects.toThrow('No account with name asdf')
+    await expect(
+      routeTest.client.wallet.getAccountStatus({
+        account: 'asdf',
+      }),
+    ).rejects.toThrow('No account with name asdf')
   })
 })

--- a/ironfish/src/rpc/routes/wallet/getAccountTransactions.test.ts
+++ b/ironfish/src/rpc/routes/wallet/getAccountTransactions.test.ts
@@ -11,10 +11,7 @@ import {
 } from '../../../testUtilities'
 import { createRouteTest } from '../../../testUtilities/routeTest'
 import { AsyncUtils } from '../../../utils'
-import {
-  GetAccountTransactionsRequest,
-  GetAccountTransactionsResponse,
-} from './getAccountTransactions'
+import { GetAccountTransactionsRequest } from './getAccountTransactions'
 
 describe('Route wallet/getAccountTransactions', () => {
   const routeTest = createRouteTest(true)
@@ -41,8 +38,8 @@ describe('Route wallet/getAccountTransactions', () => {
     const node = routeTest.node
     const account = await useAccountFixture(node.wallet, 'invalid-sequence')
 
-    const response = routeTest.client
-      .request<unknown, GetAccountTransactionsResponse>('wallet/getAccountTransactions', {
+    const response = routeTest.client.wallet
+      .getAccountTransactionsStream({
         account: account.name,
         sequence: 0,
       })
@@ -78,13 +75,10 @@ describe('Route wallet/getAccountTransactions', () => {
     await expect(node.chain).toAddBlock(block)
     await node.wallet.updateHead()
 
-    const response = routeTest.client.request<unknown, GetAccountTransactionsResponse>(
-      'wallet/getAccountTransactions',
-      {
-        account: account.name,
-        sequence: block.header.sequence,
-      },
-    )
+    const response = routeTest.client.wallet.getAccountTransactionsStream({
+      account: account.name,
+      sequence: block.header.sequence,
+    })
 
     const blockTransactionHashes = block.transactions
       .map((transaction) => transaction.hash())
@@ -109,12 +103,9 @@ describe('Route wallet/getAccountTransactions', () => {
     await expect(node.chain).toAddBlock(blockB)
     await node.wallet.updateHead()
 
-    const response = routeTest.client.request<unknown, GetAccountTransactionsResponse>(
-      'wallet/getAccountTransactions',
-      {
-        account: account.name,
-      },
-    )
+    const response = routeTest.client.wallet.getAccountTransactionsStream({
+      account: account.name,
+    })
 
     const transactions = await AsyncUtils.materialize(response.contentStream())
     expect(transactions).toHaveLength(2)
@@ -128,13 +119,10 @@ describe('Route wallet/getAccountTransactions', () => {
     await expect(node.chain).toAddBlock(blockA)
     await node.wallet.updateHead()
 
-    const response = routeTest.client.request<unknown, GetAccountTransactionsResponse>(
-      'wallet/getAccountTransactions',
-      {
-        account: account.name,
-        notes: true,
-      },
-    )
+    const response = routeTest.client.wallet.getAccountTransactionsStream({
+      account: account.name,
+      notes: true,
+    })
 
     const transactions = await AsyncUtils.materialize(response.contentStream())
     expect(transactions).toHaveLength(1)
@@ -151,13 +139,10 @@ describe('Route wallet/getAccountTransactions', () => {
 
     const { transaction } = await useTxSpendsFixture(node, { account })
 
-    const response = routeTest.client.request<unknown, GetAccountTransactionsResponse>(
-      'wallet/getAccountTransactions',
-      {
-        account: account.name,
-        spends: true,
-      },
-    )
+    const response = routeTest.client.wallet.getAccountTransactionsStream({
+      account: account.name,
+      spends: true,
+    })
 
     const transactions = await AsyncUtils.materialize(response.contentStream())
     expect(transactions).toHaveLength(2)
@@ -197,10 +182,8 @@ describe('Route wallet/getAccountTransactions', () => {
       account: account.name,
     }
 
-    const defaultSortResponse = routeTest.client.request<
-      unknown,
-      GetAccountTransactionsResponse
-    >('wallet/getAccountTransactions', defaultSort)
+    const defaultSortResponse =
+      routeTest.client.wallet.getAccountTransactionsStream(defaultSort)
 
     const defaultSortTransactions = await AsyncUtils.materialize(
       defaultSortResponse.contentStream(),
@@ -215,10 +198,8 @@ describe('Route wallet/getAccountTransactions', () => {
       reverse: true,
     }
 
-    const reverseSortResponse = routeTest.client.request<
-      unknown,
-      GetAccountTransactionsResponse
-    >('wallet/getAccountTransactions', reverseSort)
+    const reverseSortResponse =
+      routeTest.client.wallet.getAccountTransactionsStream(reverseSort)
 
     const reverseSortTransactions = await AsyncUtils.materialize(
       reverseSortResponse.contentStream(),
@@ -233,10 +214,8 @@ describe('Route wallet/getAccountTransactions', () => {
       reverse: false,
     }
 
-    const forwardSortResponse = routeTest.client.request<
-      unknown,
-      GetAccountTransactionsResponse
-    >('wallet/getAccountTransactions', forwardSort)
+    const forwardSortResponse =
+      routeTest.client.wallet.getAccountTransactionsStream(forwardSort)
 
     const forwardSortTransactions = await AsyncUtils.materialize(
       forwardSortResponse.contentStream(),

--- a/ironfish/src/rpc/routes/wallet/getAccountsStatus.test.ts
+++ b/ironfish/src/rpc/routes/wallet/getAccountsStatus.test.ts
@@ -23,9 +23,7 @@ describe('Route wallet/getAccountsStatus', () => {
     await expect(routeTest.chain).toAddBlock(block)
     await routeTest.wallet.updateHead()
 
-    const response = await routeTest.client
-      .request<any>('wallet/getAccountsStatus', {})
-      .waitForEnd()
+    const response = await routeTest.client.wallet.getAccountsStatus()
 
     expect(response.status).toBe(200)
     expect(response.content).toMatchObject({
@@ -53,9 +51,7 @@ describe('Route wallet/getAccountsStatus', () => {
       spendingKey: null,
     })
 
-    const response = await routeTest.client
-      .request<any>('wallet/getAccountsStatus', {})
-      .waitForEnd()
+    const response = await routeTest.client.wallet.getAccountsStatus()
 
     expect(response.status).toBe(200)
     expect(response.content).toMatchObject({

--- a/ironfish/src/rpc/routes/wallet/getPublicKey.test.ts
+++ b/ironfish/src/rpc/routes/wallet/getPublicKey.test.ts
@@ -32,12 +32,9 @@ describe('Route wallet/getPublicKey', () => {
   })
 
   it('should return the account data', async () => {
-    const response = await routeTest.client
-      .request<any>('wallet/getPublicKey', {
-        account: account.name,
-        generate: false,
-      })
-      .waitForEnd()
+    const response = await routeTest.client.wallet.getAccountPublicKey({
+      account: account.name,
+    })
 
     expect(response.status).toBe(200)
     expect(response.content).toMatchObject({

--- a/ironfish/src/rpc/routes/wallet/importAccount.test.ts
+++ b/ironfish/src/rpc/routes/wallet/importAccount.test.ts
@@ -11,8 +11,6 @@ import { Bech32Encoder } from '../../../wallet/account/encoder/bech32'
 import { Bech32JsonEncoder } from '../../../wallet/account/encoder/bech32json'
 import { AccountFormat } from '../../../wallet/account/encoder/encoder'
 import { RpcClient } from '../../clients'
-import { ImportResponse } from './importAccount'
-import { CreateParticipantResponse } from './multisig/createParticipant'
 
 describe('Route wallet/importAccount', () => {
   const routeTest = createRouteTest(true)
@@ -27,21 +25,20 @@ describe('Route wallet/importAccount', () => {
     const key = generateKey()
 
     const accountName = 'foo'
-    const response = await routeTest.client
-      .request<ImportResponse>('wallet/importAccount', {
-        account: {
-          name: accountName,
-          viewKey: key.viewKey,
-          spendingKey: null,
-          publicAddress: key.publicAddress,
-          incomingViewKey: key.incomingViewKey,
-          outgoingViewKey: key.outgoingViewKey,
-          version: 1,
-          createdAt: null,
-        },
-        rescan: false,
-      })
-      .waitForEnd()
+    const response = await routeTest.client.wallet.importAccount({
+      account: {
+        name: accountName,
+        viewKey: key.viewKey,
+        spendingKey: null,
+        publicAddress: key.publicAddress,
+        incomingViewKey: key.incomingViewKey,
+        outgoingViewKey: key.outgoingViewKey,
+        proofAuthorizingKey: null,
+        version: 1,
+        createdAt: null,
+      },
+      rescan: false,
+    })
 
     expect(response.status).toBe(200)
     expect(response.content).toMatchObject({
@@ -54,25 +51,23 @@ describe('Route wallet/importAccount', () => {
     const trustedDealerPackages = createTrustedDealerKeyPackages()
 
     const accountName = 'multisig'
-    const response = await routeTest.client
-      .request<ImportResponse>('wallet/importAccount', {
-        account: {
-          version: 1,
-          name: accountName,
-          viewKey: trustedDealerPackages.viewKey,
-          incomingViewKey: trustedDealerPackages.incomingViewKey,
-          outgoingViewKey: trustedDealerPackages.outgoingViewKey,
-          publicAddress: trustedDealerPackages.publicAddress,
-          spendingKey: null,
-          createdAt: null,
-          proofAuthorizingKey: trustedDealerPackages.proofAuthorizingKey,
-          multisigKeys: {
-            publicKeyPackage: trustedDealerPackages.publicKeyPackage,
-          },
+    const response = await routeTest.client.wallet.importAccount({
+      account: {
+        version: 1,
+        name: accountName,
+        viewKey: trustedDealerPackages.viewKey,
+        incomingViewKey: trustedDealerPackages.incomingViewKey,
+        outgoingViewKey: trustedDealerPackages.outgoingViewKey,
+        publicAddress: trustedDealerPackages.publicAddress,
+        spendingKey: null,
+        createdAt: null,
+        proofAuthorizingKey: trustedDealerPackages.proofAuthorizingKey,
+        multisigKeys: {
+          publicKeyPackage: trustedDealerPackages.publicKeyPackage,
         },
-        rescan: false,
-      })
-      .waitForEnd()
+      },
+      rescan: false,
+    })
 
     expect(response.status).toBe(200)
     expect(response.content).toMatchObject({
@@ -85,21 +80,20 @@ describe('Route wallet/importAccount', () => {
     const key = generateKey()
 
     const accountName = 'bar'
-    const response = await routeTest.client
-      .request<ImportResponse>('wallet/importAccount', {
-        account: {
-          name: accountName,
-          viewKey: key.viewKey,
-          spendingKey: key.spendingKey,
-          publicAddress: key.publicAddress,
-          incomingViewKey: key.incomingViewKey,
-          outgoingViewKey: key.outgoingViewKey,
-          version: 1,
-          createdAt: null,
-        },
-        rescan: false,
-      })
-      .waitForEnd()
+    const response = await routeTest.client.wallet.importAccount({
+      account: {
+        name: accountName,
+        viewKey: key.viewKey,
+        spendingKey: key.spendingKey,
+        publicAddress: key.publicAddress,
+        incomingViewKey: key.incomingViewKey,
+        outgoingViewKey: key.outgoingViewKey,
+        proofAuthorizingKey: null,
+        version: 1,
+        createdAt: null,
+      },
+      rescan: false,
+    })
 
     expect(response.status).toBe(200)
     expect(response.content).toMatchObject({
@@ -129,22 +123,21 @@ describe('Route wallet/importAccount', () => {
       const skipRescanSpy = jest.spyOn(routeTest.node.wallet, 'skipRescan')
 
       const accountName = 'baz'
-      const response = await routeTest.client
-        .request<ImportResponse>('wallet/importAccount', {
-          account: {
-            name: accountName,
-            viewKey: key.viewKey,
-            spendingKey: key.spendingKey,
-            publicAddress: key.publicAddress,
-            incomingViewKey: key.incomingViewKey,
-            outgoingViewKey: key.outgoingViewKey,
-            version: 1,
-            createdAt: null,
-          },
-          // set rescan to true so that skipRescan should not be called
-          rescan: true,
-        })
-        .waitForEnd()
+      const response = await routeTest.client.wallet.importAccount({
+        account: {
+          name: accountName,
+          viewKey: key.viewKey,
+          spendingKey: key.spendingKey,
+          publicAddress: key.publicAddress,
+          incomingViewKey: key.incomingViewKey,
+          outgoingViewKey: key.outgoingViewKey,
+          proofAuthorizingKey: null,
+          version: 1,
+          createdAt: null,
+        },
+        // set rescan to true so that skipRescan should not be called
+        rescan: true,
+      })
 
       expect(response.status).toBe(200)
       expect(response.content).toMatchObject({
@@ -176,12 +169,10 @@ describe('Route wallet/importAccount', () => {
       const name = 'json'
       const jsonString = encodeAccount(createAccountImport(name), AccountFormat.JSON)
 
-      const response = await routeTest.client
-        .request<ImportResponse>('wallet/importAccount', {
-          account: jsonString,
-          rescan: false,
-        })
-        .waitForEnd()
+      const response = await routeTest.client.wallet.importAccount({
+        account: jsonString,
+        rescan: false,
+      })
 
       expect(response.status).toBe(200)
       expect(response.content).toMatchObject({
@@ -194,12 +185,10 @@ describe('Route wallet/importAccount', () => {
       const name = 'bech32json'
       const bech32Json = new Bech32JsonEncoder().encode(createAccountImport(name))
 
-      const response = await routeTest.client
-        .request<ImportResponse>('wallet/importAccount', {
-          account: bech32Json,
-          rescan: false,
-        })
-        .waitForEnd()
+      const response = await routeTest.client.wallet.importAccount({
+        account: bech32Json,
+        rescan: false,
+      })
 
       expect(response.status).toBe(200)
       expect(response.content).toMatchObject({
@@ -212,12 +201,10 @@ describe('Route wallet/importAccount', () => {
       const name = 'bech32'
       const bech32 = new Bech32Encoder().encode(createAccountImport(name))
 
-      const response = await routeTest.client
-        .request<ImportResponse>('wallet/importAccount', {
-          account: bech32,
-          rescan: false,
-        })
-        .waitForEnd()
+      const response = await routeTest.client.wallet.importAccount({
+        account: bech32,
+        rescan: false,
+      })
 
       expect(response.status).toBe(200)
       expect(response.content).toMatchObject({
@@ -230,12 +217,10 @@ describe('Route wallet/importAccount', () => {
       const name = 'base64'
       const base64 = encodeAccount(createAccountImport(name), AccountFormat.Base64Json)
 
-      const response = await routeTest.client
-        .request<ImportResponse>('wallet/importAccount', {
-          account: base64,
-          rescan: false,
-        })
-        .waitForEnd()
+      const response = await routeTest.client.wallet.importAccount({
+        account: base64,
+        rescan: false,
+      })
 
       expect(response.status).toBe(200)
       expect(response.content).toMatchObject({
@@ -248,13 +233,11 @@ describe('Route wallet/importAccount', () => {
       const name = 'spendingKey'
       const spendingKey = generateKey().spendingKey
 
-      const response = await routeTest.client
-        .request<ImportResponse>('wallet/importAccount', {
-          account: spendingKey,
-          name: name,
-          rescan: false,
-        })
-        .waitForEnd()
+      const response = await routeTest.client.wallet.importAccount({
+        account: spendingKey,
+        name: name,
+        rescan: false,
+      })
 
       expect(response.status).toBe(200)
       expect(response.content).toMatchObject({
@@ -267,13 +250,11 @@ describe('Route wallet/importAccount', () => {
       const name = 'mnemonic'
       const mnemonic = spendingKeyToWords(generateKey().spendingKey, LanguageCode.English)
 
-      const response = await routeTest.client
-        .request<ImportResponse>('wallet/importAccount', {
-          account: mnemonic,
-          name: name,
-          rescan: false,
-        })
-        .waitForEnd()
+      const response = await routeTest.client.wallet.importAccount({
+        account: mnemonic,
+        name: name,
+        rescan: false,
+      })
 
       expect(response.status).toBe(200)
       expect(response.content).toMatchObject({
@@ -296,12 +277,10 @@ describe('Route wallet/importAccount', () => {
           path.join(testCaseDir, testCaseFile),
         )
 
-        const response = await routeTest.client
-          .request<ImportResponse>('wallet/importAccount', {
-            account: testCase,
-            name: testCaseFile,
-          })
-          .waitForEnd()
+        const response = await routeTest.client.wallet.importAccount({
+          account: testCase,
+          name: testCaseFile,
+        })
 
         expect(response.status).toBe(200)
         expect(response.content.name).not.toBeNull()
@@ -312,22 +291,17 @@ describe('Route wallet/importAccount', () => {
       it('should import a base64 encoded account', async () => {
         const name = 'multisig-encrypted-base64'
 
-        const identity = (
-          await routeTest.client
-            .request<CreateParticipantResponse>('wallet/multisig/createParticipant', { name })
-            .waitForEnd()
-        ).content.identity
+        const identity = (await routeTest.client.wallet.multisig.createParticipant({ name }))
+          .content.identity
         const base64 = encodeAccount(createAccountImport(name), AccountFormat.Base64Json, {
           encryptWith: { kind: 'MultisigIdentity', identity: Buffer.from(identity, 'hex') },
         })
 
-        const response = await routeTest.client
-          .request<ImportResponse>('wallet/importAccount', {
-            name,
-            account: base64,
-            rescan: false,
-          })
-          .waitForEnd()
+        const response = await routeTest.client.wallet.importAccount({
+          name,
+          account: base64,
+          rescan: false,
+        })
 
         expect(response.status).toBe(200)
         expect(response.content).toMatchObject({
@@ -345,13 +319,11 @@ describe('Route wallet/importAccount', () => {
         })
 
         await expect(
-          routeTest.client
-            .request<ImportResponse>('wallet/importAccount', {
-              name,
-              account: base64,
-              rescan: false,
-            })
-            .waitForEnd(),
+          routeTest.client.wallet.importAccount({
+            name,
+            account: base64,
+            rescan: false,
+          }),
         ).rejects.toThrow(
           expect.objectContaining({
             message: expect.stringContaining(
@@ -365,22 +337,18 @@ describe('Route wallet/importAccount', () => {
       it('should fail to import a base64 encode account if the wrong multisig identity is used', async () => {
         const name = 'multisig-encrypted-base64 (wrong key)'
 
-        await routeTest.client
-          .request<CreateParticipantResponse>('wallet/multisig/createParticipant', { name })
-          .waitForEnd()
+        await routeTest.client.wallet.multisig.createParticipant({ name })
         const encryptingParticipant = multisig.ParticipantSecret.random().toIdentity()
         const base64 = encodeAccount(createAccountImport(name), AccountFormat.Base64Json, {
           encryptWith: { kind: 'MultisigIdentity', identity: encryptingParticipant },
         })
 
         await expect(
-          routeTest.client
-            .request<ImportResponse>('wallet/importAccount', {
-              name,
-              account: base64,
-              rescan: false,
-            })
-            .waitForEnd(),
+          routeTest.client.wallet.importAccount({
+            name,
+            account: base64,
+            rescan: false,
+          }),
         ).rejects.toThrow(
           expect.objectContaining({
             message: expect.stringContaining(
@@ -422,12 +390,10 @@ describe('Route wallet/importAccount', () => {
             name: testCaseFile,
           })
 
-          const response = await routeTest.client
-            .request<ImportResponse>('wallet/importAccount', {
-              account: testCase,
-              name: testCaseFile,
-            })
-            .waitForEnd()
+          const response = await routeTest.client.wallet.importAccount({
+            account: testCase,
+            name: testCaseFile,
+          })
 
           expect(response.status).toBe(200)
           expect(response.content.name).not.toBeNull()

--- a/ironfish/src/rpc/routes/wallet/multisig/createSigningCommitment.test.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/createSigningCommitment.test.ts
@@ -5,7 +5,6 @@ import { multisig } from '@ironfish/rust-nodejs'
 import { useAccountAndAddFundsFixture, useUnsignedTxFixture } from '../../../../testUtilities'
 import { createRouteTest } from '../../../../testUtilities/routeTest'
 import { ACCOUNT_SCHEMA_VERSION } from '../../../../wallet'
-import { CreateParticipantResponse } from './createParticipant'
 
 describe('Route wallet/multisig/createSigningCommitment', () => {
   const routeTest = createRouteTest()
@@ -92,9 +91,7 @@ describe('Route wallet/multisig/createSigningCommitment', () => {
       accountNames.map(
         async (name) =>
           (
-            await routeTest.client
-              .request<CreateParticipantResponse>('wallet/multisig/createParticipant', { name })
-              .waitForEnd()
+            await routeTest.client.wallet.multisig.createParticipant({ name })
           ).content,
       ),
     )

--- a/ironfish/src/rpc/routes/wallet/multisig/createSigningPackage.test.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/createSigningPackage.test.ts
@@ -3,7 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { useAccountAndAddFundsFixture, useUnsignedTxFixture } from '../../../../testUtilities'
 import { createRouteTest } from '../../../../testUtilities/routeTest'
-import { CreateParticipantResponse } from './createParticipant'
 
 describe('Route multisig/createSigningPackage', () => {
   const routeTest = createRouteTest()
@@ -13,11 +12,8 @@ describe('Route multisig/createSigningPackage', () => {
     const accountNames = Array.from({ length: 3 }, (_, index) => `test-account-${index}`)
     const participants = await Promise.all(
       accountNames.map(async (name) => {
-        const identity = (
-          await routeTest.client
-            .request<CreateParticipantResponse>('wallet/multisig/createParticipant', { name })
-            .waitForEnd()
-        ).content.identity
+        const identity = (await routeTest.client.wallet.multisig.createParticipant({ name }))
+          .content.identity
         return { name, identity }
       }),
     )
@@ -77,11 +73,8 @@ describe('Route multisig/createSigningPackage', () => {
       const accountNames = Array.from({ length: 4 }, (_, index) => `test-account-${index}`)
       const participants = await Promise.all(
         accountNames.map(async (name) => {
-          const identity = (
-            await routeTest.client
-              .request<CreateParticipantResponse>('wallet/multisig/createParticipant', { name })
-              .waitForEnd()
-          ).content.identity
+          const identity = (await routeTest.client.wallet.multisig.createParticipant({ name }))
+            .content.identity
           return { name, identity }
         }),
       )
@@ -185,11 +178,8 @@ describe('Route multisig/createSigningPackage', () => {
       const accountNames = Array.from({ length: 4 }, (_, index) => `test-account-${index}`)
       const participants = await Promise.all(
         accountNames.map(async (name) => {
-          const identity = (
-            await routeTest.client
-              .request<CreateParticipantResponse>('wallet/multisig/createParticipant', { name })
-              .waitForEnd()
-          ).content.identity
+          const identity = (await routeTest.client.wallet.multisig.createParticipant({ name }))
+            .content.identity
           return { name, identity }
         }),
       )
@@ -265,11 +255,8 @@ describe('Route multisig/createSigningPackage', () => {
       const accountNames = Array.from({ length: 4 }, (_, index) => `test-account-${index}`)
       const participants = await Promise.all(
         accountNames.map(async (name) => {
-          const identity = (
-            await routeTest.client
-              .request<CreateParticipantResponse>('wallet/multisig/createParticipant', { name })
-              .waitForEnd()
-          ).content.identity
+          const identity = (await routeTest.client.wallet.multisig.createParticipant({ name }))
+            .content.identity
           return { name, identity }
         }),
       )


### PR DESCRIPTION
## Summary

This replaces code like the following:

    await routeTest.client.request<FooResponse>('foo', ...).waitForEnd()

with:

    await routeTest.client.foo(...)

Not all the uses of `request` have been replaced in this PR: only the trivial ones. The remaining ones require a bit more involved changes.

This PR also fixes some typing errors in the request parameters, and fixes some tests that were using `try`/`catch` instead of `expect` (the try/catch approach had the problem that if the RPC did not throw any exception, the test would have not failed).

## Testing Plan

Unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
