### PR TITLE
allows deploying Docker images for staging branch

### DIFF
--- a/.github/workflows/deploy-node-docker-image.yml
+++ b/.github/workflows/deploy-node-docker-image.yml
@@ -1,5 +1,8 @@
 name: Deploy Node Docker Image
 on:
+  push:
+    branches:
+      'staging'
   workflow_dispatch:
     inputs:
       github_tag_mainnet:

--- a/.github/workflows/deploy-node-docker-image.yml
+++ b/.github/workflows/deploy-node-docker-image.yml
@@ -78,6 +78,13 @@ jobs:
           docker tag ironfish ghcr.io/iron-fish/ironfish:${{ github.ref_name }}
           docker push ghcr.io/iron-fish/ironfish:${{ github.ref_name }}
 
+      # Used to deploy images for specific branches
+      - name: Deploy Node Image to GitHub:${{ github.ref_name }}
+        if: ${{ github.ref_type == 'branch' }}
+        run: |
+          docker tag ironfish ghcr.io/iron-fish/ironfish:${{ github.ref_name }}
+          docker push ghcr.io/iron-fish/ironfish:${{ github.ref_name }}
+
       - name: Deploy Node Image to GitHub:testnet
         if: ${{ inputs.github_tag_testnet }}
         run: |


### PR DESCRIPTION
## Summary

adds deploy step to deploy to image to github for branch refs

adds rule to deploy docker image on push to staging

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
