### PR TITLE
updates text of identities prompts

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/commitment/aggregate.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/commitment/aggregate.ts
@@ -48,7 +48,7 @@ export class CreateSigningPackage extends IronfishCommand {
 
     let commitments = options.commitment
     if (!commitments) {
-      const input = await longPrompt('Enter the signing commitments separated by commas', {
+      const input = await longPrompt('Enter the signing commitments, separated by commas', {
         required: true,
       })
       commitments = input.split(',')

--- a/ironfish-cli/src/commands/wallet/multisig/commitment/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/commitment/create.ts
@@ -48,7 +48,7 @@ export class CreateSigningCommitmentCommand extends IronfishCommand {
     let identities = options.identity
     if (!identities || identities.length < 2) {
       const input = await longPrompt(
-        'Enter the identities of all participants who will sign the transaction separated by commas',
+        'Enter the identities of all participants who will sign the transaction, separated by commas',
         {
           required: true,
         },

--- a/ironfish-cli/src/commands/wallet/multisig/commitment/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/commitment/create.ts
@@ -47,9 +47,12 @@ export class CreateSigningCommitmentCommand extends IronfishCommand {
 
     let identities = options.identity
     if (!identities || identities.length < 2) {
-      const input = await longPrompt('Enter the identities separated by commas', {
-        required: true,
-      })
+      const input = await longPrompt(
+        'Enter the identities of all participants who will sign the transaction separated by commas',
+        {
+          required: true,
+        },
+      )
       identities = input.split(',')
 
       if (identities.length < 2) {

--- a/ironfish-cli/src/commands/wallet/multisig/dealer/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dealer/create.ts
@@ -39,7 +39,7 @@ export class MultisigCreateDealer extends IronfishCommand {
     let identities = flags.identity
     if (!identities || identities.length < 2) {
       const input = await longPrompt(
-        'Enter the identities of all participants separated by commas',
+        'Enter the identities of all participants, separated by commas',
         {
           required: true,
         },

--- a/ironfish-cli/src/commands/wallet/multisig/dealer/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dealer/create.ts
@@ -38,9 +38,12 @@ export class MultisigCreateDealer extends IronfishCommand {
 
     let identities = flags.identity
     if (!identities || identities.length < 2) {
-      const input = await longPrompt('Enter the identities separated by commas', {
-        required: true,
-      })
+      const input = await longPrompt(
+        'Enter the identities of all participants separated by commas',
+        {
+          required: true,
+        },
+      )
       identities = input.split(',')
 
       if (identities.length < 2) {

--- a/ironfish-cli/src/commands/wallet/multisig/dkg/round1.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/round1.ts
@@ -43,7 +43,7 @@ export class DkgRound1Command extends IronfishCommand {
     let identities = flags.identity
     if (!identities || identities.length < 2) {
       const input = await longPrompt(
-        'Enter the identities of all participants separated by commas',
+        'Enter the identities of all participants, separated by commas',
         {
           required: true,
         },

--- a/ironfish-cli/src/commands/wallet/multisig/dkg/round1.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/round1.ts
@@ -42,9 +42,12 @@ export class DkgRound1Command extends IronfishCommand {
 
     let identities = flags.identity
     if (!identities || identities.length < 2) {
-      const input = await longPrompt('Enter the identities separated by commas', {
-        required: true,
-      })
+      const input = await longPrompt(
+        'Enter the identities of all participants separated by commas',
+        {
+          required: true,
+        },
+      )
       identities = input.split(',')
 
       if (identities.length < 2) {

--- a/ironfish-cli/src/commands/wallet/multisig/dkg/round2.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/round2.ts
@@ -51,7 +51,7 @@ export class DkgRound2Command extends IronfishCommand {
     let round1PublicPackages = flags.round1PublicPackages
     if (!round1PublicPackages || round1PublicPackages.length < 2) {
       const input = await longPrompt(
-        'Enter round 1 public packages separated by commas, one for each participant',
+        'Enter round 1 public packages, separated by commas, one for each participant',
         { required: true },
       )
       round1PublicPackages = input.split(',')

--- a/ironfish-cli/src/commands/wallet/multisig/dkg/round3.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/round3.ts
@@ -63,7 +63,7 @@ export class DkgRound3Command extends IronfishCommand {
     let round1PublicPackages = flags.round1PublicPackages
     if (!round1PublicPackages || round1PublicPackages.length < 2) {
       const input = await longPrompt(
-        'Enter round 1 public packages separated by commas, one for each participant',
+        'Enter round 1 public packages, separated by commas, one for each participant',
         {
           required: true,
         },
@@ -81,7 +81,7 @@ export class DkgRound3Command extends IronfishCommand {
     let round2PublicPackages = flags.round2PublicPackages
     if (!round2PublicPackages) {
       const input = await longPrompt(
-        'Enter round 2 public packages separated by commas, one for each participant',
+        'Enter round 2 public packages, separated by commas, one for each participant',
         {
           required: true,
         },

--- a/ironfish-cli/src/commands/wallet/multisig/signature/aggregate.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/signature/aggregate.ts
@@ -55,7 +55,7 @@ export class MultisigSign extends IronfishCommand {
 
     let signatureShares = options.signatureShare
     if (!signatureShares) {
-      const input = await longPrompt('Enter the signature shares separated by commas', {
+      const input = await longPrompt('Enter the signature shares, separated by commas', {
         required: true,
       })
       signatureShares = input.split(',')


### PR DESCRIPTION
## Summary

clarifies which participant identities are expected when prompting for a list of identities on the command line in 'commitment:create', 'dealer:create', and 'dkg:round1'

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
