### PR TITLE
Fix migration 031 to use proper multisig encoder

### DIFF
--- a/ironfish/src/migrations/data/031-add-pak-to-account/new/MultisigKeys.ts
+++ b/ironfish/src/migrations/data/031-add-pak-to-account/new/MultisigKeys.ts
@@ -1,0 +1,78 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import bufio from 'bufio'
+import { IDatabaseEncoding } from '../../../../storage'
+
+export class MultisigKeysEncoding implements IDatabaseEncoding<MultisigKeys> {
+  serialize(value: MultisigKeys): Buffer {
+    const bw = bufio.write(this.getSize(value))
+
+    let flags = 0
+    flags |= Number(!!isSignerMultisig(value)) << 0
+    bw.writeU8(flags)
+
+    bw.writeVarBytes(Buffer.from(value.publicKeyPackage, 'hex'))
+    if (isSignerMultisig(value)) {
+      bw.writeVarBytes(Buffer.from(value.secret, 'hex'))
+      bw.writeVarBytes(Buffer.from(value.keyPackage, 'hex'))
+    }
+
+    return bw.render()
+  }
+
+  deserialize(buffer: Buffer): MultisigKeys {
+    const reader = bufio.read(buffer, true)
+
+    const flags = reader.readU8()
+    const isSigner = flags & (1 << 0)
+
+    const publicKeyPackage = reader.readVarBytes().toString('hex')
+    if (isSigner) {
+      const secret = reader.readVarBytes().toString('hex')
+      const keyPackage = reader.readVarBytes().toString('hex')
+      return {
+        publicKeyPackage,
+        secret,
+        keyPackage,
+      }
+    }
+
+    return {
+      publicKeyPackage,
+    }
+  }
+
+  getSize(value: MultisigKeys): number {
+    let size = 0
+    size += 1 // flags
+
+    size += bufio.sizeVarString(value.publicKeyPackage, 'hex')
+    if (isSignerMultisig(value)) {
+      size += bufio.sizeVarString(value.secret, 'hex')
+      size += bufio.sizeVarString(value.keyPackage, 'hex')
+    }
+
+    return size
+  }
+}
+
+export interface MultisigSigner {
+  secret: string
+  keyPackage: string
+  publicKeyPackage: string
+}
+
+export interface MultisigCoordinator {
+  publicKeyPackage: string
+}
+
+export type MultisigKeys = MultisigSigner | MultisigCoordinator
+
+export function isSignerMultisig(multisigKeys: MultisigKeys): multisigKeys is MultisigSigner {
+  return 'keyPackage' in multisigKeys && 'secret' in multisigKeys
+}

--- a/ironfish/src/wallet/interfaces/multisigKeys.ts
+++ b/ironfish/src/wallet/interfaces/multisigKeys.ts
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 export interface MultisigSigner {
   secret: string
   keyPackage: string


### PR DESCRIPTION
## Summary

031 is not using the correct multisig encoder that matches AccountValue. This leads to errors when you try to use the new migration for 31 in any future migration such as 32.

## Testing Plan

Run the migration on an old database.

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
