### PR TITLE
fixes incorrect sibling hash caching during witness creation

### DIFF
--- a/ironfish/src/merkletree/merkletree.ts
+++ b/ironfish/src/merkletree/merkletree.ts
@@ -598,7 +598,6 @@ export class MerkleTree<
         const sibling = await this.getLeaf(leafIndex - 1, tx)
         const siblingHash = sibling.merkleHash
         currentHash = this.hasher.combineHash(0, siblingHash, currentHash)
-        pastHashes.set(leafIndex - 1, currentHash)
       } else {
         currentHash = this.hasher.combineHash(0, currentHash, currentHash)
       }


### PR DESCRIPTION
## Summary

when calculating witnesses at past tree sizes we cache the sibling hashes of left nodes at the past tree size

the merkle tree has separate datastores for nodes and leaves. the cache is keyed by node index, not leaf index.

when building the cache we incorrectly set a leaf index to a sibling hash. if that index is visited as a node index when creating the witness, then the cached value may be used incorrectly resulting in an invalid commitment.

the commitment may still be correct if that node index corresponds to a right node or if the node index is overwritten by the correct sibling hash in the cache while building the past root

there are four criteria for the merkle tree, past size, and witness index that produce an incorrect commitment:
1. the leaf at leaf index `pastSize - 1` is a right leaf
2. the node at node index `pastSize - 2` is a left node
3. the node at node index `pastSize - 2` is _not_ on the path from the leaf `pastSize - 1` to the root (or the incorrect cache would be overwritten
4. the node at node index `pastSize - 2` is on the path from the witness leaf index to the root

these criteria depend on the tree size, past size, and witness index, so reproducing the incorrect commitment is somewhat random. an example that produces the incorrect commitment is a tree size of 128, a pasts ize of 74, and witness indexes of 68 or 69

## Testing Plan

manually tested with `ironfish repl`, contrived unit test for specific case

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
