### PR TITLE
Rahul/ifl 1881 adds transaction progress bar to wallet send

### DIFF
--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -19,7 +19,11 @@ import { IronFlag, RemoteFlags } from '../../../flags'
 import { getExplorer } from '../../../utils/explorer'
 import { selectFee } from '../../../utils/fees'
 import { fetchNotes } from '../../../utils/note'
-import { benchmarkSpendPostTime, getSpendPostTimeInMs } from '../../../utils/spendPostTime'
+import {
+  benchmarkSpendPostTime,
+  getSpendPostTimeInMs,
+  updateSpendPostTimeInMs,
+} from '../../../utils/spendPostTime'
 import {
   displayTransactionSummary,
   TransactionTimer,
@@ -340,6 +344,13 @@ export class CombineNotesCommand extends IronfishCommand {
     const transaction = new Transaction(bytes)
 
     transactionTimer.end()
+
+    await updateSpendPostTimeInMs(
+      this.sdk,
+      raw,
+      transactionTimer.getStartTime(),
+      transactionTimer.getEndTime(),
+    )
 
     this.log(
       `Combining took ${TimeUtils.renderSpan(

--- a/ironfish/.eslintrc.js
+++ b/ironfish/.eslintrc.js
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 module.exports = {
   extends: ['ironfish'],
   parserOptions: {

--- a/ironfish/src/fileStores/internal.ts
+++ b/ironfish/src/fileStores/internal.ts
@@ -12,6 +12,7 @@ export type InternalOptions = {
   rpcAuthToken: string
   networkId: number
   spendPostTime: number // in milliseconds
+  spendPostTimeMeasurements: number // used to calculate the average spendPostTime
 }
 
 export const InternalOptionsDefaults: InternalOptions = {
@@ -21,6 +22,7 @@ export const InternalOptionsDefaults: InternalOptions = {
   rpcAuthToken: '',
   networkId: DEFAULT_NETWORK_ID,
   spendPostTime: 0,
+  spendPostTimeMeasurements: 0,
 }
 
 export class InternalStore extends KeyStore<InternalOptions> {


### PR DESCRIPTION
## Summary

- Adds transaction timer to wallet:send 
- when spendPostTime is not available, transaction timer displays the "normal" output 
- after posting a transaction, the spend post time is recalculated  
- The spendPostTime is averaged to smooth out anomalies over time
- We no longer need the `spendPostTimeAt` in the internal settings because of the above features

Example: 

![image](https://github.com/iron-fish/ironfish/assets/13268167/1f88ddcc-85e0-4f1e-8644-a63b64d8b85a)


## Testing Plan
 
1. With no spend post time in internal.json [you can manually remove it] run `wallet:send` - this will show you `Sending the transaction...` without an estimate. The next time you run the command, an estimate will be displayed
2. With a time estimate, run `wallet:send` you should get time estimated for both 

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
