### PR TITLE
adds account flag to wallet commands

### DIFF
--- a/ironfish-cli/src/commands/wallet/assets.ts
+++ b/ironfish-cli/src/commands/wallet/assets.ts
@@ -9,7 +9,7 @@ import {
   PUBLIC_ADDRESS_LENGTH,
 } from '@ironfish/rust-nodejs'
 import { BufferUtils } from '@ironfish/sdk'
-import { CliUx } from '@oclif/core'
+import { CliUx, Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 import { renderAssetWithVerificationStatus } from '../../utils'
@@ -27,19 +27,24 @@ export class AssetsCommand extends IronfishCommand {
   static flags = {
     ...RemoteFlags,
     ...TableFlags,
+    account: Flags.string({
+      char: 'a',
+      description: 'Name of the account to get assets for',
+    }),
   }
 
   static args = [
     {
       name: 'account',
       required: false,
-      description: 'Name of the account',
+      description: 'Name of the account. DEPRECATED: use --account flag',
     },
   ]
 
   async start(): Promise<void> {
     const { flags, args } = await this.parse(AssetsCommand)
-    const account = args.account as string | undefined
+    // TODO: remove account arg
+    const account = (flags.account ? flags.account : args.account) as string | undefined
 
     const client = await this.sdk.connectRpc()
     const response = client.wallet.getAssets({

--- a/ironfish-cli/src/commands/wallet/assets.ts
+++ b/ironfish-cli/src/commands/wallet/assets.ts
@@ -44,7 +44,7 @@ export class AssetsCommand extends IronfishCommand {
   async start(): Promise<void> {
     const { flags, args } = await this.parse(AssetsCommand)
     // TODO: remove account arg
-    const account = (flags.account ? flags.account : args.account) as string | undefined
+    const account = flags.account ? flags.account : (args.account as string | undefined)
 
     const client = await this.sdk.connectRpc()
     const response = client.wallet.getAssets({

--- a/ironfish-cli/src/commands/wallet/balance.ts
+++ b/ironfish-cli/src/commands/wallet/balance.ts
@@ -49,7 +49,7 @@ export class BalanceCommand extends IronfishCommand {
   async start(): Promise<void> {
     const { flags, args } = await this.parse(BalanceCommand)
     // TODO: remove account arg
-    const account = (flags.account ? flags.account : args.account) as string | undefined
+    const account = flags.account ? flags.account : (args.account as string | undefined)
 
     const client = await this.sdk.connectRpc()
 

--- a/ironfish-cli/src/commands/wallet/balance.ts
+++ b/ironfish-cli/src/commands/wallet/balance.ts
@@ -16,6 +16,10 @@ export class BalanceCommand extends IronfishCommand {
 
   static flags = {
     ...RemoteFlags,
+    account: Flags.string({
+      char: 'a',
+      description: 'Name of the account to get balance for',
+    }),
     explain: Flags.boolean({
       default: false,
       description: 'Explain your balance',
@@ -38,13 +42,14 @@ export class BalanceCommand extends IronfishCommand {
     {
       name: 'account',
       required: false,
-      description: 'Name of the account to get balance for',
+      description: 'Name of the account to get balance for. DEPRECATED: use --account flag',
     },
   ]
 
   async start(): Promise<void> {
     const { flags, args } = await this.parse(BalanceCommand)
-    const account = args.account as string | undefined
+    // TODO: remove account arg
+    const account = (flags.account ? flags.account : args.account) as string | undefined
 
     const client = await this.sdk.connectRpc()
 

--- a/ironfish-cli/src/commands/wallet/balances.ts
+++ b/ironfish-cli/src/commands/wallet/balances.ts
@@ -43,7 +43,7 @@ export class BalancesCommand extends IronfishCommand {
     const client = await this.sdk.connectRpc()
 
     // TODO: remove account arg
-    const account = (flags.account ? flags.account : args.account) as string | undefined
+    const account = flags.account ? flags.account : (args.account as string | undefined)
     const response = await client.wallet.getAccountBalances({
       account,
       confirmations: flags.confirmations,

--- a/ironfish-cli/src/commands/wallet/balances.ts
+++ b/ironfish-cli/src/commands/wallet/balances.ts
@@ -16,6 +16,10 @@ export class BalancesCommand extends IronfishCommand {
   static flags = {
     ...RemoteFlags,
     ...TableFlags,
+    account: Flags.string({
+      char: 'a',
+      description: 'Name of the account to get balances for',
+    }),
     all: Flags.boolean({
       default: false,
       description: `Also show unconfirmed balance, head hash, and head sequence`,
@@ -30,7 +34,7 @@ export class BalancesCommand extends IronfishCommand {
     {
       name: 'account',
       required: false,
-      description: 'Name of the account to get balances for',
+      description: 'Name of the account to get balances for. DEPRECATED: use --account flag',
     },
   ]
 
@@ -38,7 +42,8 @@ export class BalancesCommand extends IronfishCommand {
     const { flags, args } = await this.parse(BalancesCommand)
     const client = await this.sdk.connectRpc()
 
-    const account = args.account as string | undefined
+    // TODO: remove account arg
+    const account = (flags.account ? flags.account : args.account) as string | undefined
     const response = await client.wallet.getAccountBalances({
       account,
       confirmations: flags.confirmations,

--- a/ironfish-cli/src/commands/wallet/notes/index.ts
+++ b/ironfish-cli/src/commands/wallet/notes/index.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { CurrencyUtils, RpcAsset } from '@ironfish/sdk'
-import { CliUx } from '@oclif/core'
+import { CliUx, Flags } from '@oclif/core'
 import { IronfishCommand } from '../../../command'
 import { RemoteFlags } from '../../../flags'
 import { TableCols, TableFlags } from '../../../utils/table'
@@ -14,19 +14,24 @@ export class NotesCommand extends IronfishCommand {
   static flags = {
     ...RemoteFlags,
     ...tableFlags,
+    account: Flags.string({
+      char: 'a',
+      description: 'Name of the account to get notes for',
+    }),
   }
 
   static args = [
     {
       name: 'account',
       required: false,
-      description: 'Name of the account to get notes for',
+      description: 'Name of the account to get notes for. DEPRECATED: use --account flag',
     },
   ]
 
   async start(): Promise<void> {
     const { flags, args } = await this.parse(NotesCommand)
-    const account = args.account as string | undefined
+    // TODO: remove account arg
+    const account = (flags.account ? flags.account : args.account) as string | undefined
 
     const assetLookup: Map<string, RpcAsset> = new Map()
 

--- a/ironfish-cli/src/commands/wallet/notes/index.ts
+++ b/ironfish-cli/src/commands/wallet/notes/index.ts
@@ -31,7 +31,7 @@ export class NotesCommand extends IronfishCommand {
   async start(): Promise<void> {
     const { flags, args } = await this.parse(NotesCommand)
     // TODO: remove account arg
-    const account = (flags.account ? flags.account : args.account) as string | undefined
+    const account = flags.account ? flags.account : (args.account as string | undefined)
 
     const assetLookup: Map<string, RpcAsset> = new Map()
 

--- a/ironfish-cli/src/commands/wallet/transaction/index.ts
+++ b/ironfish-cli/src/commands/wallet/transaction/index.ts
@@ -43,7 +43,7 @@ export class TransactionCommand extends IronfishCommand {
     const { flags, args } = await this.parse(TransactionCommand)
     const hash = args.hash as string
     // TODO: remove account arg
-    const account = (flags.account ? flags.account : args.account) as string | undefined
+    const account = flags.account ? flags.account : (args.account as string | undefined)
 
     const client = await this.sdk.connectRpc()
 

--- a/ironfish-cli/src/commands/wallet/transaction/index.ts
+++ b/ironfish-cli/src/commands/wallet/transaction/index.ts
@@ -9,7 +9,7 @@ import {
   RpcWalletNote,
   TimeUtils,
 } from '@ironfish/sdk'
-import { CliUx } from '@oclif/core'
+import { CliUx, Flags } from '@oclif/core'
 import { IronfishCommand } from '../../../command'
 import { RemoteFlags } from '../../../flags'
 import { getAssetsByIDs } from '../../../utils'
@@ -19,6 +19,10 @@ export class TransactionCommand extends IronfishCommand {
 
   static flags = {
     ...RemoteFlags,
+    account: Flags.string({
+      char: 'a',
+      description: 'Name of the account to get transaction details for',
+    }),
   }
 
   static args = [
@@ -31,14 +35,15 @@ export class TransactionCommand extends IronfishCommand {
     {
       name: 'account',
       required: false,
-      description: 'Name of the account',
+      description: 'Name of the account. DEPRECATED: use --account flag',
     },
   ]
 
   async start(): Promise<void> {
-    const { args } = await this.parse(TransactionCommand)
+    const { flags, args } = await this.parse(TransactionCommand)
     const hash = args.hash as string
-    const account = args.account as string | undefined
+    // TODO: remove account arg
+    const account = (flags.account ? flags.account : args.account) as string | undefined
 
     const client = await this.sdk.connectRpc()
 

--- a/ironfish-cli/src/commands/wallet/transaction/watch.ts
+++ b/ironfish-cli/src/commands/wallet/transaction/watch.ts
@@ -11,6 +11,10 @@ export class WatchTxCommand extends IronfishCommand {
 
   static flags = {
     ...RemoteFlags,
+    account: Flags.string({
+      char: 'a',
+      description: 'Name of the account to get transaction details for',
+    }),
     confirmations: Flags.integer({
       required: false,
       description: 'Minimum number of blocks confirmations for a transaction',
@@ -27,14 +31,15 @@ export class WatchTxCommand extends IronfishCommand {
     {
       name: 'account',
       required: false,
-      description: 'Name of the account',
+      description: 'Name of the account. DEPRECATED: use --account flag',
     },
   ]
 
   async start(): Promise<void> {
     const { flags, args } = await this.parse(WatchTxCommand)
     const hash = args.hash as string
-    const account = args.account as string | undefined
+    // TODO: remove account arg
+    const account = (flags.account ? flags.account : args.account) as string | undefined
 
     const client = await this.sdk.connectRpc()
 

--- a/ironfish-cli/src/commands/wallet/transaction/watch.ts
+++ b/ironfish-cli/src/commands/wallet/transaction/watch.ts
@@ -39,7 +39,7 @@ export class WatchTxCommand extends IronfishCommand {
     const { flags, args } = await this.parse(WatchTxCommand)
     const hash = args.hash as string
     // TODO: remove account arg
-    const account = (flags.account ? flags.account : args.account) as string | undefined
+    const account = flags.account ? flags.account : (args.account as string | undefined)
 
     const client = await this.sdk.connectRpc()
 

--- a/ironfish-cli/src/commands/wallet/transactions.ts
+++ b/ironfish-cli/src/commands/wallet/transactions.ts
@@ -61,7 +61,7 @@ export class TransactionsCommand extends IronfishCommand {
   async start(): Promise<void> {
     const { flags, args } = await this.parse(TransactionsCommand)
     // TODO: remove account arg
-    const account = (flags.account ? flags.account : args.account) as string | undefined
+    const account = flags.account ? flags.account : (args.account as string | undefined)
 
     const format: Format =
       flags.csv || flags.output === 'csv'

--- a/ironfish-cli/src/commands/wallet/transactions.ts
+++ b/ironfish-cli/src/commands/wallet/transactions.ts
@@ -23,6 +23,10 @@ export class TransactionsCommand extends IronfishCommand {
   static flags = {
     ...RemoteFlags,
     ...tableFlags,
+    account: Flags.string({
+      char: 'a',
+      description: 'Name of the account to get transactions for',
+    }),
     hash: Flags.string({
       char: 't',
       description: 'Transaction hash to get details for',
@@ -50,13 +54,14 @@ export class TransactionsCommand extends IronfishCommand {
     {
       name: 'account',
       required: false,
-      description: 'Name of the account',
+      description: 'Name of the account. DEPRECATED: use --account flag',
     },
   ]
 
   async start(): Promise<void> {
     const { flags, args } = await this.parse(TransactionsCommand)
-    const account = args.account as string | undefined
+    // TODO: remove account arg
+    const account = (flags.account ? flags.account : args.account) as string | undefined
 
     const format: Format =
       flags.csv || flags.output === 'csv'


### PR DESCRIPTION
## Summary

some wallet commands take 'account' as a positional argument when it may make more sense as a flag.

adds account flag to commands that list things for an account: assets, balances, notes, transactions

adds account flag where commands are oriented around a transaction rather than an account: wallet:transaction, wallet:transaction:watch

parse flags and args so that account flag is preferred, but account arg still accepted

updates arg description to display that argument is deprecated

## Testing Plan

manual testing

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
