### PR TITLE
implement dkg/round2 RPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1521,7 +1521,7 @@ dependencies = [
 [[package]]
 name = "ironfish-frost"
 version = "0.1.0"
-source = "git+https://github.com/iron-fish/ironfish-frost.git?branch=main#e34173b50e7dcad25219cf0373ab7df220e4afc1"
+source = "git+https://github.com/iron-fish/ironfish-frost.git?branch=main#282d92d4b400fa85661c4fde7f3883f6c6a96fbf"
 dependencies = [
  "blake3",
  "chacha20 0.9.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1521,7 +1521,7 @@ dependencies = [
 [[package]]
 name = "ironfish-frost"
 version = "0.1.0"
-source = "git+https://github.com/iron-fish/ironfish-frost.git?branch=main#282d92d4b400fa85661c4fde7f3883f6c6a96fbf"
+source = "git+https://github.com/iron-fish/ironfish-frost.git?branch=main#b6b11147654602c0ea6142bb26b7df2b5651073f"
 dependencies = [
  "blake3",
  "chacha20 0.9.1",

--- a/ironfish-rust-nodejs/index.d.ts
+++ b/ironfish-rust-nodejs/index.d.ts
@@ -256,9 +256,13 @@ export namespace multisig {
     publicPackage: string
   }
   export function dkgRound2(secret: string, encryptedSecretPackage: string, publicPackages: Array<string>): DkgRound2Packages
+  export interface DkgRound2PublicPackage {
+    recipientIdentity: string
+    publicPackage: string
+  }
   export interface DkgRound2Packages {
     encryptedSecretPackage: string
-    publicPackages: Array<string>
+    publicPackages: Array<DkgRound2PublicPackage>
   }
   export function aggregateSignatureShares(publicKeyPackageStr: string, signingPackageStr: string, signatureSharesArr: Array<string>): Buffer
   export class ParticipantSecret {

--- a/ironfish-rust-nodejs/index.d.ts
+++ b/ironfish-rust-nodejs/index.d.ts
@@ -258,7 +258,7 @@ export namespace multisig {
   export function dkgRound2(secret: string, encryptedSecretPackage: string, publicPackages: Array<string>): DkgRound2Packages
   export interface DkgRound2Packages {
     encryptedSecretPackage: string
-    publicPackages: Record<string, string>
+    publicPackages: Array<string>
   }
   export function aggregateSignatureShares(publicKeyPackageStr: string, signingPackageStr: string, signatureSharesArr: Array<string>): Buffer
   export class ParticipantSecret {

--- a/ironfish-rust-nodejs/index.d.ts
+++ b/ironfish-rust-nodejs/index.d.ts
@@ -255,6 +255,11 @@ export namespace multisig {
     encryptedSecretPackage: string
     publicPackage: string
   }
+  export function dkgRound2(secret: string, encryptedSecretPackage: string, publicPackages: Array<string>): DkgRound2Packages
+  export interface DkgRound2Packages {
+    encryptedSecretPackage: string
+    publicPackages: Record<string, string>
+  }
   export function aggregateSignatureShares(publicKeyPackageStr: string, signingPackageStr: string, signatureSharesArr: Array<string>): Buffer
   export class ParticipantSecret {
     constructor(jsBytes: Buffer)

--- a/ironfish-rust-nodejs/src/multisig.rs
+++ b/ironfish-rust-nodejs/src/multisig.rs
@@ -21,7 +21,7 @@ use ironfish_frost::{
 use napi::{bindgen_prelude::*, JsBuffer};
 use napi_derive::napi;
 use rand::thread_rng;
-use std::{collections::HashMap, ops::Deref};
+use std::ops::Deref;
 
 #[napi(namespace = "multisig")]
 pub const IDENTITY_LEN: u32 = ironfish::frost_utils::IDENTITY_LEN as u32;
@@ -394,7 +394,6 @@ pub fn dkg_round1(
     )
     .map_err(to_napi_err)?;
 
-    // TODO bind the min/max signers and the list of participants to the packages
     Ok(DkgRound1Packages {
         encrypted_secret_package: bytes_to_hex(&encrypted_secret_package),
         public_package: bytes_to_hex(&public_package.serialize()),
@@ -430,22 +429,19 @@ pub fn dkg_round2(
     )
     .map_err(to_napi_err)?;
 
-    let mut serialized_public_packages: HashMap<String, String> = HashMap::new();
-    for (identity, public_package) in public_packages {
-        serialized_public_packages.insert(
-            bytes_to_hex(&identity.serialize()),
-            bytes_to_hex(&public_package.serialize()),
-        );
-    }
+    let public_packages = public_packages
+        .iter()
+        .map(|p| bytes_to_hex(&p.serialize()))
+        .collect();
 
     Ok(DkgRound2Packages {
         encrypted_secret_package: bytes_to_hex(&encrypted_secret_package),
-        public_packages: serialized_public_packages,
+        public_packages,
     })
 }
 
 #[napi(object, namespace = "multisig")]
 pub struct DkgRound2Packages {
     pub encrypted_secret_package: String,
-    pub public_packages: HashMap<String, String>,
+    pub public_packages: Vec<String>,
 }

--- a/ironfish-rust-nodejs/src/multisig.rs
+++ b/ironfish-rust-nodejs/src/multisig.rs
@@ -431,7 +431,10 @@ pub fn dkg_round2(
 
     let public_packages = public_packages
         .iter()
-        .map(|p| bytes_to_hex(&p.serialize()))
+        .map(|p| DkgRound2PublicPackage {
+            recipient_identity: bytes_to_hex(&p.recipient_identity().serialize()),
+            public_package: bytes_to_hex(&p.serialize()),
+        })
         .collect();
 
     Ok(DkgRound2Packages {
@@ -441,7 +444,13 @@ pub fn dkg_round2(
 }
 
 #[napi(object, namespace = "multisig")]
+pub struct DkgRound2PublicPackage {
+    pub recipient_identity: String,
+    pub public_package: String,
+}
+
+#[napi(object, namespace = "multisig")]
 pub struct DkgRound2Packages {
     pub encrypted_secret_package: String,
-    pub public_packages: Vec<String>,
+    pub public_packages: Vec<DkgRound2PublicPackage>,
 }

--- a/ironfish/src/rpc/clients/client.ts
+++ b/ironfish/src/rpc/clients/client.ts
@@ -35,6 +35,8 @@ import type {
   CreateTrustedDealerKeyPackageResponse,
   DkgRound1Request,
   DkgRound1Response,
+  DkgRound2Request,
+  DkgRound2Response,
   EstimateFeeRateRequest,
   EstimateFeeRateResponse,
   EstimateFeeRatesRequest,
@@ -278,6 +280,13 @@ export abstract class RpcClient {
         round1: (params: DkgRound1Request): Promise<RpcResponseEnded<DkgRound1Response>> => {
           return this.request<DkgRound1Response>(
             `${ApiNamespace.wallet}/multisig/dkg/round1`,
+            params,
+          ).waitForEnd()
+        },
+
+        round2: (params: DkgRound2Request): Promise<RpcResponseEnded<DkgRound2Response>> => {
+          return this.request<DkgRound2Response>(
+            `${ApiNamespace.wallet}/multisig/dkg/round2`,
             params,
           ).waitForEnd()
         },

--- a/ironfish/src/rpc/routes/wallet/multisig/dkg/index.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/dkg/index.ts
@@ -2,3 +2,4 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 export * from './round1'
+export * from './round2'

--- a/ironfish/src/rpc/routes/wallet/multisig/dkg/round2.test.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/dkg/round2.test.ts
@@ -1,0 +1,59 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { createRouteTest } from '../../../../../testUtilities/routeTest'
+
+describe('Route multisig/dkg/round2', () => {
+  const routeTest = createRouteTest()
+
+  it('should create round 2 packages', async () => {
+    const secretName1 = 'name1'
+    await routeTest.client.wallet.multisig.createParticipant({ name: secretName1 })
+    const secretName2 = 'name2'
+    await routeTest.client.wallet.multisig.createParticipant({ name: secretName2 })
+
+    const identity1 = (
+      await routeTest.client.wallet.multisig.getIdentity({ name: secretName1 })
+    ).content.identity
+    const identity2 = (
+      await routeTest.client.wallet.multisig.getIdentity({ name: secretName2 })
+    ).content.identity
+    const participants = [{ identity: identity1 }, { identity: identity2 }]
+
+    const round1Request1 = { secretName: secretName1, minSigners: 2, participants }
+    const round1Response1 = await routeTest.client.wallet.multisig.dkg.round1(round1Request1)
+
+    const round1Request2 = { secretName: secretName2, minSigners: 2, participants }
+    const round1Response2 = await routeTest.client.wallet.multisig.dkg.round1(round1Request2)
+
+    const round2Request = {
+      secretName: secretName1,
+      encryptedSecretPackage: round1Response1.content.encryptedSecretPackage,
+      publicPackages: [
+        round1Response1.content.publicPackage,
+        round1Response2.content.publicPackage,
+      ],
+    }
+
+    const round2Response = await routeTest.client.wallet.multisig.dkg.round2(round2Request)
+
+    expect(round2Response.content).toMatchObject({
+      encryptedSecretPackage: expect.any(String),
+    })
+  })
+
+  it('should fail if the named secret does not exist', async () => {
+    const request = {
+      secretName: 'fakeName',
+      encryptedSecretPackage: 'foo',
+      publicPackages: ['bar', 'baz'],
+    }
+
+    await expect(routeTest.client.wallet.multisig.dkg.round2(request)).rejects.toThrow(
+      expect.objectContaining({
+        message: expect.stringContaining("Multisig secret with name 'fakeName' not found"),
+        status: 400,
+      }),
+    )
+  })
+})

--- a/ironfish/src/rpc/routes/wallet/multisig/dkg/round2.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/dkg/round2.ts
@@ -16,7 +16,7 @@ export type DkgRound2Request = {
 
 export type DkgRound2Response = {
   encryptedSecretPackage: string
-  publicPackages: Record<string, string>
+  publicPackages: Array<string>
 }
 
 export const DkgRound2RequestSchema: yup.ObjectSchema<DkgRound2Request> = yup
@@ -30,7 +30,7 @@ export const DkgRound2RequestSchema: yup.ObjectSchema<DkgRound2Request> = yup
 export const DkgRound2ResponseSchema: yup.ObjectSchema<DkgRound2Response> = yup
   .object({
     encryptedSecretPackage: yup.string().defined(),
-    publicPackages: yup.mixed().required(),
+    publicPackages: yup.array().of(yup.string().defined()).defined(),
   })
   .defined()
 

--- a/ironfish/src/rpc/routes/wallet/multisig/dkg/round2.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/dkg/round2.ts
@@ -16,7 +16,7 @@ export type DkgRound2Request = {
 
 export type DkgRound2Response = {
   encryptedSecretPackage: string
-  publicPackages: Array<string>
+  publicPackages: Array<{ recipientIdentity: string; publicPackage: string }>
 }
 
 export const DkgRound2RequestSchema: yup.ObjectSchema<DkgRound2Request> = yup
@@ -30,7 +30,16 @@ export const DkgRound2RequestSchema: yup.ObjectSchema<DkgRound2Request> = yup
 export const DkgRound2ResponseSchema: yup.ObjectSchema<DkgRound2Response> = yup
   .object({
     encryptedSecretPackage: yup.string().defined(),
-    publicPackages: yup.array().of(yup.string().defined()).defined(),
+    publicPackages: yup
+      .array(
+        yup
+          .object({
+            recipientIdentity: yup.string().defined(),
+            publicPackage: yup.string().defined(),
+          })
+          .defined(),
+      )
+      .defined(),
   })
   .defined()
 

--- a/ironfish/src/rpc/routes/wallet/multisig/dkg/round2.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/dkg/round2.ts
@@ -1,0 +1,60 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { multisig } from '@ironfish/rust-nodejs'
+import * as yup from 'yup'
+import { RPC_ERROR_CODES, RpcValidationError } from '../../../../adapters'
+import { ApiNamespace } from '../../../namespaces'
+import { routes } from '../../../router'
+import { AssertHasRpcContext } from '../../../rpcContext'
+
+export type DkgRound2Request = {
+  secretName: string
+  encryptedSecretPackage: string
+  publicPackages: Array<string>
+}
+
+export type DkgRound2Response = {
+  encryptedSecretPackage: string
+  publicPackages: Record<string, string>
+}
+
+export const DkgRound2RequestSchema: yup.ObjectSchema<DkgRound2Request> = yup
+  .object({
+    secretName: yup.string().defined(),
+    encryptedSecretPackage: yup.string().defined(),
+    publicPackages: yup.array().of(yup.string().defined()).defined(),
+  })
+  .defined()
+
+export const DkgRound2ResponseSchema: yup.ObjectSchema<DkgRound2Response> = yup
+  .object({
+    encryptedSecretPackage: yup.string().defined(),
+    publicPackages: yup.mixed().required(),
+  })
+  .defined()
+
+routes.register<typeof DkgRound2RequestSchema, DkgRound2Response>(
+  `${ApiNamespace.wallet}/multisig/dkg/round2`,
+  DkgRound2RequestSchema,
+  async (request, node): Promise<void> => {
+    AssertHasRpcContext(request, node, 'wallet')
+
+    const { secretName, encryptedSecretPackage, publicPackages } = request.data
+    const multisigSecret = await node.wallet.walletDb.getMultisigSecretByName(secretName)
+
+    if (!multisigSecret) {
+      throw new RpcValidationError(
+        `Multisig secret with name '${secretName}' not found`,
+        400,
+        RPC_ERROR_CODES.MULTISIG_SECRET_NOT_FOUND,
+      )
+    }
+
+    const secret = multisigSecret.secret.toString('hex')
+
+    const packages = multisig.dkgRound2(secret, encryptedSecretPackage, publicPackages)
+
+    request.end(packages)
+  },
+)


### PR DESCRIPTION
## Summary

- updates ironfish-frost version to latest main
- defines round2 in ironfish-rust-nodejs
- defines round2 RPC endpoint

## Testing Plan

- adds unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
