### PR TITLE
Give bech32 encoder it's own multisig encoder

### DIFF
--- a/ironfish/src/utils/types.ts
+++ b/ironfish/src/utils/types.ts
@@ -59,3 +59,6 @@ export type WithNonNull<T, K extends keyof T> = T & { [P in K]: NonNullable<T[P]
 
 // When used requires that an optional property K be defined in type T
 export type WithRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] }
+
+// When used removes undefined from a type union
+export type NonUndefined<T> = T extends undefined ? never : T

--- a/ironfish/src/wallet/exporter/encoders/bech32.ts
+++ b/ironfish/src/wallet/exporter/encoders/bech32.ts
@@ -6,9 +6,9 @@ import bufio, { EncodingError } from 'bufio'
 import { Bech32m } from '../../../utils'
 import { ACCOUNT_SCHEMA_VERSION } from '../../account/account'
 import { KEY_LENGTH, VIEW_KEY_LENGTH } from '../../walletdb/accountValue'
-import { MultisigKeysEncoding } from '../../walletdb/multisigKeys'
 import { AccountImport } from '../accountImport'
 import { AccountDecodingOptions, AccountEncoder, DecodeFailed, DecodeInvalid } from '../encoder'
+import { MultisigKeysEncoding } from './multisigKeys'
 
 export const BECH32_ACCOUNT_PREFIX = 'ifaccount'
 

--- a/ironfish/src/wallet/exporter/encoders/multisigKeys.ts
+++ b/ironfish/src/wallet/exporter/encoders/multisigKeys.ts
@@ -1,0 +1,70 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import bufio from 'bufio'
+import { Assert } from '../../../assert'
+import { IDatabaseEncoding } from '../../../storage'
+import { MultisigKeys, MultisigSigner } from '../../interfaces/multisigKeys'
+
+export class MultisigKeysEncoding implements IDatabaseEncoding<MultisigKeys> {
+  serialize(value: MultisigKeys): Buffer {
+    const bw = bufio.write(this.getSize(value))
+
+    let flags = 0
+    flags |= Number(!!isSignerMultisig(value)) << 0
+    bw.writeU8(flags)
+
+    bw.writeVarBytes(Buffer.from(value.publicKeyPackage, 'hex'))
+    if (isSignerMultisig(value)) {
+      bw.writeVarBytes(Buffer.from(value.secret, 'hex'))
+      bw.writeVarBytes(Buffer.from(value.keyPackage, 'hex'))
+    }
+
+    return bw.render()
+  }
+
+  deserialize(buffer: Buffer): MultisigKeys {
+    const reader = bufio.read(buffer, true)
+
+    const flags = reader.readU8()
+    const isSigner = flags & (1 << 0)
+
+    const publicKeyPackage = reader.readVarBytes().toString('hex')
+    if (isSigner) {
+      const secret = reader.readVarBytes().toString('hex')
+      const keyPackage = reader.readVarBytes().toString('hex')
+      return {
+        publicKeyPackage,
+        secret,
+        keyPackage,
+      }
+    }
+
+    return {
+      publicKeyPackage,
+    }
+  }
+
+  getSize(value: MultisigKeys): number {
+    let size = 0
+    size += 1 // flags
+
+    size += bufio.sizeVarString(value.publicKeyPackage, 'hex')
+    if (isSignerMultisig(value)) {
+      size += bufio.sizeVarString(value.secret, 'hex')
+      size += bufio.sizeVarString(value.keyPackage, 'hex')
+    }
+
+    return size
+  }
+}
+
+export function isSignerMultisig(multisigKeys: MultisigKeys): multisigKeys is MultisigSigner {
+  return 'keyPackage' in multisigKeys && 'secret' in multisigKeys
+}
+
+export function AssertIsSignerMultisig(
+  multisigKeys: MultisigKeys,
+): asserts multisigKeys is MultisigSigner {
+  Assert.isTrue(isSignerMultisig(multisigKeys))
+}

--- a/ironfish/src/wallet/exporter/encoders/multisigKeys.ts
+++ b/ironfish/src/wallet/exporter/encoders/multisigKeys.ts
@@ -2,11 +2,22 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import bufio from 'bufio'
-import { Assert } from '../../../assert'
-import { IDatabaseEncoding } from '../../../storage'
-import { MultisigKeys, MultisigSigner } from '../../interfaces/multisigKeys'
+import { NonUndefined } from '../../../utils'
+import { AccountImport } from '../accountImport'
 
-export class MultisigKeysEncoding implements IDatabaseEncoding<MultisigKeys> {
+type MultisigKeys = NonUndefined<AccountImport['multisigKeys']>
+
+type MultisigSigner = {
+  secret: string
+  keyPackage: string
+  publicKeyPackage: string
+}
+
+function isSignerMultisig(multisigKeys: MultisigKeys): multisigKeys is MultisigSigner {
+  return 'keyPackage' in multisigKeys && 'secret' in multisigKeys
+}
+
+export class MultisigKeysEncoding {
   serialize(value: MultisigKeys): Buffer {
     const bw = bufio.write(this.getSize(value))
 
@@ -57,14 +68,4 @@ export class MultisigKeysEncoding implements IDatabaseEncoding<MultisigKeys> {
 
     return size
   }
-}
-
-export function isSignerMultisig(multisigKeys: MultisigKeys): multisigKeys is MultisigSigner {
-  return 'keyPackage' in multisigKeys && 'secret' in multisigKeys
-}
-
-export function AssertIsSignerMultisig(
-  multisigKeys: MultisigKeys,
-): asserts multisigKeys is MultisigSigner {
-  Assert.isTrue(isSignerMultisig(multisigKeys))
 }


### PR DESCRIPTION
## Summary

These should not share the same encoder. It's possible to break old wallets by updating the account value Multisig encoder. There should be _no_ code share between the exporter system and the DB schemas.

## Testing Plan

Existing wallet import / export tests cover this.

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
