### PR TITLE
removes 'next step' from participant:create output

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/participant/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/participant/create.ts
@@ -49,9 +49,5 @@ export class MultisigIdentityCreate extends IronfishCommand {
 
     this.log('Identity:')
     this.log(response.content.identity)
-
-    this.log()
-    this.log('Next step:')
-    this.log('Send the identity to the multisig account dealer.')
   }
 }


### PR DESCRIPTION
## Summary

the next step instruction refers to the dealer in trusted dealer keygen, so it doesn't always apply now that we support dkg

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
