### PR TITLE
Persist Account.scanningEnabled

### DIFF
--- a/ironfish/src/rpc/routes/wallet/startScanning.test.ts
+++ b/ironfish/src/rpc/routes/wallet/startScanning.test.ts
@@ -23,7 +23,7 @@ describe('Route wallet/startScanning', () => {
   it('Should set scanning to true', async () => {
     let account = routeTest.node.wallet.getAccountByName(accountName)
     Assert.isNotNull(account)
-    account.updateScanningEnabled(false)
+    await account.updateScanningEnabled(false)
     expect(account.scanningEnabled).toBe(false)
 
     await routeTest.client
@@ -40,7 +40,7 @@ describe('Route wallet/startScanning', () => {
   it('Should do nothing if scanning is already started', async () => {
     let account = routeTest.node.wallet.getAccountByName(accountName)
     Assert.isNotNull(account)
-    account.updateScanningEnabled(true)
+    await account.updateScanningEnabled(true)
     expect(account.scanningEnabled).toBe(true)
 
     await routeTest.client

--- a/ironfish/src/rpc/routes/wallet/startScanning.ts
+++ b/ironfish/src/rpc/routes/wallet/startScanning.ts
@@ -23,11 +23,11 @@ export const StartScanningResponseSchema: yup.MixedSchema<StartScanningResponse>
 routes.register<typeof StartScanningRequestSchema, StartScanningResponse>(
   `${ApiNamespace.wallet}/startScanning`,
   StartScanningRequestSchema,
-  (request, context): void => {
+  async (request, context): Promise<void> => {
     AssertHasRpcContext(request, context, 'wallet')
 
     const account = getAccount(context.wallet, request.data.account)
-    account.updateScanningEnabled(true)
+    await account.updateScanningEnabled(true)
     request.end()
   },
 )

--- a/ironfish/src/rpc/routes/wallet/stopScanning.test.ts
+++ b/ironfish/src/rpc/routes/wallet/stopScanning.test.ts
@@ -23,7 +23,7 @@ describe('Route wallet/stopScanning', () => {
   it('Should set scanning to false', async () => {
     let account = routeTest.node.wallet.getAccountByName(accountName)
     Assert.isNotNull(account)
-    account.updateScanningEnabled(true)
+    await account.updateScanningEnabled(true)
     expect(account.scanningEnabled).toBe(true)
 
     await routeTest.client
@@ -40,7 +40,7 @@ describe('Route wallet/stopScanning', () => {
   it('Should do nothing if scanning is already stopped', async () => {
     let account = routeTest.node.wallet.getAccountByName(accountName)
     Assert.isNotNull(account)
-    account.updateScanningEnabled(false)
+    await account.updateScanningEnabled(false)
     expect(account.scanningEnabled).toBe(false)
 
     await routeTest.client

--- a/ironfish/src/rpc/routes/wallet/stopScanning.ts
+++ b/ironfish/src/rpc/routes/wallet/stopScanning.ts
@@ -23,11 +23,11 @@ export const StopScanningResponseSchema: yup.MixedSchema<StopScanningResponse> =
 routes.register<typeof StopScanningRequestSchema, StopScanningResponse>(
   `${ApiNamespace.wallet}/stopScanning`,
   StopScanningRequestSchema,
-  (request, context): void => {
+  async (request, context): Promise<void> => {
     AssertHasRpcContext(request, context, 'wallet')
 
     const account = getAccount(context.wallet, request.data.account)
-    account.updateScanningEnabled(false)
+    await account.updateScanningEnabled(false)
     request.end()
   },
 )

--- a/ironfish/src/wallet/account/account.ts
+++ b/ironfish/src/wallet/account/account.ts
@@ -114,6 +114,7 @@ export class Account {
       outgoingViewKey: this.outgoingViewKey,
       publicAddress: this.publicAddress,
       createdAt: this.createdAt,
+      scanningEnabled: this.scanningEnabled,
       multisigKeys: this.multisigKeys,
       proofAuthorizingKey: this.proofAuthorizingKey,
     }
@@ -1253,9 +1254,12 @@ export class Account {
     await this.walletDb.setAccount(this, tx)
   }
 
-  updateScanningEnabled(scanningEnabled: boolean): void {
-    // TODO: Save this in DB
+  async updateScanningEnabled(
+    scanningEnabled: boolean,
+    tx?: IDatabaseTransaction,
+  ): Promise<void> {
     this.scanningEnabled = scanningEnabled
+    await this.walletDb.setAccount(this, tx)
   }
 
   async getTransactionNotes(

--- a/ironfish/src/wallet/wallet.test.ts
+++ b/ironfish/src/wallet/wallet.test.ts
@@ -607,7 +607,7 @@ describe('Wallet', () => {
       const accountB = await useAccountFixture(node.wallet, 'accountB')
 
       await node.wallet.updateHead()
-      accountA.updateScanningEnabled(false)
+      await accountA.updateScanningEnabled(false)
 
       const blockA = await useMinerBlockFixture(node.chain, 2, accountA)
       await node.chain.addBlock(blockA)
@@ -620,7 +620,7 @@ describe('Wallet', () => {
 
       expect(await node.wallet.getEarliestHeadHash()).toEqual(blockB.header.hash)
 
-      accountB.updateScanningEnabled(false)
+      await accountB.updateScanningEnabled(false)
 
       expect(await node.wallet.getEarliestHeadHash()).toBeNull()
     })
@@ -657,21 +657,21 @@ describe('Wallet', () => {
       await node.chain.addBlock(blockA)
 
       await node.wallet.updateHead()
-      accountA.updateScanningEnabled(false)
+      await accountA.updateScanningEnabled(false)
 
       const blockB = await useMinerBlockFixture(node.chain, 3, accountA)
       await node.chain.addBlock(blockB)
       await node.wallet.updateHead()
 
-      accountA.updateScanningEnabled(true)
-      accountB.updateScanningEnabled(false)
+      await accountA.updateScanningEnabled(true)
+      await accountB.updateScanningEnabled(false)
 
       expect((await accountA.getHead())?.sequence).toBe(2)
       expect((await accountB.getHead())?.sequence).toBe(3)
 
       expect(await node.wallet.getLatestHeadHash()).toEqual(blockA.header.hash)
 
-      accountA.updateScanningEnabled(false)
+      await accountA.updateScanningEnabled(false)
 
       expect(await node.wallet.getLatestHeadHash()).toBeNull()
     })
@@ -2149,7 +2149,7 @@ describe('Wallet', () => {
       const accountB: Account = await useAccountFixture(node.wallet, 'b')
       await node.wallet.updateHead()
 
-      accountA.updateScanningEnabled(false)
+      await accountA.updateScanningEnabled(false)
 
       const block2 = await useMinerBlockFixture(node.chain, 2, undefined)
       await node.chain.addBlock(block2)
@@ -2596,7 +2596,7 @@ describe('Wallet', () => {
       expect(accountAHead?.hash).toEqualHash(blockA2.header.hash)
       expect(accountBHead?.hash).toEqualHash(blockA2.header.hash)
 
-      accountA.updateScanningEnabled(false)
+      await accountA.updateScanningEnabled(false)
 
       await node.chain.blockchainDb.db.transaction(async (tx) => {
         await node.chain.disconnect(blockA2, tx)

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -1528,6 +1528,7 @@ export class Wallet {
         publicAddress: key.publicAddress,
         spendingKey: key.spendingKey,
         viewKey: key.viewKey,
+        scanningEnabled: true,
         createdAt,
       },
       walletDb: this.walletDb,
@@ -1627,6 +1628,7 @@ export class Wallet {
         createdAt,
         name,
         multisigKeys,
+        scanningEnabled: true,
       },
       walletDb: this.walletDb,
     })


### PR DESCRIPTION
## Summary
This will persist scanningEnabled to the DB

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
