### PR TITLE
add public account description for multisig bridge integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -851,9 +851,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f628eaec48bfd21b865dc2950cfa014450c01d2fa2b69a86c2fd5844ec523c0"
+checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
@@ -1473,6 +1473,7 @@ dependencies = [
  "byteorder",
  "chacha20poly1305 0.9.1",
  "crypto_box",
+ "ed25519-dalek",
  "ff 0.12.1",
  "fish_hash",
  "group 0.12.1",

--- a/ironfish-rust/Cargo.toml
+++ b/ironfish-rust/Cargo.toml
@@ -40,6 +40,7 @@ blstrs = { version = "0.6.0", features = ["portable"] }
 byteorder = "1.4.3"
 chacha20poly1305 = "0.9.0"
 crypto_box = { version = "0.9", features = ["std"] }
+ed25519-dalek = "2.1.1"
 ff = "0.12.0"
 group = "0.12.0"
 ironfish-frost = { git = "https://github.com/iron-fish/ironfish-frost.git", branch = "main" }

--- a/ironfish-rust/src/errors.rs
+++ b/ironfish-rust/src/errors.rs
@@ -55,6 +55,7 @@ pub enum IronfishErrorKind {
     InvalidSecret,
     InvalidRandomizer,
     InvalidSignature,
+    InvalidSigner,
     InvalidSigningKey,
     InvalidSpendProof,
     InvalidSpendSignature,
@@ -68,6 +69,7 @@ pub enum IronfishErrorKind {
     IsSmallOrder,
     RandomnessError,
     RoundTwoSigningFailure,
+    SignatureThresholdNotMet,
     TryFromInt,
     Utf8,
 }

--- a/ironfish-rust/src/errors.rs
+++ b/ironfish-rust/src/errors.rs
@@ -56,6 +56,7 @@ pub enum IronfishErrorKind {
     InvalidSigningKey,
     InvalidSpendProof,
     InvalidSpendSignature,
+    InvalidThreshold,
     InvalidTransaction,
     InvalidTransactionVersion,
     InvalidViewingKey,

--- a/ironfish-rust/src/errors.rs
+++ b/ironfish-rust/src/errors.rs
@@ -26,6 +26,8 @@ pub struct IronfishError {
 pub enum IronfishErrorKind {
     BellpersonSynthesis,
     CryptoBox,
+    DuplicateSignature,
+    DuplicateSigner,
     FrostLibError,
     FailedSignatureAggregation,
     FailedSignatureVerification,

--- a/ironfish-rust/src/errors.rs
+++ b/ironfish-rust/src/errors.rs
@@ -59,6 +59,7 @@ pub enum IronfishErrorKind {
     InvalidTransaction,
     InvalidTransactionVersion,
     InvalidViewingKey,
+    InvalidVerifyingKey,
     InvalidWord,
     Io,
     IsSmallOrder,

--- a/ironfish-rust/src/lib.rs
+++ b/ironfish-rust/src/lib.rs
@@ -13,6 +13,7 @@ pub mod merkle_note_hash;
 pub mod mining;
 pub mod nacl;
 pub mod note;
+pub mod public_account;
 pub mod rolling_filter;
 pub mod sapling_bls12;
 pub mod serializing;

--- a/ironfish-rust/src/public_account/create.rs
+++ b/ironfish-rust/src/public_account/create.rs
@@ -1,0 +1,112 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use ed25519_dalek::{Signature, VerifyingKey, Verifier};
+use std::io;
+
+use crate::errors::{IronfishError, IronfishErrorKind};
+
+
+#[derive(Clone)]
+pub struct PublicAccountCreateDescription {
+    /// TODO(jwp): do we need a separate account address for later migration
+    /// pub(crate) account_address: EthereumAddress
+
+    // Minimum number of required signers
+    pub(crate) threshold: i16,
+    // Signers of the public account
+    pub(crate) signers: Vec<VerifyingKey>,
+    // TODO(jwp): do we need to include signatures for create?
+    pub(crate) signatures: Vec<Signature>,
+}
+
+impl PublicAccountCreateDescription {
+    pub fn read<R: io::Read>(mut reader: R) -> Result<Self, IronfishError> {
+        let mut threshold_buf = [0; 1];
+        reader.read_exact(&mut threshold_buf)?;
+        let threshold = threshold_buf[0] as i16;
+
+        let mut signers_len_buf = [0; 2];
+        reader.read_exact(&mut signers_len_buf)?;
+        let signers_len = i16::from_le_bytes(signers_len_buf) as usize;
+
+        let mut signers = Vec::with_capacity(signers_len);
+        for _ in 0..signers_len {
+            let mut signer_buf = [0; 32];
+            reader.read_exact(&mut signer_buf)?;
+            let signer = VerifyingKey::from_bytes(&signer_buf)
+                .map_err(|_| IronfishError::new(IronfishErrorKind::InvalidData))?;
+            signers.push(signer);
+        }
+
+        let mut signatures_len_buf = [0; 2];
+        reader.read_exact(&mut signatures_len_buf)?;
+        let signatures_len = i16::from_le_bytes(signatures_len_buf) as usize;
+
+        let mut signatures = Vec::with_capacity(signatures_len);
+        for _ in 0..signatures_len {
+            let mut signature_buf = [0; 64];
+            reader.read_exact(&mut signature_buf)?;
+            let signature = Signature::from_bytes(&signature_buf);
+            signatures.push(signature);
+        }
+
+        Ok(Self { threshold, signers, signatures })
+    }
+
+    pub fn write<W: io::Write>(&self, mut writer: W) -> Result<(), IronfishError> {
+        writer.write_all(&self.threshold.to_le_bytes())?;
+
+        let signers_len = self.signers.len() as i16;
+        writer.write_all(&signers_len.to_le_bytes())?;
+
+        for signer in &self.signers {
+            writer.write_all(signer.as_bytes())?;
+        }
+
+        let signatures_len = self.signatures.len() as i16;
+        writer.write_all(&signatures_len.to_le_bytes())?;
+
+        for signature in &self.signatures {
+            writer.write_all(&signature.to_bytes())?;
+        }
+
+        Ok(())
+    }
+
+    pub fn verify(&self) -> Result<(), IronfishError> {
+        if self.threshold < 1 {
+            return Err(IronfishError::new(IronfishErrorKind::InvalidData));
+        }
+
+        if self.signers.len() < self.threshold as usize {
+            return Err(IronfishError::new(IronfishErrorKind::InvalidData));
+        }
+
+        if self.signatures.len() < self.threshold as usize {
+            return Err(IronfishError::new(IronfishErrorKind::InvalidData));
+        }
+
+        // verify signatures
+        let is_valid = self.signers.iter().zip(&self.signatures).any(|(signer, signature)| {
+            signer.verify(&self.hash(), signature).is_ok()
+        });
+        if !is_valid {
+            return Err(IronfishError::new(IronfishErrorKind::InvalidSignature));
+        }
+
+
+        Ok(())
+    }
+
+    pub fn hash(&self) -> [u8; 32] {
+        // TODO(jwp): verify which hashers supported by axelar
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(&self.threshold.to_le_bytes());
+        for signer in &self.signers {
+            hasher.update(signer.as_bytes());
+        }
+        hasher.finalize().into()
+    }
+}

--- a/ironfish-rust/src/public_account/description.rs
+++ b/ironfish-rust/src/public_account/description.rs
@@ -197,8 +197,9 @@ impl PublicAccountDescription {
         Ok(hasher.finalize().into())
     }
 
-    pub fn sign(&mut self, signatures: &Vec<Signature>) -> Result<(), IronfishError> {
-        self.verify(signatures)?;
+    pub fn sign(&mut self, signatures: impl IntoIterator<Item = Signature>) -> Result<(), IronfishError> {
+        let signatures = signatures.into_iter().collect::<Vec<_>>();
+        self.verify(&signatures)?;
         self.signatures.extend(signatures);
         Ok(())
     }
@@ -211,15 +212,15 @@ impl PublicAccountDescription {
         self.min_signers
     }
 
-    pub fn signers(&self) -> &Vec<VerifyingKey> {
+    pub fn signers(&self) -> &[VerifyingKey] {
         &self.signers
     }
 
-    pub fn signatures(&self) -> &Vec<Signature> {
+    pub fn signatures(&self) -> &[Signature] {
         &self.signatures
     }
 
-    pub fn transfers(&self) -> &Vec<Transfer> {
+    pub fn transfers(&self) -> &[Transfer] {
         &self.transfers
     }
 
@@ -261,7 +262,7 @@ mod tests {
         let signature = signing_key.sign(&hash);
 
         original
-            .sign(&vec![signature])
+            .sign(vec![signature])
             .expect("Should be valid/verified creation");
         
         assert_eq!(original.signatures.len(), 1);

--- a/ironfish-rust/src/public_account/description.rs
+++ b/ironfish-rust/src/public_account/description.rs
@@ -5,7 +5,10 @@
 use ed25519_dalek::{Signature, Verifier, VerifyingKey};
 use std::io;
 
-use crate::{errors::{IronfishError, IronfishErrorKind}, PublicAddress};
+use crate::{
+    errors::{IronfishError, IronfishErrorKind},
+    PublicAddress,
+};
 
 use super::transfer::Transfer;
 
@@ -13,32 +16,53 @@ use super::transfer::Transfer;
 pub struct PublicAccountDescription {
     /// TODO(jwp): do we need a separate account address for later migration
     /// pub(crate) account_address: EthereumAddress
-    pub(crate) version: u8,
-    // Minimum number of required signers
-    pub(crate) threshold: i16,
+    version: u8,
+    // Minimum number of signers required to sign a message and be valid
+    min_signers: u16,
     // Signers of the public account
-    pub(crate) signers: Vec<VerifyingKey>,
+    signers: Vec<VerifyingKey>,
     // Signatures of the signers for a given message
-    pub(crate) signatures: Vec<Signature>,
+    signatures: Vec<Signature>,
     // asset transfers
-    pub(crate) transfers: Vec<Transfer>,
+    transfers: Vec<Transfer>,
     // address of the account
-    pub(crate) address: PublicAddress,
+    address: PublicAddress,
 }
 
 impl PublicAccountDescription {
+    pub fn new(
+        version: u8,
+        min_signers: u16,
+        signers: Vec<VerifyingKey>,
+        signatures: Vec<Signature>,
+        transfers: Vec<Transfer>,
+        address: PublicAddress,
+    ) -> Result<PublicAccountDescription, IronfishError> {
+        let description = Self {
+            version,
+            min_signers,
+            signers,
+            signatures,
+            address,
+            transfers,
+        };
+
+        description.valid()?;
+
+        Ok(description)
+    }
     pub fn read<R: io::Read>(mut reader: R) -> Result<Self, IronfishError> {
         let mut version_buf = [0; 1];
         reader.read_exact(&mut version_buf)?;
         let version = version_buf[0];
-        
-        let mut threshold_buf = [0; 2];
-        reader.read_exact(&mut threshold_buf)?;
-        let threshold = i16::from_le_bytes(threshold_buf);
+
+        let mut min_signers_buf = [0; 2];
+        reader.read_exact(&mut min_signers_buf)?;
+        let min_signers = u16::from_le_bytes(min_signers_buf);
 
         let mut signers_len_buf = [0; 2];
         reader.read_exact(&mut signers_len_buf)?;
-        let signers_len = i16::from_le_bytes(signers_len_buf) as usize;
+        let signers_len = u16::from_le_bytes(signers_len_buf) as usize;
 
         let mut signers = Vec::with_capacity(signers_len);
         for _ in 0..signers_len {
@@ -51,7 +75,7 @@ impl PublicAccountDescription {
 
         let mut signatures_len_buf = [0; 2];
         reader.read_exact(&mut signatures_len_buf)?;
-        let signatures_len = i16::from_le_bytes(signatures_len_buf) as usize;
+        let signatures_len = u16::from_le_bytes(signatures_len_buf) as usize;
 
         let mut signatures = Vec::with_capacity(signatures_len);
         for _ in 0..signatures_len {
@@ -63,7 +87,7 @@ impl PublicAccountDescription {
 
         let mut transfers_len_buf = [0; 2];
         reader.read_exact(&mut transfers_len_buf)?;
-        let transfers_len = i16::from_le_bytes(transfers_len_buf) as usize;
+        let transfers_len = u16::from_le_bytes(transfers_len_buf) as usize;
 
         let mut transfers = Vec::with_capacity(transfers_len);
         for _ in 0..transfers_len {
@@ -72,38 +96,39 @@ impl PublicAccountDescription {
         }
         let address = PublicAddress::read(&mut reader)?;
 
-
-        Ok(Self {
+        let description = Self {
             version,
-            threshold,
+            min_signers,
             signers,
             signatures,
             address,
             transfers,
-        })
+        };
+        description.valid()?;
+        Ok(description)
     }
 
     pub fn write<W: io::Write>(&self, mut writer: W) -> Result<(), IronfishError> {
         // TODO: think about ideal ordering here
         writer.write_all(&self.version.to_le_bytes())?;
-        
-        writer.write_all(&self.threshold.to_le_bytes())?;
 
-        let signers_len = self.signers.len() as i16;
+        writer.write_all(&self.min_signers.to_le_bytes())?;
+
+        let signers_len: u16 = self.signers.len().try_into()?;
         writer.write_all(&signers_len.to_le_bytes())?;
 
         for signer in &self.signers {
             writer.write_all(signer.as_bytes())?;
         }
 
-        let signatures_len = self.signatures.len() as i16;
+        let signatures_len: u16 = self.signatures.len().try_into()?;
         writer.write_all(&signatures_len.to_le_bytes())?;
 
         for signature in &self.signatures {
             writer.write_all(&signature.to_bytes())?;
         }
 
-        let transfers_len = self.transfers.len() as i16;
+        let transfers_len: u16 = self.transfers.len().try_into()?;
         writer.write_all(&transfers_len.to_le_bytes())?;
 
         for transfer in &self.transfers {
@@ -115,16 +140,16 @@ impl PublicAccountDescription {
         Ok(())
     }
 
-    pub fn valid(&self) -> Result<(), IronfishError> {
-        if self.threshold < 1 {
+    fn valid(&self) -> Result<(), IronfishError> {
+        if self.min_signers < 1 {
             return Err(IronfishError::new(IronfishErrorKind::InvalidThreshold));
         }
 
-        if self.signers.len() < self.threshold as usize {
+        if self.signers.len() < self.min_signers as usize {
             return Err(IronfishError::new(IronfishErrorKind::InvalidThreshold));
         }
 
-        if self.signatures.len() < self.threshold as usize {
+        if self.signatures.len() < self.min_signers as usize {
             return Err(IronfishError::new(IronfishErrorKind::InvalidData));
         }
 
@@ -134,8 +159,13 @@ impl PublicAccountDescription {
     pub fn verify(&self) -> Result<(), IronfishError> {
         self.valid()?;
 
-        let hash =
-            &PublicAccountDescription::hash(&self.version, &self.threshold, &self.signers, &self.address, &self.transfers)?;
+        let hash = &PublicAccountDescription::hash(
+            &self.version,
+            &self.min_signers,
+            &self.signers,
+            &self.address,
+            &self.transfers,
+        )?;
         let is_valid = self
             .signers
             .iter()
@@ -149,7 +179,7 @@ impl PublicAccountDescription {
 
     pub fn hash(
         version: &u8,
-        threshold: &i16,
+        threshold: &u16,
         signers: &Vec<VerifyingKey>,
         address: &PublicAddress,
         transfers: &Vec<Transfer>,
@@ -166,6 +196,30 @@ impl PublicAccountDescription {
         }
         hasher.update(&address.public_address());
         Ok(hasher.finalize().into())
+    }
+
+    pub fn version(&self) -> u8 {
+        self.version
+    }
+
+    pub fn min_signers(&self) -> u16 {
+        self.min_signers
+    }
+
+    pub fn signers(&self) -> &Vec<VerifyingKey> {
+        &self.signers
+    }
+
+    pub fn signatures(&self) -> &Vec<Signature> {
+        &self.signatures
+    }
+
+    pub fn transfers(&self) -> &Vec<Transfer> {
+        &self.transfers
+    }
+
+    pub fn address(&self) -> &PublicAddress {
+        &self.address
     }
 }
 
@@ -190,18 +244,26 @@ mod tests {
             to: public_address,
             memo: PublicMemo([0; 256]),
         };
-        let hash = PublicAccountDescription::hash(&1, &1, &vec![verifying_key], &public_address, &vec![transfer])
-            .expect("Should successfully hash");
+        let hash = PublicAccountDescription::hash(
+            &1,
+            &1,
+            &vec![verifying_key],
+            &public_address,
+            &vec![transfer],
+        )
+        .expect("Should successfully hash");
         let signature = signing_key.sign(&hash);
 
-        let original = PublicAccountDescription {
-            version: 1,
-            threshold: 1,
-            signers: vec![verifying_key],
-            signatures: vec![signature],
-            address: public_address,
-            transfers: vec![transfer],
-        };
+        let original = PublicAccountDescription::new(
+            1,
+            1,
+            vec![verifying_key],
+            vec![signature],
+            vec![transfer],
+            public_address,
+        )
+        .expect("Should successfully create description");
+
         original
             .verify()
             .expect("Should be valid/verified creation");
@@ -211,7 +273,7 @@ mod tests {
 
         let read = PublicAccountDescription::read(&buffer[..]).unwrap();
 
-        assert_eq!(original.threshold, read.threshold);
+        assert_eq!(original.min_signers, read.min_signers);
         assert_eq!(original.signers, read.signers);
         assert_eq!(original.signatures, read.signatures);
     }

--- a/ironfish-rust/src/public_account/description.rs
+++ b/ironfish-rust/src/public_account/description.rs
@@ -153,6 +153,16 @@ impl PublicAccountDescription {
             return Err(IronfishError::new(IronfishErrorKind::InvalidData));
         }
 
+        let unique_signers: Vec<_> = self.signers.iter().collect();
+        if unique_signers.len() != self.signers.len() {
+            return Err(IronfishError::new(IronfishErrorKind::DuplicateSigner));
+        }
+    
+        let unique_signatures: Vec<_> = self.signatures.iter().collect();
+        if unique_signatures.len() != self.signatures.len() {
+            return Err(IronfishError::new(IronfishErrorKind::DuplicateSignature));
+        }
+
         Ok(())
     }
 
@@ -166,13 +176,12 @@ impl PublicAccountDescription {
             &self.address,
             &self.transfers,
         )?;
-        let is_valid = self
-            .signers
-            .iter()
-            .zip(&self.signatures)
-            .any(|(signer, signature)| signer.verify(hash, signature).is_ok());
-        if !is_valid {
-            return Err(IronfishError::new(IronfishErrorKind::InvalidSignature));
+        for signature in &self.signatures {
+            let is_valid = self.signers.iter().any(|signer| signer.verify(hash, signature).is_ok());
+    
+            if !is_valid {
+                return Err(IronfishError::new(IronfishErrorKind::InvalidSignature));
+            }
         }
         Ok(())
     }

--- a/ironfish-rust/src/public_account/description.rs
+++ b/ironfish-rust/src/public_account/description.rs
@@ -10,7 +10,7 @@ use crate::{
     PublicAddress,
 };
 
-use super::transfer::{self, Transfer};
+use super::transfer::{Transfer};
 
 #[derive(Clone)]
 pub struct PublicAccountDescription {
@@ -152,7 +152,7 @@ impl PublicAccountDescription {
         if unique_signers.len() != self.signers.len() {
             return Err(IronfishError::new(IronfishErrorKind::DuplicateSigner));
         }
-    
+
         let unique_signatures: Vec<_> = self.signatures.iter().collect();
         if unique_signatures.len() != self.signatures.len() {
             return Err(IronfishError::new(IronfishErrorKind::DuplicateSignature));
@@ -161,13 +161,16 @@ impl PublicAccountDescription {
         Ok(())
     }
 
-    pub fn verify(&self) -> Result<(), IronfishError> {
+    fn verify(&self) -> Result<(), IronfishError> {
         self.valid()?;
 
         let hash = &self.hash()?;
         for signature in &self.signatures {
-            let is_valid = self.signers.iter().any(|signer| signer.verify(hash, signature).is_ok());
-    
+            let is_valid = self
+                .signers
+                .iter()
+                .any(|signer| signer.verify(hash, signature).is_ok());
+
             if !is_valid {
                 return Err(IronfishError::new(IronfishErrorKind::InvalidSignature));
             }
@@ -175,9 +178,7 @@ impl PublicAccountDescription {
         Ok(())
     }
 
-    pub fn hash(
-        &self
-    ) -> Result<[u8; 32], IronfishError> {
+    pub fn hash(&self) -> Result<[u8; 32], IronfishError> {
         // TODO(jwp): verify which hashers supported by axelar
         let mut hasher = blake3::Hasher::new();
         hasher.update(&self.version.to_le_bytes());
@@ -255,9 +256,7 @@ mod tests {
         )
         .expect("Should successfully create description");
 
-        let hash = original
-            .hash()
-            .expect("Should successfully hash");
+        let hash = original.hash().expect("Should successfully hash");
         let signature = signing_key.sign(&hash);
 
         original

--- a/ironfish-rust/src/public_account/mod.rs
+++ b/ironfish-rust/src/public_account/mod.rs
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
- 
- pub mod description;
- pub mod transfer;
- 
+
+pub mod description;
+pub mod transfer;

--- a/ironfish-rust/src/public_account/mod.rs
+++ b/ironfish-rust/src/public_account/mod.rs
@@ -1,0 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+ 
+ pub mod create;
+ 

--- a/ironfish-rust/src/public_account/mod.rs
+++ b/ironfish-rust/src/public_account/mod.rs
@@ -2,5 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
  
- pub mod create;
+ pub mod description;
+ pub mod transfer;
  

--- a/ironfish-rust/src/public_account/transfer.rs
+++ b/ironfish-rust/src/public_account/transfer.rs
@@ -9,9 +9,10 @@ pub struct PublicMemo(pub [u8; 256]);
 pub struct Transfer {
     pub(crate) asset_id: AssetIdentifier,
     pub(crate) amount: u64,
+    // TODO assumes we are using same public address space for these accounts
     pub(crate) to: PublicAddress,
     // TODO is this a reasonable memo size
-    pub(crate) memo: PublicMemo
+    pub(crate) memo: PublicMemo,
 }
 
 impl Transfer {
@@ -27,7 +28,12 @@ impl Transfer {
         reader.read_exact(&mut memo_buf)?;
         let memo = PublicMemo(memo_buf);
 
-        Ok(Self { asset_id, amount, to, memo })
+        Ok(Self {
+            asset_id,
+            amount,
+            to,
+            memo,
+        })
     }
 
     pub fn write<W: io::Write>(&self, mut writer: W) -> Result<(), IronfishError> {

--- a/ironfish-rust/src/public_account/transfer.rs
+++ b/ironfish-rust/src/public_account/transfer.rs
@@ -8,7 +8,7 @@ pub struct PublicMemo(pub [u8; 256]);
 #[derive(Clone, Copy)]
 pub struct Transfer {
     pub(crate) asset_id: AssetIdentifier,
-    pub(crate) amount: u64,
+    pub(crate) amount: i64,
     // TODO assumes we are using same public address space for these accounts
     pub(crate) to: PublicAddress,
     // TODO is this a reasonable memo size
@@ -20,7 +20,7 @@ impl Transfer {
         let asset_id = AssetIdentifier::read(&mut reader)?;
         let mut amount_buf = [0; 8];
         reader.read_exact(&mut amount_buf)?;
-        let amount = u64::from_le_bytes(amount_buf);
+        let amount = i64::from_le_bytes(amount_buf);
 
         let to = PublicAddress::read(&mut reader)?;
 

--- a/ironfish-rust/src/public_account/transfer.rs
+++ b/ironfish-rust/src/public_account/transfer.rs
@@ -1,0 +1,47 @@
+use std::io;
+
+use crate::{assets::asset_identifier::AssetIdentifier, errors::IronfishError, PublicAddress};
+
+#[derive(Clone, Copy)]
+pub struct PublicMemo(pub [u8; 256]);
+
+#[derive(Clone, Copy)]
+pub struct Transfer {
+    pub(crate) asset_id: AssetIdentifier,
+    pub(crate) amount: u64,
+    pub(crate) to: PublicAddress,
+    // TODO is this a reasonable memo size
+    pub(crate) memo: PublicMemo
+}
+
+impl Transfer {
+    pub fn read<R: io::Read>(mut reader: R) -> Result<Self, IronfishError> {
+        let asset_id = AssetIdentifier::read(&mut reader)?;
+        let mut amount_buf = [0; 8];
+        reader.read_exact(&mut amount_buf)?;
+        let amount = u64::from_le_bytes(amount_buf);
+
+        let to = PublicAddress::read(&mut reader)?;
+
+        let mut memo_buf = [0; 256];
+        reader.read_exact(&mut memo_buf)?;
+        let memo = PublicMemo(memo_buf);
+
+        Ok(Self { asset_id, amount, to, memo })
+    }
+
+    pub fn write<W: io::Write>(&self, mut writer: W) -> Result<(), IronfishError> {
+        self.asset_id.write(&mut writer)?;
+        writer.write_all(&self.amount.to_le_bytes())?;
+        self.to.write(&mut writer)?;
+        writer.write_all(&self.memo.0)?;
+
+        Ok(())
+    }
+
+    pub fn as_bytes(&self) -> Result<Vec<u8>, IronfishError> {
+        let mut bytes = Vec::new();
+        self.write(&mut bytes)?;
+        Ok(bytes)
+    }
+}


### PR DESCRIPTION
## Summary
- Creates a separate description for creation of these public accounts. It is possible to combine them all into a single description, but it seemed cleaner to have them separated, particularly for the verification step.
## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
