### PR TITLE
fix: add dispatch param

### DIFF
--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -2,6 +2,10 @@ name: Build @ironfish binaries
 
 on:
   workflow_dispatch:
+    inputs:
+      checkout_ref:
+        description: 'Git ref (branch, tag, commit SHA)'
+        required: false
   release:
     types:
       - published
@@ -66,6 +70,8 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.checkout_ref }}
 
       - name: Create random identifier so binary extraction will be unique
         id: identifier
@@ -88,7 +94,7 @@ jobs:
           cd build
           cp $(node -e "console.log(process.execPath)") ${{ matrix.settings.system != 'windows' && 'node' || 'node.exe' }}
           npm init -y
-          npm install ironfish@${{ github.event.release.tag_name }}
+          npm install ironfish@${{ github.event_name == 'release' && github.event.release.tag_name || github.event.inputs.checkout_ref }}
           tar -czf ../tools/build.tar.gz -C . .
 
       - name: Create binary
@@ -100,7 +106,7 @@ jobs:
         id: set_paths
         shell: bash
         run: |
-          name="ironfish-standalone-${{ matrix.settings.system }}-${{ matrix.settings.arch }}-${{ github.event.release.tag_name }}"
+          name="ironfish-standalone-${{ matrix.settings.system }}-${{ matrix.settings.arch }}-${{ github.event_name == 'release' && github.event.release.tag_name || github.event.inputs.checkout_ref }}"
           echo "name=${name}" >> $GITHUB_OUTPUT
           echo "zip=${name}.zip" >> $GITHUB_OUTPUT
           echo "binary=${{ matrix.settings.system != 'windows' && 'ironfish' || 'ironfish.exe' }}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
Adds workflow dispatch ref so that programmatic triggering can happen with this param when running from a different branch (ie `staging`).
## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
