### PR TITLE
Render question mark for unknown assets

### DIFF
--- a/ironfish-cli/src/commands/wallet/assets.ts
+++ b/ironfish-cli/src/commands/wallet/assets.ts
@@ -12,7 +12,7 @@ import { BufferUtils } from '@ironfish/sdk'
 import { CliUx } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
-import { renderAssetNameFromHex } from '../../utils'
+import { renderAssetWithVerificationStatus } from '../../utils'
 import { TableCols } from '../../utils/table'
 
 const MAX_ASSET_METADATA_COLUMN_WIDTH = ASSET_METADATA_LENGTH + 1
@@ -64,12 +64,13 @@ export class AssetsCommand extends IronfishCommand {
             header: 'Name',
             width: assetNameWidth,
             get: (row) =>
-              renderAssetNameFromHex(row.name, {
-                verification: row.verification,
-                outputType: flags.output,
-                verbose: !!flags.verbose,
-                logWarn: this.warn.bind(this),
-              }),
+              renderAssetWithVerificationStatus(
+                BufferUtils.toHuman(Buffer.from(row.name, 'hex')),
+                {
+                  verification: row.verification,
+                  outputType: flags.output,
+                },
+              ),
           }),
           id: {
             header: 'ID',

--- a/ironfish-cli/src/commands/wallet/balance.ts
+++ b/ironfish-cli/src/commands/wallet/balance.ts
@@ -5,7 +5,7 @@ import { CurrencyUtils, GetBalanceResponse, isNativeIdentifier } from '@ironfish
 import { Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
-import { renderAssetName } from '../../utils'
+import { renderAssetWithVerificationStatus } from '../../utils'
 
 export class BalanceCommand extends IronfishCommand {
   static description =
@@ -63,11 +63,10 @@ export class BalanceCommand extends IronfishCommand {
     ).content
 
     const assetId = response.content.assetId
-    const assetName = renderAssetName(isNativeIdentifier(assetId) ? '$IRON' : assetId, {
-      verification: asset.verification,
-      verbose: !!flags.verbose,
-      logWarn: this.warn.bind(this),
-    })
+    const assetName = renderAssetWithVerificationStatus(
+      isNativeIdentifier(assetId) ? '$IRON' : assetId,
+      asset,
+    )
 
     if (flags.explain) {
       this.explainBalance(response.content, assetName)

--- a/ironfish-cli/src/commands/wallet/balances.ts
+++ b/ironfish-cli/src/commands/wallet/balances.ts
@@ -1,11 +1,11 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { CurrencyUtils, GetBalancesResponse, RpcAsset } from '@ironfish/sdk'
+import { BufferUtils, CurrencyUtils, GetBalancesResponse, RpcAsset } from '@ironfish/sdk'
 import { CliUx, Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
-import { compareAssets, renderAssetNameFromHex } from '../../utils'
+import { compareAssets, renderAssetWithVerificationStatus } from '../../utils'
 
 type AssetBalancePairs = { asset: RpcAsset; balance: GetBalancesResponse['balances'][number] }
 
@@ -63,12 +63,13 @@ export class BalancesCommand extends IronfishCommand {
       assetName: {
         header: 'Asset Name',
         get: ({ asset }) =>
-          renderAssetNameFromHex(asset.name, {
-            verification: asset.verification,
-            outputType: flags.output,
-            verbose: !!flags.verbose,
-            logWarn: this.warn.bind(this),
-          }),
+          renderAssetWithVerificationStatus(
+            BufferUtils.toHuman(Buffer.from(asset.name, 'hex')),
+            {
+              verification: asset.verification,
+              outputType: flags.output,
+            },
+          ),
       },
       'asset.id': {
         header: 'Asset Id',

--- a/ironfish-cli/src/utils/asset.ts
+++ b/ironfish-cli/src/utils/asset.ts
@@ -17,11 +17,12 @@ import inquirer from 'inquirer'
 type RenderAssetNameOptions = {
   verification?: RpcAssetVerification
   outputType?: string
-  verbose?: boolean
-  logWarn?: (msg: string) => void
 }
 
-export function renderAssetName(name: string, options?: RenderAssetNameOptions): string {
+export function renderAssetWithVerificationStatus(
+  name: string,
+  options?: RenderAssetNameOptions,
+): string {
   if (options?.outputType) {
     // User requested some machine-readable output (like CSV, JSON, or YAML).
     // Do not alter the name in any way.
@@ -34,21 +35,10 @@ export function renderAssetName(name: string, options?: RenderAssetNameOptions):
     case 'verified':
       return chalk.green(name + '✓')
     case 'unknown':
-      if (options?.verbose && options?.logWarn) {
-        options.logWarn(`Could not check whether ${name} is a verified asset`)
-      }
-      return name
+      return chalk.green(name + '?')
     default:
       return name
   }
-}
-
-export function renderAssetNameFromHex(
-  hexName: string,
-  options?: RenderAssetNameOptions,
-): string {
-  const name = BufferUtils.toHuman(Buffer.from(hexName, 'hex'))
-  return renderAssetName(name, options)
 }
 
 export function compareAssets(


### PR DESCRIPTION
## Summary
When the node fails to query the verified asset lists, it is unknown which assets are verified. This should be displayed inline with the assets. It also cleans up the code a bit so that warnings are not logged inline with rendering data.

## Testing Plan
Unit tests + running commands on testnet node

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
