### PR TITLE
Show verified checkmark when selecting asset and sort by verified

### DIFF
--- a/ironfish-cli/src/utils/asset.ts
+++ b/ironfish-cli/src/utils/asset.ts
@@ -129,20 +129,35 @@ export async function selectAsset(
     balances = balances.filter((balance) => filter(assetLookup[balance.assetId]))
   }
 
+  // Show verified assets at top of the list
+  balances = balances.sort((asset1, asset2) => {
+    const verified1 = assetLookup[asset1.assetId].verification.status === 'verified'
+    const verified2 = assetLookup[asset2.assetId].verification.status === 'verified'
+    if (verified1 && verified2) {
+      return 0
+    }
+
+    return verified1 ? -1 : 1
+  })
+
   const choices = balances.map((balance) => {
+    const asset = assetLookup[balance.assetId]
+
     const assetName = BufferUtils.toHuman(Buffer.from(assetLookup[balance.assetId].name, 'hex'))
+    const assetNameWithVerification = renderAssetWithVerificationStatus(assetName, asset)
 
     const renderedAvailable = CurrencyUtils.render(
       balance.available,
       false,
       balance.assetId,
-      assetLookup[balance.assetId].verification,
+      asset.verification,
     )
-    const name = `${balance.assetId} (${assetName}) (${renderedAvailable})`
+
+    const name = `${balance.assetId} (${assetNameWithVerification}) (${renderedAvailable})`
 
     const value = {
       id: balance.assetId,
-      name: assetLookup[balance.assetId].name,
+      name: asset.name,
     }
 
     return { value, name }


### PR DESCRIPTION
## Summary
For mint, burn and send display whether the asset is verified or not and sort by verified assets

## Testing Plan
Tested locally

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
