### PR TITLE
Rahul/ifl 2637 add chainport config

### DIFF
--- a/ironfish-cli/src/utils/chainport/config.ts
+++ b/ironfish-cli/src/utils/chainport/config.ts
@@ -16,7 +16,7 @@ const config = {
   },
 } // MAINNET support to follow
 
-export const getNetworkConfig = (networkId: number) => {
+export const getConfig = (networkId: number) => {
   if (!config[networkId]) {
     throw new Error(`Unsupported network ${networkId} for chainport`)
   }

--- a/ironfish-cli/src/utils/chainport/config.ts
+++ b/ironfish-cli/src/utils/chainport/config.ts
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { TESTNET } from '@ironfish/sdk'
+
+const config = {
+  [TESTNET.id]: {
+    endpoint: 'https://preprod-api.chainport.io',
+    outgoingAddresses: [
+      '06102d319ab7e77b914a1bd135577f3e266fd82a3e537a02db281421ed8b3d13',
+      'db2cf6ec67addde84cc1092378ea22e7bb2eecdeecac5e43febc1cb8fb64b5e5',
+      '3bE494deb669ff8d943463bb6042eabcf0c5346cf444d569e07204487716cb85',
+    ],
+    incomingAddresses: ['06102d319ab7e77b914a1bd135577f3e266fd82a3e537a02db281421ed8b3d13'],
+  },
+} // MAINNET support to follow
+
+export const getNetworkConfig = (networkId: number) => {
+  if (!config[networkId]) {
+    throw new Error(`Unsupported network ${networkId} for chainport`)
+  }
+
+  return config[networkId]
+}


### PR DESCRIPTION
## Summary

Adds a config file for the chainport endpoint and valid to/ from address for outgoing/ incoming bridge transactions.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
