### PR TITLE
Adds a transaction timer class to reuse

### DIFF
--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -466,6 +466,7 @@ export class CombineNotesCommand extends IronfishCommand {
     displayTransactionSummary(raw, Asset.nativeId().toString('hex'), amount, from, to, memo)
 
     const transactionTimer = new TransactionTimer(spendPostTime, raw, this.logger)
+    transactionTimer.displayEstimate()
 
     if (!flags.confirm) {
       const confirmed = await CliUx.ux.confirm('Do you confirm (Y/N)?')

--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -474,7 +474,7 @@ export class CombineNotesCommand extends IronfishCommand {
       }
     }
 
-    transactionTimer.startTimer()
+    transactionTimer.start()
 
     const response = await client.wallet.postTransaction({
       transaction: RawTransactionSerde.serialize(raw).toString('hex'),
@@ -484,7 +484,7 @@ export class CombineNotesCommand extends IronfishCommand {
     const bytes = Buffer.from(response.content.transaction, 'hex')
     const transaction = new Transaction(bytes)
 
-    transactionTimer.endTimer()
+    transactionTimer.end()
 
     if (response.content.accepted === false) {
       this.warn(

--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -22,8 +22,8 @@ import { IronFlag, RemoteFlags } from '../../../flags'
 import { getExplorer } from '../../../utils/explorer'
 import { selectFee } from '../../../utils/fees'
 import {
-  TransactionTimer,
   displayTransactionSummary,
+  TransactionTimer,
   watchTransaction,
 } from '../../../utils/transaction'
 

--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -19,10 +19,13 @@ import { CliUx, Flags } from '@oclif/core'
 import inquirer from 'inquirer'
 import { IronfishCommand } from '../../../command'
 import { IronFlag, RemoteFlags } from '../../../flags'
-import { ProgressBar } from '../../../types'
 import { getExplorer } from '../../../utils/explorer'
 import { selectFee } from '../../../utils/fees'
-import { displayTransactionSummary, watchTransaction } from '../../../utils/transaction'
+import {
+  TransactionTimer,
+  displayTransactionSummary,
+  watchTransaction,
+} from '../../../utils/transaction'
 
 export class CombineNotesCommand extends IronfishCommand {
   static description = `Combine notes into a single note`
@@ -462,13 +465,8 @@ export class CombineNotesCommand extends IronfishCommand {
 
     displayTransactionSummary(raw, Asset.nativeId().toString('hex'), amount, from, to, memo)
 
-    const estimateInMs = Math.max(Math.ceil(spendPostTime * raw.spends.length), 1000)
+    const transactionTimer = new TransactionTimer(spendPostTime, raw, this.logger)
 
-    this.log(
-      `Time to send: ${TimeUtils.renderSpan(estimateInMs, {
-        hideMilliseconds: true,
-      })}`,
-    )
     if (!flags.confirm) {
       const confirmed = await CliUx.ux.confirm('Do you confirm (Y/N)?')
       if (!confirmed) {
@@ -476,26 +474,7 @@ export class CombineNotesCommand extends IronfishCommand {
       }
     }
 
-    const progressBar = CliUx.ux.progress({
-      format: '{title}: [{bar}] {percentage}% | {estimate}',
-    }) as ProgressBar
-
-    const startTime = Date.now()
-
-    progressBar.start(100, 0, {
-      title: 'Sending the transaction',
-      estimate: TimeUtils.renderSpan(estimateInMs, { hideMilliseconds: true }),
-    })
-
-    const timer = setInterval(() => {
-      const durationInMs = Date.now() - startTime
-      const timeRemaining = estimateInMs - durationInMs
-      const progress = Math.round((durationInMs / estimateInMs) * 100)
-
-      progressBar.update(progress, {
-        estimate: TimeUtils.renderSpan(timeRemaining, { hideMilliseconds: true }),
-      })
-    }, 1000)
+    transactionTimer.startTimer()
 
     const response = await client.wallet.postTransaction({
       transaction: RawTransactionSerde.serialize(raw).toString('hex'),
@@ -505,15 +484,7 @@ export class CombineNotesCommand extends IronfishCommand {
     const bytes = Buffer.from(response.content.transaction, 'hex')
     const transaction = new Transaction(bytes)
 
-    clearInterval(timer)
-    progressBar.update(100)
-    progressBar.stop()
-
-    this.log(
-      `Sending took ${TimeUtils.renderSpan(Date.now() - startTime, {
-        hideMilliseconds: true,
-      })}`,
-    )
+    transactionTimer.endTimer()
 
     if (response.content.accepted === false) {
       this.warn(

--- a/ironfish-cli/src/utils/transaction.ts
+++ b/ironfish-cli/src/utils/transaction.ts
@@ -23,22 +23,12 @@ export class TransactionTimer {
   private estimateInMs: number
   private timer: NodeJS.Timer | undefined
 
-  constructor(
-    spendPostTime: number,
-    raw: RawTransaction,
-    logger?: Logger,
-    options: {
-      displayEstimate?: boolean
-    } = {
-      displayEstimate: true,
-    },
-  ) {
+  constructor(spendPostTime: number, raw: RawTransaction, logger?: Logger) {
     this.logger = logger ?? createRootLogger()
     this.estimateInMs = Math.max(Math.ceil(spendPostTime * raw.spends.length), 1000)
-    options.displayEstimate && this.displayEstimate()
   }
 
-  private displayEstimate() {
+  displayEstimate() {
     this.logger.log(
       `Time to send: ${TimeUtils.renderSpan(this.estimateInMs, {
         hideMilliseconds: true,

--- a/ironfish-cli/src/utils/transaction.ts
+++ b/ironfish-cli/src/utils/transaction.ts
@@ -46,7 +46,7 @@ export class TransactionTimer {
     )
   }
 
-  startTimer() {
+  start() {
     this.progressBar = CliUx.ux.progress({
       format: '{title}: [{bar}] {percentage}% | {estimate}',
     }) as ProgressBar
@@ -72,7 +72,7 @@ export class TransactionTimer {
     }, 1000)
   }
 
-  endTimer() {
+  end() {
     if (!this.progressBar || !this.startTime || !this.timer) {
       return
     }

--- a/ironfish-cli/src/utils/transaction.ts
+++ b/ironfish-cli/src/utils/transaction.ts
@@ -14,6 +14,80 @@ import {
   UnsignedTransaction,
 } from '@ironfish/sdk'
 import { CliUx } from '@oclif/core'
+import { ProgressBar } from '../types'
+
+export class TransactionTimer {
+  private logger: Logger
+  private progressBar: ProgressBar | undefined
+  private startTime: number | undefined
+  private estimateInMs: number
+  private timer: NodeJS.Timer | undefined
+
+  constructor(
+    spendPostTime: number,
+    raw: RawTransaction,
+    logger?: Logger,
+    options: {
+      displayEstimate?: boolean
+    } = {
+      displayEstimate: true,
+    },
+  ) {
+    this.logger = logger ?? createRootLogger()
+    this.estimateInMs = Math.max(Math.ceil(spendPostTime * raw.spends.length), 1000)
+    options.displayEstimate && this.displayEstimate()
+  }
+
+  private displayEstimate() {
+    this.logger.log(
+      `Time to send: ${TimeUtils.renderSpan(this.estimateInMs, {
+        hideMilliseconds: true,
+      })}`,
+    )
+  }
+
+  startTimer() {
+    this.progressBar = CliUx.ux.progress({
+      format: '{title}: [{bar}] {percentage}% | {estimate}',
+    }) as ProgressBar
+
+    this.startTime = Date.now()
+
+    this.progressBar.start(100, 0, {
+      title: 'Sending the transaction',
+      estimate: TimeUtils.renderSpan(this.estimateInMs, { hideMilliseconds: true }),
+    })
+
+    this.timer = setInterval(() => {
+      if (!this.progressBar || !this.startTime) {
+        return
+      }
+      const durationInMs = Date.now() - this.startTime
+      const timeRemaining = this.estimateInMs - durationInMs
+      const progress = Math.round((durationInMs / this.estimateInMs) * 100)
+
+      this.progressBar.update(progress, {
+        estimate: TimeUtils.renderSpan(timeRemaining, { hideMilliseconds: true }),
+      })
+    }, 1000)
+  }
+
+  endTimer() {
+    if (!this.progressBar || !this.startTime || !this.timer) {
+      return
+    }
+
+    clearInterval(this.timer)
+    this.progressBar.update(100)
+    this.progressBar.stop()
+
+    this.logger.log(
+      `Sending took ${TimeUtils.renderSpan(Date.now() - this.startTime, {
+        hideMilliseconds: true,
+      })}`,
+    )
+  }
+}
 
 export async function renderUnsignedTransactionDetails(
   client: RpcClient,


### PR DESCRIPTION
## Summary

Adds a transaction timer class that abstracts the timer logic away from combine notes. 
This is in setup for adding the timer to `wallet:send`

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
