### PR TITLE
Multisig: fetch participant identities from the public key package

### DIFF
--- a/ironfish/src/rpc/routes/wallet/multisig/createSignatureShare.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/createSignatureShare.ts
@@ -4,7 +4,6 @@
 import { multisig } from '@ironfish/rust-nodejs'
 import { BufferSet } from 'buffer-map'
 import * as yup from 'yup'
-import { AsyncUtils } from '../../../../utils'
 import { AssertMultisigSigner } from '../../../../wallet'
 import { RpcValidationError } from '../../../adapters'
 import { ApiNamespace } from '../../namespaces'
@@ -39,7 +38,7 @@ export const CreateSignatureShareResponseSchema: yup.ObjectSchema<CreateSignatur
 routes.register<typeof CreateSignatureShareRequestSchema, CreateSignatureShareResponse>(
   `${ApiNamespace.wallet}/multisig/createSignatureShare`,
   CreateSignatureShareRequestSchema,
-  async (request, node): Promise<void> => {
+  (request, node) => {
     AssertHasRpcContext(request, node, 'wallet')
 
     const account = getAccount(node.wallet, request.data.account)
@@ -49,10 +48,7 @@ routes.register<typeof CreateSignatureShareRequestSchema, CreateSignatureShareRe
       Buffer.from(request.data.signingPackage, 'hex'),
     )
 
-    const participantIdentities = new BufferSet(
-      await AsyncUtils.materialize(node.wallet.walletDb.getParticipantIdentities(account)),
-    )
-
+    const participantIdentities = new BufferSet(account.getMultisigParticipantIdentities())
     for (const signer of signingPackage.signers()) {
       if (!participantIdentities.has(signer)) {
         throw new RpcValidationError(

--- a/ironfish/src/rpc/routes/wallet/multisig/getAccountIdentities.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/getAccountIdentities.ts
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { multisig } from '@ironfish/rust-nodejs'
 import * as yup from 'yup'
 import { AssertMultisig } from '../../../../wallet'
 import { ApiNamespace } from '../../namespaces'
@@ -39,10 +38,9 @@ routes.register<typeof GetAccountIdentitiesRequestSchema, GetAccountIdentitiesRe
     const account = getAccount(context.wallet, request.data.account)
     AssertMultisig(account)
 
-    const publicKeyPackage = new multisig.PublicKeyPackage(
-      account.multisigKeys.publicKeyPackage,
-    )
-    const identities = publicKeyPackage.identities().map((identity) => identity.toString('hex'))
+    const identities = account
+      .getMultisigParticipantIdentities()
+      .map((identity) => identity.toString('hex'))
 
     request.end({ identities })
   },

--- a/ironfish/src/wallet/account/account.ts
+++ b/ironfish/src/wallet/account/account.ts
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { multisig } from '@ironfish/rust-nodejs'
 import { Asset } from '@ironfish/rust-nodejs'
 import { BufferMap, BufferSet } from 'buffer-map'
 import MurmurHash3 from 'imurmurhash'
@@ -1281,6 +1282,12 @@ export class Account {
     }
 
     return notes
+  }
+
+  getMultisigParticipantIdentities(): Array<Buffer> {
+    AssertMultisig(this)
+    const publicKeyPackage = new multisig.PublicKeyPackage(this.multisigKeys.publicKeyPackage)
+    return publicKeyPackage.identities()
   }
 }
 

--- a/ironfish/src/wallet/wallet.test.slow.ts
+++ b/ironfish/src/wallet/wallet.test.slow.ts
@@ -1362,11 +1362,7 @@ describe('Wallet', () => {
       ...trustedDealerPackage,
     })
 
-    const storedIdentities: string[] = []
-    for await (const identity of node.wallet.walletDb.getParticipantIdentities(account)) {
-      storedIdentities.push(identity.toString('hex'))
-    }
-
+    const storedIdentities = account.getMultisigParticipantIdentities()
     expect(identities.sort()).toEqual(storedIdentities.sort())
   })
 })

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -1640,16 +1640,6 @@ export class Wallet {
       } else {
         await account.updateHead(null, tx)
       }
-
-      if (account.multisigKeys) {
-        const publicKeyPackage = new multisig.PublicKeyPackage(
-          account.multisigKeys.publicKeyPackage,
-        )
-
-        for (const identity of publicKeyPackage.identities()) {
-          await this.walletDb.addParticipantIdentity(account, identity, tx)
-        }
-      }
     })
 
     this.accounts.set(account.id, account)

--- a/ironfish/src/wallet/walletdb/walletdb.test.ts
+++ b/ironfish/src/wallet/walletdb/walletdb.test.ts
@@ -410,24 +410,4 @@ describe('WalletDB', () => {
       expect(storedSecret.secret).toEqualBuffer(serializedSecret)
     })
   })
-
-  describe('participantIdentities', () => {
-    it('should store participant identities for a multisig account', async () => {
-      const node = (await nodeTest.createSetup()).node
-      const walletDb = node.wallet.walletDb
-
-      const account = await useAccountFixture(node.wallet, 'multisig')
-
-      const identity = multisig.ParticipantSecret.random().toIdentity()
-
-      await walletDb.addParticipantIdentity(account, identity.serialize())
-
-      const storedIdentities = await AsyncUtils.materialize(
-        walletDb.getParticipantIdentities(account),
-      )
-
-      expect(storedIdentities.length).toEqual(1)
-      expect(storedIdentities[0]).toEqualBuffer(identity.serialize())
-    })
-  })
 })

--- a/ironfish/src/wallet/walletdb/walletdb.ts
+++ b/ironfish/src/wallet/walletdb/walletdb.ts
@@ -1297,32 +1297,4 @@ export class WalletDB {
       yield value
     }
   }
-
-  async addParticipantIdentity(
-    account: Account,
-    identity: Buffer,
-    tx?: IDatabaseTransaction,
-  ): Promise<void> {
-    await this.participantIdentities.put([account.prefix, identity], { identity }, tx)
-  }
-
-  async deleteParticipantIdentity(
-    account: Account,
-    identity: Buffer,
-    tx?: IDatabaseTransaction,
-  ): Promise<void> {
-    await this.participantIdentities.del([account.prefix, identity], tx)
-  }
-
-  async *getParticipantIdentities(
-    account: Account,
-    tx?: IDatabaseTransaction,
-  ): AsyncGenerator<Buffer> {
-    for await (const [_, identity] of this.participantIdentities.getAllKeysIter(
-      tx,
-      account.prefixRange,
-    )) {
-      yield identity
-    }
-  }
 }


### PR DESCRIPTION
## Summary

When importing a multisig account, participant identities are stored in two places:

1. the public key package (part of the account record in the walletdb)
2. on dedicated records in the walletdb

The \#2 records can sometimes get lost. This is the case currently of account rescans.

Because there is no future development scheduled that will benefit from #2, it's easier to just ignore those records and instead rely only on the public key package.

## Testing Plan

Unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
