### PR TITLE
Multisig: do not include the multisig secret when exporting view-only account

### DIFF
--- a/ironfish/src/rpc/routes/wallet/exportAccount.ts
+++ b/ironfish/src/rpc/routes/wallet/exportAccount.ts
@@ -46,6 +46,11 @@ routes.register<typeof ExportAccountRequestSchema, ExportAccountResponse>(
     const { id: _, ...accountInfo } = account.serialize()
     if (request.data.viewOnly) {
       accountInfo.spendingKey = null
+      if (accountInfo.multisigKeys) {
+        accountInfo.multisigKeys = {
+          publicKeyPackage: accountInfo.multisigKeys.publicKeyPackage,
+        }
+      }
     }
 
     if (!request.data.format) {


### PR DESCRIPTION
## Summary

When exporting an account with `viewOnly: true`, the multisig secret (i.e. the authorization key shard) should be omitted from the output.

## Testing Plan

* unit tests
* create a multisig account, export it as view only, verify that the output does not include any secrets

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
