### PR TITLE
adds memoHex to RpcWalletNote

### DIFF
--- a/ironfish/src/rpc/routes/wallet/getAccountNotesStream.ts
+++ b/ironfish/src/rpc/routes/wallet/getAccountNotesStream.ts
@@ -50,6 +50,7 @@ routes.register<typeof GetAccountNotesStreamRequestSchema, GetAccountNotesStream
           assetId: note.assetId().toString('hex'),
           assetName: asset?.name.toString('hex') || '',
           memo: BufferUtils.toHuman(note.memo()),
+          memoHex: note.memo().toString('hex'),
           sender: note.sender(),
           owner: note.owner(),
           noteHash: note.hash().toString('hex'),

--- a/ironfish/src/rpc/routes/wallet/getAccountTransaction.test.ts
+++ b/ironfish/src/rpc/routes/wallet/getAccountTransaction.test.ts
@@ -35,5 +35,8 @@ describe('Route wallet/getAccountTransaction', () => {
       })),
     )
     expect(responseTransaction.notes).toHaveLength(transaction.notes.length)
+
+    // each note should include a hex representation of the memo in memoHex
+    responseTransaction.notes?.map((note) => expect(note.memoHex).toBeDefined())
   })
 })

--- a/ironfish/src/rpc/routes/wallet/types.ts
+++ b/ironfish/src/rpc/routes/wallet/types.ts
@@ -50,6 +50,7 @@ export type RpcWalletNote = {
   assetId: string
   value: string
   memo: string
+  memoHex: string
   sender: string
   owner: string
   noteHash: string
@@ -77,6 +78,7 @@ export const RpcWalletNoteSchema: yup.ObjectSchema<RpcWalletNote> = yup
     assetId: yup.string().defined(),
     assetName: yup.string().defined(),
     memo: yup.string().defined(),
+    memoHex: yup.string().defined(),
     sender: yup.string().defined(),
     owner: yup.string().defined(),
     noteHash: yup.string().defined(),

--- a/ironfish/src/rpc/routes/wallet/utils.ts
+++ b/ironfish/src/rpc/routes/wallet/utils.ts
@@ -248,6 +248,7 @@ export function serializeRpcWalletNote(
     assetId: note.note.assetId().toString('hex'),
     assetName: asset?.name.toString('hex') || '',
     memo: BufferUtils.toHuman(note.note.memo()),
+    memoHex: note.note.memo().toString('hex'),
     owner: note.note.owner(),
     sender: note.note.sender(),
     noteHash: note.note.hash().toString('hex'),


### PR DESCRIPTION
## Summary

the 'memo' included with each note is modified to remove non-human-readable characters. if the memo included in the note is encoding data then this can make it impossible to recover the data from the rpc response.

adds memoHex to return the memo as a hex string to preserve memo data in wallet rpc responses

## Testing Plan

- updates unit test
- manual testing

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[X] Yes
```

https://github.com/iron-fish/website/pull/658

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
