### PR TITLE
Always honor the `name` parameter passed to `importAccount`

### DIFF
--- a/ironfish/src/rpc/routes/wallet/importAccount.test.ts
+++ b/ironfish/src/rpc/routes/wallet/importAccount.test.ts
@@ -102,6 +102,34 @@ describe('Route wallet/importAccount', () => {
     })
   })
 
+  it('should import a spending account with the specified name', async () => {
+    const key = generateKey()
+
+    const accountName = 'bar'
+    const overriddenAccountName = 'not-bar'
+    const response = await routeTest.client.wallet.importAccount({
+      account: {
+        name: accountName,
+        viewKey: key.viewKey,
+        spendingKey: key.spendingKey,
+        publicAddress: key.publicAddress,
+        incomingViewKey: key.incomingViewKey,
+        outgoingViewKey: key.outgoingViewKey,
+        proofAuthorizingKey: null,
+        version: 1,
+        createdAt: null,
+      },
+      name: overriddenAccountName,
+      rescan: false,
+    })
+
+    expect(response.status).toBe(200)
+    expect(response.content).toMatchObject({
+      name: overriddenAccountName,
+      isDefaultAccount: false, // This is false because the default account is already imported in a previous test
+    })
+  })
+
   describe('import rescanning', () => {
     let nodeClient: RpcClient | null = null
 

--- a/ironfish/src/rpc/routes/wallet/importAccount.ts
+++ b/ironfish/src/rpc/routes/wallet/importAccount.ts
@@ -66,6 +66,9 @@ routes.register<typeof ImportAccountRequestSchema, ImportResponse>(
         }
       } else {
         accountImport = deserializeRpcAccountImport(request.data.account)
+        if (request.data.name) {
+          accountImport.name = request.data.name
+        }
       }
 
       account = await context.wallet.importAccount(accountImport)


### PR DESCRIPTION
## Summary

When calling `importAccount` with an `RpcAccountImport` and a non-undefined `name`, the `name` parameter used to be ignored. This is no longer the case: passing a non-undefined `name` now overrides the name of the `RpcAccountImport`.

## Testing Plan

Unit tests

## Documentation

No doc change required because the current doc (https://ironfish.network/developers/documentation/rpc/wallet/import_account) does not specify any limitations for `name`

## Breaking Change

This is a breaking change because the behavior of calls to `importAccount` using `name` has changed.