### PR TITLE
Rahul/ifl 2455 refactor explicitly call benchmark spend post time

### DIFF
--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -234,7 +234,7 @@ export class CombineNotesCommand extends IronfishCommand {
 
     let spendPostTime = getSpendPostTimeInMs(this.sdk)
 
-    if (spendPostTime === 0 || flags.benchmark) {
+    if (spendPostTime <= 0 || flags.benchmark) {
       spendPostTime = await benchmarkSpendPostTime(this.sdk, client, from)
     }
 

--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -18,7 +18,7 @@ import { IronFlag, RemoteFlags } from '../../../flags'
 import { getExplorer } from '../../../utils/explorer'
 import { selectFee } from '../../../utils/fees'
 import { fetchNotes } from '../../../utils/note'
-import { getSpendPostTimeInMs } from '../../../utils/spendPostTime'
+import { benchmarkSpendPostTime, getSpendPostTimeInMs } from '../../../utils/spendPostTime'
 import {
   displayTransactionSummary,
   TransactionTimer,
@@ -232,7 +232,11 @@ export class CombineNotesCommand extends IronfishCommand {
 
     await this.ensureUserHasEnoughNotesToCombine(client, from)
 
-    const spendPostTime = await getSpendPostTimeInMs(this.sdk, client, from, flags.benchmark)
+    let spendPostTime = getSpendPostTimeInMs(this.sdk)
+
+    if (spendPostTime === 0 || flags.benchmark) {
+      spendPostTime = await benchmarkSpendPostTime(this.sdk, client, from)
+    }
 
     let numberOfNotes = flags.notes
 

--- a/ironfish-cli/src/utils/spendPostTime.ts
+++ b/ironfish-cli/src/utils/spendPostTime.ts
@@ -15,16 +15,11 @@ import {
 import { CliUx } from '@oclif/core'
 import { fetchNotes } from './note'
 
-export async function getSpendPostTimeInMs(
-  sdk: IronfishSdk,
-  client: RpcClient,
-  account: string,
-  forceBenchmark: boolean,
-): Promise<number> {
+export function getSpendPostTimeInMs(sdk: IronfishSdk): number {
   return sdk.internal.get('spendPostTime')
 }
 
-async function benchmarkSpendPostTime(
+export async function benchmarkSpendPostTime(
   sdk: IronfishSdk,
   client: RpcClient,
   account: string,

--- a/ironfish-cli/src/utils/spendPostTime.ts
+++ b/ironfish-cli/src/utils/spendPostTime.ts
@@ -24,6 +24,8 @@ export async function benchmarkSpendPostTime(
   client: RpcClient,
   account: string,
 ): Promise<number> {
+  CliUx.ux.action.start('Measuring time to combine 1 note')
+
   const publicKey = (
     await client.wallet.getAccountPublicKey({
       account: account,
@@ -34,10 +36,8 @@ export async function benchmarkSpendPostTime(
 
   // Not enough notes in the account to measure the time to combine a note
   if (notes.length < 3) {
-    return 0
+    CliUx.ux.error('Not enough notes.')
   }
-
-  CliUx.ux.action.start('Measuring time to combine 1 note')
 
   const feeRates = await client.wallet.estimateFeeRates()
 

--- a/ironfish-cli/src/utils/spendPostTime.ts
+++ b/ironfish-cli/src/utils/spendPostTime.ts
@@ -90,9 +90,7 @@ export async function benchmarkSpendPostTime(
       3,
   )
 
-  const test = true
-
-  if (test || spendPostTime < 0) {
+  if (spendPostTime < 0) {
     CliUx.ux.error('Error calculating spendPostTime. Please try again.')
   }
 

--- a/ironfish-cli/src/utils/spendPostTime.ts
+++ b/ironfish-cli/src/utils/spendPostTime.ts
@@ -90,7 +90,7 @@ export async function benchmarkSpendPostTime(
       3,
   )
 
-  if (spendPostTime < 0) {
+  if (spendPostTime <= 0) {
     CliUx.ux.error('Error calculating spendPostTime. Please try again.')
   }
 

--- a/ironfish-cli/src/utils/spendPostTime.ts
+++ b/ironfish-cli/src/utils/spendPostTime.ts
@@ -90,6 +90,12 @@ export async function benchmarkSpendPostTime(
       3,
   )
 
+  const test = true
+
+  if (test || spendPostTime < 0) {
+    CliUx.ux.error('Error calculating spendPostTime. Please try again.')
+  }
+
   CliUx.ux.action.stop(TimeUtils.renderSpan(spendPostTime))
   sdk.internal.set('spendPostTime', spendPostTime)
 

--- a/ironfish/src/fileStores/internal.ts
+++ b/ironfish/src/fileStores/internal.ts
@@ -12,7 +12,6 @@ export type InternalOptions = {
   rpcAuthToken: string
   networkId: number
   spendPostTime: number // in milliseconds
-  spendPostTimeAt: number // when the spend post time measurement was done
 }
 
 export const InternalOptionsDefaults: InternalOptions = {
@@ -22,7 +21,6 @@ export const InternalOptionsDefaults: InternalOptions = {
   rpcAuthToken: '',
   networkId: DEFAULT_NETWORK_ID,
   spendPostTime: 0,
-  spendPostTimeAt: 0,
 }
 
 export class InternalStore extends KeyStore<InternalOptions> {


### PR DESCRIPTION
## Summary

Refactors combine to explicitly call benchmarkSpendPostTime

Also removes `spendPostTimeAt` from internal store. In an upcoming PR this will be replaced with a different variable to create more accurate measurements for spendPostTime. details here: https://github.com/iron-fish/ironfish/pull/4854/files
This refactor is to make it easier to understand where `spendPostTime` is being called and how the value is being calculated.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
