### PR TITLE
feat(cli): Add CLI command to list identities

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/participants/index.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/participants/index.ts
@@ -1,0 +1,47 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { CliUx } from '@oclif/core'
+import { IronfishCommand } from '../../../../command'
+import { RemoteFlags } from '../../../../flags'
+
+export class MultisigParticipants extends IronfishCommand {
+  static description = 'List out all the participant names and identities'
+
+  static flags = {
+    ...RemoteFlags,
+  }
+
+  async start(): Promise<void> {
+    const client = await this.sdk.connectRpc()
+    const response = await client.wallet.multisig.getIdentities()
+
+    const participants = []
+    for (const { name, identity } of response.content.identities) {
+      participants.push({
+        name,
+        value: identity,
+      })
+    }
+
+    // sort identities by name
+    participants.sort((a, b) => a.name.localeCompare(b.name))
+
+    CliUx.ux.table(
+      participants,
+      {
+        name: {
+          header: 'Participant Name',
+          get: (p) => p.name,
+        },
+        identity: {
+          header: 'Identity',
+          get: (p) => p.value,
+        },
+      },
+      {
+        'no-truncate': true,
+      },
+    )
+  }
+}


### PR DESCRIPTION
## Summary

List out a table of participant names and identities

## Testing Plan

Manually ran the command

![image](https://github.com/iron-fish/ironfish/assets/5459049/cff598e8-f93d-46ee-aa47-0514b9030fc9)

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
