### PR TITLE
feat(cli,ironfish): Add flag to override name in round3

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/dkg/round3.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/round3.ts
@@ -17,7 +17,7 @@ export class DkgRound3Command extends IronfishCommand {
       description: 'The name of the secret to use for decryption during DKG',
       required: true,
     }),
-    name: Flags.string({
+    accountName: Flags.string({
       char: 'n',
       description: 'The name to set for the imported account',
     }),
@@ -92,7 +92,7 @@ export class DkgRound3Command extends IronfishCommand {
 
     const response = await client.wallet.multisig.dkg.round3({
       secretName: flags.secretName,
-      accountName: flags.name,
+      accountName: flags.accountName,
       round2SecretPackage,
       round1PublicPackages,
       round2PublicPackages,

--- a/ironfish-cli/src/commands/wallet/multisig/dkg/round3.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/round3.ts
@@ -92,7 +92,7 @@ export class DkgRound3Command extends IronfishCommand {
 
     const response = await client.wallet.multisig.dkg.round3({
       secretName: flags.secretName,
-      name: flags.name,
+      accountName: flags.name,
       round2SecretPackage,
       round1PublicPackages,
       round2PublicPackages,

--- a/ironfish-cli/src/commands/wallet/multisig/dkg/round3.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/round3.ts
@@ -17,6 +17,10 @@ export class DkgRound3Command extends IronfishCommand {
       description: 'The name of the secret to use for decryption during DKG',
       required: true,
     }),
+    name: Flags.string({
+      char: 'n',
+      description: 'The name to set for the imported account',
+    }),
     round2SecretPackage: Flags.string({
       char: 'e',
       description: 'The encrypted secret package created during DKG round2',
@@ -88,6 +92,7 @@ export class DkgRound3Command extends IronfishCommand {
 
     const response = await client.wallet.multisig.dkg.round3({
       secretName: flags.secretName,
+      name: flags.name,
       round2SecretPackage,
       round1PublicPackages,
       round2PublicPackages,

--- a/ironfish/src/rpc/routes/wallet/multisig/dkg/round3.test.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/dkg/round3.test.ts
@@ -59,7 +59,7 @@ describe('Route multisig/dkg/round3', () => {
       secretNames.map((secretName, index) =>
         routeTest.client.wallet.multisig.dkg.round3({
           secretName,
-          name: secretNamesToName[secretName],
+          accountName: secretNamesToName[secretName],
           round2SecretPackage: round2Packages[index].content.encryptedSecretPackage,
           round1PublicPackages: round1Packages.map((pkg) => pkg.content.publicPackage),
           round2PublicPackages: round2Packages.flatMap((pkg) =>

--- a/ironfish/src/rpc/routes/wallet/multisig/dkg/round3.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/dkg/round3.ts
@@ -15,7 +15,7 @@ export type DkgRound3Request = {
   round2SecretPackage: string
   round1PublicPackages: Array<string>
   round2PublicPackages: Array<string>
-  name?: string
+  accountName?: string
 }
 
 export type DkgRound3Response = {
@@ -29,7 +29,7 @@ export const DkgRound3RequestSchema: yup.ObjectSchema<DkgRound3Request> = yup
     round2SecretPackage: yup.string().defined(),
     round1PublicPackages: yup.array().of(yup.string().defined()).defined(),
     round2PublicPackages: yup.array().of(yup.string().defined()).defined(),
-    name: yup.string().optional(),
+    accountName: yup.string().optional(),
   })
   .defined()
 
@@ -76,7 +76,7 @@ routes.register<typeof DkgRound3RequestSchema, DkgRound3Response>(
     )
 
     const accountImport = {
-      name: request.data.name ?? secretName,
+      name: request.data.accountName ?? secretName,
       version: ACCOUNT_SCHEMA_VERSION,
       createdAt: null,
       spendingKey: null,

--- a/ironfish/src/rpc/routes/wallet/multisig/dkg/round3.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/dkg/round3.ts
@@ -15,6 +15,7 @@ export type DkgRound3Request = {
   round2SecretPackage: string
   round1PublicPackages: Array<string>
   round2PublicPackages: Array<string>
+  name?: string
 }
 
 export type DkgRound3Response = {
@@ -28,6 +29,7 @@ export const DkgRound3RequestSchema: yup.ObjectSchema<DkgRound3Request> = yup
     round2SecretPackage: yup.string().defined(),
     round1PublicPackages: yup.array().of(yup.string().defined()).defined(),
     round2PublicPackages: yup.array().of(yup.string().defined()).defined(),
+    name: yup.string().optional(),
   })
   .defined()
 
@@ -74,7 +76,7 @@ routes.register<typeof DkgRound3RequestSchema, DkgRound3Response>(
     )
 
     const accountImport = {
-      name: secretName,
+      name: request.data.name ?? secretName,
       version: ACCOUNT_SCHEMA_VERSION,
       createdAt: null,
       spendingKey: null,


### PR DESCRIPTION
## Summary

Allow an override of the secret name for the account name during round 3

## Testing Plan

Updated unit test

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
