### PR TITLE
Cleanup more uses of `request()` in tests

### DIFF
--- a/ironfish/src/rpc/routes/config/getConfig.test.ts
+++ b/ironfish/src/rpc/routes/config/getConfig.test.ts
@@ -11,11 +11,9 @@ describe('Route config/getConfig', () => {
   })
 
   it('returns value of the requested ConfigOptions', async () => {
-    const response = await routeTest.client
-      .request('config/getConfig', {
-        name: 'minerBatchSize',
-      })
-      .waitForEnd()
+    const response = await routeTest.client.config.getConfig({
+      name: 'minerBatchSize',
+    })
     expect(response.status).toBe(200)
     expect(response.content).toEqual({
       minerBatchSize: routeTest.node.config.get('minerBatchSize'),
@@ -24,12 +22,10 @@ describe('Route config/getConfig', () => {
 
   it('returns nothing when no datadir exists', async () => {
     const target = {}
-    const response = await routeTest.client
-      .request('config/getConfig', {
-        name: 'minerBatchSize',
-        user: true,
-      })
-      .waitForEnd()
+    const response = await routeTest.client.config.getConfig({
+      name: 'minerBatchSize',
+      user: true,
+    })
     expect(response.status).toBe(200)
     expect(response.content).toEqual(target)
   })

--- a/ironfish/src/rpc/routes/config/setConfig.test.ts
+++ b/ironfish/src/rpc/routes/config/setConfig.test.ts
@@ -10,36 +10,28 @@ describe('Route config/setConfig', () => {
 
   it('should error if the config name does not exist', async () => {
     await expect(
-      routeTest.client
-        .request('config/setConfig', { name: 'asdf', value: 'asdf' })
-        .waitForEnd(),
+      routeTest.client.config.setConfig({ name: 'asdf', value: 'asdf' }),
     ).rejects.toThrow()
   })
 
   describe('Convert string to array', () => {
     it('does not special-case brackets', async () => {
-      const response = await routeTest.client
-        .request('config/setConfig', {
-          name: 'bootstrapNodes',
-          value: '[]',
-        })
-        .waitForEnd()
-      const content = await response.content
+      const response = await routeTest.client.config.setConfig({
+        name: 'bootstrapNodes',
+        value: '[]',
+      })
       expect(response.status).toBe(200)
-      expect(content).toBeUndefined()
+      expect(response.content).toBeUndefined()
       expect(routeTest.sdk.config.get('bootstrapNodes')).toEqual(['[]'])
     })
 
     it('should convert strings to arrays', async () => {
-      const response = await routeTest.client
-        .request('config/setConfig', {
-          name: 'bootstrapNodes',
-          value: 'test.node.com,test2.node.com',
-        })
-        .waitForEnd()
-      const content = await response.content
+      const response = await routeTest.client.config.setConfig({
+        name: 'bootstrapNodes',
+        value: 'test.node.com,test2.node.com',
+      })
       expect(response.status).toBe(200)
-      expect(content).toBeUndefined()
+      expect(response.content).toBeUndefined()
       expect(routeTest.sdk.config.get('bootstrapNodes')).toEqual([
         'test.node.com',
         'test2.node.com',
@@ -47,41 +39,32 @@ describe('Route config/setConfig', () => {
     })
 
     it('handles single values', async () => {
-      const response = await routeTest.client
-        .request('config/setConfig', {
-          name: 'bootstrapNodes',
-          value: 'test.node.com',
-        })
-        .waitForEnd()
-      const content = await response.content
+      const response = await routeTest.client.config.setConfig({
+        name: 'bootstrapNodes',
+        value: 'test.node.com',
+      })
       expect(response.status).toBe(200)
-      expect(content).toBeUndefined()
+      expect(response.content).toBeUndefined()
       expect(routeTest.sdk.config.get('bootstrapNodes')).toEqual(['test.node.com'])
     })
 
     it('should strip leading and trailing whitespace', async () => {
-      const response = await routeTest.client
-        .request('config/setConfig', {
-          name: 'bootstrapNodes',
-          value: '  node1  ,   node2  ',
-        })
-        .waitForEnd()
-      const content = await response.content
+      const response = await routeTest.client.config.setConfig({
+        name: 'bootstrapNodes',
+        value: '  node1  ,   node2  ',
+      })
       expect(response.status).toBe(200)
-      expect(content).toBeUndefined()
+      expect(response.content).toBeUndefined()
       expect(routeTest.sdk.config.get('bootstrapNodes')).toEqual(['node1', 'node2'])
     })
 
     it('should leave quotes', async () => {
-      const response = await routeTest.client
-        .request('config/setConfig', {
-          name: 'bootstrapNodes',
-          value: ' \' node1 \' , " node2 " ',
-        })
-        .waitForEnd()
-      const content = await response.content
+      const response = await routeTest.client.config.setConfig({
+        name: 'bootstrapNodes',
+        value: ' \' node1 \' , " node2 " ',
+      })
       expect(response.status).toBe(200)
-      expect(content).toBeUndefined()
+      expect(response.content).toBeUndefined()
       expect(routeTest.sdk.config.get('bootstrapNodes')).toEqual(["' node1 '", '" node2 "'])
     })
   })

--- a/ironfish/src/rpc/routes/wallet/multisig/createTrustedDealerKeyPackage.test.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/createTrustedDealerKeyPackage.test.ts
@@ -12,9 +12,9 @@ describe('Route multisig/createTrustedDealerKeyPackage', () => {
       identity: multisig.ParticipantSecret.random().toIdentity().serialize().toString('hex'),
     }))
     const request = { minSigners: 2, participants }
-    const response = await routeTest.client
-      .request('wallet/multisig/createTrustedDealerKeyPackage', request)
-      .waitForEnd()
+    const response = await routeTest.client.wallet.multisig.createTrustedDealerKeyPackage(
+      request,
+    )
 
     expect(response.content).toMatchObject({
       publicAddress: expect.any(String),

--- a/ironfish/src/rpc/routes/worker/getStatus.test.ts
+++ b/ironfish/src/rpc/routes/worker/getStatus.test.ts
@@ -9,9 +9,7 @@ describe('Route worker/getStatus', () => {
 
   it('should get status', async () => {
     const request: GetWorkersStatusRequest = { stream: false }
-    const response = await routeTest.client
-      .request('worker/getStatus', { request })
-      .waitForEnd()
+    const response = await routeTest.client.worker.getWorkersStatus(request)
 
     expect(response.status).toBe(200)
 


### PR DESCRIPTION
## Summary

This is a follow up to 98fcad2e45a8f699893d03f70d2defa2fd86b84a and removes a few more uses of `request()` in tests.

## Testing Plan

Unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
