### PR TITLE
Use ironfish decimal parsing function

### DIFF
--- a/ironfish-cli/src/commands/wallet/burn.ts
+++ b/ironfish-cli/src/commands/wallet/burn.ts
@@ -149,7 +149,7 @@ export class Burn extends IronfishCommand {
       )
 
       if (error) {
-        this.error(`${error.reason}`)
+        this.error(`${error.message}`)
       }
 
       amount = parsedAmount

--- a/ironfish-cli/src/commands/wallet/mint.ts
+++ b/ironfish-cli/src/commands/wallet/mint.ts
@@ -213,7 +213,7 @@ export class Mint extends IronfishCommand {
       )
 
       if (error) {
-        this.error(`${error.reason}`)
+        this.error(`${error.message}`)
       }
 
       amount = parsedAmount

--- a/ironfish-cli/src/commands/wallet/send.ts
+++ b/ironfish-cli/src/commands/wallet/send.ts
@@ -163,7 +163,7 @@ export class Send extends IronfishCommand {
       )
 
       if (error) {
-        this.error(`${error.reason}`)
+        this.error(`${error.message}`)
       }
 
       amount = parsedAmount

--- a/ironfish-cli/src/utils/currency.ts
+++ b/ironfish-cli/src/utils/currency.ts
@@ -72,7 +72,7 @@ export async function promptCurrency(options: {
     )
 
     if (error) {
-      options.logger.error(`Error: ${error.reason}`)
+      options.logger.error(`Error: ${error.message}`)
       continue
     }
 

--- a/ironfish/src/utils/currency.test.ts
+++ b/ironfish/src/utils/currency.test.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Asset } from '@ironfish/rust-nodejs'
-import { CurrencyUtils, isParseFixedError } from './currency'
+import { CurrencyUtils } from './currency'
 
 describe('CurrencyUtils', () => {
   it('encode', () => {
@@ -94,7 +94,7 @@ describe('CurrencyUtils', () => {
     it('should return an error if the given amount cannot be parsed', () => {
       const [value, err] = CurrencyUtils.tryMajorToMinor('1.0.0')
       expect(value).toBeNull()
-      expect(isParseFixedError(err)).toEqual(true)
+      expect(err?.message).toEqual('too many decimal points')
     })
   })
 

--- a/ironfish/src/utils/currency.ts
+++ b/ironfish/src/utils/currency.ts
@@ -5,7 +5,6 @@
 import { formatFixed, parseFixed } from '@ethersproject/bignumber'
 import { isNativeIdentifier } from './asset'
 import { BigIntUtils } from './bigint'
-import { ErrorUtils } from './error'
 import { FixedNumberUtils } from './fixedNumber'
 
 export class CurrencyUtils {
@@ -132,20 +131,6 @@ export class CurrencyUtils {
 
     return ore
   }
-}
-
-interface ParseFixedError extends Error {
-  code: 'INVALID_ARGUMENT' | 'NUMERIC_FAULT'
-  reason: string
-}
-
-function isParseFixedError(error: unknown): error is ParseFixedError {
-  return (
-    ErrorUtils.isNodeError(error) &&
-    (error['code'] === 'INVALID_ARGUMENT' || error['code'] === 'NUMERIC_FAULT') &&
-    'reason' in error &&
-    typeof error['reason'] === 'string'
-  )
 }
 
 const IRON_DECIMAL_PLACES = 8

--- a/ironfish/src/utils/currency.ts
+++ b/ironfish/src/utils/currency.ts
@@ -60,14 +60,14 @@ export class CurrencyUtils {
     verifiedAssetMetadata?: {
       decimals?: number
     },
-  ): [bigint, null] | [null, ParseFixedError] {
+  ): [bigint, null] | [null, Error] {
     try {
       const { decimals } = assetMetadataWithDefaults(assetId, verifiedAssetMetadata)
       const parsed = parseFixed(amount.toString(), decimals).toBigInt()
       return [parsed, null]
     } catch (e) {
       if (isParseFixedError(e)) {
-        return [null, e]
+        return [null, new Error(e.reason)]
       }
       throw e
     }
@@ -126,12 +126,12 @@ export class CurrencyUtils {
   }
 }
 
-export interface ParseFixedError extends Error {
+interface ParseFixedError extends Error {
   code: 'INVALID_ARGUMENT' | 'NUMERIC_FAULT'
   reason: string
 }
 
-export function isParseFixedError(error: unknown): error is ParseFixedError {
+function isParseFixedError(error: unknown): error is ParseFixedError {
   return (
     ErrorUtils.isNodeError(error) &&
     (error['code'] === 'INVALID_ARGUMENT' || error['code'] === 'NUMERIC_FAULT') &&

--- a/ironfish/src/utils/fixedNumber.ts
+++ b/ironfish/src/utils/fixedNumber.ts
@@ -43,7 +43,7 @@ export class FixedNumberUtils {
     const split = input.split('.')
 
     if (split.length > 2) {
-      throw new Error('Invalid number of decimals')
+      throw new Error('too many decimal points')
     } else if (split.length === 1) {
       return { value: BigInt(split[0]), decimals: 0 }
     } else {


### PR DESCRIPTION
## Summary
Standardizing which function we use for parsing decimal values to BigInts

## Testing Plan
Existing unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Removes exports `ParseFixedError` and `isParseFixedError` from `CurrencyUtils` and changes the error value in `CurrencyUtils.tryMajorToMinor`
