### PR TITLE
add option to force full account rescan from genesis

### DIFF
--- a/ironfish-cli/src/commands/wallet/rescan.ts
+++ b/ironfish-cli/src/commands/wallet/rescan.ts
@@ -28,11 +28,14 @@ export class RescanCommand extends IronfishCommand {
       description: 'Sequence to start account rescan from',
       hidden: true,
     }),
+    full: Flags.boolean({
+      description: 'Force a full rescan of the chain starting from the genesis block',
+    }),
   }
 
   async start(): Promise<void> {
     const { flags } = await this.parse(RescanCommand)
-    const { follow, local, from } = flags
+    const { follow, local, from, full } = flags
 
     if (local && !follow) {
       this.error('You cannot pass both --local and --no-follow')
@@ -44,7 +47,7 @@ export class RescanCommand extends IronfishCommand {
       stdout: true,
     })
 
-    const response = client.wallet.rescanAccountStream({ follow, from })
+    const response = client.wallet.rescanAccountStream({ follow, from, full })
 
     const speed = new Meter()
 

--- a/ironfish/src/rpc/routes/wallet/rescanAccount.test.ts
+++ b/ironfish/src/rpc/routes/wallet/rescanAccount.test.ts
@@ -149,4 +149,25 @@ describe('Route wallet/rescanAccount', () => {
     expect(updateHead).not.toHaveBeenCalled()
     expect(scanTransactions).toHaveBeenCalledTimes(1)
   })
+
+  it('resets createdAt on accounts on full rescans', async () => {
+    const chain = routeTest.node.chain
+
+    let accountReloaded = routeTest.node.wallet.getAccountByName(account.name)
+    expect(accountReloaded).toBeDefined()
+    expect(accountReloaded?.createdAt?.hash).toEqualHash(chain.genesis.hash)
+
+    jest.spyOn(routeTest.node.wallet, 'scanTransactions').mockReturnValue(Promise.resolve())
+
+    await routeTest.client
+      .request<RescanAccountResponse>('wallet/rescanAccount', {
+        follow: false,
+        full: true,
+      })
+      .waitForEnd()
+
+    accountReloaded = routeTest.node.wallet.getAccountByName(account.name)
+    expect(accountReloaded).toBeDefined()
+    expect(accountReloaded?.createdAt).toBeNull()
+  })
 })

--- a/ironfish/src/rpc/routes/wallet/rescanAccount.ts
+++ b/ironfish/src/rpc/routes/wallet/rescanAccount.ts
@@ -8,13 +8,14 @@ import { ApiNamespace } from '../namespaces'
 import { routes } from '../router'
 import { AssertHasRpcContext } from '../rpcContext'
 
-export type RescanAccountRequest = { follow?: boolean; from?: number }
+export type RescanAccountRequest = { follow?: boolean; from?: number; full?: boolean }
 export type RescanAccountResponse = { sequence: number; startedAt: number; endSequence: number }
 
 export const RescanAccountRequestSchema: yup.ObjectSchema<RescanAccountRequest> = yup
   .object({
     follow: yup.boolean().optional(),
     from: yup.number().optional(),
+    full: yup.boolean().optional(),
   })
   .defined()
 
@@ -43,7 +44,7 @@ routes.register<typeof RescanAccountRequestSchema, RescanAccountResponse>(
         await context.wallet.updateHeadState.abort()
       }
 
-      await context.wallet.reset()
+      await context.wallet.reset({ resetCreatedAt: request.data.full })
 
       let fromHash = undefined
       if (request.data.from && request.data.from > GENESIS_BLOCK_SEQUENCE) {


### PR DESCRIPTION
## Summary

resets account createdAt to null on all accounts if the 'full' option is set on requests to wallet/rescanAccount. this forces rescans for all accounts to start at the genesis block instead of beginning at the account birthday.

adds '--full' flag to wallet:rescan command.

## Testing Plan

- adds unit test
- manual testing: checked account createdAt in JSON export before and after starting a rescan with `wallet:rescan --full`

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
