### PR TITLE
Moved multisig importing into wallet/exporter

### DIFF
--- a/ironfish/src/rpc/routes/wallet/utils.ts
+++ b/ironfish/src/rpc/routes/wallet/utils.ts
@@ -10,7 +10,7 @@ import {
   isMultisigSignerImport,
   isMultisigSignerTrustedDealerImport,
   MultisigKeysImport,
-} from '../../../wallet/interfaces/multisigKeys'
+} from '../../../wallet/exporter/multisig'
 import { AssetValue } from '../../../wallet/walletdb/assetValue'
 import { DecryptedNoteValue } from '../../../wallet/walletdb/decryptedNoteValue'
 import { TransactionValue } from '../../../wallet/walletdb/transactionValue'

--- a/ironfish/src/wallet/exporter/accountImport.ts
+++ b/ironfish/src/wallet/exporter/accountImport.ts
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Account } from '../account/account'
-import { MultisigKeysImport } from '../interfaces/multisigKeys'
 import { HeadValue } from '../walletdb/headValue'
+import { MultisigKeysImport } from './multisig'
 
 export type AccountImport = {
   version: number

--- a/ironfish/src/wallet/exporter/multisig.ts
+++ b/ironfish/src/wallet/exporter/multisig.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { multisig } from '@ironfish/rust-nodejs'
+import { MultisigKeys, MultisigSigner } from '../interfaces/multisigKeys'
 import {
   AccountDecodingOptions,
   MultisigIdentityEncryption,
@@ -36,4 +37,25 @@ export function decodeEncryptedMultisigAccount(
   } catch (e) {
     throw new Error(`Failed to decrypt multisig account: ${String(e)}`)
   }
+}
+
+// Multisig signing data can come from:
+// 1. Regular account export and imported which will have the secret
+// 2. Import from a trusted dealer, which will only have the identity
+export type MultisigKeysImport = MultisigKeys | MultisigSignerTrustedDealerImport
+
+export interface MultisigSignerTrustedDealerImport {
+  identity: string
+  keyPackage: string
+  publicKeyPackage: string
+}
+
+export function isMultisigSignerImport(data: MultisigKeysImport): data is MultisigSigner {
+  return 'secret' in data
+}
+
+export function isMultisigSignerTrustedDealerImport(
+  data: MultisigKeysImport,
+): data is MultisigSignerTrustedDealerImport {
+  return 'identity' in data
 }

--- a/ironfish/src/wallet/interfaces/multisigKeys.ts
+++ b/ironfish/src/wallet/interfaces/multisigKeys.ts
@@ -7,29 +7,8 @@ export interface MultisigSigner {
   publicKeyPackage: string
 }
 
-export interface MultisigSignerTrustedDealerImport {
-  identity: string
-  keyPackage: string
-  publicKeyPackage: string
-}
-
 export interface MultisigCoordinator {
   publicKeyPackage: string
 }
 
 export type MultisigKeys = MultisigSigner | MultisigCoordinator
-
-// Multisig signing data can come from:
-// 1. Regular account export and imported which will have the secret
-// 2. Import from a trusted dealer, which will only have the identity
-export type MultisigKeysImport = MultisigKeys | MultisigSignerTrustedDealerImport
-
-export function isMultisigSignerImport(data: MultisigKeysImport): data is MultisigSigner {
-  return 'secret' in data
-}
-
-export function isMultisigSignerTrustedDealerImport(
-  data: MultisigKeysImport,
-): data is MultisigSignerTrustedDealerImport {
-  return 'identity' in data
-}

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -51,8 +51,8 @@ import {
   NotEnoughFundsError,
 } from './errors'
 import { AccountImport } from './exporter/accountImport'
+import { isMultisigSignerTrustedDealerImport } from './exporter/multisig'
 import { MintAssetOptions } from './interfaces/mintAssetOptions'
-import { isMultisigSignerTrustedDealerImport } from './interfaces/multisigKeys'
 import {
   RemoteChainProcessor,
   WalletBlockHeader,


### PR DESCRIPTION
## Summary

These should not be located in the database schema module. They should be in the exporter code since it's only related to exporting and importing wallet data.

## Testing Plan

Existing tests and typescript checks cover this.

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
