### PR TITLE
fix: rescanning account crash delete

### DIFF
--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -1620,6 +1620,7 @@ export class Wallet {
     })
 
     this.accounts.set(account.id, account)
+    this.logger.debug(`Account ${account.id} imported successfully`)
     this.onAccountImported.emit(account)
 
     return account
@@ -1646,6 +1647,7 @@ export class Wallet {
       id: uuid(),
       walletDb: this.walletDb,
     })
+    this.logger.debug(`Resetting account name: ${account.name}, id: ${account.id}`)
 
     await this.walletDb.db.withTransaction(options?.tx, async (tx) => {
       await this.walletDb.setAccount(newAccount, tx)
@@ -1672,6 +1674,7 @@ export class Wallet {
   }
 
   async removeAccount(account: Account, tx?: IDatabaseTransaction): Promise<void> {
+    this.accounts.delete(account.id)
     await this.walletDb.db.withTransaction(tx, async (tx) => {
       if (account.id === this.defaultAccount) {
         await this.walletDb.setDefaultAccount(null, tx)
@@ -1682,7 +1685,7 @@ export class Wallet {
       await this.walletDb.removeHead(account, tx)
     })
 
-    this.accounts.delete(account.id)
+    this.logger.debug(`Removed account name: ${account.name}, id: ${account.id}`)
     this.onAccountRemoved.emit(account)
   }
 


### PR DESCRIPTION
tl;dr: when called delete account on a node that is rescanning, head is deleted for the account before it is deleted from in memory store of `wallet.accounts`.

## Problem
RPC Client - delete account sent to remote node. Occasionally, node will crash saying head isn't set. 

### RCA:
Order of events that cause failure:
1. Client: Account import requested
2. Node: Imports account, rescan initiated
3. Client: Account delete requested
4. Node: Head is deleted [here](https://github.com/iron-fish/ironfish/blob/923fc6972f44444988addbc6b50fed4b6bb60983/ironfish/src/wallet/wallet.ts#L1675-L1685), but subsequent code line  `this.accounts.delete(account.id)` is not yet called.
5. Node: New block `connect` is called, `wallet.accounts` still contains account created from step 1/2.

## Testing Plan
Manual testing, difficult to reproduce.

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
