### PR TITLE
fix: adjust GHA runner apple binary to publish arm64

### DIFF
--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -42,11 +42,18 @@ jobs:
     runs-on: ${{ matrix.settings.host }}
     steps:
       - name: Check runner architecture
+        shell: bash
         run: |
           if [[ "$(uname -m)" != "${{ matrix.settings.arch }}" ]]; then
             echo "Runner architecture does not match specified architecture"
             exit 1
           fi
+      
+      # needed for distutils, which is used by nodegyp, arm64 mac runners have 3.12
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: 3.9
 
       - name: Use node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -1,8 +1,8 @@
 name: Build @ironfish binaries
 
-# on:
-#   push
 on:
+  push:
+  workflow_dispatch:
   release:
     types:
       - published
@@ -41,6 +41,12 @@ jobs:
     name: Build ${{ matrix.settings.system }} ${{ matrix.settings.arch }}
     runs-on: ${{ matrix.settings.host }}
     steps:
+      - name: Check runner architecture
+        run: |
+          if [[ "$(uname -m)" != "${{ matrix.settings.arch }}" ]]; then
+            echo "Runner architecture does not match specified architecture"
+            exit 1
+          fi
 
       - name: Use node.js
         uses: actions/setup-node@v4
@@ -183,6 +189,7 @@ jobs:
 
       - name: Upload release asset
         id: upload-release-asset
+        if: github.event_name == 'release'
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -26,7 +26,7 @@ jobs:
             arch: x86_64
             system: linux
 
-          - host: macos-latest-large
+          - host: macos-latest-xlarge
             arch: arm64
             system: apple
 

--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -48,11 +48,12 @@ jobs:
             echo "Runner architecture does not match specified architecture"
             exit 1
           fi
-
-      - name: python setup tools
-        run:
-          python -m pip install --upgrade pip
-          pip install setuptools
+      
+      # needed for distutils, which is used by nodegyp, arm64 mac runners have 3.12
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: 3.11
 
       - name: Use node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -1,7 +1,6 @@
 name: Build @ironfish binaries
 
 on:
-  push:
   workflow_dispatch:
   release:
     types:

--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -48,12 +48,11 @@ jobs:
             echo "Runner architecture does not match specified architecture"
             exit 1
           fi
-      
-      # needed for distutils, which is used by nodegyp, arm64 mac runners have 3.12
-      - name: Set up Python
-        uses: actions/setup-python@v3
-        with:
-          python-version: 3.9
+
+      - name: python setup tools
+        run:
+          python -m pip install --upgrade pip
+          pip install setuptools
 
       - name: Use node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
[## Summary

Previously `macos-latest-large` was M1 runner. `macos-latest-xlarge` is now m1. Adds arch check and manual workflow dispatch (for backfilling use cases).

## Testing Plan
Tested here:
https://github.com/iron-fish/ironfish/actions/runs/8605207764/job/23580976352?pr=4881

output from downloaded/extracted binaries:

```
# arm64
 file ironfish 
ironfish: Mach-O 64-bit executable arm64

# x86_64
file ironfish                                                                                                                                                                                                  
ironfish: Mach-O 64-bit executable x86_64
```

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
](https://github.com/iron-fish/ironfish/actions/runs/8605207764/job/23580976352?pr=4881)