### PR TITLE
Fix: Fee calculation exception handling

### DIFF
--- a/ironfish-cli/src/utils/fees.ts
+++ b/ironfish-cli/src/utils/fees.ts
@@ -29,25 +29,23 @@ export async function selectFee(options: {
 
   const feeRates = await options.client.wallet.estimateFeeRates()
 
-  const promises = [
-    getTxWithFee(
-      options.client,
-      options.transaction,
-      CurrencyUtils.decode(feeRates.content.slow),
-    ),
-    getTxWithFee(
-      options.client,
-      options.transaction,
-      CurrencyUtils.decode(feeRates.content.average),
-    ),
-    getTxWithFee(
-      options.client,
-      options.transaction,
-      CurrencyUtils.decode(feeRates.content.fast),
-    ),
-  ]
+  const slow = await getTxWithFee(
+    options.client,
+    options.transaction,
+    CurrencyUtils.decode(feeRates.content.slow),
+  )
 
-  const [slow, average, fast] = await Promise.all(promises)
+  const average = await getTxWithFee(
+    options.client,
+    options.transaction,
+    CurrencyUtils.decode(feeRates.content.slow),
+  )
+
+  const fast = await getTxWithFee(
+    options.client,
+    options.transaction,
+    CurrencyUtils.decode(feeRates.content.slow),
+  )
 
   const choices = [
     getChoiceFromTx('Slow', slow),


### PR DESCRIPTION

![image](https://github.com/iron-fish/ironfish/assets/13268167/53ea34a1-afa6-4a63-83ee-491531757fd9)

How to replicate: send a transaction for a user with an account with 0 funds/ not enough funds for the transaction amount. The calculating fees step hangs. 

Root cause of this issue is unclear. It looks like there is an issue with how errors are handling in the RPC. When multiple errors occur simultaneously, the RPC "hangs" (no response is sent back).

This for the moment fixes the issue by individually handling each promise.

## Summary

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
