### PR TITLE
Rahul/ifl 2471 normalize confirm message in cli in a helper function

### DIFF
--- a/ironfish-cli/src/commands/reset.ts
+++ b/ironfish-cli/src/commands/reset.ts
@@ -13,6 +13,7 @@ import {
   VerboseFlag,
   VerboseFlagKey,
 } from '../flags'
+import { confirmOperation } from '../utils'
 
 export default class Reset extends IronfishCommand {
   static description = 'Reset the node to its initial state'
@@ -60,12 +61,11 @@ export default class Reset extends IronfishCommand {
       networkIdMessage +
       `\n\nAre you sure? (Y)es / (N)o`
 
-    const confirmed = flags.confirm || (await CliUx.ux.confirm(message))
-
-    if (!confirmed) {
-      this.log('Reset aborted.')
-      this.exit(0)
-    }
+    await confirmOperation({
+      confirm: flags.confirm,
+      confirmMessage: message,
+      cancelledMessage: 'Reset aborted.',
+    })
 
     CliUx.ux.action.start('Deleting databases...')
 

--- a/ironfish-cli/src/commands/wallet/burn.ts
+++ b/ironfish-cli/src/commands/wallet/burn.ts
@@ -13,6 +13,7 @@ import {
 import { CliUx, Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { IronFlag, RemoteFlags, ValueFlag } from '../../flags'
+import { confirmOperation } from '../../utils'
 import { selectAsset } from '../../utils/asset'
 import { promptCurrency } from '../../utils/currency'
 import { getExplorer } from '../../utils/explorer'
@@ -207,9 +208,7 @@ export class Burn extends IronfishCommand {
       this.exit(0)
     }
 
-    if (!flags.confirm && !(await this.confirm(assetData, amount, raw.fee, account))) {
-      this.error('Transaction aborted.')
-    }
+    await this.confirm(assetData, amount, raw.fee, account, flags.confirm)
 
     CliUx.ux.action.start('Sending the transaction')
 
@@ -273,13 +272,14 @@ export class Burn extends IronfishCommand {
     amount: bigint,
     fee: bigint,
     account: string,
-  ): Promise<boolean> {
+    confirm?: boolean,
+  ): Promise<void> {
     const renderedAmount = CurrencyUtils.render(amount, true, asset.id, asset.verification)
     const renderedFee = CurrencyUtils.render(fee, true)
-    this.log(
-      `You are about to burn: ${renderedAmount} plus a transaction fee of ${renderedFee} with the account ${account}`,
-    )
 
-    return CliUx.ux.confirm('Do you confirm (Y/N)?')
+    await confirmOperation({
+      confirm,
+      confirmMessage: `You are about to burn: ${renderedAmount} plus a transaction fee of ${renderedFee} with the account ${account}\nDo you confirm(Y/N)?`,
+    })
   }
 }

--- a/ironfish-cli/src/commands/wallet/burn.ts
+++ b/ironfish-cli/src/commands/wallet/burn.ts
@@ -280,6 +280,7 @@ export class Burn extends IronfishCommand {
     await confirmOperation({
       confirm,
       confirmMessage: `You are about to burn: ${renderedAmount} plus a transaction fee of ${renderedFee} with the account ${account}\nDo you confirm(Y/N)?`,
+      cancelledMessage: 'Burn aborted.',
     })
   }
 }

--- a/ironfish-cli/src/commands/wallet/mint.ts
+++ b/ironfish-cli/src/commands/wallet/mint.ts
@@ -386,6 +386,7 @@ export class Mint extends IronfishCommand {
 
     await confirmOperation({
       confirmMessage: confirmMessage.join('\n'),
+      cancelledMessage: 'Mint aborted.',
       confirm,
     })
   }

--- a/ironfish-cli/src/commands/wallet/mint.ts
+++ b/ironfish-cli/src/commands/wallet/mint.ts
@@ -17,6 +17,7 @@ import {
 import { CliUx, Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { IronFlag, RemoteFlags, ValueFlag } from '../../flags'
+import { confirmOperation } from '../../utils'
 import { selectAsset } from '../../utils/asset'
 import { promptCurrency } from '../../utils/currency'
 import { getExplorer } from '../../utils/explorer'
@@ -277,21 +278,17 @@ export class Mint extends IronfishCommand {
       this.exit(0)
     }
 
-    if (
-      !flags.confirm &&
-      !(await this.confirm(
-        account,
-        amount,
-        raw.fee,
-        assetId,
-        name,
-        metadata,
-        flags.transferOwnershipTo,
-        assetData,
-      ))
-    ) {
-      this.error('Transaction aborted.')
-    }
+    await this.confirm(
+      account,
+      amount,
+      raw.fee,
+      assetId,
+      name,
+      metadata,
+      flags.transferOwnershipTo,
+      flags.confirm,
+      assetData,
+    )
 
     CliUx.ux.action.start('Sending the transaction')
 
@@ -359,8 +356,9 @@ export class Mint extends IronfishCommand {
     name?: string,
     metadata?: string,
     transferOwnershipTo?: string,
+    confirm?: boolean,
     assetData?: RpcAsset,
-  ): Promise<boolean> {
+  ): Promise<void> {
     const nameString = name ? `\nName: ${name}` : ''
     const metadataString = metadata ? `\nMetadata: ${metadata}` : ''
 
@@ -372,18 +370,23 @@ export class Mint extends IronfishCommand {
     )
     const renderedFee = CurrencyUtils.render(fee, true)
 
-    this.log(
+    const confirmMessage = [
       `You are about to mint an asset with the account ${account}:${nameString}${metadataString}`,
-    )
-    this.log(`Amount: ${renderedAmount}`)
-    this.log(`Fee: ${renderedFee}`)
+      `Amount: ${renderedAmount}`,
+      `Fee: ${renderedFee}`,
+    ]
 
     if (transferOwnershipTo) {
-      this.log(
+      confirmMessage.push(
         `Ownership of this asset will be transferred to ${transferOwnershipTo}. The current account will no longer have any permission to mint or modify this asset. This cannot be undone.`,
       )
     }
 
-    return CliUx.ux.confirm('Do you confirm (Y/N)?')
+    confirmMessage.push('Do you confirm (Y/N)?')
+
+    await confirmOperation({
+      confirmMessage: confirmMessage.join('\n'),
+      confirm,
+    })
   }
 }

--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -329,6 +329,7 @@ export class CombineNotesCommand extends IronfishCommand {
 
     await confirmOperation({
       confirm: flags.confirm,
+      cancelledMessage: 'Combine aborted.',
     })
 
     transactionTimer.start()

--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -16,6 +16,7 @@ import { CliUx, Flags } from '@oclif/core'
 import inquirer from 'inquirer'
 import { IronfishCommand } from '../../../command'
 import { IronFlag, RemoteFlags } from '../../../flags'
+import { confirmOperation } from '../../../utils'
 import { getExplorer } from '../../../utils/explorer'
 import { selectFee } from '../../../utils/fees'
 import { fetchNotes } from '../../../utils/note'
@@ -326,12 +327,9 @@ export class CombineNotesCommand extends IronfishCommand {
       })}`,
     )
 
-    if (!flags.confirm) {
-      const confirmed = await CliUx.ux.confirm('Do you confirm (Y/N)?')
-      if (!confirmed) {
-        this.error('Transaction aborted.')
-      }
-    }
+    await confirmOperation({
+      confirm: flags.confirm,
+    })
 
     transactionTimer.start()
 

--- a/ironfish-cli/src/commands/wallet/send.ts
+++ b/ironfish-cli/src/commands/wallet/send.ts
@@ -14,6 +14,7 @@ import {
 import { CliUx, Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { HexFlag, IronFlag, RemoteFlags, ValueFlag } from '../../flags'
+import { confirmOperation } from '../../utils'
 import { selectAsset } from '../../utils/asset'
 import { promptCurrency } from '../../utils/currency'
 import { getExplorer } from '../../utils/explorer'
@@ -280,12 +281,9 @@ export class Send extends IronfishCommand {
       )
     }
 
-    if (!flags.confirm) {
-      const confirmed = await CliUx.ux.confirm('Do you confirm (Y/N)?')
-      if (!confirmed) {
-        this.error('Transaction aborted.')
-      }
-    }
+    await confirmOperation({
+      confirm: flags.confirm,
+    })
 
     transactionTimer.start()
 

--- a/ironfish-cli/src/commands/wallet/send.ts
+++ b/ironfish-cli/src/commands/wallet/send.ts
@@ -283,6 +283,7 @@ export class Send extends IronfishCommand {
 
     await confirmOperation({
       confirm: flags.confirm,
+      cancelledMessage: 'Transaction aborted.',
     })
 
     transactionTimer.start()

--- a/ironfish-cli/src/utils/confirm.ts
+++ b/ironfish-cli/src/utils/confirm.ts
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { CliUx } from '@oclif/core'
+
+export const confirmOperation = async (options: {
+  confirmMessage?: string
+  cancelledMessage?: string
+  confirm?: boolean
+}) => {
+  const { confirmMessage, cancelledMessage, confirm } = options
+
+  if (confirm) {
+    return true
+  }
+
+  const confirmed = await CliUx.ux.confirm(confirmMessage || 'Do you confirm (Y/N)?')
+
+  if (!confirmed) {
+    CliUx.ux.log(cancelledMessage || 'Operation aborted.')
+    CliUx.ux.exit(0)
+  }
+}

--- a/ironfish-cli/src/utils/index.ts
+++ b/ironfish-cli/src/utils/index.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 export * from './asset'
+export * from './confirm'
 export * from './editor'
 export * from './platform'
 export * from './rpc'


### PR DESCRIPTION
## Summary

Closes https://linear.app/if-labs/issue/IFL-2471/normalize-confirm-message-in-cli-in-a-helper-function 

Adds a standardize confirmation helper function for our CLI 

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
