### PR TITLE
Render custom assets with their defined decimal places

### DIFF
--- a/ironfish-cli/src/commands/wallet/balance.ts
+++ b/ironfish-cli/src/commands/wallet/balance.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { CurrencyUtils, GetBalanceResponse, isNativeIdentifier } from '@ironfish/sdk'
+import { CurrencyUtils, GetBalanceResponse, isNativeIdentifier, RpcAsset } from '@ironfish/sdk'
 import { Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
@@ -54,60 +54,56 @@ export class BalanceCommand extends IronfishCommand {
       confirmations: flags.confirmations,
     })
 
+    const assetId = response.content.assetId
+
     const asset = (
       await client.wallet.getAsset({
         account,
-        id: response.content.assetId,
+        id: assetId,
         confirmations: flags.confirmations,
       })
     ).content
 
-    const assetId = response.content.assetId
-    const assetName = renderAssetName(isNativeIdentifier(assetId) ? '$IRON' : assetId, {
+    let nameToRender
+    if (isNativeIdentifier(assetId)) {
+      nameToRender = '$IRON'
+    } else if (asset.symbol) {
+      nameToRender = asset.symbol
+    } else {
+      nameToRender = assetId
+    }
+
+    const assetName = renderAssetName(nameToRender, {
       verification: asset.verification,
       verbose: !!flags.verbose,
       logWarn: this.warn.bind(this),
     })
 
     if (flags.explain) {
-      this.explainBalance(response.content, assetName)
+      this.explainBalance(response.content, asset, assetName)
       return
     }
 
+    const renderedAvailable = renderValue(response.content.available, asset, assetName)
+    const renderedConfirmed = renderValue(response.content.confirmed, asset, assetName)
+    const renderedUnconfirmed = renderValue(response.content.unconfirmed, asset, assetName)
+    const renderedPending = renderValue(response.content.pending, asset, assetName)
     if (flags.all) {
       this.log(`Account: ${response.content.account}`)
       this.log(`Head Hash: ${response.content.blockHash || 'NULL'}`)
       this.log(`Head Sequence: ${response.content.sequence || 'NULL'}`)
-      this.log(
-        `Available:   ${CurrencyUtils.renderIron(response.content.available, true, assetName)}`,
-      )
-      this.log(
-        `Confirmed:   ${CurrencyUtils.renderIron(response.content.confirmed, true, assetName)}`,
-      )
-      this.log(
-        `Unconfirmed: ${CurrencyUtils.renderIron(
-          response.content.unconfirmed,
-          true,
-          assetName,
-        )}`,
-      )
-      this.log(
-        `Pending:     ${CurrencyUtils.renderIron(response.content.pending, true, assetName)}`,
-      )
+      this.log(`Available:   ${renderedAvailable}`)
+      this.log(`Confirmed:   ${renderedConfirmed}`)
+      this.log(`Unconfirmed: ${renderedUnconfirmed}`)
+      this.log(`Pending:     ${renderedPending}`)
       return
     }
 
     this.log(`Account: ${response.content.account}`)
-    this.log(
-      `Available Balance: ${CurrencyUtils.renderIron(
-        response.content.available,
-        true,
-        assetName,
-      )}`,
-    )
+    this.log(`Available Balance: ${renderedAvailable}`)
   }
 
-  explainBalance(response: GetBalanceResponse, assetId: string): void {
+  explainBalance(response: GetBalanceResponse, asset: RpcAsset, assetName: string): void {
     const unconfirmed = CurrencyUtils.decode(response.unconfirmed)
     const confirmed = CurrencyUtils.decode(response.confirmed)
     const pending = CurrencyUtils.decode(response.pending)
@@ -115,6 +111,13 @@ export class BalanceCommand extends IronfishCommand {
 
     const unconfirmedDelta = unconfirmed - confirmed
     const pendingDelta = pending - unconfirmed
+
+    const renderedUnconfirmed = renderValue(unconfirmed, asset, assetName)
+    const renderedUnconfirmedDelta = renderValue(unconfirmedDelta, asset, assetName)
+    const renderedConfirmed = renderValue(confirmed, asset, assetName)
+    const renderedPending = renderValue(pending, asset, assetName)
+    const renderedPendingDelta = renderValue(pendingDelta, asset, assetName)
+    const renderedAvailable = renderValue(available, asset, assetName)
 
     this.log(`Account: ${response.account}`)
 
@@ -126,26 +129,34 @@ export class BalanceCommand extends IronfishCommand {
     this.log('')
 
     this.log(`Your available balance is made of notes on the chain that are safe to spend`)
-    this.log(`Available: ${CurrencyUtils.renderIron(available, true, assetId)}`)
+    this.log(`Available: ${renderedAvailable}`)
     this.log('')
 
     this.log('Your confirmed balance includes all notes from transactions on the chain')
-    this.log(`Confirmed: ${CurrencyUtils.renderIron(confirmed, true, assetId)}`)
+    this.log(`Confirmed: ${renderedConfirmed}`)
     this.log('')
 
     this.log(
-      `${response.unconfirmedCount} transactions worth ${CurrencyUtils.renderIron(
-        unconfirmedDelta,
-      )} are on the chain within ${response.confirmations} blocks of the head`,
+      `${response.unconfirmedCount} transactions worth ${renderedUnconfirmedDelta} are on the chain within ${response.confirmations} blocks of the head`,
     )
-    this.log(`Unconfirmed: ${CurrencyUtils.renderIron(unconfirmed, true, assetId)}`)
+    this.log(`Unconfirmed: ${renderedUnconfirmed}`)
     this.log('')
 
     this.log(
-      `${response.pendingCount} transactions worth ${CurrencyUtils.renderIron(
-        pendingDelta,
-      )} are pending and have not been added to the chain`,
+      `${response.pendingCount} transactions worth ${renderedPendingDelta} are pending and have not been added to the chain`,
     )
-    this.log(`Pending: ${CurrencyUtils.renderIron(pending, true, assetId)}`)
+    this.log(`Pending: ${renderedPending}`)
+  }
+}
+
+// TODO(mat): Eventually this logic should probably be rolled into
+// CurrencyUtils.render() via additional options
+function renderValue(amount: string | bigint, asset: RpcAsset, assetName: string): string {
+  const renderNameManually = asset.verification.status === 'verified'
+
+  if (renderNameManually) {
+    return `${assetName} ${CurrencyUtils.render(amount, false, asset)}`
+  } else {
+    return CurrencyUtils.render(amount, true, asset)
   }
 }

--- a/ironfish-cli/src/commands/wallet/balances.ts
+++ b/ironfish-cli/src/commands/wallet/balances.ts
@@ -76,7 +76,7 @@ export class BalancesCommand extends IronfishCommand {
       },
       available: {
         header: 'Available Balance',
-        get: ({ balance }) => CurrencyUtils.renderIron(balance.available),
+        get: ({ asset, balance }) => CurrencyUtils.render(balance.available, false, asset),
       },
     }
 
@@ -85,15 +85,15 @@ export class BalancesCommand extends IronfishCommand {
         ...columns,
         confirmed: {
           header: 'Confirmed Balance',
-          get: ({ balance }) => CurrencyUtils.renderIron(balance.confirmed),
+          get: ({ asset, balance }) => CurrencyUtils.render(balance.confirmed, false, asset),
         },
         unconfirmed: {
           header: 'Unconfirmed Balance',
-          get: ({ balance }) => CurrencyUtils.renderIron(balance.unconfirmed),
+          get: ({ asset, balance }) => CurrencyUtils.render(balance.unconfirmed, false, asset),
         },
         pending: {
           header: 'Pending Balance',
-          get: ({ balance }) => CurrencyUtils.renderIron(balance.pending),
+          get: ({ asset, balance }) => CurrencyUtils.render(balance.pending, false, asset),
         },
         blockHash: {
           header: 'Head Hash',

--- a/ironfish-cli/src/commands/wallet/mint.ts
+++ b/ironfish-cli/src/commands/wallet/mint.ts
@@ -9,7 +9,7 @@ import {
   isValidPublicAddress,
   RawTransaction,
   RawTransactionSerde,
-  RpcClient,
+  RpcAsset,
   Transaction,
 } from '@ironfish/sdk'
 import { CliUx, Flags } from '@oclif/core'
@@ -180,8 +180,10 @@ export class Mint extends IronfishCommand {
       assetId = asset.id
     }
 
+    let assetData
     if (assetId) {
-      const isAssetOwner = await this.isAssetOwner(client, assetId, accountPublicKey)
+      assetData = (await client.chain.getAsset({ id: assetId })).content
+      const isAssetOwner = this.isAssetOwner(assetData, accountPublicKey)
       if (!isAssetOwner) {
         this.error(`The account '${account}' does not own this asset.`)
       }
@@ -195,6 +197,9 @@ export class Mint extends IronfishCommand {
         text: 'Enter the amount',
         minimum: 0n,
         logger: this.logger,
+        balance: {
+          asset: assetData,
+        },
       })
     }
 
@@ -254,6 +259,7 @@ export class Mint extends IronfishCommand {
         name,
         metadata,
         flags.transferOwnershipTo,
+        assetData,
       ))
     ) {
       this.error('Transaction aborted.')
@@ -283,16 +289,15 @@ export class Mint extends IronfishCommand {
       this.warn(`Transaction '${transaction.hash().toString('hex')}' failed to broadcast`)
     }
 
+    const renderedValue = CurrencyUtils.render(minted.value, true, {
+      id: minted.asset.id().toString('hex'),
+      ...assetData,
+    })
+    const renderedFee = CurrencyUtils.render(transaction.fee(), true)
     this.log(`Minted asset ${BufferUtils.toHuman(minted.asset.name())} from ${account}`)
     this.log(`Asset Identifier: ${minted.asset.id().toString('hex')}`)
-    this.log(
-      `Value: ${CurrencyUtils.renderIron(
-        minted.value,
-        true,
-        minted.asset.id().toString('hex'),
-      )}`,
-    )
-    this.log(`Fee: ${CurrencyUtils.renderIron(transaction.fee(), true)}`)
+    this.log(`Value: ${renderedValue}`)
+    this.log(`Fee: ${renderedFee}`)
     this.log(`Hash: ${transaction.hash().toString('hex')}`)
 
     const networkId = (await client.chain.getNetworkInfo()).content.networkId
@@ -324,14 +329,22 @@ export class Mint extends IronfishCommand {
     name?: string,
     metadata?: string,
     transferOwnershipTo?: string,
+    assetData?: RpcAsset,
   ): Promise<boolean> {
     const nameString = name ? `\nName: ${name}` : ''
     const metadataString = metadata ? `\nMetadata: ${metadata}` : ''
+
+    const renderedAmount = CurrencyUtils.render(amount, !!assetId, {
+      id: assetId,
+      ...assetData,
+    })
+    const renderedFee = CurrencyUtils.render(fee, true)
+
     this.log(
       `You are about to mint an asset with the account ${account}:${nameString}${metadataString}`,
     )
-    this.log(`Amount: ${CurrencyUtils.renderIron(amount, !!assetId, assetId)}`)
-    this.log(`Fee: ${CurrencyUtils.renderIron(fee, true)}`)
+    this.log(`Amount: ${renderedAmount}`)
+    this.log(`Fee: ${renderedFee}`)
 
     if (transferOwnershipTo) {
       this.log(
@@ -342,14 +355,9 @@ export class Mint extends IronfishCommand {
     return CliUx.ux.confirm('Do you confirm (Y/N)?')
   }
 
-  async isAssetOwner(
-    client: RpcClient,
-    assetId: string,
-    ownerPublicKey: string,
-  ): Promise<boolean> {
+  isAssetOwner(asset: RpcAsset, ownerPublicKey: string): boolean {
     try {
-      const assetResponse = await client.chain.getAsset({ id: assetId })
-      if (assetResponse.content.owner === ownerPublicKey) {
+      if (asset.owner === ownerPublicKey) {
         return true
       }
     } catch (e) {

--- a/ironfish-cli/src/commands/wallet/multisig/signature/aggregate.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/signature/aggregate.ts
@@ -90,7 +90,7 @@ export class MultisigSign extends IronfishCommand {
 
     this.log(`Transaction: ${response.content.transaction}`)
     this.log(`Hash: ${transaction.hash().toString('hex')}`)
-    this.log(`Fee: ${CurrencyUtils.renderIron(transaction.fee(), true)}`)
+    this.log(`Fee: ${CurrencyUtils.render(transaction.fee(), true)}`)
 
     if (flags.watch) {
       this.log('')

--- a/ironfish-cli/src/commands/wallet/notes/index.ts
+++ b/ironfish-cli/src/commands/wallet/notes/index.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { CurrencyUtils } from '@ironfish/sdk'
+import { CurrencyUtils, RpcAsset } from '@ironfish/sdk'
 import { CliUx } from '@oclif/core'
 import { IronfishCommand } from '../../../command'
 import { RemoteFlags } from '../../../flags'
@@ -28,6 +28,8 @@ export class NotesCommand extends IronfishCommand {
     const { flags, args } = await this.parse(NotesCommand)
     const account = args.account as string | undefined
 
+    const assetLookup: Map<string, RpcAsset> = new Map()
+
     const client = await this.sdk.connectRpc()
 
     const response = client.wallet.getAccountNotesStream({ account })
@@ -35,6 +37,13 @@ export class NotesCommand extends IronfishCommand {
     let showHeader = !flags['no-header']
 
     for await (const note of response.contentStream()) {
+      if (!assetLookup.has(note.assetId)) {
+        assetLookup.set(
+          note.assetId,
+          (await client.wallet.getAsset({ id: note.assetId, account })).content,
+        )
+      }
+
       CliUx.ux.table(
         [note],
         {
@@ -62,7 +71,7 @@ export class NotesCommand extends IronfishCommand {
           ...TableCols.asset({ extended: flags.extended }),
           value: {
             header: 'Amount',
-            get: (row) => CurrencyUtils.renderIron(row.value),
+            get: (row) => CurrencyUtils.render(row.value, false, assetLookup.get(row.assetId)),
             minWidth: 16,
           },
           noteHash: {

--- a/ironfish-cli/src/commands/wallet/post.ts
+++ b/ironfish-cli/src/commands/wallet/post.ts
@@ -116,13 +116,10 @@ export class PostCommand extends IronfishCommand {
       spending += output.note.value()
     }
 
+    const renderedSpending = CurrencyUtils.render(spending, true)
+    const renderedFee = CurrencyUtils.render(raw.fee, true)
     this.log(
-      `You are about to post a transaction that sends ${CurrencyUtils.renderIron(
-        spending,
-        true,
-      )}, with ${raw.mints.length} mints and ${
-        raw.burns.length
-      } burns with a fee ${CurrencyUtils.renderIron(raw.fee, true)} using account ${account}`,
+      `You are about to post a transaction that sends ${renderedSpending}, with ${raw.mints.length} mints and ${raw.burns.length} burns with a fee ${renderedFee} using account ${account}`,
     )
 
     return CliUx.ux.confirm('Do you want to post this (Y/N)?')

--- a/ironfish-cli/src/commands/wallet/transaction/index.ts
+++ b/ironfish-cli/src/commands/wallet/transaction/index.ts
@@ -55,12 +55,13 @@ export class TransactionCommand extends IronfishCommand {
     Assert.isNotUndefined(response.content.transaction.notes)
     Assert.isNotUndefined(response.content.transaction.spends)
 
+    const renderedFee = CurrencyUtils.render(response.content.transaction.fee, true)
     this.log(`Transaction: ${hash}`)
     this.log(`Account: ${response.content.account}`)
     this.log(`Status: ${response.content.transaction.status}`)
     this.log(`Type: ${response.content.transaction.type}`)
     this.log(`Timestamp: ${TimeUtils.renderString(response.content.transaction.timestamp)}`)
-    this.log(`Fee: ${CurrencyUtils.renderIron(response.content.transaction.fee, true)}`)
+    this.log(`Fee: ${renderedFee}`)
     if (response.content.transaction.blockHash && response.content.transaction.blockSequence) {
       this.log(`Block Hash: ${response.content.transaction.blockHash}`)
       this.log(`Block Sequence: ${response.content.transaction.blockSequence}`)
@@ -93,7 +94,7 @@ export class TransactionCommand extends IronfishCommand {
       CliUx.ux.table(noteAssetPairs, {
         amount: {
           header: 'Amount',
-          get: ({ note }) => CurrencyUtils.renderIron(note.value),
+          get: ({ asset, note }) => CurrencyUtils.render(note.value, false, asset),
         },
         assetName: {
           header: 'Asset Name',

--- a/ironfish-cli/src/commands/wallet/transactions.ts
+++ b/ironfish-cli/src/commands/wallet/transactions.ts
@@ -198,6 +198,8 @@ export class TransactionsCommand extends IronfishCommand {
       const amount = BigInt(note.value)
       const assetId = note.assetId
       const assetName = assetLookup[note.assetId].name
+      const assetDecimals = assetLookup[note.assetId].decimals
+      const assetSymbol = assetLookup[note.assetId].symbol
       const sender = note.sender
       const recipient = note.owner
       const memo = note.memo
@@ -211,6 +213,8 @@ export class TransactionsCommand extends IronfishCommand {
           group,
           assetId,
           assetName,
+          assetDecimals,
+          assetSymbol,
           amount,
           feePaid,
           sender,
@@ -222,6 +226,8 @@ export class TransactionsCommand extends IronfishCommand {
           group,
           assetId,
           assetName,
+          assetDecimals,
+          assetSymbol,
           amount,
           sender,
           recipient,
@@ -283,14 +289,18 @@ export class TransactionsCommand extends IronfishCommand {
       feePaid: {
         header: 'Fee Paid ($IRON)',
         get: (row) =>
-          row.feePaid && row.feePaid !== 0n ? CurrencyUtils.renderIron(row.feePaid) : '',
+          row.feePaid && row.feePaid !== 0n ? CurrencyUtils.render(row.feePaid) : '',
       },
       ...TableCols.asset({ extended, format }),
       amount: {
         header: 'Amount',
         get: (row) => {
           Assert.isNotUndefined(row.amount)
-          return CurrencyUtils.renderIron(row.amount)
+          return CurrencyUtils.render(row.amount, false, {
+            id: row.assetId,
+            decimals: row.assetDecimals,
+            symbol: row.assetSymbol,
+          })
         },
         minWidth: 16,
       },
@@ -347,6 +357,8 @@ type TransactionRow = {
   hash: string
   assetId: string
   assetName: string
+  assetDecimals?: number
+  assetSymbol?: string
   amount: bigint
   feePaid?: bigint
   notesCount: number

--- a/ironfish-cli/src/utils/asset.ts
+++ b/ironfish-cli/src/utils/asset.ts
@@ -134,9 +134,12 @@ export async function selectAsset(
   const choices = balances.map((balance) => {
     const assetName = BufferUtils.toHuman(Buffer.from(assetLookup[balance.assetId].name, 'hex'))
 
-    const name = `${balance.assetId} (${assetName}) (${CurrencyUtils.renderIron(
+    const renderedAvailable = CurrencyUtils.render(
       balance.available,
-    )})`
+      false,
+      assetLookup[balance.assetId],
+    )
+    const name = `${balance.assetId} (${assetName}) (${renderedAvailable})`
 
     const value = {
       id: balance.assetId,

--- a/ironfish-cli/src/utils/fees.ts
+++ b/ironfish-cli/src/utils/fees.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { Asset } from '@ironfish/rust-nodejs'
 import {
   Assert,
   CreateTransactionRequest,
@@ -81,7 +80,6 @@ export async function selectFee(options: {
       balance: {
         account: options.account,
         confirmations: options.confirmations,
-        assetId: Asset.nativeId().toString('hex'),
       },
     })
 
@@ -137,7 +135,7 @@ function getChoiceFromTx(
   value: RawTransaction | null
 } {
   return {
-    name: `${name} ${transaction ? CurrencyUtils.renderIron(transaction.fee) : ''}`,
+    name: `${name} ${transaction ? CurrencyUtils.render(transaction.fee) : ''}`,
     disabled: transaction ? false : 'Not enough $IRON',
     value: transaction,
   }

--- a/ironfish-cli/src/utils/note.ts
+++ b/ironfish-cli/src/utils/note.ts
@@ -7,6 +7,7 @@ import { Assert, RpcClient } from '@ironfish/sdk'
 export async function fetchNotes(client: RpcClient, account: string, notesToCombine: number) {
   const noteSize = await getNoteTreeSize(client)
 
+  // TODO(mat): We need to add asset support here for bridges, etc.
   const getNotesResponse = await client.wallet.getNotes({
     account,
     pageSize: notesToCombine,

--- a/ironfish-cli/src/utils/transaction.ts
+++ b/ironfish-cli/src/utils/transaction.ts
@@ -5,9 +5,11 @@
 import {
   createRootLogger,
   CurrencyUtils,
+  GetUnsignedTransactionNotesResponse,
   Logger,
   PromiseUtils,
   RawTransaction,
+  RpcAsset,
   RpcClient,
   TimeUtils,
   TransactionStatus,
@@ -15,6 +17,7 @@ import {
 } from '@ironfish/sdk'
 import { CliUx } from '@oclif/core'
 import { ProgressBar } from '../types'
+import { getAssetsByIDs } from './asset'
 
 export class TransactionTimer {
   private progressBar: ProgressBar | undefined
@@ -91,6 +94,17 @@ export async function renderUnsignedTransactionDetails(
 ): Promise<void> {
   logger = logger ?? createRootLogger()
 
+  let response
+  if (unsignedTransaction.notes.length > 0) {
+    response = await client.wallet.getUnsignedTransactionNotes({
+      account,
+      unsignedTransaction: unsignedTransaction.serialize().toString('hex'),
+    })
+  }
+
+  const assetIds = collectAssetIds(unsignedTransaction, response?.content)
+  const assetLookup = await getAssetsByIDs(client, assetIds, account, undefined)
+
   if (unsignedTransaction.mints.length > 0) {
     logger.log('')
     logger.log('==================')
@@ -103,9 +117,14 @@ export async function renderUnsignedTransactionDetails(
       }
       logger.log('')
 
+      const renderedAmount = CurrencyUtils.render(
+        mint.value,
+        false,
+        assetLookup[mint.asset.id().toString('hex')],
+      )
       logger.log(`Asset ID:      ${mint.asset.id().toString('hex')}`)
       logger.log(`Name:          ${mint.asset.name().toString('utf8')}`)
-      logger.log(`Amount:        ${CurrencyUtils.renderIron(mint.value, false)}`)
+      logger.log(`Amount:        ${renderedAmount}`)
 
       if (mint.transferOwnershipTo) {
         logger.log(
@@ -130,8 +149,13 @@ export async function renderUnsignedTransactionDetails(
       }
       logger.log('')
 
+      const renderedAmount = CurrencyUtils.render(
+        burn.value,
+        false,
+        assetLookup[burn.assetId.toString('hex')],
+      )
       logger.log(`Asset ID:      ${burn.assetId.toString('hex')}`)
-      logger.log(`Amount:        ${CurrencyUtils.renderIron(burn.value, false)}`)
+      logger.log(`Amount:        ${renderedAmount}`)
       logger.log('')
     }
   }
@@ -158,7 +182,8 @@ export async function renderUnsignedTransactionDetails(
       }
       logger.log('')
 
-      logger.log(`Amount:        ${CurrencyUtils.renderIron(note.value, true, note.assetId)}`)
+      const renderedAmount = CurrencyUtils.render(note.value, true, assetLookup[note.assetId])
+      logger.log(`Amount:        ${renderedAmount}`)
       logger.log(`Memo:          ${note.memo}`)
       logger.log(`Recipient:     ${note.owner}`)
       logger.log(`Sender:        ${note.sender}`)
@@ -176,7 +201,8 @@ export async function renderUnsignedTransactionDetails(
       }
       logger.log('')
 
-      logger.log(`Amount:        ${CurrencyUtils.renderIron(note.value, true, note.assetId)}`)
+      const renderedAmount = CurrencyUtils.render(note.value, true, assetLookup[note.assetId])
+      logger.log(`Amount:        ${renderedAmount}`)
       logger.log(`Memo:          ${note.memo}`)
       logger.log(`Recipient:     ${note.owner}`)
       logger.log(`Sender:        ${note.sender}`)
@@ -196,7 +222,7 @@ export async function renderUnsignedTransactionDetails(
 
 export function displayTransactionSummary(
   transaction: RawTransaction,
-  assetId: string,
+  asset: RpcAsset,
   amount: bigint,
   from: string,
   to: string,
@@ -205,8 +231,8 @@ export function displayTransactionSummary(
 ): void {
   logger = logger ?? createRootLogger()
 
-  const amountString = CurrencyUtils.renderIron(amount, true, assetId)
-  const feeString = CurrencyUtils.renderIron(transaction.fee, true)
+  const amountString = CurrencyUtils.render(amount, true, asset)
+  const feeString = CurrencyUtils.render(transaction.fee, true)
 
   const summary = `\
 \nTRANSACTION SUMMARY:
@@ -309,4 +335,31 @@ export async function watchTransaction(options: {
       break
     }
   }
+}
+
+function collectAssetIds(
+  unsignedTransaction: UnsignedTransaction,
+  notes?: GetUnsignedTransactionNotesResponse,
+): string[] {
+  const assetIds = new Set<string>()
+
+  for (const mint of unsignedTransaction.mints) {
+    assetIds.add(mint.asset.id().toString('hex'))
+  }
+
+  for (const burn of unsignedTransaction.burns) {
+    assetIds.add(burn.assetId.toString('hex'))
+  }
+
+  if (notes) {
+    for (const receivedNote of notes.receivedNotes) {
+      assetIds.add(receivedNote.assetId)
+    }
+
+    for (const sentNotes of notes.sentNotes) {
+      assetIds.add(sentNotes.assetId)
+    }
+  }
+
+  return Array.from(assetIds)
 }

--- a/ironfish/src/assets/assetsVerificationApi.ts
+++ b/ironfish/src/assets/assetsVerificationApi.ts
@@ -5,7 +5,7 @@ import axios, { AxiosAdapter, AxiosError, AxiosRequestConfig, AxiosResponse } fr
 import url, { URL } from 'url'
 import { FileSystem } from '../fileSystems'
 
-type AssetData = {
+export type AssetData = {
   identifier: string
   symbol: string
   decimals?: number
@@ -51,6 +51,13 @@ export class VerifiedAssets {
       assetId = assetId.toString('hex')
     }
     return this.assets.has(assetId)
+  }
+
+  getAssetData(assetId: Buffer | string): AssetData | undefined {
+    if (!(typeof assetId === 'string')) {
+      assetId = assetId.toString('hex')
+    }
+    return this.assets.get(assetId)
   }
 }
 

--- a/ironfish/src/assets/assetsVerificationApi.ts
+++ b/ironfish/src/assets/assetsVerificationApi.ts
@@ -5,17 +5,18 @@ import axios, { AxiosAdapter, AxiosError, AxiosRequestConfig, AxiosResponse } fr
 import url, { URL } from 'url'
 import { FileSystem } from '../fileSystems'
 
-export type AssetData = {
-  identifier: string
+export type AdditionalAssetData = {
   symbol: string
   decimals?: number
   logoURI?: string
   website?: string
 }
 
+export type VerifiedAssetMetadata = { identifier: string } & AdditionalAssetData
+
 type GetAssetDataResponse = {
   version?: number
-  assets: AssetData[]
+  assets: VerifiedAssetMetadata[]
 }
 
 type GetVerifiedAssetsRequestHeaders = {
@@ -27,7 +28,7 @@ type GetVerifiedAssetsResponseHeaders = {
 }
 
 export class VerifiedAssets {
-  private readonly assets: Map<string, AssetData> = new Map()
+  private readonly assets: Map<string, VerifiedAssetMetadata> = new Map()
   private lastModified?: string
 
   export(): ExportedVerifiedAssets {
@@ -53,7 +54,7 @@ export class VerifiedAssets {
     return this.assets.has(assetId)
   }
 
-  getAssetData(assetId: Buffer | string): AssetData | undefined {
+  getAssetData(assetId: Buffer | string): VerifiedAssetMetadata | undefined {
     if (!(typeof assetId === 'string')) {
       assetId = assetId.toString('hex')
     }
@@ -70,7 +71,7 @@ export class VerifiedAssets {
 // - The `assets` field from `VerifiedAssets` is a `Map`, which is not
 //   properly supported by the cache serializer.
 export type ExportedVerifiedAssets = {
-  assets: AssetData[]
+  assets: VerifiedAssetMetadata[]
   lastModified?: string
 }
 
@@ -160,7 +161,7 @@ const axiosFileAdapter =
       }))
   }
 
-const sanitizedAssetData = (assetData: AssetData): AssetData => {
+const sanitizedAssetData = (assetData: VerifiedAssetMetadata): VerifiedAssetMetadata => {
   return {
     identifier: assetData.identifier,
     symbol: assetData.symbol,

--- a/ironfish/src/assets/assetsVerifier.ts
+++ b/ironfish/src/assets/assetsVerifier.ts
@@ -7,7 +7,11 @@ import { createRootLogger, Logger } from '../logger'
 import { ErrorUtils } from '../utils'
 import { SetIntervalToken } from '../utils'
 import { Retry } from '../utils'
-import { AssetData, AssetsVerificationApi, VerifiedAssets } from './assetsVerificationApi'
+import {
+  AdditionalAssetData,
+  AssetsVerificationApi,
+  VerifiedAssets,
+} from './assetsVerificationApi'
 
 export type AssetVerification = {
   status: 'verified' | 'unverified' | 'unknown'
@@ -115,7 +119,32 @@ export class AssetsVerifier {
     }
   }
 
-  getAssetData(assetId: Buffer | string): AssetData | undefined {
+  // TODO(mat): this function is no longer necessary
+  getAssetData(assetId: Buffer | string): AdditionalAssetData | undefined {
     return this.verifiedAssets?.getAssetData(assetId)
+  }
+
+  verifyWithMetadata(
+    assetId: Buffer | string,
+  ):
+    | { verification: AssetVerification }
+    | ({ verification: AssetVerification } & AdditionalAssetData) {
+    const verification = this.verify(assetId)
+    if (verification.status === 'verified') {
+      const assetData = this.getAssetData(assetId)
+      if (assetData) {
+        return {
+          verification,
+          symbol: assetData.symbol,
+          decimals: assetData.decimals,
+          logoURI: assetData.logoURI,
+          website: assetData.website,
+        }
+      }
+    }
+
+    return {
+      verification,
+    }
   }
 }

--- a/ironfish/src/assets/assetsVerifier.ts
+++ b/ironfish/src/assets/assetsVerifier.ts
@@ -7,7 +7,7 @@ import { createRootLogger, Logger } from '../logger'
 import { ErrorUtils } from '../utils'
 import { SetIntervalToken } from '../utils'
 import { Retry } from '../utils'
-import { AssetsVerificationApi, VerifiedAssets } from './assetsVerificationApi'
+import { AssetData, AssetsVerificationApi, VerifiedAssets } from './assetsVerificationApi'
 
 export type AssetVerification = {
   status: 'verified' | 'unverified' | 'unknown'
@@ -113,5 +113,9 @@ export class AssetsVerifier {
     } else {
       return { status: 'unverified' }
     }
+  }
+
+  getAssetData(assetId: Buffer | string): AssetData | undefined {
+    return this.verifiedAssets?.getAssetData(assetId)
   }
 }

--- a/ironfish/src/mining/webhooks/webhookNotifier.ts
+++ b/ironfish/src/mining/webhooks/webhookNotifier.ts
@@ -54,10 +54,11 @@ export abstract class WebhookNotifier {
   ): void {
     const total = outputs.reduce((m, c) => BigInt(c.amount) + m, BigInt(0))
 
+    const renderedValue = CurrencyUtils.render(total, true)
     this.sendText(
       `Successfully created payout of ${shareCount} shares to ${
         outputs.length
-      } users for ${CurrencyUtils.renderIron(total, true)} in transaction ${
+      } users for ${renderedValue} in transaction ${
         this.explorer?.getTransactionUrl(transactionHashHex) ?? `\`${transactionHashHex}\``
       }. Transaction pending (${payoutPeriodId})`,
     )
@@ -76,10 +77,9 @@ export abstract class WebhookNotifier {
   ): void {
     const total = outputs.reduce((m, c) => BigInt(c.amount) + m, BigInt(0))
 
+    const renderedValue = CurrencyUtils.render(total, true)
     this.sendText(
-      `Creating payout of ${shareCount} shares to ${
-        outputs.length
-      } users for ${CurrencyUtils.renderIron(total, true)} (${payoutPeriodId})`,
+      `Creating payout of ${shareCount} shares to ${outputs.length} users for ${renderedValue} (${payoutPeriodId})`,
     )
   }
 

--- a/ironfish/src/primitives/rawTransaction.ts
+++ b/ironfish/src/primitives/rawTransaction.ts
@@ -132,10 +132,10 @@ export class RawTransaction {
 
     for (const mint of this.mints) {
       if (mint.value > MAX_MINT_OR_BURN_VALUE) {
+        const renderedValue = CurrencyUtils.renderOre(mint.value)
+        const renderedMax = CurrencyUtils.renderOre(MAX_MINT_OR_BURN_VALUE)
         throw new Error(
-          `Cannot post transaction. Mint value ${CurrencyUtils.renderIron(
-            mint.value,
-          )} exceededs maximum ${CurrencyUtils.renderIron(MAX_MINT_OR_BURN_VALUE)}. `,
+          `Cannot post transaction. Mint value ${renderedValue} exceededs maximum ${renderedMax}.`,
         )
       }
       const asset = new Asset(mint.creator, mint.name, mint.metadata)
@@ -145,10 +145,10 @@ export class RawTransaction {
 
     for (const burn of this.burns) {
       if (burn.value > MAX_MINT_OR_BURN_VALUE) {
+        const renderedValue = CurrencyUtils.renderOre(burn.value)
+        const renderedMax = CurrencyUtils.renderOre(MAX_MINT_OR_BURN_VALUE)
         throw new Error(
-          `Cannot post transaction. Burn value ${CurrencyUtils.renderIron(
-            burn.value,
-          )} exceededs maximum ${CurrencyUtils.renderIron(MAX_MINT_OR_BURN_VALUE)}`,
+          `Cannot post transaction. Burn value ${renderedValue} exceededs maximum ${renderedMax}`,
         )
       }
 

--- a/ironfish/src/rpc/routes/chain/getAsset.ts
+++ b/ironfish/src/rpc/routes/chain/getAsset.ts
@@ -73,9 +73,7 @@ routes.register<typeof GetAssetRequestSchema, GetAssetResponse>(
       throw new RpcNotFoundError(`No asset found with identifier ${request.data.id}`)
     }
 
-    const verification = node.assetsVerifier.verify(asset.id)
-
-    const payload: RpcAsset = {
+    request.end({
       createdTransactionHash: asset.createdTransactionHash.toString('hex'),
       id: asset.id.toString('hex'),
       metadata: asset.metadata.toString('hex'),
@@ -85,21 +83,7 @@ routes.register<typeof GetAssetRequestSchema, GetAssetResponse>(
       owner: asset.owner.toString('hex'),
       supply: CurrencyUtils.encode(asset.supply),
       status: await getAssetStatus(node, asset),
-      verification,
-    }
-
-    // TODO(mat): Make sure this logic is added for all occurrences of RpcAsset, or
-    // at least the ones that make sense. Encapsulate in helper function?
-    if (verification.status === 'verified') {
-      const additionalFields = node.assetsVerifier.getAssetData(asset.id)
-      if (additionalFields !== undefined) {
-        payload.symbol = additionalFields.symbol
-        payload.decimals = additionalFields.decimals
-        payload.logoURI = additionalFields.logoURI
-        payload.website = additionalFields.website
-      }
-    }
-
-    request.end(payload)
+      ...node.assetsVerifier.verifyWithMetadata(asset.id),
+    })
   },
 )

--- a/ironfish/src/rpc/routes/types.ts
+++ b/ironfish/src/rpc/routes/types.ts
@@ -79,6 +79,10 @@ export type RpcAsset = {
   metadata: string
   createdTransactionHash: string
   verification: AssetVerification
+  symbol?: string
+  decimals?: number
+  logoURI?: string
+  website?: string
   supply?: string
   /**
    * @deprecated query for the transaction to find it's status

--- a/ironfish/src/rpc/routes/types.ts
+++ b/ironfish/src/rpc/routes/types.ts
@@ -104,6 +104,10 @@ export const RpcAssetSchema: yup.ObjectSchema<RpcAsset> = yup
     supply: yup.string().optional(),
     owner: yup.string().defined(),
     createdTransactionHash: yup.string().defined(),
+    symbol: yup.string().optional(),
+    decimals: yup.number().optional(),
+    logoURI: yup.string().optional(),
+    website: yup.string().optional(),
   })
   .defined()
 

--- a/ironfish/src/rpc/routes/wallet/burnAsset.ts
+++ b/ironfish/src/rpc/routes/wallet/burnAsset.ts
@@ -105,11 +105,11 @@ routes.register<typeof BurnAssetRequestSchema, BurnAssetResponse>(
         nonce: asset.nonce,
         creator: asset.creator.toString('hex'),
         owner: asset.owner.toString('hex'),
-        verification: context.assetsVerifier.verify(asset.id),
         status: await context.wallet.getAssetStatus(account, asset, {
           confirmations: request.data.confirmations,
         }),
         createdTransactionHash: asset.createdTransactionHash.toString('hex'),
+        ...context.assetsVerifier.verifyWithMetadata(asset.id),
       },
       transaction: await serializeRpcWalletTransaction(
         context.config,

--- a/ironfish/src/rpc/routes/wallet/createTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/createTransaction.ts
@@ -112,7 +112,7 @@ routes.register<typeof CreateTransactionRequestSchema, CreateTransactionResponse
   `${ApiNamespace.wallet}/createTransaction`,
   CreateTransactionRequestSchema,
   async (request, node): Promise<void> => {
-    AssertHasRpcContext(request, node, 'wallet')
+    AssertHasRpcContext(request, node, 'wallet', 'assetsVerifier')
 
     const account = getAccount(node.wallet, request.data.account)
 
@@ -227,7 +227,12 @@ routes.register<typeof CreateTransactionRequestSchema, CreateTransactionResponse
       })
     } catch (e) {
       if (e instanceof NotEnoughFundsError) {
-        throw new RpcValidationError(e.message, 400, RPC_ERROR_CODES.INSUFFICIENT_BALANCE)
+        // We are overriding the error message from the node to include verified assets in their appropriate denomination.
+        const assetData = node.assetsVerifier.getAssetData(e.assetId)
+        const renderedAmountNeeded = CurrencyUtils.render(e.amountNeeded, true, assetData)
+        const renderedAmount = CurrencyUtils.render(e.amount, false, assetData)
+        const message = `Insufficient funds: Needed ${renderedAmountNeeded} but have ${renderedAmount} available to spend. Please fund your account and/or wait for any pending transactions to be confirmed.'`
+        throw new RpcValidationError(message, 400, RPC_ERROR_CODES.INSUFFICIENT_BALANCE)
       }
       throw e
     }

--- a/ironfish/src/rpc/routes/wallet/getAsset.ts
+++ b/ironfish/src/rpc/routes/wallet/getAsset.ts
@@ -51,9 +51,7 @@ routes.register<typeof GetWalletAssetRequestSchema, GetWalletAssetResponse>(
       throw new RpcNotFoundError(`No asset found with identifier ${request.data.id}`)
     }
 
-    const verification = node.assetsVerifier.verify(asset.id)
-
-    const payload: RpcAsset = {
+    request.end({
       createdTransactionHash: asset.createdTransactionHash.toString('hex'),
       creator: asset.creator.toString('hex'),
       owner: asset.owner.toString('hex'),
@@ -65,19 +63,7 @@ routes.register<typeof GetWalletAssetRequestSchema, GetWalletAssetResponse>(
         confirmations: request.data.confirmations,
       }),
       supply: asset.supply ? CurrencyUtils.encode(asset.supply) : undefined,
-      verification,
-    }
-
-    if (verification.status === 'verified') {
-      const additionalFields = node.assetsVerifier.getAssetData(asset.id)
-      if (additionalFields !== undefined) {
-        payload.symbol = additionalFields.symbol
-        payload.decimals = additionalFields.decimals
-        payload.logoURI = additionalFields.logoURI
-        payload.website = additionalFields.website
-      }
-    }
-
-    request.end(payload)
+      ...node.assetsVerifier.verifyWithMetadata(asset.id),
+    })
   },
 )

--- a/ironfish/src/rpc/routes/wallet/getAssets.ts
+++ b/ironfish/src/rpc/routes/wallet/getAssets.ts
@@ -51,8 +51,8 @@ routes.register<typeof GetAssetsRequestSchema, GetAssetsResponse>(
           confirmations: request.data.confirmations,
         }),
         supply: asset.supply !== null ? CurrencyUtils.encode(asset.supply) : undefined,
-        verification: node.assetsVerifier.verify(asset.id),
         createdTransactionHash: asset.createdTransactionHash.toString('hex'),
+        ...node.assetsVerifier.verifyWithMetadata(asset.id),
       })
     }
 

--- a/ironfish/src/rpc/routes/wallet/mintAsset.ts
+++ b/ironfish/src/rpc/routes/wallet/mintAsset.ts
@@ -143,11 +143,11 @@ routes.register<typeof MintAssetRequestSchema, MintAssetResponse>(
         nonce: asset.nonce,
         creator: asset.creator.toString('hex'),
         owner: asset.owner.toString('hex'),
-        verification: context.assetsVerifier.verify(mint.asset.id()),
         status: await context.wallet.getAssetStatus(account, asset, {
           confirmations: request.data.confirmations,
         }),
         createdTransactionHash: asset.createdTransactionHash.toString('hex'),
+        ...context.assetsVerifier.verifyWithMetadata(mint.asset.id()),
       },
       transaction: await serializeRpcWalletTransaction(
         context.config,

--- a/ironfish/src/utils/currency.test.ts
+++ b/ironfish/src/utils/currency.test.ts
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Asset } from '@ironfish/rust-nodejs'
 import { CurrencyUtils } from './currency'
 
 describe('CurrencyUtils', () => {
@@ -40,6 +41,64 @@ describe('CurrencyUtils', () => {
 
     expect(CurrencyUtils.decodeIron('0.00002394')).toBe(2394n)
     expect(CurrencyUtils.decodeIron('0.00000999')).toBe(999n)
+  })
+
+  describe('render', () => {
+    // Randomly generated custom asset ID
+    const assetId = '1a75bf033c1c1925cfcd1a77461364e77c6e861c2a3acabaf9e398e980146651'
+
+    it('should render iron with no extra parameters with 8 decimal places', () => {
+      expect(CurrencyUtils.render(0n)).toEqual('0.00000000')
+      expect(CurrencyUtils.render(1n)).toEqual('0.00000001')
+      expect(CurrencyUtils.render(100n)).toEqual('0.00000100')
+      expect(CurrencyUtils.render(10000n)).toEqual('0.00010000')
+      expect(CurrencyUtils.render(100000000n)).toEqual('1.00000000')
+    })
+
+    it('should include IRON for the iron asset ticker', () => {
+      expect(CurrencyUtils.render(1n, true)).toEqual('$IRON 0.00000001')
+    })
+
+    it('should still render iron with 8 decimals and $IRON symbol even if parameters are given', () => {
+      expect(
+        CurrencyUtils.render(1n, false, {
+          id: Asset.nativeId().toString('hex'),
+          decimals: 2,
+          symbol: 'FOO',
+        }),
+      ).toEqual('0.00000001')
+      expect(
+        CurrencyUtils.render(1n, true, {
+          id: Asset.nativeId().toString('hex'),
+          decimals: 2,
+          symbol: 'FOO',
+        }),
+      ).toEqual('$IRON 0.00000001')
+    })
+
+    it('should render an asset value with 0 decimals by default', () => {
+      expect(CurrencyUtils.render(1n, false, { id: assetId })).toEqual('1')
+      expect(CurrencyUtils.render(1n, true, { id: assetId })).toEqual(`${assetId} 1`)
+    })
+
+    it('should render an asset value with the given decimals and symbol', () => {
+      expect(CurrencyUtils.render(1n, false, { id: assetId, decimals: 2 })).toEqual('0.01')
+      expect(CurrencyUtils.render(1n, true, { id: assetId, decimals: 2 })).toEqual(
+        `${assetId} 0.01`,
+      )
+
+      expect(CurrencyUtils.render(100n, false, { id: assetId, decimals: 2 })).toEqual('1.00')
+      expect(CurrencyUtils.render(100n, true, { id: assetId, decimals: 2 })).toEqual(
+        `${assetId} 1.00`,
+      )
+
+      expect(
+        CurrencyUtils.render(100n, false, { id: assetId, decimals: 2, symbol: 'FOO' }),
+      ).toEqual('1.00')
+      expect(
+        CurrencyUtils.render(100n, true, { id: assetId, decimals: 2, symbol: 'FOO' }),
+      ).toEqual(`FOO 1.00`)
+    })
   })
 
   it('renderIron', () => {

--- a/ironfish/src/wallet/errors.ts
+++ b/ironfish/src/wallet/errors.ts
@@ -7,16 +7,19 @@ import { CurrencyUtils } from '../utils'
 
 export class NotEnoughFundsError extends Error {
   name = this.constructor.name
+  assetId: string
+  amount: bigint
+  amountNeeded: bigint
 
   constructor(assetId: Buffer, amount: bigint, amountNeeded: bigint) {
     super()
-    this.message = `Insufficient funds: Needed ${CurrencyUtils.renderIron(
-      amountNeeded,
-      true,
-      assetId.toString('hex'),
-    )} but have ${CurrencyUtils.renderIron(
-      amount,
-    )} available to spend. Please fund your account and/or wait for any pending transactions to be confirmed.'`
+    this.assetId = assetId.toString('hex')
+    this.amount = amount
+    this.amountNeeded = amountNeeded
+
+    const renderedAmountNeeded = CurrencyUtils.render(amountNeeded, true, { id: this.assetId })
+    const renderedAmount = CurrencyUtils.render(amount)
+    this.message = `Insufficient funds: Needed ${renderedAmountNeeded} but have ${renderedAmount} available to spend. Please fund your account and/or wait for any pending transactions to be confirmed.'`
   }
 }
 


### PR DESCRIPTION
## Summary

- Introduces CurrencyUtil.render as the new main entry point for rendering human
readable values.
- Modifies all existing usage of CurrencyUtil renderIron to use this new function
instead. To do this, many places in the CLI need to now fetch the asset data
from the RPC, as expected.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
