### PR TITLE
Remove unused eventLoopResolve in Wallet

### DIFF
--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -118,7 +118,6 @@ export class Wallet {
   private readonly createTransactionMutex: Mutex
   private readonly eventLoopAbortController: AbortController
   private eventLoopPromise: Promise<void> | null = null
-  private eventLoopResolve: PromiseResolve<void> | null = null
 
   constructor({
     config,
@@ -332,7 +331,6 @@ export class Wallet {
 
     const [promise, resolve] = PromiseUtils.split<void>()
     this.eventLoopPromise = promise
-    this.eventLoopResolve = resolve
 
     await this.updateHead()
     void this.syncTransactionGossip()
@@ -344,7 +342,6 @@ export class Wallet {
 
     resolve()
     this.eventLoopPromise = null
-    this.eventLoopResolve = null
   }
 
   async syncTransactionGossip(): Promise<void> {


### PR DESCRIPTION
## Summary

The `eventLoopResolve` field on Wallet isn't used anywhere.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
