### PR TITLE
Separate out block getter from RPC serialization

### DIFF
--- a/ironfish/src/blockchain/blockchain.test.ts
+++ b/ironfish/src/blockchain/blockchain.test.ts
@@ -1962,6 +1962,19 @@ describe('Blockchain', () => {
     })
   })
 
+  describe('getBlockAtSequence()', () => {
+    it('should fetch block at a sequence', async () => {
+      const block = await nodeTest.chain.getBlockAtSequence(nodeTest.chain.head.sequence)
+      expect(block?.header.sequence).toEqual(nodeTest.chain.head.sequence)
+      expect(block?.header.hash).toEqualBuffer(nodeTest.chain.head.hash)
+    })
+
+    it('should return null if no block at a sequence', async () => {
+      const block = await nodeTest.chain.getBlockAtSequence(nodeTest.chain.head.sequence + 1)
+      expect(block).toBeNull()
+    })
+  })
+
   describe('createMinersFee()', () => {
     it('Creates transactions with the correct version based on the sequence', async () => {
       const spendingKey = generateKey().spendingKey

--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -854,6 +854,25 @@ export class Blockchain {
   }
 
   /**
+   * Get the block on the main chain at the given sequence, if it exists.
+   */
+  async getBlockAtSequence(sequence: number, tx?: IDatabaseTransaction): Promise<Block | null> {
+    return this.blockchainDb.db.withTransaction(tx, async (tx) => {
+      const header = await this.blockchainDb.getBlockHeaderAtSequence(sequence)
+      if (!header) {
+        return null
+      }
+
+      const transactions = await this.blockchainDb.getTransactions(header.hash, tx)
+      if (!transactions) {
+        return null
+      }
+
+      return new Block(header, transactions.transactions)
+    })
+  }
+
+  /**
    * Returns true if the blockchain has a block at the given hash
    */
   async hasBlock(hash: BlockHash, tx?: IDatabaseTransaction): Promise<boolean> {

--- a/ironfish/src/rpc/routes/chain/utils.ts
+++ b/ironfish/src/rpc/routes/chain/utils.ts
@@ -180,6 +180,7 @@ export const serializeRpcBlock = (block: Block, serialized?: boolean): RpcBlock 
     transactions,
   }
 }
+
 export const serializeRpcTransaction = (
   tx: Transaction,
   serialized?: boolean,

--- a/ironfish/src/rpc/routes/chain/utils.ts
+++ b/ironfish/src/rpc/routes/chain/utils.ts
@@ -6,10 +6,11 @@ import { Assert } from '../../../assert'
 import { Blockchain } from '../../../blockchain'
 import { VerificationResult } from '../../../consensus/verifier'
 import { createRootLogger, Logger } from '../../../logger'
-import { getTransactionSize } from '../../../network/utils/serializers'
-import { Transaction } from '../../../primitives'
+import { getBlockSize, getTransactionSize } from '../../../network/utils/serializers'
+import { Block, Transaction } from '../../../primitives'
 import { BlockHeader } from '../../../primitives/blockheader'
 import { BlockchainUtils, BufferUtils, HashUtils } from '../../../utils'
+import { RpcBlock, serializeRpcBlockHeader } from '../types'
 import { RpcTransaction } from './types'
 
 const DEFAULT_OPTIONS = {
@@ -165,6 +166,20 @@ export async function renderGraph(
   }
 }
 
+export const serializeRpcBlock = (block: Block, serialized?: boolean): RpcBlock => {
+  const blockHeaderResponse = serializeRpcBlockHeader(block.header)
+
+  const transactions: RpcTransaction[] = []
+  for (const tx of block.transactions) {
+    transactions.push(serializeRpcTransaction(tx, serialized))
+  }
+
+  return {
+    ...blockHeaderResponse,
+    size: getBlockSize(block),
+    transactions,
+  }
+}
 export const serializeRpcTransaction = (
   tx: Transaction,
   serialized?: boolean,


### PR DESCRIPTION
## Summary
This adds a new method to the block chain by adding a new matching
method getBlockAtSequence which matches getHeaderAtSequence. It also
does not conflate data fetching with serialization so getBlocks is a lot
cleaner now.

## Testing Plan
Added a new test

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
