### PR TITLE
support json file input to dkg commands

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/dkg/round2.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/round2.ts
@@ -5,6 +5,7 @@ import { CliUx, Flags } from '@oclif/core'
 import { IronfishCommand } from '../../../../command'
 import { RemoteFlags } from '../../../../flags'
 import { longPrompt } from '../../../../utils/longPrompt'
+import { MultisigDkgJson } from '../../../../utils/multisig'
 
 export class DkgRound2Command extends IronfishCommand {
   static description = 'Perform round2 of the DKG protocol for multisig account creation'
@@ -17,24 +18,30 @@ export class DkgRound2Command extends IronfishCommand {
       description: 'The name of the secret to use for encryption during DKG',
       required: true,
     }),
-    encryptedSecretPackage: Flags.string({
+    round1SecretPackage: Flags.string({
       char: 'e',
       description: 'The ecrypted secret package created during DKG round1',
     }),
-    publicPackage: Flags.string({
+    round1PublicPackage: Flags.string({
       char: 'p',
       description:
         'The public package that a participant generated during DKG round1 (may be specified multiple times for multiple participants). Must include your own round1 public package',
       multiple: true,
+    }),
+    path: Flags.string({
+      description: 'Path to a JSON file containing DKG data',
     }),
   }
 
   async start(): Promise<void> {
     const { flags } = await this.parse(DkgRound2Command)
 
-    let encryptedSecretPackage = flags.encryptedSecretPackage
-    if (!encryptedSecretPackage) {
-      encryptedSecretPackage = await CliUx.ux.prompt(
+    const loaded = await MultisigDkgJson.load(this.sdk.fileSystem, flags.path)
+    const options = MultisigDkgJson.resolveFlags(flags, loaded)
+
+    let round1SecretPackage = options.round1SecretPackage
+    if (!round1SecretPackage) {
+      round1SecretPackage = await CliUx.ux.prompt(
         `Enter the encrypted secret package for secret ${flags.secretName}`,
         {
           required: true,
@@ -42,30 +49,30 @@ export class DkgRound2Command extends IronfishCommand {
       )
     }
 
-    let publicPackages = flags.publicPackage
-    if (!publicPackages || publicPackages.length < 2) {
+    let round1PublicPackages = options.round1PublicPackage
+    if (!round1PublicPackages || round1PublicPackages.length < 2) {
       const input = await longPrompt(
         'Enter public packages separated by commas, one for each participant',
         {
           required: true,
         },
       )
-      publicPackages = input.split(',')
+      round1PublicPackages = input.split(',')
 
-      if (publicPackages.length < 2) {
+      if (round1PublicPackages.length < 2) {
         this.error(
           'Must include a public package for each participant; at least 2 participants required',
         )
       }
     }
-    publicPackages = publicPackages.map((i) => i.trim())
+    round1PublicPackages = round1PublicPackages.map((i) => i.trim())
 
     const client = await this.sdk.connectRpc()
 
     const response = await client.wallet.multisig.dkg.round2({
       secretName: flags.secretName,
-      encryptedSecretPackage,
-      publicPackages,
+      encryptedSecretPackage: round1SecretPackage,
+      publicPackages: round1PublicPackages,
     })
 
     this.log('\nEncrypted Secret Package:\n')

--- a/ironfish-cli/src/utils/multisig.ts
+++ b/ironfish-cli/src/utils/multisig.ts
@@ -24,47 +24,91 @@ export const MultisigTransactionOptionsSchema: yup.ObjectSchema<
   })
   .defined()
 
-async function load(
-  files: FileSystem,
-  path?: string,
-): Promise<Partial<MultisigTransactionOptions>> {
-  if (path === undefined) {
-    return {}
+export abstract class MultisigTransactionJson {
+  static async load(
+    files: FileSystem,
+    path?: string,
+  ): Promise<Partial<MultisigTransactionOptions>> {
+    if (path === undefined) {
+      return {}
+    }
+
+    const data = (await files.readFile(files.resolve(path))).trim()
+
+    const { error, result } = await YupUtils.tryValidate(MultisigTransactionOptionsSchema, data)
+
+    if (error) {
+      throw error
+    }
+
+    return result
   }
 
-  const data = (await files.readFile(files.resolve(path))).trim()
-
-  const { error, result } = await YupUtils.tryValidate(MultisigTransactionOptionsSchema, data)
-
-  if (error) {
-    throw error
-  }
-
-  return result
-}
-
-type MultisigTransactionFlags = {
-  identity?: string[]
-  unsignedTransaction?: string
-  commitment?: string[]
-  signingPackage?: string
-  signatureShare?: string[]
-}
-
-function resolveFlags(
-  flags: MultisigTransactionFlags,
-  json: Partial<MultisigTransactionOptions>,
-): Partial<MultisigTransactionOptions> {
-  return {
-    identity: flags.identity ?? json.identity,
-    unsignedTransaction: flags.unsignedTransaction?.trim() ?? json.unsignedTransaction,
-    commitment: flags.commitment ?? json.commitment,
-    signingPackage: flags.signingPackage?.trim() ?? json.signingPackage,
-    signatureShare: flags.signatureShare ?? json.signatureShare,
+  static resolveFlags(
+    flags: Partial<MultisigTransactionOptions>,
+    json: Partial<MultisigTransactionOptions>,
+  ): Partial<MultisigTransactionOptions> {
+    return {
+      identity: flags.identity ?? json.identity,
+      unsignedTransaction: flags.unsignedTransaction?.trim() ?? json.unsignedTransaction,
+      commitment: flags.commitment ?? json.commitment,
+      signingPackage: flags.signingPackage?.trim() ?? json.signingPackage,
+      signatureShare: flags.signatureShare ?? json.signatureShare,
+    }
   }
 }
 
-export const MultisigTransactionJson = {
-  load,
-  resolveFlags,
+export type MultisigDkgOptions = {
+  secretName: string
+  identity: string[]
+  minSigners: number
+  round1SecretPackage: string
+  round1PublicPackage: string[]
+  round2SecretPackage: string
+  round2PublicPackage: string[]
+}
+
+export const MultisigDkgOptionsSchema: yup.ObjectSchema<Partial<MultisigDkgOptions>> = yup
+  .object({
+    secretName: yup.string(),
+    identity: yup.array().of(yup.string().defined()),
+    minSigners: yup.number(),
+    round1SecretPackage: yup.string(),
+    round1PublicPackage: yup.array().of(yup.string().defined()),
+    round2SecretPackage: yup.string(),
+    round2PublicPackage: yup.array().of(yup.string().defined()),
+  })
+  .defined()
+
+export abstract class MultisigDkgJson {
+  static async load(files: FileSystem, path?: string): Promise<Partial<MultisigDkgOptions>> {
+    if (path === undefined) {
+      return {}
+    }
+
+    const data = (await files.readFile(files.resolve(path))).trim()
+
+    const { error, result } = await YupUtils.tryValidate(MultisigDkgOptionsSchema, data)
+
+    if (error) {
+      throw error
+    }
+
+    return result
+  }
+
+  static resolveFlags(
+    flags: Partial<MultisigDkgOptions>,
+    json: Partial<MultisigDkgOptions>,
+  ): Partial<MultisigDkgOptions> {
+    return {
+      secretName: flags.secretName ?? json.secretName,
+      identity: flags.identity ?? json.identity,
+      minSigners: flags.minSigners ?? json.minSigners,
+      round1SecretPackage: flags.round1SecretPackage ?? json.round1SecretPackage,
+      round1PublicPackage: flags.round1PublicPackage ?? json.round1PublicPackage,
+      round2SecretPackage: flags.round2SecretPackage ?? json.round2SecretPackage,
+      round2PublicPackage: flags.round2PublicPackage ?? json.round2PublicPackage,
+    }
+  }
 }


### PR DESCRIPTION
## Summary

allows users to run dkg commands with a '--path' flag referencing a json file that contains the packages needed for each command

defines MultisigDkgJson abstract class for loading json file and resolving command options against command flags

additional changes:
- converts MultisigTransactionJson to abstract class
- changes dkg command flags to be uniform across round2 and round3 (e.g., 'round1SecretPackage' instead of 'encryptedSecretPackage' in round2)

## Testing Plan

manual testing with dkg cli commands

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
