### PR TITLE
Multisig DKG: use the round 2 "combined" public packages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1493,7 +1493,7 @@ dependencies = [
 [[package]]
 name = "ironfish-frost"
 version = "0.1.0"
-source = "git+https://github.com/iron-fish/ironfish-frost.git?branch=main#e432d1fc6f466b19cb01231ff20443d9bcb182a5"
+source = "git+https://github.com/iron-fish/ironfish-frost.git?branch=main#d2b082e3cd25d12073c1b113da941960c08fcb32"
 dependencies = [
  "blake3",
  "chacha20 0.9.1",

--- a/ironfish-cli/src/commands/wallet/multisig/dkg/round2.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/round2.ts
@@ -77,17 +77,12 @@ export class DkgRound2Command extends IronfishCommand {
     this.log(response.content.encryptedSecretPackage)
     this.log()
 
-    this.log('\nPublic Packages:\n')
-    for (const { recipientIdentity, publicPackage } of response.content.publicPackages) {
-      this.log('Recipient Identity')
-      this.log(recipientIdentity)
-      this.log('----------------')
-      this.log(publicPackage)
-      this.log()
-    }
+    this.log('\nPublic Package:\n')
+    this.log(response.content.publicPackages)
+    this.log()
 
     this.log()
     this.log('Next step:')
-    this.log('Send each public package to the participant with the matching identity')
+    this.log('Send the public package to each participant')
   }
 }

--- a/ironfish-cli/src/commands/wallet/multisig/dkg/round3.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/round3.ts
@@ -87,9 +87,16 @@ export class DkgRound3Command extends IronfishCommand {
       )
       round2PublicPackages = input.split(',')
 
-      if (round2PublicPackages.length !== round1PublicPackages.length - 1) {
+      // Our own public package is optional in this step (if provided, it will
+      // be ignored), so we can accept both `n` and `n-1` packages
+      if (
+        round2PublicPackages.length < round1PublicPackages.length - 1 ||
+        round2PublicPackages.length > round1PublicPackages.length
+      ) {
+        // Suggest to provide `n-1` packages; don't mention the `n` case to
+        // avoid making the error message too hard to decipher.
         this.error(
-          'The number of round 2 public packages must be 1 less than the number of round 1 public packages',
+          'The number of round 2 public packages should be 1 less than the number of round 1 public packages',
         )
       }
     }

--- a/ironfish-rust-nodejs/index.d.ts
+++ b/ironfish-rust-nodejs/index.d.ts
@@ -254,13 +254,9 @@ export namespace multisig {
     publicPackage: string
   }
   export function dkgRound2(secret: string, encryptedSecretPackage: string, publicPackages: Array<string>): DkgRound2Packages
-  export interface DkgRound2PublicPackage {
-    recipientIdentity: string
-    publicPackage: string
-  }
   export interface DkgRound2Packages {
     encryptedSecretPackage: string
-    publicPackages: Array<DkgRound2PublicPackage>
+    publicPackages: string
   }
   export function dkgRound3(secret: ParticipantSecret, round2SecretPackage: string, round1PublicPackages: Array<string>, round2PublicPackages: Array<string>): DkgRound3Packages
   export interface DkgRound3Packages {

--- a/ironfish-rust-nodejs/src/multisig.rs
+++ b/ironfish-rust-nodejs/src/multisig.rs
@@ -418,30 +418,16 @@ pub fn dkg_round2(
     )
     .map_err(to_napi_err)?;
 
-    let public_packages = public_packages
-        .iter()
-        .map(|p| DkgRound2PublicPackage {
-            recipient_identity: bytes_to_hex(&p.recipient_identity().serialize()),
-            public_package: bytes_to_hex(&p.serialize()),
-        })
-        .collect();
-
     Ok(DkgRound2Packages {
         encrypted_secret_package: bytes_to_hex(&encrypted_secret_package),
-        public_packages,
+        public_packages: bytes_to_hex(&public_packages.serialize()),
     })
-}
-
-#[napi(object, namespace = "multisig")]
-pub struct DkgRound2PublicPackage {
-    pub recipient_identity: String,
-    pub public_package: String,
 }
 
 #[napi(object, namespace = "multisig")]
 pub struct DkgRound2Packages {
     pub encrypted_secret_package: String,
-    pub public_packages: Vec<DkgRound2PublicPackage>,
+    pub public_packages: String,
 }
 
 #[napi(object, namespace = "multisig")]
@@ -456,7 +442,7 @@ pub fn dkg_round3(
         dkg::round1::PublicPackage::deserialize_from(bytes)
     })?;
     let round2_public_packages = try_deserialize(round2_public_packages, |bytes| {
-        dkg::round2::PublicPackage::deserialize_from(bytes)
+        dkg::round2::CombinedPublicPackage::deserialize_from(bytes)
     })?;
 
     let (key_package, public_key_package, group_secret_key) = dkg::round3::round3(

--- a/ironfish/src/rpc/routes/wallet/multisig/dkg/round2.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/dkg/round2.ts
@@ -16,7 +16,7 @@ export type DkgRound2Request = {
 
 export type DkgRound2Response = {
   encryptedSecretPackage: string
-  publicPackages: Array<{ recipientIdentity: string; publicPackage: string }>
+  publicPackages: string
 }
 
 export const DkgRound2RequestSchema: yup.ObjectSchema<DkgRound2Request> = yup
@@ -30,16 +30,7 @@ export const DkgRound2RequestSchema: yup.ObjectSchema<DkgRound2Request> = yup
 export const DkgRound2ResponseSchema: yup.ObjectSchema<DkgRound2Response> = yup
   .object({
     encryptedSecretPackage: yup.string().defined(),
-    publicPackages: yup
-      .array(
-        yup
-          .object({
-            recipientIdentity: yup.string().defined(),
-            publicPackage: yup.string().defined(),
-          })
-          .defined(),
-      )
-      .defined(),
+    publicPackages: yup.string().defined(),
   })
   .defined()
 

--- a/ironfish/src/rpc/routes/wallet/multisig/dkg/round3.test.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/dkg/round3.test.ts
@@ -58,13 +58,7 @@ describe('Route multisig/dkg/round3', () => {
           accountName: accountNames[index],
           round2SecretPackage: round2Packages[index].content.encryptedSecretPackage,
           round1PublicPackages: round1Packages.map((pkg) => pkg.content.publicPackage),
-          round2PublicPackages: round2Packages.flatMap((pkg) =>
-            pkg.content.publicPackages
-              .filter(
-                ({ recipientIdentity }) => recipientIdentity === participants[index].identity,
-              )
-              .map(({ publicPackage }) => publicPackage),
-          ),
+          round2PublicPackages: round2Packages.map((pkg) => pkg.content.publicPackages),
         }),
       ),
     )
