### PR TITLE
sorts accounts by name in 'wallet:transaction:view'

### DIFF
--- a/ironfish-cli/src/commands/wallet/transaction/view.ts
+++ b/ironfish-cli/src/commands/wallet/transaction/view.ts
@@ -87,7 +87,7 @@ export class TransactionViewCommand extends IronfishCommand {
       })
     }
 
-    choices.sort()
+    choices.sort((a, b) => a.account.localeCompare(b.account))
 
     const selection = await inquirer.prompt<{
       account: string


### PR DESCRIPTION
## Summary

displays account names in alphabetical order when no account is specified by flags

## Testing Plan

before:
<img width="252" alt="image" src="https://github.com/iron-fish/ironfish/assets/57735705/08672a7a-3b0f-4931-bcd6-df68ffd8905a">


after:
<img width="262" alt="image" src="https://github.com/iron-fish/ironfish/assets/57735705/c071f4f0-5687-4e8c-a890-8c6c521ea9c8">



## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
