### PR TITLE
Only log transaction flushing if non-zero

### DIFF
--- a/ironfish/src/memPool/recentlyEvictedCache.ts
+++ b/ironfish/src/memPool/recentlyEvictedCache.ts
@@ -203,9 +203,11 @@ export class RecentlyEvictedCache {
       toFlush = this.removeAtSequenceQueue.peek()
     }
 
-    this.logger.debug(
-      `Flushed ${flushCount} transactions from RecentlyEvictedCache after adding block ${sequence}`,
-    )
+    if (flushCount !== 0) {
+      this.logger.debug(
+        `Flushed ${flushCount} transactions from RecentlyEvictedCache after adding block ${sequence}`,
+      )
+    }
 
     this.updateMetrics()
 


### PR DESCRIPTION
## Summary

This log pops up a lot in verbose mode and isn't that useful unless it's non-zero.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
