### PR TITLE
Multisig DKG Round 3: add an option to rescan the imported account

### DIFF
--- a/ironfish/src/rpc/routes/wallet/multisig/dkg/round3.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/dkg/round3.ts
@@ -16,6 +16,7 @@ export type DkgRound3Request = {
   round1PublicPackages: Array<string>
   round2PublicPackages: Array<string>
   accountName?: string
+  rescan?: boolean
 }
 
 export type DkgRound3Response = {
@@ -30,6 +31,7 @@ export const DkgRound3RequestSchema: yup.ObjectSchema<DkgRound3Request> = yup
     round1PublicPackages: yup.array().of(yup.string().defined()).defined(),
     round2PublicPackages: yup.array().of(yup.string().defined()).defined(),
     accountName: yup.string().optional(),
+    rescan: yup.boolean().optional().default(false),
   })
   .defined()
 
@@ -94,7 +96,13 @@ routes.register<typeof DkgRound3RequestSchema, DkgRound3Response>(
 
     const account = await node.wallet.importAccount(accountImport)
 
-    // TODO: add an option to skip rescan
+    if (request.data.rescan) {
+      if (node.wallet.nodeClient) {
+        void node.wallet.scanTransactions(undefined, true)
+      }
+    } else {
+      await node.wallet.skipRescan(account)
+    }
 
     request.end({
       name: account.name,


### PR DESCRIPTION
## Summary

This adds a new `--rescan` option to force the rescan of the account created during round 3. It also properly handles the case where `--rescan` is not provided by calling `skipRescan()`.

**NOTE:** This behavior differs from the "standard" `importAccount` command, which triggers a rescan by default. The reason for defaulting to no rescan is that it should be a rare event (although not impossible) to have a newly created DKG account that has transactions associated to it.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
