### PR TITLE
Add syncingEnabled migration

### DIFF
--- a/ironfish/src/migrations/data/032-add-account-scanning.ts
+++ b/ironfish/src/migrations/data/032-add-account-scanning.ts
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Logger } from '../../logger'
+import { IDatabase, IDatabaseTransaction } from '../../storage'
+import { createDB } from '../../storage/utils'
+import { Database, Migration, MigrationContext } from '../migration'
+import { GetStores } from './032-add-account-syncing/stores'
+
+export class Migration032 extends Migration {
+  path = __filename
+  database = Database.WALLET
+
+  prepare(context: MigrationContext): IDatabase {
+    return createDB({ location: context.config.walletDatabasePath })
+  }
+
+  async forward(
+    _context: MigrationContext,
+    db: IDatabase,
+    tx: IDatabaseTransaction | undefined,
+    logger: Logger,
+  ): Promise<void> {
+    const stores = GetStores(db)
+
+    for await (const accountValue of stores.old.accounts.getAllValuesIter(tx)) {
+      logger.debug(` Migrating account ${accountValue.name}`)
+
+      const migrated = {
+        ...accountValue,
+        scanningEnabled: true,
+      }
+
+      await stores.new.accounts.put(accountValue.id, migrated, tx)
+    }
+  }
+
+  async backward(
+    _context: MigrationContext,
+    db: IDatabase,
+    tx: IDatabaseTransaction | undefined,
+  ): Promise<void> {
+    const stores = GetStores(db)
+
+    for await (const accountValue of stores.new.accounts.getAllValuesIter(tx)) {
+      await stores.old.accounts.put(accountValue.id, accountValue, tx)
+    }
+  }
+}

--- a/ironfish/src/migrations/data/032-add-account-syncing/new/HeadValue.ts
+++ b/ironfish/src/migrations/data/032-add-account-syncing/new/HeadValue.ts
@@ -1,0 +1,41 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import bufio from 'bufio'
+import { IDatabaseEncoding } from '../../../../storage'
+
+export type HeadValue = {
+  hash: Buffer
+  sequence: number
+}
+
+export class NullableHeadValueEncoding implements IDatabaseEncoding<HeadValue | null> {
+  readonly nonNullSize = 32 + 4 // 256-bit block hash + 32-bit integer
+
+  serialize(value: HeadValue | null): Buffer {
+    const bw = bufio.write(this.getSize(value))
+
+    if (value) {
+      bw.writeHash(value.hash)
+      bw.writeU32(value.sequence)
+    }
+
+    return bw.render()
+  }
+
+  deserialize(buffer: Buffer): HeadValue | null {
+    const reader = bufio.read(buffer, true)
+
+    if (reader.left()) {
+      const hash = reader.readHash()
+      const sequence = reader.readU32()
+      return { hash, sequence }
+    }
+
+    return null
+  }
+
+  getSize(value: HeadValue | null): number {
+    return value ? this.nonNullSize : 0
+  }
+}

--- a/ironfish/src/migrations/data/032-add-account-syncing/new/index.ts
+++ b/ironfish/src/migrations/data/032-add-account-syncing/new/index.ts
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { IDatabase, IDatabaseStore, StringEncoding } from '../../../../storage'
+import { AccountValue, AccountValueEncoding } from './AccountValue'
+
+export function GetNewStores(db: IDatabase): {
+  accounts: IDatabaseStore<{ key: string; value: AccountValue }>
+} {
+  const accounts: IDatabaseStore<{ key: string; value: AccountValue }> = db.addStore(
+    {
+      name: 'a',
+      keyEncoding: new StringEncoding(),
+      valueEncoding: new AccountValueEncoding(),
+    },
+    false,
+  )
+
+  return { accounts }
+}

