### PR TITLE
Remove old migration code

### DIFF
--- a/ironfish/src/migrations/data/021-add-version-to-accounts/schemaOld.ts
+++ b/ironfish/src/migrations/data/021-add-version-to-accounts/schemaOld.ts
@@ -1,17 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { generateKeyFromPrivateKey, PUBLIC_ADDRESS_LENGTH } from '@ironfish/rust-nodejs'
+import { PUBLIC_ADDRESS_LENGTH } from '@ironfish/rust-nodejs'
 import bufio from 'bufio'
-import {
-  IDatabase,
-  IDatabaseEncoding,
-  IDatabaseStore,
-  IDatabaseTransaction,
-  StringEncoding,
-} from '../../../storage'
-import { Account } from '../../../wallet'
-import { MigrationContext } from '../../migration'
+import { IDatabase, IDatabaseEncoding, IDatabaseStore, StringEncoding } from '../../../storage'
 
 const KEY_LENGTH = 32
 
@@ -82,30 +74,4 @@ export function GetOldStores(db: IDatabase): {
   )
 
   return { accounts }
-}
-
-export async function GetOldAccounts(
-  context: MigrationContext,
-  db: IDatabase,
-  tx?: IDatabaseTransaction,
-): Promise<Account[]> {
-  const accounts = []
-  const oldStores = GetOldStores(db)
-
-  for await (const account of oldStores.accounts.getAllValuesIter(tx)) {
-    const key = generateKeyFromPrivateKey(account.spendingKey)
-
-    accounts.push(
-      new Account({
-        ...account,
-        version: 1,
-        proofAuthorizingKey: null,
-        viewKey: key.viewKey,
-        createdAt: null,
-        walletDb: context.wallet.walletDb,
-      }),
-    )
-  }
-
-  return accounts
 }


### PR DESCRIPTION
## Summary

This code is not correct in the first place because it should never use current encoders or models in a migration.

## Testing Plan

Unused code.

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
