### PR TITLE
Change account not to have 1 object constructor

### DIFF
--- a/ironfish/src/wallet/account/account.ts
+++ b/ironfish/src/wallet/account/account.ts
@@ -76,38 +76,25 @@ export class Account {
   readonly multisigKeys?: MultisigKeys
   readonly proofAuthorizingKey: string | null
 
-  constructor({
-    id,
-    name,
-    publicAddress,
-    walletDb,
-    spendingKey,
-    viewKey,
-    incomingViewKey,
-    outgoingViewKey,
-    version,
-    createdAt,
-    multisigKeys,
-    proofAuthorizingKey,
-  }: AccountValue & { walletDb: WalletDB }) {
-    this.id = id
-    this.name = name
-    this.spendingKey = spendingKey
-    this.viewKey = viewKey
-    this.incomingViewKey = incomingViewKey
-    this.outgoingViewKey = outgoingViewKey
-    this.publicAddress = publicAddress
+  constructor({ accountValue, walletDb }: { accountValue: AccountValue; walletDb: WalletDB }) {
+    this.id = accountValue.id
+    this.name = accountValue.name
+    this.spendingKey = accountValue.spendingKey
+    this.viewKey = accountValue.viewKey
+    this.incomingViewKey = accountValue.incomingViewKey
+    this.outgoingViewKey = accountValue.outgoingViewKey
+    this.publicAddress = accountValue.publicAddress
 
-    this.prefix = calculateAccountPrefix(id)
+    this.prefix = calculateAccountPrefix(accountValue.id)
     this.prefixRange = StorageUtils.getPrefixKeyRange(this.prefix)
 
-    this.displayName = `${name} (${id.slice(0, 7)})`
+    this.displayName = `${accountValue.name} (${accountValue.id.slice(0, 7)})`
 
     this.walletDb = walletDb
-    this.version = version ?? 1
-    this.createdAt = createdAt
-    this.multisigKeys = multisigKeys
-    this.proofAuthorizingKey = proofAuthorizingKey
+    this.version = accountValue.version ?? 1
+    this.createdAt = accountValue.createdAt
+    this.multisigKeys = accountValue.multisigKeys
+    this.proofAuthorizingKey = accountValue.proofAuthorizingKey
   }
 
   isSpendingAccount(): this is SpendingAccount {

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -228,11 +228,7 @@ export class Wallet {
 
   private async load(): Promise<void> {
     for await (const accountValue of this.walletDb.loadAccounts()) {
-      const account = new Account({
-        ...accountValue,
-        walletDb: this.walletDb,
-      })
-
+      const account = new Account({ accountValue, walletDb: this.walletDb })
       this.accounts.set(account.id, account)
     }
 
@@ -1511,16 +1507,18 @@ export class Wallet {
     }
 
     const account = new Account({
-      version: ACCOUNT_SCHEMA_VERSION,
-      id: uuid(),
-      name,
-      incomingViewKey: key.incomingViewKey,
-      outgoingViewKey: key.outgoingViewKey,
-      proofAuthorizingKey: key.proofAuthorizingKey,
-      publicAddress: key.publicAddress,
-      spendingKey: key.spendingKey,
-      viewKey: key.viewKey,
-      createdAt,
+      accountValue: {
+        version: ACCOUNT_SCHEMA_VERSION,
+        id: uuid(),
+        name,
+        incomingViewKey: key.incomingViewKey,
+        outgoingViewKey: key.outgoingViewKey,
+        proofAuthorizingKey: key.proofAuthorizingKey,
+        publicAddress: key.publicAddress,
+        spendingKey: key.spendingKey,
+        viewKey: key.viewKey,
+        createdAt,
+      },
       walletDb: this.walletDb,
     })
 
@@ -1612,11 +1610,13 @@ export class Wallet {
     }
 
     const account = new Account({
-      ...accountValue,
-      id: uuid(),
-      createdAt,
-      name,
-      multisigKeys,
+      accountValue: {
+        ...accountValue,
+        id: uuid(),
+        createdAt,
+        name,
+        multisigKeys,
+      },
       walletDb: this.walletDb,
     })
 
@@ -1662,11 +1662,14 @@ export class Wallet {
     },
   ): Promise<void> {
     const newAccount = new Account({
-      ...account,
-      createdAt: options?.resetCreatedAt ? null : account.createdAt,
-      id: uuid(),
+      accountValue: {
+        ...account,
+        createdAt: options?.resetCreatedAt ? null : account.createdAt,
+        id: uuid(),
+      },
       walletDb: this.walletDb,
     })
+
     this.logger.debug(`Resetting account name: ${account.name}, id: ${account.id}`)
 
     await this.walletDb.db.withTransaction(options?.tx, async (tx) => {


### PR DESCRIPTION
## Summary

This was merging an AccountValue type and walletDB into this. There's no reason to do that since the intent is to accept an AccountInfo, and a WalletDB constructor.

## Testing Plan
Run existing tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
