### PR TITLE
fix(ironfish): Use CLI flag option for encrypted trusted dealer imports

### DIFF
--- a/ironfish/src/rpc/routes/wallet/importAccount.test.ts
+++ b/ironfish/src/rpc/routes/wallet/importAccount.test.ts
@@ -390,13 +390,14 @@ describe('Route wallet/importAccount', () => {
             name: testCaseFile,
           })
 
+          const name = 'new-account-name'
           const response = await routeTest.client.wallet.importAccount({
             account: testCase,
-            name: testCaseFile,
+            name,
           })
 
           expect(response.status).toBe(200)
-          expect(response.content.name).not.toBeNull()
+          expect(response.content.name).toEqual(name)
         }
       })
     })

--- a/ironfish/src/rpc/routes/wallet/importAccount.ts
+++ b/ironfish/src/rpc/routes/wallet/importAccount.ts
@@ -57,6 +57,7 @@ routes.register<typeof ImportAccountRequestSchema, ImportResponse>(
           accountImport = await tryDecodeAccountWithMultisigSecrets(
             context.wallet,
             request.data.account,
+            { name },
           )
         }
 

--- a/ironfish/src/rpc/routes/wallet/utils.ts
+++ b/ironfish/src/rpc/routes/wallet/utils.ts
@@ -284,12 +284,13 @@ export async function serializeRpcAccountStatus(
 export async function tryDecodeAccountWithMultisigSecrets(
   wallet: Wallet,
   value: string,
+  options?: { name?: string },
 ): Promise<AccountImport | undefined> {
   const encoder = new Base64JsonEncoder()
 
   for await (const { name, secret } of wallet.walletDb.getMultisigSecrets()) {
     try {
-      return encoder.decode(value, { name, multisigSecret: secret })
+      return encoder.decode(value, { name: options?.name ?? name, multisigSecret: secret })
     } catch (e: unknown) {
       continue
     }

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -1526,7 +1526,7 @@ export class Wallet {
 
   async importAccount(accountValue: AccountImport): Promise<Account> {
     let multisigKeys = accountValue.multisigKeys
-    let name = accountValue.name
+    const name = accountValue.name
 
     if (
       accountValue.multisigKeys &&
@@ -1539,7 +1539,6 @@ export class Wallet {
         throw new Error('Cannot import identity without a corresponding multisig secret')
       }
 
-      name = multisigSecret.name
       multisigKeys = {
         keyPackage: accountValue.multisigKeys.keyPackage,
         publicKeyPackage: accountValue.multisigKeys.publicKeyPackage,


### PR DESCRIPTION
## Summary

The `--name` flag is ignored when importing public packages from a dealer. This overwrites the secret name if it's provided, otherwise defaults to it.

## Testing Plan

Update a unit test

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
