### PR TITLE
Avoid an infinite loop in `SaplingKey::generate_key`

### DIFF
--- a/ironfish-rust/src/keys/mod.rs
+++ b/ironfish-rust/src/keys/mod.rs
@@ -135,8 +135,8 @@ impl SaplingKey {
     /// first time.
     /// Note that unlike `new`, this function always successfully returns a value.
     pub fn generate_key() -> Self {
-        let spending_key: [u8; SPEND_KEY_SIZE] = random();
         loop {
+            let spending_key: [u8; SPEND_KEY_SIZE] = random();
             if let Ok(key) = Self::new(spending_key) {
                 return key;
             }


### PR DESCRIPTION
## Summary

If the random scalar generated is zero (which is a rare occurrence, almost impossible, and has the same probability to occur as guessing somebody's private key), `SaplingKey::generate_key` is supposed to generate a new random scalar and try again. The current code however, does not generate a new random scalar if that occurs, resulting in an infinite loop.

## Testing Plan

Unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
