### PR TITLE
defaults cli tables to no-truncate

### DIFF
--- a/ironfish-cli/src/commands/mempool/transactions.ts
+++ b/ironfish-cli/src/commands/mempool/transactions.ts
@@ -6,8 +6,9 @@ import { CliUx, Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 import { CommandFlags } from '../../types'
+import { TableFlags } from '../../utils/table'
 
-const { sort: _, ...tableFlags } = CliUx.ux.table.flags()
+const { sort: _, ...tableFlags } = TableFlags
 
 const parseMinMax = (input: string): MinMax | undefined => {
   if (input.split(':').length === 1) {

--- a/ironfish-cli/src/commands/peers/banned.ts
+++ b/ironfish-cli/src/commands/peers/banned.ts
@@ -6,8 +6,9 @@ import { CliUx, Flags } from '@oclif/core'
 import blessed from 'blessed'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
+import { TableFlags } from '../../utils/table'
 
-const { sort, ...tableFlags } = CliUx.ux.table.flags()
+const { sort, ...tableFlags } = TableFlags
 
 export class BannedCommand extends IronfishCommand {
   static description = `List all banned peers`

--- a/ironfish-cli/src/commands/peers/index.ts
+++ b/ironfish-cli/src/commands/peers/index.ts
@@ -7,6 +7,7 @@ import blessed from 'blessed'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 import { CommandFlags } from '../../types'
+import { TableFlags } from '../../utils/table'
 
 type GetPeerResponsePeer = GetPeersResponse['peers'][0]
 
@@ -17,7 +18,7 @@ export class ListCommand extends IronfishCommand {
 
   static flags = {
     ...RemoteFlags,
-    ...CliUx.ux.table.flags(),
+    ...TableFlags,
     follow: Flags.boolean({
       char: 'f',
       default: false,

--- a/ironfish-cli/src/commands/wallet/assets.ts
+++ b/ironfish-cli/src/commands/wallet/assets.ts
@@ -13,7 +13,7 @@ import { CliUx } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 import { renderAssetWithVerificationStatus } from '../../utils'
-import { TableCols } from '../../utils/table'
+import { TableCols, TableFlags } from '../../utils/table'
 
 const MAX_ASSET_METADATA_COLUMN_WIDTH = ASSET_METADATA_LENGTH + 1
 const MIN_ASSET_METADATA_COLUMN_WIDTH = ASSET_METADATA_LENGTH / 2 + 1
@@ -21,14 +21,12 @@ const MIN_ASSET_METADATA_COLUMN_WIDTH = ASSET_METADATA_LENGTH / 2 + 1
 const MAX_ASSET_NAME_COLUMN_WIDTH = ASSET_NAME_LENGTH + 1
 const MIN_ASSET_NAME_COLUMN_WIDTH = ASSET_NAME_LENGTH / 2 + 1
 
-const { ...tableFlags } = CliUx.ux.table.flags()
-
 export class AssetsCommand extends IronfishCommand {
   static description = `Display the wallet's assets`
 
   static flags = {
     ...RemoteFlags,
-    ...tableFlags,
+    ...TableFlags,
   }
 
   static args = [

--- a/ironfish-cli/src/commands/wallet/balances.ts
+++ b/ironfish-cli/src/commands/wallet/balances.ts
@@ -6,6 +6,7 @@ import { CliUx, Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 import { compareAssets, renderAssetWithVerificationStatus } from '../../utils'
+import { TableFlags } from '../../utils/table'
 
 type AssetBalancePairs = { asset: RpcAsset; balance: GetBalancesResponse['balances'][number] }
 
@@ -14,7 +15,7 @@ export class BalancesCommand extends IronfishCommand {
 
   static flags = {
     ...RemoteFlags,
-    ...CliUx.ux.table.flags(),
+    ...TableFlags,
     all: Flags.boolean({
       default: false,
       description: `Also show unconfirmed balance, head hash, and head sequence`,
@@ -120,6 +121,6 @@ export class BalancesCommand extends IronfishCommand {
       ),
     )
 
-    CliUx.ux.table(assetBalancePairs, columns, flags)
+    CliUx.ux.table(assetBalancePairs, columns, { ...flags })
   }
 }

--- a/ironfish-cli/src/commands/wallet/notes/index.ts
+++ b/ironfish-cli/src/commands/wallet/notes/index.ts
@@ -5,9 +5,9 @@ import { CurrencyUtils, RpcAsset } from '@ironfish/sdk'
 import { CliUx } from '@oclif/core'
 import { IronfishCommand } from '../../../command'
 import { RemoteFlags } from '../../../flags'
-import { TableCols } from '../../../utils/table'
+import { TableCols, TableFlags } from '../../../utils/table'
 
-const { sort: _, ...tableFlags } = CliUx.ux.table.flags()
+const { sort: _, ...tableFlags } = TableFlags
 export class NotesCommand extends IronfishCommand {
   static description = `Display the account notes`
 

--- a/ironfish-cli/src/commands/wallet/status.ts
+++ b/ironfish-cli/src/commands/wallet/status.ts
@@ -4,13 +4,14 @@
 import { CliUx } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
+import { TableFlags } from '../../utils/table'
 
 export class StatusCommand extends IronfishCommand {
   static description = `Get status of all accounts`
 
   static flags = {
     ...RemoteFlags,
-    ...CliUx.ux.table.flags(),
+    ...TableFlags,
   }
 
   async start(): Promise<void> {

--- a/ironfish-cli/src/commands/wallet/transactions.ts
+++ b/ironfish-cli/src/commands/wallet/transactions.ts
@@ -14,9 +14,9 @@ import { CliUx, Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 import { getAssetsByIDs } from '../../utils'
-import { Format, TableCols } from '../../utils/table'
+import { Format, TableCols, TableFlags } from '../../utils/table'
 
-const { sort: _, ...tableFlags } = CliUx.ux.table.flags()
+const { sort: _, ...tableFlags } = TableFlags
 export class TransactionsCommand extends IronfishCommand {
   static description = `Display the account transactions`
 

--- a/ironfish-cli/src/utils/table.ts
+++ b/ironfish-cli/src/utils/table.ts
@@ -148,16 +148,5 @@ export const TableFlags = {
     default(context) {
       return Promise.resolve(!context.flags['truncate'])
     },
-    relationships: [
-      {
-        type: 'all',
-        flags: [
-          {
-            name: 'truncate',
-            when: async (flags) => Promise.resolve(flags['truncate'] === true),
-          },
-        ],
-      },
-    ],
   }),
 }

--- a/ironfish-cli/src/utils/table.ts
+++ b/ironfish-cli/src/utils/table.ts
@@ -4,6 +4,7 @@
 
 import { ASSET_NAME_LENGTH } from '@ironfish/rust-nodejs'
 import { Assert, BufferUtils, TimeUtils } from '@ironfish/sdk'
+import { CliUx, Flags } from '@oclif/core'
 import { table } from '@oclif/core/lib/cli-ux/styled/table'
 
 /**
@@ -132,3 +133,31 @@ export enum Format {
 }
 
 export const TableCols = { timestamp, asset, fixedWidth }
+
+const { 'no-truncate': _, ...tableFlags } = CliUx.ux.table.flags()
+
+export const TableFlags = {
+  ...tableFlags,
+  truncate: Flags.boolean({
+    description: 'truncate output to fit screen',
+    default: false,
+    allowNo: true,
+  }),
+  'no-truncate': Flags.boolean({
+    hidden: true,
+    default(context) {
+      return Promise.resolve(!context.flags['truncate'])
+    },
+    relationships: [
+      {
+        type: 'all',
+        flags: [
+          {
+            name: 'truncate',
+            when: async (flags) => Promise.resolve(flags['truncate'] === true),
+          },
+        ],
+      },
+    ],
+  }),
+}


### PR DESCRIPTION
## Summary

we typically do not want to truncate data that we display, especially hashes

- wraps oclif 'CliUx.ux.table.flags()' and adds a 'truncate' flag which defaults to false
- includes 'no-truncate' as a hidden flag that defaults to the inverse of the 'truncate' flag. this allows passing table flags to the oclif table constructor without handling our own truncate flag

- replaces all uses of oclif table flags with our own constant

## Testing Plan

manual testing with '--truncate' and '--no-truncate'

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
