### PR TITLE
adds memos to 'wallet:transactions' output

### DIFF
--- a/ironfish-cli/src/commands/wallet/transactions.ts
+++ b/ironfish-cli/src/commands/wallet/transactions.ts
@@ -200,6 +200,7 @@ export class TransactionsCommand extends IronfishCommand {
       const assetName = assetLookup[note.assetId].name
       const sender = note.sender
       const recipient = note.owner
+      const memo = note.memo
 
       const group = this.getRowGroup(index, noteCount, transactionRows.length)
 
@@ -214,6 +215,7 @@ export class TransactionsCommand extends IronfishCommand {
           feePaid,
           sender,
           recipient,
+          memo,
         })
       } else {
         transactionRows.push({
@@ -223,6 +225,7 @@ export class TransactionsCommand extends IronfishCommand {
           amount,
           sender,
           recipient,
+          memo,
         })
       }
     }
@@ -301,6 +304,9 @@ export class TransactionsCommand extends IronfishCommand {
         },
         recipient: {
           header: 'Recipient Address',
+        },
+        memo: {
+          header: 'Memo',
         },
       }
     }


### PR DESCRIPTION
## Summary

requires using the '--notes' flag because memos are only available on notes, not transactions

## Testing Plan

manual testing:
<img width="1000" alt="image" src="https://github.com/iron-fish/ironfish/assets/57735705/3ba836bb-60f1-481a-8e1f-f7560b41b064">

selects only a few columns for visibility

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
