### PR TITLE
Multisig DKG: prefix every occurrence of "package" with the round number

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/dkg/round1.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/round1.ts
@@ -69,15 +69,15 @@ export class DkgRound1Command extends IronfishCommand {
       minSigners: minSigners,
     })
 
-    this.log('\nEncrypted Secret Package:\n')
-    this.log(response.content.encryptedSecretPackage)
+    this.log('\nRound 1 Encrypted Secret Package:\n')
+    this.log(response.content.round1SecretPackage)
     this.log()
 
-    this.log('\nPublic Package:\n')
-    this.log(response.content.publicPackage)
+    this.log('\nRound 1 Public Package:\n')
+    this.log(response.content.round1PublicPackage)
     this.log()
 
     this.log('Next step:')
-    this.log('Send the public package to each participant')
+    this.log('Send the round 1 public package to each participant')
   }
 }

--- a/ironfish-cli/src/commands/wallet/multisig/dkg/round2.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/round2.ts
@@ -17,14 +17,14 @@ export class DkgRound2Command extends IronfishCommand {
       char: 's',
       description: 'The name of the secret to use for encryption during DKG',
     }),
-    encryptedSecretPackage: Flags.string({
+    round1SecretPackage: Flags.string({
       char: 'e',
-      description: 'The ecrypted secret package created during DKG round1',
+      description: 'The encrypted secret package created during DKG round 1',
     }),
-    publicPackage: Flags.string({
+    round1PublicPackages: Flags.string({
       char: 'p',
       description:
-        'The public package that a participant generated during DKG round1 (may be specified multiple times for multiple participants). Must include your own round1 public package',
+        'The public packages that each participant generated during DKG round 1 (may be specified multiple times for multiple participants). Must include your own round 1 public package',
       multiple: true,
     }),
   }
@@ -39,50 +39,46 @@ export class DkgRound2Command extends IronfishCommand {
       secretName = await selectSecret(client)
     }
 
-    let encryptedSecretPackage = flags.encryptedSecretPackage
-    if (!encryptedSecretPackage) {
-      encryptedSecretPackage = await CliUx.ux.prompt(
-        `Enter the encrypted secret package for secret ${secretName}`,
-        {
-          required: true,
-        },
+    let round1SecretPackage = flags.round1SecretPackage
+    if (!round1SecretPackage) {
+      round1SecretPackage = await CliUx.ux.prompt(
+        `Enter the round 1 secret package for secret ${secretName}`,
+        { required: true },
       )
     }
 
-    let publicPackages = flags.publicPackage
-    if (!publicPackages || publicPackages.length < 2) {
+    let round1PublicPackages = flags.round1PublicPackages
+    if (!round1PublicPackages || round1PublicPackages.length < 2) {
       const input = await longPrompt(
-        'Enter public packages separated by commas, one for each participant',
-        {
-          required: true,
-        },
+        'Enter round 1 public packages separated by commas, one for each participant',
+        { required: true },
       )
-      publicPackages = input.split(',')
+      round1PublicPackages = input.split(',')
 
-      if (publicPackages.length < 2) {
+      if (round1PublicPackages.length < 2) {
         this.error(
-          'Must include a public package for each participant; at least 2 participants required',
+          'Must include a round 1 public package for each participant; at least 2 participants required',
         )
       }
     }
-    publicPackages = publicPackages.map((i) => i.trim())
+    round1PublicPackages = round1PublicPackages.map((i) => i.trim())
 
     const response = await client.wallet.multisig.dkg.round2({
       secretName,
-      encryptedSecretPackage,
-      publicPackages,
+      round1SecretPackage,
+      round1PublicPackages,
     })
 
-    this.log('\nEncrypted Secret Package:\n')
-    this.log(response.content.encryptedSecretPackage)
+    this.log('\nRound 2 Encrypted Secret Package:\n')
+    this.log(response.content.round2SecretPackage)
     this.log()
 
-    this.log('\nPublic Package:\n')
-    this.log(response.content.publicPackages)
+    this.log('\nRound 2 Public Package:\n')
+    this.log(response.content.round2PublicPackage)
     this.log()
 
     this.log()
     this.log('Next step:')
-    this.log('Send the public package to each participant')
+    this.log('Send the round 2 public package to each participant')
   }
 }

--- a/ironfish-cli/src/commands/wallet/multisig/dkg/round3.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/round3.ts
@@ -23,18 +23,18 @@ export class DkgRound3Command extends IronfishCommand {
     }),
     round2SecretPackage: Flags.string({
       char: 'e',
-      description: 'The encrypted secret package created during DKG round2',
+      description: 'The encrypted secret package created during DKG round 2',
     }),
     round1PublicPackages: Flags.string({
       char: 'p',
       description:
-        'The public package that a participant generated during DKG round1 (may be specified multiple times for multiple participants). Must include your own round1 public package',
+        'The public package that a participant generated during DKG round 1 (may be specified multiple times for multiple participants). Must include your own round 1 public package',
       multiple: true,
     }),
     round2PublicPackages: Flags.string({
       char: 'q',
       description:
-        'The public package that a participant generated during DKG round2 where the recipient matches the identity associated with the secret',
+        'The public package that a participant generated during DKG round 2 (may be specified multiple times for multiple participants). Your own round 2 public package is optional; if included, it will be ignored',
       multiple: true,
     }),
   }
@@ -52,7 +52,7 @@ export class DkgRound3Command extends IronfishCommand {
     let round2SecretPackage = flags.round2SecretPackage
     if (!round2SecretPackage) {
       round2SecretPackage = await CliUx.ux.prompt(
-        `Enter the encrypted secret package for secret ${secretName}`,
+        `Enter the encrypted round 2 secret package for secret ${secretName}`,
         {
           required: true,
         },
@@ -71,7 +71,7 @@ export class DkgRound3Command extends IronfishCommand {
 
       if (round1PublicPackages.length < 2) {
         this.error(
-          'Must include a public package for each participant; at least 2 participants required',
+          'Must include a round 1 public package for each participant; at least 2 participants required',
         )
       }
     }

--- a/ironfish-rust-nodejs/index.d.ts
+++ b/ironfish-rust-nodejs/index.d.ts
@@ -250,13 +250,13 @@ export namespace multisig {
   }
   export function dkgRound1(selfIdentity: string, minSigners: number, participantIdentities: Array<string>): DkgRound1Packages
   export interface DkgRound1Packages {
-    encryptedSecretPackage: string
-    publicPackage: string
+    round1SecretPackage: string
+    round1PublicPackage: string
   }
-  export function dkgRound2(secret: string, encryptedSecretPackage: string, publicPackages: Array<string>): DkgRound2Packages
+  export function dkgRound2(secret: string, round1SecretPackage: string, round1PublicPackages: Array<string>): DkgRound2Packages
   export interface DkgRound2Packages {
-    encryptedSecretPackage: string
-    publicPackages: string
+    round2SecretPackage: string
+    round2PublicPackage: string
   }
   export function dkgRound3(secret: ParticipantSecret, round2SecretPackage: string, round1PublicPackages: Array<string>, round2PublicPackages: Array<string>): DkgRound3Packages
   export interface DkgRound3Packages {

--- a/ironfish-rust-nodejs/src/multisig.rs
+++ b/ironfish-rust-nodejs/src/multisig.rs
@@ -377,7 +377,7 @@ pub fn dkg_round1(
         Identity::deserialize_from(&hex_to_vec_bytes(&self_identity).map_err(to_napi_err)?[..])?;
     let participant_identities = try_deserialize_identities(participant_identities)?;
 
-    let (encrypted_secret_package, public_package) = dkg::round1::round1(
+    let (round1_secret_package, round1_public_package) = dkg::round1::round1(
         &self_identity,
         min_signers,
         &participant_identities,
@@ -386,48 +386,47 @@ pub fn dkg_round1(
     .map_err(to_napi_err)?;
 
     Ok(DkgRound1Packages {
-        encrypted_secret_package: bytes_to_hex(&encrypted_secret_package),
-        public_package: bytes_to_hex(&public_package.serialize()),
+        round1_secret_package: bytes_to_hex(&round1_secret_package),
+        round1_public_package: bytes_to_hex(&round1_public_package.serialize()),
     })
 }
 
 #[napi(object, namespace = "multisig")]
 pub struct DkgRound1Packages {
-    pub encrypted_secret_package: String,
-    pub public_package: String,
+    pub round1_secret_package: String,
+    pub round1_public_package: String,
 }
 
 #[napi(namespace = "multisig")]
 pub fn dkg_round2(
     secret: String,
-    encrypted_secret_package: String,
-    public_packages: Vec<String>,
+    round1_secret_package: String,
+    round1_public_packages: Vec<String>,
 ) -> Result<DkgRound2Packages> {
     let secret = Secret::deserialize_from(&hex_to_vec_bytes(&secret).map_err(to_napi_err)?[..])?;
-    let public_packages = try_deserialize(public_packages, |bytes| {
+    let round1_public_packages = try_deserialize(round1_public_packages, |bytes| {
         dkg::round1::PublicPackage::deserialize_from(bytes)
     })?;
-    let encrypted_secret_package =
-        hex_to_vec_bytes(&encrypted_secret_package).map_err(to_napi_err)?;
+    let round1_secret_package = hex_to_vec_bytes(&round1_secret_package).map_err(to_napi_err)?;
 
-    let (encrypted_secret_package, public_packages) = dkg::round2::round2(
+    let (round2_secret_package, round2_public_package) = dkg::round2::round2(
         &secret,
-        &encrypted_secret_package,
-        &public_packages,
+        &round1_secret_package,
+        &round1_public_packages,
         thread_rng(),
     )
     .map_err(to_napi_err)?;
 
     Ok(DkgRound2Packages {
-        encrypted_secret_package: bytes_to_hex(&encrypted_secret_package),
-        public_packages: bytes_to_hex(&public_packages.serialize()),
+        round2_secret_package: bytes_to_hex(&round2_secret_package),
+        round2_public_package: bytes_to_hex(&round2_public_package.serialize()),
     })
 }
 
 #[napi(object, namespace = "multisig")]
 pub struct DkgRound2Packages {
-    pub encrypted_secret_package: String,
-    pub public_packages: String,
+    pub round2_secret_package: String,
+    pub round2_public_package: String,
 }
 
 #[napi(object, namespace = "multisig")]

--- a/ironfish/src/rpc/routes/wallet/multisig/dkg/round1.test.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/dkg/round1.test.ts
@@ -23,15 +23,15 @@ describe('Route multisig/dkg/round1', () => {
     const response = await routeTest.client.wallet.multisig.dkg.round1(request)
 
     expect(response.content).toMatchObject({
-      encryptedSecretPackage: expect.any(String),
-      publicPackage: expect.any(String),
+      round1SecretPackage: expect.any(String),
+      round1PublicPackage: expect.any(String),
     })
 
-    // Ensure that the encrypted secret package can be decrypted
+    // Ensure that the round 1 secret package can be decrypted
     const secretValue = await routeTest.node.wallet.walletDb.getMultisigSecretByName(secretName)
     Assert.isNotUndefined(secretValue)
     const secret = new multisig.ParticipantSecret(secretValue.secret)
-    secret.decryptData(Buffer.from(response.content.encryptedSecretPackage, 'hex'))
+    secret.decryptData(Buffer.from(response.content.round1SecretPackage, 'hex'))
   })
 
   it('should fail if the named secret does not exist', async () => {
@@ -71,8 +71,8 @@ describe('Route multisig/dkg/round1', () => {
     const response = await routeTest.client.wallet.multisig.dkg.round1(request)
 
     expect(response.content).toMatchObject({
-      encryptedSecretPackage: expect.any(String),
-      publicPackage: expect.any(String),
+      round1SecretPackage: expect.any(String),
+      round1PublicPackage: expect.any(String),
     })
   })
 

--- a/ironfish/src/rpc/routes/wallet/multisig/dkg/round1.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/dkg/round1.ts
@@ -15,8 +15,8 @@ export type DkgRound1Request = {
 }
 
 export type DkgRound1Response = {
-  encryptedSecretPackage: string
-  publicPackage: string
+  round1SecretPackage: string
+  round1PublicPackage: string
 }
 
 export const DkgRound1RequestSchema: yup.ObjectSchema<DkgRound1Request> = yup
@@ -32,8 +32,8 @@ export const DkgRound1RequestSchema: yup.ObjectSchema<DkgRound1Request> = yup
 
 export const DkgRound1ResponseSchema: yup.ObjectSchema<DkgRound1Response> = yup
   .object({
-    encryptedSecretPackage: yup.string().defined(),
-    publicPackage: yup.string().defined(),
+    round1SecretPackage: yup.string().defined(),
+    round1PublicPackage: yup.string().defined(),
   })
   .defined()
 

--- a/ironfish/src/rpc/routes/wallet/multisig/dkg/round2.test.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/dkg/round2.test.ts
@@ -28,25 +28,25 @@ describe('Route multisig/dkg/round2', () => {
 
     const round2Request = {
       secretName: secretName1,
-      encryptedSecretPackage: round1Response1.content.encryptedSecretPackage,
-      publicPackages: [
-        round1Response1.content.publicPackage,
-        round1Response2.content.publicPackage,
+      round1SecretPackage: round1Response1.content.round1SecretPackage,
+      round1PublicPackages: [
+        round1Response1.content.round1PublicPackage,
+        round1Response2.content.round1PublicPackage,
       ],
     }
 
     const round2Response = await routeTest.client.wallet.multisig.dkg.round2(round2Request)
 
     expect(round2Response.content).toMatchObject({
-      encryptedSecretPackage: expect.any(String),
+      round2SecretPackage: expect.any(String),
     })
   })
 
   it('should fail if the named secret does not exist', async () => {
     const request = {
       secretName: 'fakeName',
-      encryptedSecretPackage: 'foo',
-      publicPackages: ['bar', 'baz'],
+      round1SecretPackage: 'foo',
+      round1PublicPackages: ['bar', 'baz'],
     }
 
     await expect(routeTest.client.wallet.multisig.dkg.round2(request)).rejects.toThrow(

--- a/ironfish/src/rpc/routes/wallet/multisig/dkg/round2.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/dkg/round2.ts
@@ -10,27 +10,27 @@ import { AssertHasRpcContext } from '../../../rpcContext'
 
 export type DkgRound2Request = {
   secretName: string
-  encryptedSecretPackage: string
-  publicPackages: Array<string>
+  round1SecretPackage: string
+  round1PublicPackages: Array<string>
 }
 
 export type DkgRound2Response = {
-  encryptedSecretPackage: string
-  publicPackages: string
+  round2SecretPackage: string
+  round2PublicPackage: string
 }
 
 export const DkgRound2RequestSchema: yup.ObjectSchema<DkgRound2Request> = yup
   .object({
     secretName: yup.string().defined(),
-    encryptedSecretPackage: yup.string().defined(),
-    publicPackages: yup.array().of(yup.string().defined()).defined(),
+    round1SecretPackage: yup.string().defined(),
+    round1PublicPackages: yup.array().of(yup.string().defined()).defined(),
   })
   .defined()
 
 export const DkgRound2ResponseSchema: yup.ObjectSchema<DkgRound2Response> = yup
   .object({
-    encryptedSecretPackage: yup.string().defined(),
-    publicPackages: yup.string().defined(),
+    round2SecretPackage: yup.string().defined(),
+    round2PublicPackage: yup.string().defined(),
   })
   .defined()
 
@@ -40,7 +40,7 @@ routes.register<typeof DkgRound2RequestSchema, DkgRound2Response>(
   async (request, node): Promise<void> => {
     AssertHasRpcContext(request, node, 'wallet')
 
-    const { secretName, encryptedSecretPackage, publicPackages } = request.data
+    const { secretName, round1SecretPackage, round1PublicPackages } = request.data
     const multisigSecret = await node.wallet.walletDb.getMultisigSecretByName(secretName)
 
     if (!multisigSecret) {
@@ -53,7 +53,7 @@ routes.register<typeof DkgRound2RequestSchema, DkgRound2Response>(
 
     const secret = multisigSecret.secret.toString('hex')
 
-    const packages = multisig.dkgRound2(secret, encryptedSecretPackage, publicPackages)
+    const packages = multisig.dkgRound2(secret, round1SecretPackage, round1PublicPackages)
 
     request.end(packages)
   },

--- a/ironfish/src/rpc/routes/wallet/multisig/dkg/round3.test.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/dkg/round3.test.ts
@@ -44,8 +44,8 @@ describe('Route multisig/dkg/round3', () => {
       secretNames.map((secretName, index) =>
         routeTest.client.wallet.multisig.dkg.round2({
           secretName,
-          encryptedSecretPackage: round1Packages[index].content.encryptedSecretPackage,
-          publicPackages: round1Packages.map((pkg) => pkg.content.publicPackage),
+          round1SecretPackage: round1Packages[index].content.round1SecretPackage,
+          round1PublicPackages: round1Packages.map((pkg) => pkg.content.round1PublicPackage),
         }),
       ),
     )
@@ -56,9 +56,9 @@ describe('Route multisig/dkg/round3', () => {
         routeTest.client.wallet.multisig.dkg.round3({
           secretName,
           accountName: accountNames[index],
-          round2SecretPackage: round2Packages[index].content.encryptedSecretPackage,
-          round1PublicPackages: round1Packages.map((pkg) => pkg.content.publicPackage),
-          round2PublicPackages: round2Packages.map((pkg) => pkg.content.publicPackages),
+          round2SecretPackage: round2Packages[index].content.round2SecretPackage,
+          round1PublicPackages: round1Packages.map((pkg) => pkg.content.round1PublicPackage),
+          round2PublicPackages: round2Packages.map((pkg) => pkg.content.round2PublicPackage),
         }),
       ),
     )
@@ -127,8 +127,8 @@ describe('Route multisig/dkg/round3', () => {
       secretNames.map((secretName, index) =>
         routeTest.client.wallet.multisig.dkg.round2({
           secretName,
-          encryptedSecretPackage: round1Packages[index].content.encryptedSecretPackage,
-          publicPackages: round1Packages.map((pkg) => pkg.content.publicPackage),
+          round1SecretPackage: round1Packages[index].content.round1SecretPackage,
+          round1PublicPackages: round1Packages.map((pkg) => pkg.content.round1PublicPackage),
         }),
       ),
     )
@@ -137,11 +137,11 @@ describe('Route multisig/dkg/round3', () => {
     await expect(
       routeTest.client.wallet.multisig.dkg.round3({
         secretName: secretNames[0],
-        round2SecretPackage: round2Packages[0].content.encryptedSecretPackage,
+        round2SecretPackage: round2Packages[0].content.round2SecretPackage,
         round1PublicPackages: removeOneElement(
-          round1Packages.map((pkg) => pkg.content.publicPackage),
+          round1Packages.map((pkg) => pkg.content.round1PublicPackage),
         ),
-        round2PublicPackages: round2Packages.map((pkg) => pkg.content.publicPackages),
+        round2PublicPackages: round2Packages.map((pkg) => pkg.content.round2PublicPackage),
       }),
     ).rejects.toThrow('invalid input: expected 3 round 1 public packages, got 2')
   })
@@ -175,8 +175,8 @@ describe('Route multisig/dkg/round3', () => {
       secretNames.map((secretName, index) =>
         routeTest.client.wallet.multisig.dkg.round2({
           secretName,
-          encryptedSecretPackage: round1Packages[index].content.encryptedSecretPackage,
-          publicPackages: round1Packages.map((pkg) => pkg.content.publicPackage),
+          round1SecretPackage: round1Packages[index].content.round1SecretPackage,
+          round1PublicPackages: round1Packages.map((pkg) => pkg.content.round1PublicPackage),
         }),
       ),
     )
@@ -185,14 +185,14 @@ describe('Route multisig/dkg/round3', () => {
     await expect(
       routeTest.client.wallet.multisig.dkg.round3({
         secretName: secretNames[0],
-        round2SecretPackage: round2Packages[0].content.encryptedSecretPackage,
-        round1PublicPackages: round1Packages.map((pkg) => pkg.content.publicPackage),
+        round2SecretPackage: round2Packages[0].content.round2SecretPackage,
+        round1PublicPackages: round1Packages.map((pkg) => pkg.content.round1PublicPackage),
         // Here we cannot just remove any one element to perform this test,
         // because `round2Packages[0]` does not contain any useful
         // information for `secretName[0]`, hence if that gets removed, the
         // operation won't fail. This is why we call `slice()`
         round2PublicPackages: removeOneElement(
-          round2Packages.slice(1).map((pkg) => pkg.content.publicPackages),
+          round2Packages.slice(1).map((pkg) => pkg.content.round2PublicPackage),
         ),
       }),
     ).rejects.toThrow('invalid input: expected 2 round 2 public packages, got 1')
@@ -227,8 +227,8 @@ describe('Route multisig/dkg/round3', () => {
       secretNames.map((secretName, index) =>
         routeTest.client.wallet.multisig.dkg.round2({
           secretName,
-          encryptedSecretPackage: round1Packages[index].content.encryptedSecretPackage,
-          publicPackages: round1Packages.map((pkg) => pkg.content.publicPackage),
+          round1SecretPackage: round1Packages[index].content.round1SecretPackage,
+          round1PublicPackages: round1Packages.map((pkg) => pkg.content.round1PublicPackage),
         }),
       ),
     )
@@ -237,9 +237,9 @@ describe('Route multisig/dkg/round3', () => {
     await expect(
       routeTest.client.wallet.multisig.dkg.round3({
         secretName: secretNames[0],
-        round2SecretPackage: round2Packages[1].content.encryptedSecretPackage,
-        round1PublicPackages: round1Packages.map((pkg) => pkg.content.publicPackage),
-        round2PublicPackages: round2Packages.map((pkg) => pkg.content.publicPackages),
+        round2SecretPackage: round2Packages[1].content.round2SecretPackage,
+        round1PublicPackages: round1Packages.map((pkg) => pkg.content.round1PublicPackage),
+        round2PublicPackages: round2Packages.map((pkg) => pkg.content.round2PublicPackage),
       }),
     ).rejects.toThrow('decryption error: aead::Error')
   })

--- a/ironfish/src/rpc/routes/wallet/multisig/integration.test.slow.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/integration.test.slow.ts
@@ -192,8 +192,8 @@ describe('multisig RPC integration', () => {
       participants.map(({ name }, index) =>
         routeTest.client.wallet.multisig.dkg.round2({
           secretName: name,
-          encryptedSecretPackage: round1Packages[index].content.encryptedSecretPackage,
-          publicPackages: round1Packages.map((pkg) => pkg.content.publicPackage),
+          round1SecretPackage: round1Packages[index].content.round1SecretPackage,
+          round1PublicPackages: round1Packages.map((pkg) => pkg.content.round1PublicPackage),
         }),
       ),
     )
@@ -203,9 +203,9 @@ describe('multisig RPC integration', () => {
       participants.map(async ({ name }, index) => {
         await routeTest.client.wallet.multisig.dkg.round3({
           secretName: name,
-          round2SecretPackage: round2Packages[index].content.encryptedSecretPackage,
-          round1PublicPackages: round1Packages.map((pkg) => pkg.content.publicPackage),
-          round2PublicPackages: round2Packages.map((pkg) => pkg.content.publicPackages),
+          round2SecretPackage: round2Packages[index].content.round2SecretPackage,
+          round1PublicPackages: round1Packages.map((pkg) => pkg.content.round1PublicPackage),
+          round2PublicPackages: round2Packages.map((pkg) => pkg.content.round2PublicPackage),
         })
 
         const participantAccount = routeTest.wallet.getAccountByName(name)


### PR DESCRIPTION
## Summary

Disambiguate names by *always* specifying what round the input or output refers to.

## Testing Plan

Unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
