### PR TITLE
Remove use of deprecated block.previous in RemoteChainProcessor

### DIFF
--- a/ironfish/src/wallet/remoteChainProcessor.ts
+++ b/ironfish/src/wallet/remoteChainProcessor.ts
@@ -68,7 +68,7 @@ export class RemoteChainProcessor {
 
       const blockHeader: WalletBlockHeader = {
         hash: Buffer.from(block.hash, 'hex'),
-        previousBlockHash: Buffer.from(block.previous, 'hex'),
+        previousBlockHash: Buffer.from(block.previousBlockHash, 'hex'),
         sequence: block.sequence,
         timestamp: new Date(block.timestamp),
       }


### PR DESCRIPTION
## Summary

`block.previous` is deprecated in our RPC layer, and elsewhere we use `block.previousBlockHash`, so updating this call.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