--- a/ironfish/src/migrations/data/032-add-account-syncing/old/HeadValue.ts
+++ b/ironfish/src/migrations/data/032-add-account-syncing/old/HeadValue.ts
@@ -1,0 +1,41 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import bufio from 'bufio'
+import { IDatabaseEncoding } from '../../../../storage'
+
+export type HeadValue = {
+  hash: Buffer
+  sequence: number
+}
+
+export class NullableHeadValueEncoding implements IDatabaseEncoding<HeadValue | null> {
+  readonly nonNullSize = 32 + 4 // 256-bit block hash + 32-bit integer
+
+  serialize(value: HeadValue | null): Buffer {
+    const bw = bufio.write(this.getSize(value))
+
+    if (value) {
+      bw.writeHash(value.hash)
+      bw.writeU32(value.sequence)
+    }
+
+    return bw.render()
+  }
+
+  deserialize(buffer: Buffer): HeadValue | null {
+    const reader = bufio.read(buffer, true)
+
+    if (reader.left()) {
+      const hash = reader.readHash()
+      const sequence = reader.readU32()
+      return { hash, sequence }
+    }
+
+    return null
+  }
+
+  getSize(value: HeadValue | null): number {
+    return value ? this.nonNullSize : 0
+  }
+}

--- a/ironfish/src/migrations/data/032-add-account-syncing/old/index.ts
+++ b/ironfish/src/migrations/data/032-add-account-syncing/old/index.ts
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { IDatabase, IDatabaseStore, StringEncoding } from '../../../../storage'
+import { AccountValue, AccountValueEncoding } from './AccountValue'
+
+export function GetOldStores(db: IDatabase): {
+  accounts: IDatabaseStore<{ key: string; value: AccountValue }>
+} {
+  const accounts: IDatabaseStore<{ key: string; value: AccountValue }> = db.addStore(
+    {
+      name: 'a',
+      keyEncoding: new StringEncoding(),
+      valueEncoding: new AccountValueEncoding(),
+    },
+    false,
+  )
+
+  return { accounts }
+}

--- a/ironfish/src/migrations/data/032-add-account-syncing/stores.ts
+++ b/ironfish/src/migrations/data/032-add-account-syncing/stores.ts
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { IDatabase } from '../../../storage'
+import { GetNewStores } from './new'
+import { GetOldStores } from './old'
+
+export function GetStores(db: IDatabase): {
+  old: ReturnType<typeof GetOldStores>
+  new: ReturnType<typeof GetNewStores>
+} {
+  const oldStores = GetOldStores(db)
+  const newStores = GetNewStores(db)
+
+  return { old: oldStores, new: newStores }
+}

--- a/ironfish/src/migrations/data/index.ts
+++ b/ironfish/src/migrations/data/index.ts
@@ -20,6 +20,7 @@ import { Migration028 } from './028-backfill-assets-owner'
 import { Migration029 } from './029-backfill-assets-owner-wallet'
 import { Migration030 } from './030-value-to-unspent-note'
 import { Migration031 } from './031-add-pak-to-account'
+import { Migration032 } from './032-add-account-scanning'
 
 export const MIGRATIONS = [
   Migration014,
@@ -40,4 +41,5 @@ export const MIGRATIONS = [
   Migration029,
   Migration030,
   Migration031,
+  Migration032,
 ]

--- a/ironfish/src/wallet/account/account.ts
+++ b/ironfish/src/wallet/account/account.ts
@@ -94,7 +94,7 @@ export class Account {
     this.walletDb = walletDb
     this.version = accountValue.version ?? 1
     this.createdAt = accountValue.createdAt
-    this.scanningEnabled = accountValue.scanningEnabled ?? true
+    this.scanningEnabled = accountValue.scanningEnabled
     this.multisigKeys = accountValue.multisigKeys
     this.proofAuthorizingKey = accountValue.proofAuthorizingKey
   }

--- a/ironfish/src/wallet/walletdb/accountValue.ts
+++ b/ironfish/src/wallet/walletdb/accountValue.ts
@@ -23,7 +23,7 @@ export interface AccountValue {
   outgoingViewKey: string
   publicAddress: string
   createdAt: HeadValue | null
-  scanningEnabled?: boolean
+  scanningEnabled: boolean
   multisigKeys?: MultisigKeys
   proofAuthorizingKey: string | null
 }


### PR DESCRIPTION
## Summary
This adds migration 032 to add a new field to AccountValue called `scanningEnabled` which is going to be used for controlling if an account should scan or not.

## Testing Plan
Run the migration and check the DB to see if the value persist or not.

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
