### PR TITLE
Fix `wallet.test.slow.ts` and `round3.test.ts`

### DIFF
--- a/ironfish/src/rpc/routes/wallet/multisig/dkg/round3.test.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/dkg/round3.test.ts
@@ -3,7 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Assert } from '../../../../../assert'
 import { createRouteTest } from '../../../../../testUtilities/routeTest'
-import { AsyncUtils } from '../../../../../utils'
 
 function removeOneElement<T>(array: Array<T>): Array<T> {
   const newArray = [...array]
@@ -93,17 +92,14 @@ describe('Route multisig/dkg/round3', () => {
 
     // Check that the imported accounts all know about other participants'
     // identities
-    const expectedIdentities = participants.map(({ identity }) => identity)
-    expectedIdentities.sort()
+    const expectedIdentities = participants.map(({ identity }) => identity).sort()
     for (const accountName of accountNames) {
       const account = routeTest.wallet.getAccountByName(accountName)
       Assert.isNotNull(account)
-      const knownIdentities = (
-        await AsyncUtils.materialize(
-          routeTest.wallet.walletDb.getParticipantIdentities(account),
-        )
-      ).map((identity) => identity.toString('hex'))
-      knownIdentities.sort()
+      const knownIdentities = account
+        .getMultisigParticipantIdentities()
+        .map((identity) => identity.toString('hex'))
+        .sort()
       expect(knownIdentities).toStrictEqual(expectedIdentities)
     }
   })

--- a/ironfish/src/wallet/wallet.test.slow.ts
+++ b/ironfish/src/wallet/wallet.test.slow.ts
@@ -1362,7 +1362,9 @@ describe('Wallet', () => {
       ...trustedDealerPackage,
     })
 
-    const storedIdentities = account.getMultisigParticipantIdentities()
+    const storedIdentities = account
+      .getMultisigParticipantIdentities()
+      .map((identity) => identity.toString('hex'))
     expect(identities.sort()).toEqual(storedIdentities.sort())
   })
 })


### PR DESCRIPTION
## Summary
    
`wallet.test.slow.ts` was broken by 4ab45df0, which inadvertently removed a type conversion step in the test.

`round3.test.ts` was broken by merging 17b9d680 on top of 4ab45df0 without proper rebasing.

## Testing Plan

Unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
