### PR TITLE
select secret name from list in dkg commands

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/dkg/round1.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/round1.ts
@@ -36,7 +36,7 @@ export class DkgRound1Command extends IronfishCommand {
 
     let secretName = flags.secretName
     if (!secretName) {
-      secretName = await selectSecret(client, { allowCreateNew: true })
+      secretName = await selectSecret(client)
     }
 
     let identities = flags.identity

--- a/ironfish-cli/src/commands/wallet/multisig/dkg/round1.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/round1.ts
@@ -5,6 +5,7 @@ import { CliUx, Flags } from '@oclif/core'
 import { IronfishCommand } from '../../../../command'
 import { RemoteFlags } from '../../../../flags'
 import { longPrompt } from '../../../../utils/longPrompt'
+import { selectSecret } from '../../../../utils/multisig'
 
 export class DkgRound1Command extends IronfishCommand {
   static description = 'Perform round1 of the DKG protocol for multisig account creation'
@@ -31,11 +32,11 @@ export class DkgRound1Command extends IronfishCommand {
   async start(): Promise<void> {
     const { flags } = await this.parse(DkgRound1Command)
 
+    const client = await this.sdk.connectRpc()
+
     let secretName = flags.secretName
     if (!secretName) {
-      secretName = await CliUx.ux.prompt('Enter the name of the secret to use', {
-        required: true,
-      })
+      secretName = await selectSecret(client, { allowCreateNew: true })
     }
 
     let identities = flags.identity
@@ -61,8 +62,6 @@ export class DkgRound1Command extends IronfishCommand {
         this.error('Minimum number of signers must be at least 2')
       }
     }
-
-    const client = await this.sdk.connectRpc()
 
     const response = await client.wallet.multisig.dkg.round1({
       secretName: secretName,

--- a/ironfish-cli/src/utils/multisig.ts
+++ b/ironfish-cli/src/utils/multisig.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { FileSystem, RpcClient, YupUtils } from '@ironfish/sdk'
-import { CliUx } from '@oclif/core'
 import inquirer from 'inquirer'
 import * as yup from 'yup'
 
@@ -71,10 +70,7 @@ export const MultisigTransactionJson = {
   resolveFlags,
 }
 
-export async function selectSecret(
-  client: Pick<RpcClient, 'wallet'>,
-  options?: { allowCreateNew?: boolean },
-): Promise<string> {
+export async function selectSecret(client: Pick<RpcClient, 'wallet'>): Promise<string> {
   const identitiesResponse = await client.wallet.multisig.getIdentities()
 
   const choices = []
@@ -87,14 +83,6 @@ export async function selectSecret(
 
   choices.sort((a, b) => a.name.localeCompare(b.name))
 
-  const createNewLabel = '[create new secret]'
-  if (options?.allowCreateNew) {
-    choices.push({
-      name: createNewLabel,
-      value: createNewLabel,
-    })
-  }
-
   const selection = await inquirer.prompt<{
     name: string
   }>([
@@ -106,14 +94,5 @@ export async function selectSecret(
     },
   ])
 
-  if (selection.name === createNewLabel) {
-    const name = await CliUx.ux.prompt('Enter a name for the new participant secret', {
-      required: true,
-    })
-
-    await client.wallet.multisig.createParticipant({ name })
-    return name
-  } else {
-    return selection.name
-  }
+  return selection.name
 }


### PR DESCRIPTION
## Summary

if no secretName is passed via flags allow the user to select one of their existing names from a list

in round1 allow users to create a new secret name from the list

makes it easier for users to know which secret names they have and can use in the context of the dkg commands. allows users to start the dkg process without running the participant:create command first

## Testing Plan

manual testing with dkg commands

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
