### PR TITLE
Fix scan state TODO in wallet code

### DIFF
--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -165,6 +165,7 @@ export class Wallet {
       await this.connectBlock(header, transactions)
       await this.expireTransactions(header.sequence)
       await this.rebroadcastTransactions(header.sequence)
+      this.updateHeadState?.signal(header.sequence)
     })
 
     this.chainProcessor.onRemove.on(async ({ header, transactions }) => {
@@ -179,10 +180,12 @@ export class Wallet {
       return
     }
 
-    // TODO: this isn't right, as the scan state doesn't get its sequence or
-    // endSequence set properly
     const scan = new ScanState()
     this.updateHeadState = scan
+
+    // Fetch current chain head sequence
+    const chainHead = await this.getChainHead()
+    this.updateHeadState.endSequence = chainHead.sequence
 
     try {
       let hashChanged = false


### PR DESCRIPTION
## Summary

I don't think the sequence values on the updateHead ScanState are used, but this fixes the TODO to update them properly by following the same pattern used for the rescan ScanState.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
