### PR TITLE
Moves responsibility of logging estimate out of the timer

### DIFF
--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -465,8 +465,13 @@ export class CombineNotesCommand extends IronfishCommand {
 
     displayTransactionSummary(raw, Asset.nativeId().toString('hex'), amount, from, to, memo)
 
-    const transactionTimer = new TransactionTimer(spendPostTime, raw, this.logger)
-    transactionTimer.displayEstimate()
+    const transactionTimer = new TransactionTimer(spendPostTime, raw)
+
+    this.log(
+      `Time to combine: ${TimeUtils.renderSpan(transactionTimer.getEstimate(), {
+        hideMilliseconds: true,
+      })}`,
+    )
 
     if (!flags.confirm) {
       const confirmed = await CliUx.ux.confirm('Do you confirm (Y/N)?')
@@ -486,6 +491,15 @@ export class CombineNotesCommand extends IronfishCommand {
     const transaction = new Transaction(bytes)
 
     transactionTimer.end()
+
+    this.log(
+      `Combining took ${TimeUtils.renderSpan(
+        transactionTimer.getEndTime() - transactionTimer.getStartTime(),
+        {
+          hideMilliseconds: true,
+        },
+      )}`,
+    )
 
     if (response.content.accepted === false) {
       this.warn(


### PR DESCRIPTION
## Summary

Moves responsibility of logging estimate out of the timer. 

The transaction timer should only time the transaction. Up to the consumer on how to use the total time and estimate. 

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
