### PR TITLE
Rahul/ifl 2634 chainport add memo decoder

### DIFF
--- a/ironfish-cli/src/utils/chainport/index.ts
+++ b/ironfish-cli/src/utils/chainport/index.ts
@@ -1,0 +1,5 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+export * from './metadata'

--- a/ironfish-cli/src/utils/chainport/metadata.test.ts
+++ b/ironfish-cli/src/utils/chainport/metadata.test.ts
@@ -1,0 +1,63 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { ChainportMemoMetadata } from './metadata'
+
+describe('ChainportMemoMetadata', () => {
+  test('convertNumberToBinaryString converts a number to binary string with padding', () => {
+    expect(ChainportMemoMetadata.convertNumberToBinaryString(5, 8)).toBe('00000101')
+  })
+
+  test('encodeNumberTo10Bits encodes number to 10 bits', () => {
+    expect(ChainportMemoMetadata.encodeNumberTo10Bits(5)).toBe('0000000101')
+  })
+
+  test('decodeNumberFrom10Bits decodes 10 bits to number', () => {
+    expect(ChainportMemoMetadata.decodeNumberFrom10Bits('0000000101')).toBe(5)
+  })
+
+  test('encodeCharaterTo6Bits encodes character to 6 bits', () => {
+    expect(ChainportMemoMetadata.encodeCharacterTo6Bits('a')).toBe('001010')
+    expect(ChainportMemoMetadata.encodeCharacterTo6Bits('1')).toBe('000001')
+  })
+
+  test('decodeCharFrom6Bits decodes 6 bits to character', () => {
+    expect(ChainportMemoMetadata.decodeCharFrom6Bits('001010')).toBe('a')
+    expect(ChainportMemoMetadata.decodeCharFrom6Bits('000001')).toBe('1')
+  })
+
+  test('encode encodes networkId, address and to_ironfish flag correctly', () => {
+    expect(
+      ChainportMemoMetadata.encode(2, '0x5DF170F118753CaE92aaC2868A2C25Ccb6528f9a', false),
+    ).toBe('000214d3c11c03c10481c50cc28e24228a30220620a08c08530c2c614220f24a')
+
+    expect(
+      ChainportMemoMetadata.encode(22, '0x7A68B1Cf1F16Ef89A566F5606C01BA49F4Eb420A', true),
+    ).toBe('02161ca1882c130f04f04638f2092851863c518018c0012ca1093c438b10200a')
+  })
+
+  test('decode decodes encoded hex string correctly', () => {
+    expect(
+      ChainportMemoMetadata.decode(
+        '000214d3c11c03c10481c50cc28e24228a30220620a08c08530c2c614220f24a',
+      ),
+    ).toEqual([2, '0x5DF170F118753CaE92aaC2868A2C25Ccb6528f9a'.toLowerCase(), false])
+
+    expect(
+      ChainportMemoMetadata.decode(
+        '02161ca1882c130f04f04638f2092851863c518018c0012ca1093c438b10200a',
+      ),
+    ).toEqual([22, '0x7A68B1Cf1F16Ef89A566F5606C01BA49F4Eb420A'.toLowerCase(), true])
+  })
+
+  test('encode and decode are reversible', () => {
+    const networkId = 2
+    const address = '5DF170F118753CaE92aaC2868A2C25Ccb6528f9a'
+    const toIronfish = false
+
+    const encoded = ChainportMemoMetadata.encode(networkId, address, toIronfish)
+    const decoded = ChainportMemoMetadata.decode(encoded)
+
+    expect(decoded).toEqual([networkId, '0x' + address.toLowerCase(), toIronfish])
+  })
+})

--- a/ironfish-cli/src/utils/chainport/metadata.ts
+++ b/ironfish-cli/src/utils/chainport/metadata.ts
@@ -1,0 +1,85 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Chainport memo metadata encoding and decoding
+ * The metadata is encoded in a 64 character hex string
+ * The first bit is a flag to indicate if the transaction is to IronFish or from IronFish
+ * The next 10 bits are the network id
+ * The rest of the bits are the address
+ *
+ * Official documentation: https://docs.chainport.io/for-developers/integrate-chainport/iron-fish/utilities/ironfishmetadata
+ */
+export class ChainportMemoMetadata {
+  constructor() {}
+
+  public static convertNumberToBinaryString(num: number, padding: number) {
+    return num.toString(2).padStart(padding, '0')
+  }
+
+  public static encodeNumberTo10Bits(number: number) {
+    return this.convertNumberToBinaryString(number, 10)
+  }
+
+  public static decodeNumberFrom10Bits(bits: string) {
+    return parseInt('0' + bits.slice(1, 10), 2)
+  }
+
+  public static encodeCharacterTo6Bits(character: string) {
+    const parsedInt = parseInt(character)
+    if (!isNaN(parsedInt)) {
+      return this.convertNumberToBinaryString(parsedInt, 6)
+    }
+
+    const int = character.charCodeAt(0) - 'a'.charCodeAt(0) + 10
+    return this.convertNumberToBinaryString(int, 6)
+  }
+
+  public static decodeCharFrom6Bits(bits: string) {
+    const num = parseInt(bits, 2)
+    if (num < 10) {
+      return num.toString()
+    }
+    return String.fromCharCode(num - 10 + 'a'.charCodeAt(0))
+  }
+
+  public static encode(networkId: number, address: string, toIronfish: boolean) {
+    if (address.startsWith('0x')) {
+      address = address.slice(2)
+    }
+
+    const encodedNetworkId = this.encodeNumberTo10Bits(networkId)
+    const encodedAddress = address
+      .toLowerCase()
+      .split('')
+      .map((character: string) => {
+        return this.encodeCharacterTo6Bits(character)
+      })
+      .join('')
+
+    const combined = (toIronfish ? '1' : '0') + (encodedNetworkId + encodedAddress).slice(1)
+    const hexString = BigInt('0b' + combined).toString(16)
+    return hexString.padStart(64, '0')
+  }
+
+  public static decode(encodedHex: string): [number, string, boolean] {
+    const hexInteger = BigInt('0x' + encodedHex)
+    const encodedString = hexInteger.toString(2)
+    const padded = encodedString.padStart(250, '0')
+    const networkId = this.decodeNumberFrom10Bits(padded)
+
+    const toIronfish = padded[0] === '1'
+    const addressCharacters = []
+
+    for (let i = 10; i < padded.length; i += 6) {
+      const j = i + 6
+      const charBits = padded.slice(i, j)
+      addressCharacters.push(this.decodeCharFrom6Bits(charBits))
+    }
+
+    const address = '0x' + addressCharacters.join('')
+
+    return [networkId, address.toLowerCase(), toIronfish]
+  }
+}


### PR DESCRIPTION
## Summary

Adds chainport memoHex encoder/ decoder. This implementation was shared in python to us by Chainport: https://docs.chainport.io/for-developers/integrate-chainport/iron-fish/utilities/ironfishmetadata

## Testing Plan

Unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
