### PR TITLE
Fix deprecation and wrong runners in build-ironfish-rust-nodejs.yml

### DIFF
--- a/.github/workflows/build-ironfish-rust-nodejs.yml
+++ b/.github/workflows/build-ironfish-rust-nodejs.yml
@@ -89,7 +89,7 @@ jobs:
             target: x86_64-apple-darwin
 
           - host: macos-latest
-            target: arm64-apple-darwin
+            target: aarch64-apple-darwin
 
           - host: windows-latest
             target: x86_64-pc-windows-msvc

--- a/.github/workflows/build-ironfish-rust-nodejs.yml
+++ b/.github/workflows/build-ironfish-rust-nodejs.yml
@@ -72,7 +72,7 @@ jobs:
         working-directory: ./ironfish-rust-nodejs
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bindings-${{ matrix.settings.target }}
           path: ironfish-rust-nodejs/*.node
@@ -124,7 +124,7 @@ jobs:
           node-version: 18
 
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: bindings-${{ matrix.settings.target }}
           path: ./ironfish-rust-nodejs

--- a/.github/workflows/build-ironfish-rust-nodejs.yml
+++ b/.github/workflows/build-ironfish-rust-nodejs.yml
@@ -85,8 +85,11 @@ jobs:
       fail-fast: false
       matrix:
         settings:
-          - host: macos-latest
+          - host: macos-13
             target: x86_64-apple-darwin
+
+          - host: macos-latest
+            target: arm64-apple-darwin
 
           - host: windows-latest
             target: x86_64-pc-windows-msvc

--- a/.github/workflows/deploy-brew.yml
+++ b/.github/workflows/deploy-brew.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   Deploy:
     name: Deploy
-    runs-on: macos-12
+    runs-on: macos-13
 
     steps:
       - name: Check out Git repository

--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         settings:
-          - host: macos-latest
+          - host: macos-13
             arch: x86_64
             system: apple
 
@@ -29,7 +29,7 @@ jobs:
             arch: x86_64
             system: linux
 
-          - host: macos-latest-xlarge
+          - host: macos-latest
             arch: arm64
             system: apple
 


### PR DESCRIPTION
## Summary

macos-latest runners are now arm64: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories

So updated the build-ironfish-rust-nodejs x64 build to use `macos-13`, and added testing for the macos-arm64 build using `macos-latest`. Also updated `publish-binaries.yml` to use `macos-13` for the x64 build, and regular `macos-latest` for the arm64 one

Additionally, updated the artifact dependencies to fix some deprecation warnings.

## Testing Plan

Passing run of build-ironfish-rust-nodejs is here: https://github.com/iron-fish/ironfish/actions/runs/8989745514

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