@@ -147,11 +141,7 @@ describe('Route multisig/dkg/round3', () => {
         round1PublicPackages: removeOneElement(
           round1Packages.map((pkg) => pkg.content.publicPackage),
         ),
-        round2PublicPackages: round2Packages.flatMap((pkg) =>
-          pkg.content.publicPackages
-            .filter(({ recipientIdentity }) => recipientIdentity === participants[0].identity)
-            .map(({ publicPackage }) => publicPackage),
-        ),
+        round2PublicPackages: round2Packages.map((pkg) => pkg.content.publicPackages),
       }),
     ).rejects.toThrow('invalid input: expected 3 round 1 public packages, got 2')
   })
@@ -197,12 +187,12 @@ describe('Route multisig/dkg/round3', () => {
         secretName: secretNames[0],
         round2SecretPackage: round2Packages[0].content.encryptedSecretPackage,
         round1PublicPackages: round1Packages.map((pkg) => pkg.content.publicPackage),
+        // Here we cannot just remove any one element to perform this test,
+        // because `round2Packages[0]` does not contain any useful
+        // information for `secretName[0]`, hence if that gets removed, the
+        // operation won't fail. This is why we call `slice()`
         round2PublicPackages: removeOneElement(
-          round2Packages.flatMap((pkg) =>
-            pkg.content.publicPackages
-              .filter(({ recipientIdentity }) => recipientIdentity === participants[0].identity)
-              .map(({ publicPackage }) => publicPackage),
-          ),
+          round2Packages.slice(1).map((pkg) => pkg.content.publicPackages),
         ),
       }),
     ).rejects.toThrow('invalid input: expected 2 round 2 public packages, got 1')
@@ -249,11 +239,7 @@ describe('Route multisig/dkg/round3', () => {
         secretName: secretNames[0],
         round2SecretPackage: round2Packages[1].content.encryptedSecretPackage,
         round1PublicPackages: round1Packages.map((pkg) => pkg.content.publicPackage),
-        round2PublicPackages: round2Packages.flatMap((pkg) =>
-          pkg.content.publicPackages
-            .filter(({ recipientIdentity }) => recipientIdentity === participants[0].identity)
-            .map(({ publicPackage }) => publicPackage),
-        ),
+        round2PublicPackages: round2Packages.map((pkg) => pkg.content.publicPackages),
       }),
     ).rejects.toThrow('decryption error: aead::Error')
   })

--- a/ironfish/src/rpc/routes/wallet/multisig/integration.test.slow.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/integration.test.slow.ts
@@ -205,13 +205,7 @@ describe('multisig RPC integration', () => {
           secretName: name,
           round2SecretPackage: round2Packages[index].content.encryptedSecretPackage,
           round1PublicPackages: round1Packages.map((pkg) => pkg.content.publicPackage),
-          round2PublicPackages: round2Packages.flatMap((pkg) =>
-            pkg.content.publicPackages
-              .filter(
-                ({ recipientIdentity }) => recipientIdentity === participants[index].identity,
-              )
-              .map(({ publicPackage }) => publicPackage),
-          ),
+          round2PublicPackages: round2Packages.map((pkg) => pkg.content.publicPackages),
         })
 
         const participantAccount = routeTest.wallet.getAccountByName(name)


### PR DESCRIPTION
## Summary

At the end of round 2, output a single public package, instead of *n*−1 per-participant packages.

## Testing Plan

Unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
