### PR TITLE
Show the correct decimal amount in wallet:transactions command

### DIFF
--- a/ironfish-cli/src/commands/wallet/transactions.ts
+++ b/ironfish-cli/src/commands/wallet/transactions.ts
@@ -155,23 +155,24 @@ export class TransactionsCommand extends IronfishCommand {
 
       const group = this.getRowGroup(index, assetCount, transactionRows.length)
 
+      const transactionRow = {
+        group,
+        assetId,
+        assetName: asset.name,
+        amount,
+        assetDecimals: asset.verification.decimals,
+        assetSymbol: asset.verification.symbol,
+      }
+
       // include full transaction details in first row or non-cli-formatted output
       if (transactionRows.length === 0 || format !== Format.cli) {
         transactionRows.push({
           ...transaction,
-          group,
-          assetId,
-          assetName: asset.name,
-          amount,
+          ...transactionRow,
           feePaid,
         })
       } else {
-        transactionRows.push({
-          group,
-          assetId,
-          assetName: asset.name,
-          amount,
-        })
+        transactionRows.push(transactionRow)
       }
     }
 


### PR DESCRIPTION
## Summary
The `wallet:transactions` command was not accounting for asset decimals when showing amounts

## Testing Plan
Tested running locally on devnet

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
