### PR TITLE
continue to process messages when exceptions occur

### DIFF
--- a/ironfish/src/rpc/adapters/socketAdapter/socketAdapter.ts
+++ b/ironfish/src/rpc/adapters/socketAdapter/socketAdapter.ts
@@ -201,14 +201,14 @@ export abstract class RpcSocketAdapter implements IRpcAdapter {
       const [parsed, error] = JSONUtils.tryParse(rpcMessage)
       if (error) {
         this.emitResponse(client, this.constructMalformedRequest(data))
-        return
+        continue
       }
 
       const result = await YupUtils.tryValidate(RpcSocketClientMessageSchema, parsed)
 
       if (result.error) {
         this.emitResponse(client, this.constructMalformedRequest(parsed))
-        return
+        continue
       }
 
       const message = result.result.data
@@ -253,10 +253,7 @@ export abstract class RpcSocketAdapter implements IRpcAdapter {
           })
 
           this.emitResponse(client, response, requestId)
-          return
         }
-
-        throw error
       }
     }
   }

--- a/ironfish/src/rpc/adapters/socketAdapter/socketAdapter.ts
+++ b/ironfish/src/rpc/adapters/socketAdapter/socketAdapter.ts
@@ -253,7 +253,10 @@ export abstract class RpcSocketAdapter implements IRpcAdapter {
           })
 
           this.emitResponse(client, response, requestId)
+          continue
         }
+
+        throw error
       }
     }
   }


### PR DESCRIPTION
## Summary

We stop processing RPC messages when an exception occurs. This means that all pending RPC messages don't process and the connection remains open. 

This removes the returns we have and continues to process messages as they come in. 

## Testing Plan

Run this CLI command to replicate: 
```typescript
/* This Source Code Form is subject to the terms of the Mozilla Public
 * License, v. 2.0. If a copy of the MPL was not distributed with this
 * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
import { Flags } from '@oclif/core'
import { IronfishCommand } from '../command'
import { RemoteFlags } from '../flags'

export class FeeCommand extends IronfishCommand {
  static description = `Get fee distribution for most recent blocks`

  static flags = {
    ...RemoteFlags,
    explain: Flags.boolean({
      default: false,
      description: 'Explain fee rates',
    }),
  }

  async start(): Promise<void> {
    await this.parse(FeeCommand)
    const client = await this.sdk.connectRpc()

    await Promise.allSettled([
      client.wallet.createAccount({
        name: 'default',
      }), // 0
      client.wallet.createAccount({
        name: 'default',
      }), // 1
      client.wallet.createAccount({
        name: 'default',
      }), // 2
      client.wallet.createAccount({
        name: 'default',
      }), // 3
      client.wallet.createAccount({
        name: 'default',
      }), // 4
      client.wallet.createAccount({
        name: 'default',
      }), // 5
      client.wallet.createAccount({
        name: 'default',
      }), // 6
      client.wallet.createAccount({
        name: 'default',
      }), // 7
    ])
  }
}
```


## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
