### PR TITLE
Prompt for expiration sequence when creating raw or unsigned transactions in CLI

### DIFF
--- a/ironfish-cli/src/commands/wallet/burn.ts
+++ b/ironfish-cli/src/commands/wallet/burn.ts
@@ -16,6 +16,7 @@ import { IronFlag, RemoteFlags, ValueFlag } from '../../flags'
 import { confirmOperation } from '../../utils'
 import { selectAsset } from '../../utils/asset'
 import { promptCurrency } from '../../utils/currency'
+import { promptExpiration } from '../../utils/expiration'
 import { getExplorer } from '../../utils/explorer'
 import { selectFee } from '../../utils/fees'
 import { watchTransaction } from '../../utils/transaction'
@@ -169,6 +170,16 @@ export class Burn extends IronfishCommand {
           confirmations: flags.confirmations,
         },
       })
+    }
+
+    let expiration = flags.expiration
+    if (flags.rawTransaction && expiration === undefined) {
+      expiration = await promptExpiration({ logger: this.logger, client: client })
+    }
+
+    if (expiration !== undefined && expiration < 0) {
+      this.log('Expiration sequence must be non-negative')
+      this.exit(1)
     }
 
     const params: CreateTransactionRequest = {

--- a/ironfish-cli/src/commands/wallet/mint.ts
+++ b/ironfish-cli/src/commands/wallet/mint.ts
@@ -20,6 +20,7 @@ import { IronFlag, RemoteFlags, ValueFlag } from '../../flags'
 import { confirmOperation } from '../../utils'
 import { selectAsset } from '../../utils/asset'
 import { promptCurrency } from '../../utils/currency'
+import { promptExpiration } from '../../utils/expiration'
 import { getExplorer } from '../../utils/explorer'
 import { selectFee } from '../../utils/fees'
 import { watchTransaction } from '../../utils/transaction'
@@ -138,11 +139,6 @@ export class Mint extends IronfishCommand {
     const publicKeyResponse = await client.wallet.getAccountPublicKey({ account })
     const accountPublicKey = publicKeyResponse.content.publicKey
 
-    if (flags.expiration !== undefined && flags.expiration < 0) {
-      this.log('Expiration sequence must be non-negative')
-      this.exit(1)
-    }
-
     let assetId = flags.assetId
     let metadata = flags.metadata
     let name = flags.name
@@ -237,6 +233,16 @@ export class Mint extends IronfishCommand {
       }
     }
 
+    let expiration = flags.expiration
+    if (flags.rawTransaction && expiration === undefined) {
+      expiration = await promptExpiration({ logger: this.logger, client: client })
+    }
+
+    if (expiration !== undefined && expiration < 0) {
+      this.log('Expiration sequence must be non-negative')
+      this.exit(1)
+    }
+
     const params: CreateTransactionRequest = {
       account,
       outputs: [],
@@ -252,7 +258,7 @@ export class Mint extends IronfishCommand {
       ],
       fee: flags.fee ? CurrencyUtils.encode(flags.fee) : null,
       feeRate: flags.feeRate ? CurrencyUtils.encode(flags.feeRate) : null,
-      expiration: flags.expiration,
+      expiration: expiration,
       confirmations: flags.confirmations,
     }
 

--- a/ironfish-cli/src/commands/wallet/send.ts
+++ b/ironfish-cli/src/commands/wallet/send.ts
@@ -17,6 +17,7 @@ import { HexFlag, IronFlag, RemoteFlags, ValueFlag } from '../../flags'
 import { confirmOperation } from '../../utils'
 import { selectAsset } from '../../utils/asset'
 import { promptCurrency } from '../../utils/currency'
+import { promptExpiration } from '../../utils/expiration'
 import { getExplorer } from '../../utils/explorer'
 import { selectFee } from '../../utils/fees'
 import { getSpendPostTimeInMs, updateSpendPostTimeInMs } from '../../utils/spendPostTime'
@@ -213,7 +214,12 @@ export class Send extends IronfishCommand {
       this.exit(1)
     }
 
-    if (flags.expiration !== undefined && flags.expiration < 0) {
+    let expiration = flags.expiration
+    if ((flags.rawTransaction || flags.unsignedTransaction) && expiration === undefined) {
+      expiration = await promptExpiration({ logger: this.logger })
+    }
+
+    if (expiration !== undefined && expiration < 0) {
       this.log('Expiration sequence must be non-negative')
       this.exit(1)
     }
@@ -230,7 +236,7 @@ export class Send extends IronfishCommand {
       ],
       fee: flags.fee ? CurrencyUtils.encode(flags.fee) : null,
       feeRate: flags.feeRate ? CurrencyUtils.encode(flags.feeRate) : null,
-      expiration: flags.expiration,
+      expiration: expiration,
       confirmations: flags.confirmations,
       notes: flags.note,
     }

--- a/ironfish-cli/src/commands/wallet/send.ts
+++ b/ironfish-cli/src/commands/wallet/send.ts
@@ -216,7 +216,7 @@ export class Send extends IronfishCommand {
 
     let expiration = flags.expiration
     if ((flags.rawTransaction || flags.unsignedTransaction) && expiration === undefined) {
-      expiration = await promptExpiration({ logger: this.logger })
+      expiration = await promptExpiration({ logger: this.logger, client: client })
     }
 
     if (expiration !== undefined && expiration < 0) {

--- a/ironfish-cli/src/utils/expiration.ts
+++ b/ironfish-cli/src/utils/expiration.ts
@@ -2,22 +2,31 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { Logger } from '@ironfish/sdk'
+import { Logger, RpcClient } from '@ironfish/sdk'
 import { CliUx } from '@oclif/core'
 
-export async function promptExpiration(options: { logger: Logger }): Promise<number> {
+export async function promptExpiration(options: {
+  client: RpcClient
+  logger: Logger
+}): Promise<number | undefined> {
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const input = await CliUx.ux.prompt(
-      'Enter an expiration block sequence for the transaction. Enter 0 for no expiration',
-      { required: true },
-    )
+    const { client } = options
+
+    const headSequence = (await client.wallet.getNodeStatus()).content.blockchain.head.sequence
+
+    const prompt = `Enter an expiration block sequence for the transaction. You can also enter 0 for no expiration, or leave blank to use the default. The current chain head is ${headSequence}`
+
+    const input = await CliUx.ux.prompt(prompt, { required: false })
+    if (!input) {
+      return
+    }
 
     const number = parseInt(input, 10)
 
-    if (Number.isNaN(number) || number < 0) {
+    if (Number.isNaN(number) || number < 0 || (number > 0 && number <= headSequence)) {
       options.logger.error(
-        'Error: Expiration sequence must be a number greater than or equal to 0.',
+        `Error: Expiration sequence must be 0, a number greater than the chain head sequence (${headSequence}), or blank to use the default.`,
       )
       continue
     }

--- a/ironfish-cli/src/utils/expiration.ts
+++ b/ironfish-cli/src/utils/expiration.ts
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { Logger } from '@ironfish/sdk'
+import { CliUx } from '@oclif/core'
+
+export async function promptExpiration(options: { logger: Logger }): Promise<number> {
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const input = await CliUx.ux.prompt(
+      'Enter an expiration block sequence for the transaction. Enter 0 for no expiration',
+      { required: true },
+    )
+
+    const number = parseInt(input, 10)
+
+    if (Number.isNaN(number) || number < 0) {
+      options.logger.error(
+        'Error: Expiration sequence must be a number greater than or equal to 0.',
+      )
+      continue
+    }
+
+    return number
+  }
+}


### PR DESCRIPTION
## Summary

Users will typically want to specify an expiration sequence when creating a raw or unsigned transaction, as otherwise by default they'll have 15 blocks to submit the transaction, which may not be long enough to sign it and submit it.

The check is optional, so if users leave the prompt blank, it'll use the default.

## Testing Plan

Manually tested: 
<img width="1999" alt="image" src="https://github.com/iron-fish/ironfish/assets/767083/59f53042-d696-417b-9c8b-61a687390238">


## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
