### PR TITLE
supports pruning expired tx for one account

### DIFF
--- a/ironfish-cli/src/commands/wallet/prune.ts
+++ b/ironfish-cli/src/commands/wallet/prune.ts
@@ -29,6 +29,11 @@ export default class PruneCommand extends IronfishCommand {
       allowNo: true,
       description: 'Compact the database',
     }),
+    account: Flags.string({
+      char: 'a',
+      description:
+        'Name of the account to prune expired transaction for. Prunes all accounts by default',
+    }),
   }
 
   async start(): Promise<void> {
@@ -39,8 +44,21 @@ export default class PruneCommand extends IronfishCommand {
     await NodeUtils.waitForOpen(node)
     CliUx.ux.action.stop('Done.')
 
+    let accounts
+    if (flags.account) {
+      const account = node.wallet.getAccountByName(flags.account)
+
+      if (account === null) {
+        this.error(`Wallet does not have an account named ${flags.account}`)
+      }
+
+      accounts = [account]
+    } else {
+      accounts = node.wallet.listAccounts()
+    }
+
     if (flags.expire) {
-      for (const account of node.wallet.listAccounts()) {
+      for (const account of accounts) {
         const head = await account.getHead()
 
         if (head !== null) {


### PR DESCRIPTION
## Summary

adds an '--account' flag to the 'wallet:prune' command to allow pruning expired transactions for one account at a time

## Testing Plan

manual testing

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
