### PR TITLE
add dkg round1 cli command

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/dkg/round1.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/round1.ts
@@ -1,0 +1,78 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { CliUx, Flags } from '@oclif/core'
+import { IronfishCommand } from '../../../../command'
+import { RemoteFlags } from '../../../../flags'
+import { longPrompt } from '../../../../utils/longPrompt'
+
+export class DkgRound1Command extends IronfishCommand {
+  static description = 'Perform round1 of the DKG protocol for multisig account creation'
+  static hidden = true
+
+  static flags = {
+    ...RemoteFlags,
+    secretName: Flags.string({
+      char: 's',
+      description: 'The name of the secret to use for encryption during DKG',
+      required: true,
+    }),
+    identity: Flags.string({
+      char: 'i',
+      description:
+        'The identity of the participants will generate the group keys (may be specified multiple times to add multiple participants). Must include the identity for secretName',
+      multiple: true,
+    }),
+    minSigners: Flags.integer({
+      char: 'm',
+      description: 'Minimum number of signers to meet signing threshold',
+    }),
+  }
+
+  async start(): Promise<void> {
+    const { flags } = await this.parse(DkgRound1Command)
+
+    let identities = flags.identity
+    if (!identities || identities.length < 2) {
+      const input = await longPrompt('Enter the identities separated by commas', {
+        required: true,
+      })
+      identities = input.split(',')
+
+      if (identities.length < 2) {
+        this.error('Minimum number of identities must be at least 2')
+      }
+    }
+    identities = identities.map((i) => i.trim())
+
+    let minSigners = flags.minSigners
+    if (!minSigners) {
+      const input = await CliUx.ux.prompt('Enter the number of minimum signers', {
+        required: true,
+      })
+      minSigners = parseInt(input)
+      if (isNaN(minSigners) || minSigners < 2) {
+        this.error('Minimum number of signers must be at least 2')
+      }
+    }
+
+    const client = await this.sdk.connectRpc()
+
+    const response = await client.wallet.multisig.dkg.round1({
+      secretName: flags.secretName,
+      participants: identities.map((identity) => ({ identity })),
+      minSigners: minSigners,
+    })
+
+    this.log('\nEncrypted Secret Package:\n')
+    this.log(response.content.encryptedSecretPackage)
+    this.log()
+
+    this.log('\nPublic Package:\n')
+    this.log(response.content.publicPackage)
+    this.log()
+
+    this.log('Next step:')
+    this.log('Send the public package to each participant')
+  }
+}

--- a/ironfish-cli/src/commands/wallet/multisig/dkg/round1.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/round1.ts
@@ -15,7 +15,6 @@ export class DkgRound1Command extends IronfishCommand {
     secretName: Flags.string({
       char: 's',
       description: 'The name of the secret to use for encryption during DKG',
-      required: true,
     }),
     identity: Flags.string({
       char: 'i',
@@ -31,6 +30,13 @@ export class DkgRound1Command extends IronfishCommand {
 
   async start(): Promise<void> {
     const { flags } = await this.parse(DkgRound1Command)
+
+    let secretName = flags.secretName
+    if (!secretName) {
+      secretName = await CliUx.ux.prompt('Enter the name of the secret to use', {
+        required: true,
+      })
+    }
 
     let identities = flags.identity
     if (!identities || identities.length < 2) {
@@ -59,7 +65,7 @@ export class DkgRound1Command extends IronfishCommand {
     const client = await this.sdk.connectRpc()
 
     const response = await client.wallet.multisig.dkg.round1({
-      secretName: flags.secretName,
+      secretName: secretName,
       participants: identities.map((identity) => ({ identity })),
       minSigners: minSigners,
     })


### PR DESCRIPTION
## Summary

adds a cli command to run round1 of the dkg protocol

takes flags for secret name, identities of particicpants, and minimum signers

logs encrypted secret package and public package to command-line

## Testing Plan

manual testing:
<img width="1010" alt="image" src="https://github.com/iron-fish/ironfish/assets/57735705/e45b3612-2776-4575-bc92-b0f9dfb8a803">


## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
