### PR TITLE
renames wallet:multisig:participants to wallet:multisig:account:participants

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/account/participants.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/account/participants.ts
@@ -8,9 +8,6 @@ import { RemoteFlags } from '../../../../flags'
 export class MultisigAccountParticipants extends IronfishCommand {
   static description = `List all participant identities in the group for a multisig account`
 
-  static aliases = ['wallet:multisig:participants']
-  static deprecateAliases = true
-
   static flags = {
     ...RemoteFlags,
     account: Flags.string({

--- a/ironfish-cli/src/commands/wallet/multisig/account/participants.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/account/participants.ts
@@ -6,13 +6,16 @@ import { IronfishCommand } from '../../../../command'
 import { RemoteFlags } from '../../../../flags'
 
 export class MultisigAccountParticipants extends IronfishCommand {
-  static description = `List the participant identities for a multisig account`
+  static description = `List all participant identities in the group for a multisig account`
+
+  static aliases = ['wallet:multisig:participants']
+  static deprecateAliases = true
 
   static flags = {
     ...RemoteFlags,
     account: Flags.string({
       char: 'f',
-      description: 'The account to list identities for',
+      description: 'The account to list group identities for',
     }),
   }
 


### PR DESCRIPTION
## Summary

renames the command to make it clearer that the command will list all of the participant identities in the group for a given account and not all participant identities that the wallet has created

maintains the old command name as a deprecated alias

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
