### PR TITLE
automatically add identity for secretName to round1 participants

### DIFF
--- a/ironfish/src/rpc/routes/wallet/multisig/dkg/round1.test.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/dkg/round1.test.ts
@@ -55,24 +55,25 @@ describe('Route multisig/dkg/round1', () => {
     )
   })
 
-  it('should fail if the named identity is not part of the participants', async () => {
+  it('should add the named identity if it is not in the list of participants', async () => {
     const secretName = 'name'
     await routeTest.client.wallet.multisig.createParticipant({ name: secretName })
 
-    const participants = Array.from({ length: 3 }, () => ({
-      identity: multisig.ParticipantSecret.random().toIdentity().serialize().toString('hex'),
-    }))
+    // only pass in one participant
+    const participants = [
+      {
+        identity: multisig.ParticipantSecret.random().toIdentity().serialize().toString('hex'),
+      },
+    ]
 
     const request = { secretName, minSigners: 2, participants }
 
-    await expect(routeTest.client.wallet.multisig.dkg.round1(request)).rejects.toThrow(
-      expect.objectContaining({
-        message: expect.stringContaining(
-          "List of participant identities must include the identity for 'name'",
-        ),
-        status: 400,
-      }),
-    )
+    const response = await routeTest.client.wallet.multisig.dkg.round1(request)
+
+    expect(response.content).toMatchObject({
+      encryptedSecretPackage: expect.any(String),
+      publicPackage: expect.any(String),
+    })
   })
 
   it('should fail if minSigners is too low', async () => {

--- a/ironfish/src/rpc/routes/wallet/multisig/dkg/round1.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/dkg/round1.ts
@@ -61,11 +61,7 @@ routes.register<typeof DkgRound1RequestSchema, DkgRound1Response>(
       .toString('hex')
 
     if (!participantIdentities.includes(selfIdentity)) {
-      throw new RpcValidationError(
-        `List of participant identities must include the identity for '${secretName}' (${selfIdentity})`,
-        400,
-        RPC_ERROR_CODES.VALIDATION,
-      )
+      participantIdentities.push(selfIdentity)
     }
 
     if (minSigners < 2) {


### PR DESCRIPTION
## Summary

when a user runs round1 of dkg with a given secret name they must also include the identity for that secret in the list of participants

updates the round1 rpc to automatically add that identity if it's missing instead of throwing an error

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
