### PR TITLE
adds raw transaction flag to combine notes

### DIFF
--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -326,7 +326,7 @@ export class CombineNotesCommand extends IronfishCommand {
 
     if (flags.rawTransaction) {
       this.log('Raw Transaction')
-      this.log(RawTransactionSerde.serialize(raw).toString('hex'))
+      this.log(createTransactionBytes.toString('hex'))
       this.log(`Run "ironfish wallet:post" to post the raw transaction. `)
       this.exit(0)
     }

--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -76,6 +76,11 @@ export class CombineNotesCommand extends IronfishCommand {
       default: false,
       description: 'Force run the benchmark to measure the time to combine 1 note',
     }),
+    rawTransaction: Flags.boolean({
+      default: false,
+      description:
+        'Return raw transaction. Use it to create a transaction but not post to the network',
+    }),
   }
 
   private async selectNotesToCombine(spendPostTimeMs: number): Promise<number> {
@@ -318,6 +323,13 @@ export class CombineNotesCommand extends IronfishCommand {
     ).content
 
     displayTransactionSummary(raw, assetData, amount, from, to, memo)
+
+    if (flags.rawTransaction) {
+      this.log('Raw Transaction')
+      this.log(RawTransactionSerde.serialize(raw).toString('hex'))
+      this.log(`Run "ironfish wallet:post" to post the raw transaction. `)
+      this.exit(0)
+    }
 
     const transactionTimer = new TransactionTimer(spendPostTime, raw)
 


### PR DESCRIPTION
## Summary

Adds raw transaction flag to notes:combine

Usecase: Create a transaction and post it separately using `wallet:post`. This is a common pattern we use with with other transaction types as well

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
