### PR TITLE
Clarify when users are entering iron denominations

### DIFF
--- a/ironfish-cli/src/commands/wallet/send.ts
+++ b/ironfish-cli/src/commands/wallet/send.ts
@@ -23,9 +23,9 @@ export class Send extends IronfishCommand {
   static description = `Send coins to another account`
 
   static examples = [
-    '$ ironfish wallet:send --amount 2 --fee 0.00000001 --to 997c586852d1b12da499bcff53595ba37d04e4909dbdb1a75f3bfd90dd7212217a1c2c0da652d187fc52ed',
-    '$ ironfish wallet:send --amount 2 --fee 0.00000001 --to 997c586852d1b12da499bcff53595ba37d04e4909dbdb1a75f3bfd90dd7212217a1c2c0da652d187fc52ed --account otheraccount',
-    '$ ironfish wallet:send --amount 2 --fee 0.00000001 --to 997c586852d1b12da499bcff53595ba37d04e4909dbdb1a75f3bfd90dd7212217a1c2c0da652d187fc52ed --account otheraccount --memo "enjoy!"',
+    '$ ironfish wallet:send --amount 2.003 --fee 0.00000001 --to 997c586852d1b12da499bcff53595ba37d04e4909dbdb1a75f3bfd90dd7212217a1c2c0da652d187fc52ed',
+    '$ ironfish wallet:send --amount 2.003 --fee 0.00000001 --to 997c586852d1b12da499bcff53595ba37d04e4909dbdb1a75f3bfd90dd7212217a1c2c0da652d187fc52ed --account otheraccount',
+    '$ ironfish wallet:send --amount 2.003 --fee 0.00000001 --to 997c586852d1b12da499bcff53595ba37d04e4909dbdb1a75f3bfd90dd7212217a1c2c0da652d187fc52ed --account otheraccount --memo "enjoy!"',
   ]
 
   static flags = {
@@ -36,7 +36,7 @@ export class Send extends IronfishCommand {
     }),
     amount: IronFlag({
       char: 'a',
-      description: 'Amount of coins to send',
+      description: 'The amount to send in IRON',
       flagName: 'amount',
     }),
     to: Flags.string({
@@ -144,7 +144,7 @@ export class Send extends IronfishCommand {
       amount = await promptCurrency({
         client: client,
         required: true,
-        text: 'Enter the amount',
+        text: 'Enter the amount in IRON',
         minimum: 1n,
         logger: this.logger,
         balance: {

--- a/ironfish-cli/src/utils/currency.ts
+++ b/ironfish-cli/src/utils/currency.ts
@@ -6,6 +6,10 @@ import { Asset } from '@ironfish/rust-nodejs'
 import { Assert, CurrencyUtils, Logger, RpcClient } from '@ironfish/sdk'
 import { CliUx } from '@oclif/core'
 
+/**
+ * This promps the user to enter an ammount of currency in IRON denominations
+ * and returns the value in ORE
+ */
 export async function promptCurrency(options: {
   client: Pick<RpcClient, 'wallet'>
   text: string

--- a/ironfish-cli/src/utils/currency.ts
+++ b/ironfish-cli/src/utils/currency.ts
@@ -7,7 +7,7 @@ import { Assert, CurrencyUtils, Logger, RpcClient } from '@ironfish/sdk'
 import { CliUx } from '@oclif/core'
 
 /**
- * This promps the user to enter an ammount of currency in IRON denominations
+ * This prompts the user to enter an amount of currency in IRON denominations
  * and returns the value in ORE
  */
 export async function promptCurrency(options: {


### PR DESCRIPTION
## Summary

This makes it more clear, however it also reveals a confusing issue we have. When using custom assets, why are we entering iron? What should we refer to the coin denomination for that asset? These issues will need to be fixed goign forward from a UX perspective.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
