### PR TITLE
Pool: always send out a new block template

### DIFF
--- a/ironfish/src/mining/pool.ts
+++ b/ironfish/src/mining/pool.ts
@@ -438,19 +438,6 @@ export class MiningPool {
       ),
     )
 
-    // Target might be the same if there is a slight timing issue or if the block is at max target.
-    // In this case, it is detrimental to send out new work as it will needlessly reset miner's search
-    // space, resulting in duplicated work.
-    const existingTarget = BigIntUtils.fromBytesBE(
-      Buffer.from(latestBlock.header.target, 'hex'),
-    )
-    if (newTarget.asBigInt() === existingTarget) {
-      this.logger.debug(
-        `New target ${newTarget.asBigInt()} is the same as the existing target, no need to send out new work.`,
-      )
-      return
-    }
-
     latestBlock.header.target = BigIntUtils.writeBigU256BE(newTarget.asBigInt()).toString('hex')
     latestBlock.header.timestamp = newTime.getTime()
     this.distributeNewBlock(latestBlock)


### PR DESCRIPTION
## Summary

The pool will recalculate the target of the new block template every 10 seconds. Right now, once it reaches the max target for that block, it stops sending out updated block templates with the new target and timestamp. This leads to an issue where once the max target has been reached for that block, the timestamp is never updated, so a block that takes, for example, 3 hours to mine, will still say 34 minutes because that was the last time the timestamp was updated.

By removing this check, the timestamp will be changed every 10 seconds, leading to more accurate block times for the reference pool implementation.

Closes IFL-2453

## Testing Plan

Manually tested on a local devnet

## Documentation

N/A

## Breaking Change

N/A
