### PR TITLE
renames secretName to participantName

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/dkg/round1.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/round1.ts
@@ -21,7 +21,7 @@ export class DkgRound1Command extends IronfishCommand {
     identity: Flags.string({
       char: 'i',
       description:
-        'The identity of the participants will generate the group keys (may be specified multiple times to add multiple participants). Must include the identity for participantName',
+        'The identity of the participants will generate the group keys (may be specified multiple times to add multiple participants)',
       multiple: true,
     }),
     minSigners: Flags.integer({

--- a/ironfish-cli/src/commands/wallet/multisig/dkg/round1.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/round1.ts
@@ -13,14 +13,15 @@ export class DkgRound1Command extends IronfishCommand {
 
   static flags = {
     ...RemoteFlags,
-    secretName: Flags.string({
-      char: 's',
+    participantName: Flags.string({
+      char: 'n',
       description: 'The name of the secret to use for encryption during DKG',
+      aliases: ['name'],
     }),
     identity: Flags.string({
       char: 'i',
       description:
-        'The identity of the participants will generate the group keys (may be specified multiple times to add multiple participants). Must include the identity for secretName',
+        'The identity of the participants will generate the group keys (may be specified multiple times to add multiple participants). Must include the identity for participantName',
       multiple: true,
     }),
     minSigners: Flags.integer({
@@ -34,9 +35,9 @@ export class DkgRound1Command extends IronfishCommand {
 
     const client = await this.sdk.connectRpc()
 
-    let secretName = flags.secretName
-    if (!secretName) {
-      secretName = await selectSecret(client)
+    let participantName = flags.participantName
+    if (!participantName) {
+      participantName = await selectSecret(client)
     }
 
     let identities = flags.identity
@@ -64,7 +65,7 @@ export class DkgRound1Command extends IronfishCommand {
     }
 
     const response = await client.wallet.multisig.dkg.round1({
-      secretName: secretName,
+      participantName,
       participants: identities.map((identity) => ({ identity })),
       minSigners: minSigners,
     })

--- a/ironfish-cli/src/commands/wallet/multisig/dkg/round2.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/round2.ts
@@ -13,9 +13,10 @@ export class DkgRound2Command extends IronfishCommand {
 
   static flags = {
     ...RemoteFlags,
-    secretName: Flags.string({
-      char: 's',
+    participantName: Flags.string({
+      char: 'n',
       description: 'The name of the secret to use for encryption during DKG',
+      aliases: ['name'],
     }),
     round1SecretPackage: Flags.string({
       char: 'e',
@@ -34,15 +35,15 @@ export class DkgRound2Command extends IronfishCommand {
 
     const client = await this.sdk.connectRpc()
 
-    let secretName = flags.secretName
-    if (!secretName) {
-      secretName = await selectSecret(client)
+    let participantName = flags.participantName
+    if (!participantName) {
+      participantName = await selectSecret(client)
     }
 
     let round1SecretPackage = flags.round1SecretPackage
     if (!round1SecretPackage) {
       round1SecretPackage = await CliUx.ux.prompt(
-        `Enter the round 1 secret package for secret ${secretName}`,
+        `Enter the round 1 secret package for participant ${participantName}`,
         { required: true },
       )
     }
@@ -64,7 +65,7 @@ export class DkgRound2Command extends IronfishCommand {
     round1PublicPackages = round1PublicPackages.map((i) => i.trim())
 
     const response = await client.wallet.multisig.dkg.round2({
-      secretName,
+      participantName,
       round1SecretPackage,
       round1PublicPackages,
     })

--- a/ironfish-cli/src/commands/wallet/multisig/dkg/round3.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/round3.ts
@@ -13,12 +13,13 @@ export class DkgRound3Command extends IronfishCommand {
 
   static flags = {
     ...RemoteFlags,
-    secretName: Flags.string({
-      char: 's',
+    participantName: Flags.string({
+      char: 'n',
       description: 'The name of the secret to use for decryption during DKG',
+      aliases: ['name'],
     }),
     accountName: Flags.string({
-      char: 'n',
+      char: 'a',
       description: 'The name to set for the imported account',
     }),
     round2SecretPackage: Flags.string({
@@ -44,15 +45,15 @@ export class DkgRound3Command extends IronfishCommand {
 
     const client = await this.sdk.connectRpc()
 
-    let secretName = flags.secretName
-    if (!secretName) {
-      secretName = await selectSecret(client)
+    let participantName = flags.participantName
+    if (!participantName) {
+      participantName = await selectSecret(client)
     }
 
     let round2SecretPackage = flags.round2SecretPackage
     if (!round2SecretPackage) {
       round2SecretPackage = await CliUx.ux.prompt(
-        `Enter the encrypted round 2 secret package for secret ${secretName}`,
+        `Enter the encrypted secret package for participant ${participantName}`,
         {
           required: true,
         },
@@ -103,7 +104,7 @@ export class DkgRound3Command extends IronfishCommand {
     round2PublicPackages = round2PublicPackages.map((i) => i.trim())
 
     const response = await client.wallet.multisig.dkg.round3({
-      secretName: secretName,
+      participantName,
       accountName: flags.accountName,
       round2SecretPackage,
       round1PublicPackages,

--- a/ironfish/src/rpc/routes/wallet/multisig/dkg/round1.test.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/dkg/round1.test.ts
@@ -9,17 +9,18 @@ describe('Route multisig/dkg/round1', () => {
   const routeTest = createRouteTest()
 
   it('should create round 1 packages', async () => {
-    const secretName = 'name'
-    await routeTest.client.wallet.multisig.createParticipant({ name: secretName })
+    const participantName = 'name'
+    await routeTest.client.wallet.multisig.createParticipant({ name: participantName })
 
-    const identity = (await routeTest.client.wallet.multisig.getIdentity({ name: secretName }))
-      .content.identity
+    const identity = (
+      await routeTest.client.wallet.multisig.getIdentity({ name: participantName })
+    ).content.identity
     const otherParticipants = Array.from({ length: 2 }, () => ({
       identity: multisig.ParticipantSecret.random().toIdentity().serialize().toString('hex'),
     }))
     const participants = [{ identity }, ...otherParticipants]
 
-    const request = { secretName, minSigners: 2, participants }
+    const request = { participantName, minSigners: 2, participants }
     const response = await routeTest.client.wallet.multisig.dkg.round1(request)
 
     expect(response.content).toMatchObject({
@@ -27,25 +28,33 @@ describe('Route multisig/dkg/round1', () => {
       round1PublicPackage: expect.any(String),
     })
 
+<<<<<<< HEAD
     // Ensure that the round 1 secret package can be decrypted
     const secretValue = await routeTest.node.wallet.walletDb.getMultisigSecretByName(secretName)
+=======
+    // Ensure that the encrypted secret package can be decrypted
+    const secretValue = await routeTest.node.wallet.walletDb.getMultisigSecretByName(
+      participantName,
+    )
+>>>>>>> 739831827 (renames secretName to participantName)
     Assert.isNotUndefined(secretValue)
     const secret = new multisig.ParticipantSecret(secretValue.secret)
     secret.decryptData(Buffer.from(response.content.round1SecretPackage, 'hex'))
   })
 
   it('should fail if the named secret does not exist', async () => {
-    const secretName = 'name'
-    await routeTest.client.wallet.multisig.createParticipant({ name: secretName })
+    const participantName = 'name'
+    await routeTest.client.wallet.multisig.createParticipant({ name: participantName })
 
-    const identity = (await routeTest.client.wallet.multisig.getIdentity({ name: secretName }))
-      .content.identity
+    const identity = (
+      await routeTest.client.wallet.multisig.getIdentity({ name: participantName })
+    ).content.identity
     const otherParticipants = Array.from({ length: 2 }, () => ({
       identity: multisig.ParticipantSecret.random().toIdentity().serialize().toString('hex'),
     }))
     const participants = [{ identity }, ...otherParticipants]
 
-    const request = { secretName: 'otherName', minSigners: 2, participants }
+    const request = { participantName: 'otherName', minSigners: 2, participants }
 
     await expect(routeTest.client.wallet.multisig.dkg.round1(request)).rejects.toThrow(
       expect.objectContaining({
@@ -56,8 +65,8 @@ describe('Route multisig/dkg/round1', () => {
   })
 
   it('should add the named identity if it is not in the list of participants', async () => {
-    const secretName = 'name'
-    await routeTest.client.wallet.multisig.createParticipant({ name: secretName })
+    const participantName = 'name'
+    await routeTest.client.wallet.multisig.createParticipant({ name: participantName })
 
     // only pass in one participant
     const participants = [
@@ -66,7 +75,7 @@ describe('Route multisig/dkg/round1', () => {
       },
     ]
 
-    const request = { secretName, minSigners: 2, participants }
+    const request = { participantName, minSigners: 2, participants }
 
     const response = await routeTest.client.wallet.multisig.dkg.round1(request)
 
@@ -77,17 +86,18 @@ describe('Route multisig/dkg/round1', () => {
   })
 
   it('should fail if minSigners is too low', async () => {
-    const secretName = 'name'
-    await routeTest.client.wallet.multisig.createParticipant({ name: secretName })
+    const participantName = 'name'
+    await routeTest.client.wallet.multisig.createParticipant({ name: participantName })
 
-    const identity = (await routeTest.client.wallet.multisig.getIdentity({ name: secretName }))
-      .content.identity
+    const identity = (
+      await routeTest.client.wallet.multisig.getIdentity({ name: participantName })
+    ).content.identity
     const otherParticipants = Array.from({ length: 2 }, () => ({
       identity: multisig.ParticipantSecret.random().toIdentity().serialize().toString('hex'),
     }))
     const participants = [{ identity }, ...otherParticipants]
 
-    const request = { secretName, minSigners: 1, participants }
+    const request = { participantName, minSigners: 1, participants }
 
     await expect(routeTest.client.wallet.multisig.dkg.round1(request)).rejects.toThrow(
       expect.objectContaining({
@@ -98,17 +108,18 @@ describe('Route multisig/dkg/round1', () => {
   })
 
   it('should fail if minSigners exceeds the number of participants', async () => {
-    const secretName = 'name'
-    await routeTest.client.wallet.multisig.createParticipant({ name: secretName })
+    const participantName = 'name'
+    await routeTest.client.wallet.multisig.createParticipant({ name: participantName })
 
-    const identity = (await routeTest.client.wallet.multisig.getIdentity({ name: secretName }))
-      .content.identity
+    const identity = (
+      await routeTest.client.wallet.multisig.getIdentity({ name: participantName })
+    ).content.identity
     const otherParticipants = Array.from({ length: 2 }, () => ({
       identity: multisig.ParticipantSecret.random().toIdentity().serialize().toString('hex'),
     }))
     const participants = [{ identity }, ...otherParticipants]
 
-    const request = { secretName, minSigners: 4, participants }
+    const request = { participantName, minSigners: 4, participants }
 
     await expect(routeTest.client.wallet.multisig.dkg.round1(request)).rejects.toThrow(
       expect.objectContaining({

--- a/ironfish/src/rpc/routes/wallet/multisig/dkg/round1.test.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/dkg/round1.test.ts
@@ -28,15 +28,10 @@ describe('Route multisig/dkg/round1', () => {
       round1PublicPackage: expect.any(String),
     })
 
-<<<<<<< HEAD
-    // Ensure that the round 1 secret package can be decrypted
-    const secretValue = await routeTest.node.wallet.walletDb.getMultisigSecretByName(secretName)
-=======
     // Ensure that the encrypted secret package can be decrypted
     const secretValue = await routeTest.node.wallet.walletDb.getMultisigSecretByName(
       participantName,
     )
->>>>>>> 739831827 (renames secretName to participantName)
     Assert.isNotUndefined(secretValue)
     const secret = new multisig.ParticipantSecret(secretValue.secret)
     secret.decryptData(Buffer.from(response.content.round1SecretPackage, 'hex'))

--- a/ironfish/src/rpc/routes/wallet/multisig/dkg/round1.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/dkg/round1.ts
@@ -9,7 +9,7 @@ import { routes } from '../../../router'
 import { AssertHasRpcContext } from '../../../rpcContext'
 
 export type DkgRound1Request = {
-  secretName: string
+  participantName: string
   minSigners: number
   participants: Array<{ identity: string }>
 }
@@ -21,7 +21,7 @@ export type DkgRound1Response = {
 
 export const DkgRound1RequestSchema: yup.ObjectSchema<DkgRound1Request> = yup
   .object({
-    secretName: yup.string().defined(),
+    participantName: yup.string().defined(),
     minSigners: yup.number().defined(),
     participants: yup
       .array()
@@ -43,12 +43,12 @@ routes.register<typeof DkgRound1RequestSchema, DkgRound1Response>(
   async (request, node): Promise<void> => {
     AssertHasRpcContext(request, node, 'wallet')
 
-    const { secretName, minSigners, participants } = request.data
-    const multisigSecret = await node.wallet.walletDb.getMultisigSecretByName(secretName)
+    const { participantName, minSigners, participants } = request.data
+    const multisigSecret = await node.wallet.walletDb.getMultisigSecretByName(participantName)
 
     if (!multisigSecret) {
       throw new RpcValidationError(
-        `Multisig secret with name '${secretName}' not found`,
+        `Multisig secret with name '${participantName}' not found`,
         400,
         RPC_ERROR_CODES.MULTISIG_SECRET_NOT_FOUND,
       )

--- a/ironfish/src/rpc/routes/wallet/multisig/dkg/round2.test.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/dkg/round2.test.ts
@@ -27,19 +27,11 @@ describe('Route multisig/dkg/round2', () => {
     const round1Response2 = await routeTest.client.wallet.multisig.dkg.round1(round1Request2)
 
     const round2Request = {
-<<<<<<< HEAD
-      secretName: secretName1,
+      participantName: participantName1,
       round1SecretPackage: round1Response1.content.round1SecretPackage,
       round1PublicPackages: [
         round1Response1.content.round1PublicPackage,
         round1Response2.content.round1PublicPackage,
-=======
-      participantName: participantName1,
-      encryptedSecretPackage: round1Response1.content.encryptedSecretPackage,
-      publicPackages: [
-        round1Response1.content.publicPackage,
-        round1Response2.content.publicPackage,
->>>>>>> 739831827 (renames secretName to participantName)
       ],
     }
 
@@ -52,15 +44,9 @@ describe('Route multisig/dkg/round2', () => {
 
   it('should fail if the named secret does not exist', async () => {
     const request = {
-<<<<<<< HEAD
-      secretName: 'fakeName',
+      participantName: 'fakeName',
       round1SecretPackage: 'foo',
       round1PublicPackages: ['bar', 'baz'],
-=======
-      participantName: 'fakeName',
-      encryptedSecretPackage: 'foo',
-      publicPackages: ['bar', 'baz'],
->>>>>>> 739831827 (renames secretName to participantName)
     }
 
     await expect(routeTest.client.wallet.multisig.dkg.round2(request)).rejects.toThrow(

--- a/ironfish/src/rpc/routes/wallet/multisig/dkg/round2.test.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/dkg/round2.test.ts
@@ -7,31 +7,39 @@ describe('Route multisig/dkg/round2', () => {
   const routeTest = createRouteTest()
 
   it('should create round 2 packages', async () => {
-    const secretName1 = 'name1'
-    await routeTest.client.wallet.multisig.createParticipant({ name: secretName1 })
-    const secretName2 = 'name2'
-    await routeTest.client.wallet.multisig.createParticipant({ name: secretName2 })
+    const participantName1 = 'name1'
+    await routeTest.client.wallet.multisig.createParticipant({ name: participantName1 })
+    const participantName2 = 'name2'
+    await routeTest.client.wallet.multisig.createParticipant({ name: participantName2 })
 
     const identity1 = (
-      await routeTest.client.wallet.multisig.getIdentity({ name: secretName1 })
+      await routeTest.client.wallet.multisig.getIdentity({ name: participantName1 })
     ).content.identity
     const identity2 = (
-      await routeTest.client.wallet.multisig.getIdentity({ name: secretName2 })
+      await routeTest.client.wallet.multisig.getIdentity({ name: participantName2 })
     ).content.identity
     const participants = [{ identity: identity1 }, { identity: identity2 }]
 
-    const round1Request1 = { secretName: secretName1, minSigners: 2, participants }
+    const round1Request1 = { participantName: participantName1, minSigners: 2, participants }
     const round1Response1 = await routeTest.client.wallet.multisig.dkg.round1(round1Request1)
 
-    const round1Request2 = { secretName: secretName2, minSigners: 2, participants }
+    const round1Request2 = { participantName: participantName2, minSigners: 2, participants }
     const round1Response2 = await routeTest.client.wallet.multisig.dkg.round1(round1Request2)
 
     const round2Request = {
+<<<<<<< HEAD
       secretName: secretName1,
       round1SecretPackage: round1Response1.content.round1SecretPackage,
       round1PublicPackages: [
         round1Response1.content.round1PublicPackage,
         round1Response2.content.round1PublicPackage,
+=======
+      participantName: participantName1,
+      encryptedSecretPackage: round1Response1.content.encryptedSecretPackage,
+      publicPackages: [
+        round1Response1.content.publicPackage,
+        round1Response2.content.publicPackage,
+>>>>>>> 739831827 (renames secretName to participantName)
       ],
     }
 
@@ -44,9 +52,15 @@ describe('Route multisig/dkg/round2', () => {
 
   it('should fail if the named secret does not exist', async () => {
     const request = {
+<<<<<<< HEAD
       secretName: 'fakeName',
       round1SecretPackage: 'foo',
       round1PublicPackages: ['bar', 'baz'],
+=======
+      participantName: 'fakeName',
+      encryptedSecretPackage: 'foo',
+      publicPackages: ['bar', 'baz'],
+>>>>>>> 739831827 (renames secretName to participantName)
     }
 
     await expect(routeTest.client.wallet.multisig.dkg.round2(request)).rejects.toThrow(

--- a/ironfish/src/rpc/routes/wallet/multisig/dkg/round2.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/dkg/round2.ts
@@ -9,7 +9,7 @@ import { routes } from '../../../router'
 import { AssertHasRpcContext } from '../../../rpcContext'
 
 export type DkgRound2Request = {
-  secretName: string
+  participantName: string
   round1SecretPackage: string
   round1PublicPackages: Array<string>
 }
@@ -21,6 +21,7 @@ export type DkgRound2Response = {
 
 export const DkgRound2RequestSchema: yup.ObjectSchema<DkgRound2Request> = yup
   .object({
+    participantName: yup.string().defined(),
     secretName: yup.string().defined(),
     round1SecretPackage: yup.string().defined(),
     round1PublicPackages: yup.array().of(yup.string().defined()).defined(),
@@ -40,12 +41,12 @@ routes.register<typeof DkgRound2RequestSchema, DkgRound2Response>(
   async (request, node): Promise<void> => {
     AssertHasRpcContext(request, node, 'wallet')
 
-    const { secretName, round1SecretPackage, round1PublicPackages } = request.data
-    const multisigSecret = await node.wallet.walletDb.getMultisigSecretByName(secretName)
+    const { participantName, round1SecretPackage, round1PublicPackages } = request.data
+    const multisigSecret = await node.wallet.walletDb.getMultisigSecretByName(participantName)
 
     if (!multisigSecret) {
       throw new RpcValidationError(
-        `Multisig secret with name '${secretName}' not found`,
+        `Multisig secret with name '${participantName}' not found`,
         400,
         RPC_ERROR_CODES.MULTISIG_SECRET_NOT_FOUND,
       )

--- a/ironfish/src/rpc/routes/wallet/multisig/dkg/round2.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/dkg/round2.ts
@@ -22,7 +22,6 @@ export type DkgRound2Response = {
 export const DkgRound2RequestSchema: yup.ObjectSchema<DkgRound2Request> = yup
   .object({
     participantName: yup.string().defined(),
-    secretName: yup.string().defined(),
     round1SecretPackage: yup.string().defined(),
     round1PublicPackages: yup.array().of(yup.string().defined()).defined(),
   })

--- a/ironfish/src/rpc/routes/wallet/multisig/dkg/round3.test.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/dkg/round3.test.ts
@@ -45,15 +45,9 @@ describe('Route multisig/dkg/round3', () => {
     const round2Packages = await Promise.all(
       participantNames.map((participantName, index) =>
         routeTest.client.wallet.multisig.dkg.round2({
-<<<<<<< HEAD
-          secretName,
+          participantName,
           round1SecretPackage: round1Packages[index].content.round1SecretPackage,
           round1PublicPackages: round1Packages.map((pkg) => pkg.content.round1PublicPackage),
-=======
-          participantName,
-          encryptedSecretPackage: round1Packages[index].content.encryptedSecretPackage,
-          publicPackages: round1Packages.map((pkg) => pkg.content.publicPackage),
->>>>>>> 739831827 (renames secretName to participantName)
         }),
       ),
     )
@@ -136,15 +130,9 @@ describe('Route multisig/dkg/round3', () => {
     const round2Packages = await Promise.all(
       participantNames.map((participantName, index) =>
         routeTest.client.wallet.multisig.dkg.round2({
-<<<<<<< HEAD
-          secretName,
+          participantName,
           round1SecretPackage: round1Packages[index].content.round1SecretPackage,
           round1PublicPackages: round1Packages.map((pkg) => pkg.content.round1PublicPackage),
-=======
-          participantName,
-          encryptedSecretPackage: round1Packages[index].content.encryptedSecretPackage,
-          publicPackages: round1Packages.map((pkg) => pkg.content.publicPackage),
->>>>>>> 739831827 (renames secretName to participantName)
         }),
       ),
     )
@@ -152,13 +140,8 @@ describe('Route multisig/dkg/round3', () => {
     // Perform DKG round 3
     await expect(
       routeTest.client.wallet.multisig.dkg.round3({
-<<<<<<< HEAD
-        secretName: secretNames[0],
-        round2SecretPackage: round2Packages[0].content.round2SecretPackage,
-=======
         participantName: participantNames[0],
-        round2SecretPackage: round2Packages[0].content.encryptedSecretPackage,
->>>>>>> 739831827 (renames secretName to participantName)
+        round2SecretPackage: round2Packages[0].content.round2SecretPackage,
         round1PublicPackages: removeOneElement(
           round1Packages.map((pkg) => pkg.content.round1PublicPackage),
         ),
@@ -197,15 +180,9 @@ describe('Route multisig/dkg/round3', () => {
     const round2Packages = await Promise.all(
       participantNames.map((participantName, index) =>
         routeTest.client.wallet.multisig.dkg.round2({
-<<<<<<< HEAD
-          secretName,
+          participantName,
           round1SecretPackage: round1Packages[index].content.round1SecretPackage,
           round1PublicPackages: round1Packages.map((pkg) => pkg.content.round1PublicPackage),
-=======
-          participantName,
-          encryptedSecretPackage: round1Packages[index].content.encryptedSecretPackage,
-          publicPackages: round1Packages.map((pkg) => pkg.content.publicPackage),
->>>>>>> 739831827 (renames secretName to participantName)
         }),
       ),
     )
@@ -213,15 +190,9 @@ describe('Route multisig/dkg/round3', () => {
     // Perform DKG round 3
     await expect(
       routeTest.client.wallet.multisig.dkg.round3({
-<<<<<<< HEAD
-        secretName: secretNames[0],
+        participantName: participantNames[0],
         round2SecretPackage: round2Packages[0].content.round2SecretPackage,
         round1PublicPackages: round1Packages.map((pkg) => pkg.content.round1PublicPackage),
-=======
-        participantName: participantNames[0],
-        round2SecretPackage: round2Packages[0].content.encryptedSecretPackage,
-        round1PublicPackages: round1Packages.map((pkg) => pkg.content.publicPackage),
->>>>>>> 739831827 (renames secretName to participantName)
         // Here we cannot just remove any one element to perform this test,
         // because `round2Packages[0]` does not contain any useful
         // information for `participantName[0]`, hence if that gets removed, the
@@ -263,15 +234,9 @@ describe('Route multisig/dkg/round3', () => {
     const round2Packages = await Promise.all(
       participantNames.map((participantName, index) =>
         routeTest.client.wallet.multisig.dkg.round2({
-<<<<<<< HEAD
-          secretName,
+          participantName,
           round1SecretPackage: round1Packages[index].content.round1SecretPackage,
           round1PublicPackages: round1Packages.map((pkg) => pkg.content.round1PublicPackage),
-=======
-          participantName,
-          encryptedSecretPackage: round1Packages[index].content.encryptedSecretPackage,
-          publicPackages: round1Packages.map((pkg) => pkg.content.publicPackage),
->>>>>>> 739831827 (renames secretName to participantName)
         }),
       ),
     )
@@ -279,17 +244,10 @@ describe('Route multisig/dkg/round3', () => {
     // Perform DKG round 3
     await expect(
       routeTest.client.wallet.multisig.dkg.round3({
-<<<<<<< HEAD
-        secretName: secretNames[0],
+        participantName: participantNames[0],
         round2SecretPackage: round2Packages[1].content.round2SecretPackage,
         round1PublicPackages: round1Packages.map((pkg) => pkg.content.round1PublicPackage),
         round2PublicPackages: round2Packages.map((pkg) => pkg.content.round2PublicPackage),
-=======
-        participantName: participantNames[0],
-        round2SecretPackage: round2Packages[1].content.encryptedSecretPackage,
-        round1PublicPackages: round1Packages.map((pkg) => pkg.content.publicPackage),
-        round2PublicPackages: round2Packages.map((pkg) => pkg.content.publicPackages),
->>>>>>> 739831827 (renames secretName to participantName)
       }),
     ).rejects.toThrow('decryption error: aead::Error')
   })

--- a/ironfish/src/rpc/routes/wallet/multisig/dkg/round3.test.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/dkg/round3.test.ts
@@ -20,7 +20,9 @@ describe('Route multisig/dkg/round3', () => {
 
     // Create participants and retrieve their identities
     await Promise.all(
-      participantNames.map((name) => routeTest.client.wallet.multisig.createParticipant({ name })),
+      participantNames.map((name) =>
+        routeTest.client.wallet.multisig.createParticipant({ name }),
+      ),
     )
     const participants = await Promise.all(
       participantNames.map(
@@ -109,7 +111,9 @@ describe('Route multisig/dkg/round3', () => {
 
     // Create participants and retrieve their identities
     await Promise.all(
-      participantNames.map((name) => routeTest.client.wallet.multisig.createParticipant({ name })),
+      participantNames.map((name) =>
+        routeTest.client.wallet.multisig.createParticipant({ name }),
+      ),
     )
     const participants = await Promise.all(
       participantNames.map(
@@ -168,7 +172,9 @@ describe('Route multisig/dkg/round3', () => {
 
     // Create participants and retrieve their identities
     await Promise.all(
-      participantNames.map((name) => routeTest.client.wallet.multisig.createParticipant({ name })),
+      participantNames.map((name) =>
+        routeTest.client.wallet.multisig.createParticipant({ name }),
+      ),
     )
     const participants = await Promise.all(
       participantNames.map(
@@ -232,7 +238,9 @@ describe('Route multisig/dkg/round3', () => {
 
     // Create participants and retrieve their identities
     await Promise.all(
-      participantNames.map((name) => routeTest.client.wallet.multisig.createParticipant({ name })),
+      participantNames.map((name) =>
+        routeTest.client.wallet.multisig.createParticipant({ name }),
+      ),
     )
     const participants = await Promise.all(
       participantNames.map(

--- a/ironfish/src/rpc/routes/wallet/multisig/dkg/round3.test.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/dkg/round3.test.ts
@@ -15,24 +15,24 @@ describe('Route multisig/dkg/round3', () => {
   const routeTest = createRouteTest()
 
   it('should create round 3 packages', async () => {
-    const secretNames = ['secret-0', 'secret-1', 'secret-2']
+    const participantNames = ['secret-0', 'secret-1', 'secret-2']
     const accountNames = ['account-0', 'account-1', 'account-2']
 
     // Create participants and retrieve their identities
     await Promise.all(
-      secretNames.map((name) => routeTest.client.wallet.multisig.createParticipant({ name })),
+      participantNames.map((name) => routeTest.client.wallet.multisig.createParticipant({ name })),
     )
     const participants = await Promise.all(
-      secretNames.map(
+      participantNames.map(
         async (name) => (await routeTest.client.wallet.multisig.getIdentity({ name })).content,
       ),
     )
 
     // Perform DKG round 1
     const round1Packages = await Promise.all(
-      secretNames.map((secretName) =>
+      participantNames.map((participantName) =>
         routeTest.client.wallet.multisig.dkg.round1({
-          secretName,
+          participantName,
           minSigners: 2,
           participants,
         }),
@@ -41,20 +41,26 @@ describe('Route multisig/dkg/round3', () => {
 
     // Perform DKG round 2
     const round2Packages = await Promise.all(
-      secretNames.map((secretName, index) =>
+      participantNames.map((participantName, index) =>
         routeTest.client.wallet.multisig.dkg.round2({
+<<<<<<< HEAD
           secretName,
           round1SecretPackage: round1Packages[index].content.round1SecretPackage,
           round1PublicPackages: round1Packages.map((pkg) => pkg.content.round1PublicPackage),
+=======
+          participantName,
+          encryptedSecretPackage: round1Packages[index].content.encryptedSecretPackage,
+          publicPackages: round1Packages.map((pkg) => pkg.content.publicPackage),
+>>>>>>> 739831827 (renames secretName to participantName)
         }),
       ),
     )
 
     // Perform DKG round 3
     const round3Responses = await Promise.all(
-      secretNames.map((secretName, index) =>
+      participantNames.map((participantName, index) =>
         routeTest.client.wallet.multisig.dkg.round3({
-          secretName,
+          participantName,
           accountName: accountNames[index],
           round2SecretPackage: round2Packages[index].content.round2SecretPackage,
           round1PublicPackages: round1Packages.map((pkg) => pkg.content.round1PublicPackage),
@@ -99,23 +105,23 @@ describe('Route multisig/dkg/round3', () => {
   })
 
   it('should fail if not all round 1 packages are passed as an input', async () => {
-    const secretNames = ['secret-0', 'secret-1', 'secret-2']
+    const participantNames = ['secret-0', 'secret-1', 'secret-2']
 
     // Create participants and retrieve their identities
     await Promise.all(
-      secretNames.map((name) => routeTest.client.wallet.multisig.createParticipant({ name })),
+      participantNames.map((name) => routeTest.client.wallet.multisig.createParticipant({ name })),
     )
     const participants = await Promise.all(
-      secretNames.map(
+      participantNames.map(
         async (name) => (await routeTest.client.wallet.multisig.getIdentity({ name })).content,
       ),
     )
 
     // Perform DKG round 1
     const round1Packages = await Promise.all(
-      secretNames.map((secretName) =>
+      participantNames.map((participantName) =>
         routeTest.client.wallet.multisig.dkg.round1({
-          secretName,
+          participantName,
           minSigners: 2,
           participants,
         }),
@@ -124,11 +130,17 @@ describe('Route multisig/dkg/round3', () => {
 
     // Perform DKG round 2
     const round2Packages = await Promise.all(
-      secretNames.map((secretName, index) =>
+      participantNames.map((participantName, index) =>
         routeTest.client.wallet.multisig.dkg.round2({
+<<<<<<< HEAD
           secretName,
           round1SecretPackage: round1Packages[index].content.round1SecretPackage,
           round1PublicPackages: round1Packages.map((pkg) => pkg.content.round1PublicPackage),
+=======
+          participantName,
+          encryptedSecretPackage: round1Packages[index].content.encryptedSecretPackage,
+          publicPackages: round1Packages.map((pkg) => pkg.content.publicPackage),
+>>>>>>> 739831827 (renames secretName to participantName)
         }),
       ),
     )
@@ -136,8 +148,13 @@ describe('Route multisig/dkg/round3', () => {
     // Perform DKG round 3
     await expect(
       routeTest.client.wallet.multisig.dkg.round3({
+<<<<<<< HEAD
         secretName: secretNames[0],
         round2SecretPackage: round2Packages[0].content.round2SecretPackage,
+=======
+        participantName: participantNames[0],
+        round2SecretPackage: round2Packages[0].content.encryptedSecretPackage,
+>>>>>>> 739831827 (renames secretName to participantName)
         round1PublicPackages: removeOneElement(
           round1Packages.map((pkg) => pkg.content.round1PublicPackage),
         ),
@@ -147,23 +164,23 @@ describe('Route multisig/dkg/round3', () => {
   })
 
   it('should fail if not all round 2 packages are passed as an input', async () => {
-    const secretNames = ['secret-0', 'secret-1', 'secret-2']
+    const participantNames = ['secret-0', 'secret-1', 'secret-2']
 
     // Create participants and retrieve their identities
     await Promise.all(
-      secretNames.map((name) => routeTest.client.wallet.multisig.createParticipant({ name })),
+      participantNames.map((name) => routeTest.client.wallet.multisig.createParticipant({ name })),
     )
     const participants = await Promise.all(
-      secretNames.map(
+      participantNames.map(
         async (name) => (await routeTest.client.wallet.multisig.getIdentity({ name })).content,
       ),
     )
 
     // Perform DKG round 1
     const round1Packages = await Promise.all(
-      secretNames.map((secretName) =>
+      participantNames.map((participantName) =>
         routeTest.client.wallet.multisig.dkg.round1({
-          secretName,
+          participantName,
           minSigners: 2,
           participants,
         }),
@@ -172,11 +189,17 @@ describe('Route multisig/dkg/round3', () => {
 
     // Perform DKG round 2
     const round2Packages = await Promise.all(
-      secretNames.map((secretName, index) =>
+      participantNames.map((participantName, index) =>
         routeTest.client.wallet.multisig.dkg.round2({
+<<<<<<< HEAD
           secretName,
           round1SecretPackage: round1Packages[index].content.round1SecretPackage,
           round1PublicPackages: round1Packages.map((pkg) => pkg.content.round1PublicPackage),
+=======
+          participantName,
+          encryptedSecretPackage: round1Packages[index].content.encryptedSecretPackage,
+          publicPackages: round1Packages.map((pkg) => pkg.content.publicPackage),
+>>>>>>> 739831827 (renames secretName to participantName)
         }),
       ),
     )
@@ -184,12 +207,18 @@ describe('Route multisig/dkg/round3', () => {
     // Perform DKG round 3
     await expect(
       routeTest.client.wallet.multisig.dkg.round3({
+<<<<<<< HEAD
         secretName: secretNames[0],
         round2SecretPackage: round2Packages[0].content.round2SecretPackage,
         round1PublicPackages: round1Packages.map((pkg) => pkg.content.round1PublicPackage),
+=======
+        participantName: participantNames[0],
+        round2SecretPackage: round2Packages[0].content.encryptedSecretPackage,
+        round1PublicPackages: round1Packages.map((pkg) => pkg.content.publicPackage),
+>>>>>>> 739831827 (renames secretName to participantName)
         // Here we cannot just remove any one element to perform this test,
         // because `round2Packages[0]` does not contain any useful
-        // information for `secretName[0]`, hence if that gets removed, the
+        // information for `participantName[0]`, hence if that gets removed, the
         // operation won't fail. This is why we call `slice()`
         round2PublicPackages: removeOneElement(
           round2Packages.slice(1).map((pkg) => pkg.content.round2PublicPackage),
@@ -199,23 +228,23 @@ describe('Route multisig/dkg/round3', () => {
   })
 
   it('should fail passing the wrong round 2 secret package', async () => {
-    const secretNames = ['secret-0', 'secret-1', 'secret-2']
+    const participantNames = ['secret-0', 'secret-1', 'secret-2']
 
     // Create participants and retrieve their identities
     await Promise.all(
-      secretNames.map((name) => routeTest.client.wallet.multisig.createParticipant({ name })),
+      participantNames.map((name) => routeTest.client.wallet.multisig.createParticipant({ name })),
     )
     const participants = await Promise.all(
-      secretNames.map(
+      participantNames.map(
         async (name) => (await routeTest.client.wallet.multisig.getIdentity({ name })).content,
       ),
     )
 
     // Perform DKG round 1
     const round1Packages = await Promise.all(
-      secretNames.map((secretName) =>
+      participantNames.map((participantName) =>
         routeTest.client.wallet.multisig.dkg.round1({
-          secretName,
+          participantName,
           minSigners: 2,
           participants,
         }),
@@ -224,11 +253,17 @@ describe('Route multisig/dkg/round3', () => {
 
     // Perform DKG round 2
     const round2Packages = await Promise.all(
-      secretNames.map((secretName, index) =>
+      participantNames.map((participantName, index) =>
         routeTest.client.wallet.multisig.dkg.round2({
+<<<<<<< HEAD
           secretName,
           round1SecretPackage: round1Packages[index].content.round1SecretPackage,
           round1PublicPackages: round1Packages.map((pkg) => pkg.content.round1PublicPackage),
+=======
+          participantName,
+          encryptedSecretPackage: round1Packages[index].content.encryptedSecretPackage,
+          publicPackages: round1Packages.map((pkg) => pkg.content.publicPackage),
+>>>>>>> 739831827 (renames secretName to participantName)
         }),
       ),
     )
@@ -236,10 +271,17 @@ describe('Route multisig/dkg/round3', () => {
     // Perform DKG round 3
     await expect(
       routeTest.client.wallet.multisig.dkg.round3({
+<<<<<<< HEAD
         secretName: secretNames[0],
         round2SecretPackage: round2Packages[1].content.round2SecretPackage,
         round1PublicPackages: round1Packages.map((pkg) => pkg.content.round1PublicPackage),
         round2PublicPackages: round2Packages.map((pkg) => pkg.content.round2PublicPackage),
+=======
+        participantName: participantNames[0],
+        round2SecretPackage: round2Packages[1].content.encryptedSecretPackage,
+        round1PublicPackages: round1Packages.map((pkg) => pkg.content.publicPackage),
+        round2PublicPackages: round2Packages.map((pkg) => pkg.content.publicPackages),
+>>>>>>> 739831827 (renames secretName to participantName)
       }),
     ).rejects.toThrow('decryption error: aead::Error')
   })

--- a/ironfish/src/rpc/routes/wallet/multisig/dkg/round3.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/dkg/round3.ts
@@ -11,7 +11,7 @@ import { ApiNamespace } from '../../../namespaces'
 import { routes } from '../../../router'
 
 export type DkgRound3Request = {
-  secretName: string
+  participantName: string
   round2SecretPackage: string
   round1PublicPackages: Array<string>
   round2PublicPackages: Array<string>
@@ -26,7 +26,7 @@ export type DkgRound3Response = {
 
 export const DkgRound3RequestSchema: yup.ObjectSchema<DkgRound3Request> = yup
   .object({
-    secretName: yup.string().defined(),
+    participantName: yup.string().defined(),
     round2SecretPackage: yup.string().defined(),
     round1PublicPackages: yup.array().of(yup.string().defined()).defined(),
     round2PublicPackages: yup.array().of(yup.string().defined()).defined(),
@@ -48,12 +48,12 @@ routes.register<typeof DkgRound3RequestSchema, DkgRound3Response>(
   async (request, node): Promise<void> => {
     Assert.isInstanceOf(node, FullNode)
 
-    const { secretName } = request.data
-    const multisigSecret = await node.wallet.walletDb.getMultisigSecretByName(secretName)
+    const { participantName } = request.data
+    const multisigSecret = await node.wallet.walletDb.getMultisigSecretByName(participantName)
 
     if (!multisigSecret) {
       throw new RpcValidationError(
-        `Multisig secret with name '${secretName}' not found`,
+        `Multisig secret with name '${participantName}' not found`,
         400,
         RPC_ERROR_CODES.MULTISIG_SECRET_NOT_FOUND,
       )
@@ -78,7 +78,7 @@ routes.register<typeof DkgRound3RequestSchema, DkgRound3Response>(
     )
 
     const accountImport = {
-      name: request.data.accountName ?? secretName,
+      name: request.data.accountName ?? participantName,
       version: ACCOUNT_SCHEMA_VERSION,
       createdAt: null,
       spendingKey: null,

--- a/ironfish/src/rpc/routes/wallet/multisig/integration.test.slow.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/integration.test.slow.ts
@@ -106,10 +106,10 @@ describe('multisig RPC integration', () => {
   }
 
   function createParticipants(
-    secretNames: Array<string>,
+    participantNames: Array<string>,
   ): Promise<Array<{ name: string; identity: string }>> {
     return Promise.all(
-      secretNames.map(async (name) => {
+      participantNames.map(async (name) => {
         const identity = (await routeTest.client.wallet.multisig.createParticipant({ name }))
           .content.identity
         return { name, identity }
@@ -180,7 +180,7 @@ describe('multisig RPC integration', () => {
     const round1Packages = await Promise.all(
       participants.map(({ name }) =>
         routeTest.client.wallet.multisig.dkg.round1({
-          secretName: name,
+          participantName: name,
           minSigners,
           participants,
         }),
@@ -191,7 +191,7 @@ describe('multisig RPC integration', () => {
     const round2Packages = await Promise.all(
       participants.map(({ name }, index) =>
         routeTest.client.wallet.multisig.dkg.round2({
-          secretName: name,
+          participantName: name,
           round1SecretPackage: round1Packages[index].content.round1SecretPackage,
           round1PublicPackages: round1Packages.map((pkg) => pkg.content.round1PublicPackage),
         }),
@@ -202,7 +202,7 @@ describe('multisig RPC integration', () => {
     const participantAccounts = await Promise.all(
       participants.map(async ({ name }, index) => {
         await routeTest.client.wallet.multisig.dkg.round3({
-          secretName: name,
+          participantName: name,
           round2SecretPackage: round2Packages[index].content.round2SecretPackage,
           round1PublicPackages: round1Packages.map((pkg) => pkg.content.round1PublicPackage),
           round2PublicPackages: round2Packages.map((pkg) => pkg.content.round2PublicPackage),


### PR DESCRIPTION
## Summary

the term 'secretName' does not make it clear that the name should be the same as the one used with 'participant:create', that is, the name of a participant

renames the flag and rpc parameter 'secretName' to 'participantName' across all dkg cli commands and rpc endpoints

changes flag character from s to n. in round3, this also requires changing the 'accountName' flag character from n to a

adds an alias 'name' for 'participantName' in all dkg commands

## Testing Plan

manual testing: created an account by running all three dkg rounds

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
