### PR TITLE
Allow wallet to take createdAt for new account

### DIFF
--- a/ironfish/src/rpc/routes/wallet/getAccountStatus.test.ts
+++ b/ironfish/src/rpc/routes/wallet/getAccountStatus.test.ts
@@ -13,7 +13,6 @@ describe('Route wallet/getAccountStatus', () => {
 
   it('returns account status information', async () => {
     const account = await routeTest.node.wallet.createAccount(uuid(), {
-      setCreatedAt: true,
       setDefault: true,
     })
     const response = await routeTest.client.wallet.getAccountStatus({
@@ -38,7 +37,6 @@ describe('Route wallet/getAccountStatus', () => {
 
   it('returns false if scanning is disabled', async () => {
     const account = await routeTest.node.wallet.createAccount(uuid(), {
-      setCreatedAt: true,
       setDefault: true,
     })
     await routeTest.client.wallet.setScanning({ account: account.name, enabled: false })

--- a/ironfish/src/rpc/routes/wallet/getAccountsStatus.test.ts
+++ b/ironfish/src/rpc/routes/wallet/getAccountsStatus.test.ts
@@ -14,7 +14,6 @@ describe('Route wallet/getAccountsStatus', () => {
 
   it('should return account head', async () => {
     const account = await routeTest.node.wallet.createAccount(uuid(), {
-      setCreatedAt: true,
       setDefault: true,
     })
 
@@ -70,7 +69,6 @@ describe('Route wallet/getAccountsStatus', () => {
 
   it('returns false when scanning is disabled', async () => {
     const account = await routeTest.node.wallet.createAccount(uuid(), {
-      setCreatedAt: true,
       setDefault: true,
     })
     await routeTest.client.wallet.setScanning({ account: account.name, enabled: false })

--- a/ironfish/src/rpc/routes/wallet/setAccountHead.test.ts
+++ b/ironfish/src/rpc/routes/wallet/setAccountHead.test.ts
@@ -97,9 +97,7 @@ describe('Route wallet/setAccountHead', () => {
   })
 
   it('throws if account head is null and start is not genesis', async () => {
-    const account = await useAccountFixture(routeTest.wallet, 'foo', {
-      setCreatedAt: false,
-    })
+    const account = await useAccountFixture(routeTest.wallet, 'foo', { createdAt: null })
     const block = await useMinerBlockFixture(routeTest.chain, undefined, account)
     await expect(routeTest.chain).toAddBlock(block)
     await expect(account.getHead()).resolves.toBeNull()

--- a/ironfish/src/testUtilities/fixtures/account.ts
+++ b/ironfish/src/testUtilities/fixtures/account.ts
@@ -3,13 +3,14 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Blockchain } from '../../blockchain'
 import { AccountValue, AssertSpending, SpendingAccount, Wallet } from '../../wallet'
+import { HeadValue } from '../../wallet/walletdb/headValue'
 import { useMinerBlockFixture } from './blocks'
 import { FixtureGenerate, useFixture } from './fixture'
 
 export function useAccountFixture(
   wallet: Wallet,
   generate: FixtureGenerate<SpendingAccount> | string = 'test',
-  options?: { setCreatedAt?: boolean; setDefault?: boolean },
+  options?: { createdAt?: HeadValue | null; setDefault?: boolean },
 ): Promise<SpendingAccount> {
   if (typeof generate === 'string') {
     const name = generate
@@ -50,7 +51,7 @@ export async function useAccountAndAddFundsFixture(
   wallet: Wallet,
   chain: Blockchain,
   generate: FixtureGenerate<SpendingAccount> | string = 'test',
-  options?: { setCreatedAt?: boolean; setDefault?: boolean },
+  options?: { createdAt?: HeadValue | null; setDefault?: boolean },
 ): Promise<SpendingAccount> {
   const account = await useAccountFixture(wallet, generate, options)
   const block = await useMinerBlockFixture(chain, undefined, account)

--- a/ironfish/src/wallet/wallet.test.slow.ts
+++ b/ironfish/src/wallet/wallet.test.slow.ts
@@ -557,8 +557,8 @@ describe('Wallet', () => {
     const nodeA = nodeTest.node
     const { node: nodeB } = await nodeTest.createSetup()
 
-    const accountA = await useAccountFixture(nodeA.wallet, 'testA', { setCreatedAt: false })
-    const accountB = await useAccountFixture(nodeB.wallet, 'testB', { setCreatedAt: false })
+    const accountA = await useAccountFixture(nodeA.wallet, 'testA', { createdAt: null })
+    const accountB = await useAccountFixture(nodeB.wallet, 'testB', { createdAt: null })
 
     const accountBNodeA = await nodeA.wallet.importAccount(accountB)
 
@@ -713,8 +713,8 @@ describe('Wallet', () => {
     const nodeA = nodeTest.node
     const { node: nodeB } = await nodeTest.createSetup()
 
-    const accountA = await useAccountFixture(nodeA.wallet, 'testA', { setCreatedAt: false })
-    const accountB = await useAccountFixture(nodeB.wallet, 'testB', { setCreatedAt: false })
+    const accountA = await useAccountFixture(nodeA.wallet, 'testA', { createdAt: null })
+    const accountB = await useAccountFixture(nodeB.wallet, 'testB', { createdAt: null })
     const accountBNodeA = await nodeA.wallet.importAccount(accountB)
     const accountANodeB = await nodeB.wallet.importAccount(accountA)
 
@@ -823,8 +823,8 @@ describe('Wallet', () => {
     const nodeA = nodeTest.node
     const { node: nodeB } = await nodeTest.createSetup()
 
-    const accountA = await useAccountFixture(nodeA.wallet, 'testA', { setCreatedAt: false })
-    const accountB = await useAccountFixture(nodeB.wallet, 'testB', { setCreatedAt: false })
+    const accountA = await useAccountFixture(nodeA.wallet, 'testA', { createdAt: null })
+    const accountB = await useAccountFixture(nodeB.wallet, 'testB', { createdAt: null })
     const accountBNodeA = await nodeA.wallet.importAccount(accountB)
     const accountANodeB = await nodeB.wallet.importAccount(accountA)
 

--- a/ironfish/src/wallet/wallet.test.ts
+++ b/ironfish/src/wallet/wallet.test.ts
@@ -362,7 +362,7 @@ describe('Wallet', () => {
       const { wallet, chain } = await nodeTest.createSetup({ config: { enableWallet: false } })
 
       // Create a new account but don't give it an account birthday so the wallet head does not update
-      await useAccountFixture(wallet, 'test', { setCreatedAt: false })
+      await useAccountFixture(wallet, 'test', { createdAt: null })
 
       const block1 = await useMinerBlockFixture(chain)
       await expect(chain).toAddBlock(block1)
@@ -682,9 +682,7 @@ describe('Wallet', () => {
       const { node: nodeA } = await nodeTest.createSetup()
       const { node: nodeB } = await nodeTest.createSetup()
 
-      const accountA = await useAccountFixture(nodeA.wallet, 'accountA', {
-        setCreatedAt: false,
-      })
+      const accountA = await useAccountFixture(nodeA.wallet, 'accountA', { createdAt: null })
       expect(accountA.createdAt).toBe(null)
 
       // create blocks and add them to both chains
@@ -713,9 +711,7 @@ describe('Wallet', () => {
       const { node: nodeA } = await nodeTest.createSetup()
       const { node: nodeB } = await nodeTest.createSetup()
 
-      const accountA = await useAccountFixture(nodeA.wallet, 'accountA', {
-        setCreatedAt: false,
-      })
+      const accountA = await useAccountFixture(nodeA.wallet, 'accountA', { createdAt: null })
       expect(accountA.createdAt).toBe(null)
 
       // create blocks and add them to both chains
@@ -746,9 +742,7 @@ describe('Wallet', () => {
       const { node: nodeA } = await nodeTest.createSetup()
       const { node: nodeB } = await nodeTest.createSetup()
 
-      const accountA = await useAccountFixture(nodeA.wallet, 'accountA', {
-        setCreatedAt: false,
-      })
+      const accountA = await useAccountFixture(nodeA.wallet, 'accountA', { createdAt: null })
       expect(accountA.createdAt).toBe(null)
 
       // create blocks but only add them to one chain
@@ -1947,7 +1941,7 @@ describe('Wallet', () => {
     it('should set null account.createdAt for the first on-chain transaction of an account', async () => {
       const { node } = await nodeTest.createSetup()
 
-      const accountA = await useAccountFixture(node.wallet, 'accountA', { setCreatedAt: false })
+      const accountA = await useAccountFixture(node.wallet, 'accountA', { createdAt: null })
 
       expect(accountA.createdAt).toBeNull()
 
@@ -1962,8 +1956,8 @@ describe('Wallet', () => {
     it('should not set account.createdAt if the account has no transaction on the block', async () => {
       const { node } = await nodeTest.createSetup()
 
-      const accountA = await useAccountFixture(node.wallet, 'accountA', { setCreatedAt: false })
-      const accountB = await useAccountFixture(node.wallet, 'accountB', { setCreatedAt: false })
+      const accountA = await useAccountFixture(node.wallet, 'accountA', { createdAt: null })
+      const accountB = await useAccountFixture(node.wallet, 'accountB', { createdAt: null })
 
       expect(accountA.createdAt).toBeNull()
       expect(accountB.createdAt).toBeNull()
@@ -1978,7 +1972,7 @@ describe('Wallet', () => {
     it('should not set account.createdAt if it is not null', async () => {
       const { node } = await nodeTest.createSetup()
 
-      const accountA = await useAccountFixture(node.wallet, 'accountA', { setCreatedAt: false })
+      const accountA = await useAccountFixture(node.wallet, 'accountA', { createdAt: null })
 
       expect(accountA.createdAt).toBeNull()
 

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -1468,8 +1468,7 @@ export class Wallet {
 
   async createAccount(
     name: string,
-    options: { setCreatedAt?: boolean; setDefault?: boolean } = {
-      setCreatedAt: true,
+    options: { createdAt?: HeadValue | null; setDefault?: boolean } = {
       setDefault: false,
     },
   ): Promise<Account> {
@@ -1480,7 +1479,9 @@ export class Wallet {
     const key = generateKey()
 
     let createdAt: HeadValue | null = null
-    if (options.setCreatedAt && this.nodeClient) {
+    if (options.createdAt !== undefined) {
+      createdAt = options.createdAt
+    } else if (this.nodeClient) {
       try {
         createdAt = await this.getChainHead()
       } catch {


### PR DESCRIPTION
## Summary
When downloading a snapshot for a new chain the option to set a new account's head value to the snapshot head would improve scanning performance.

## Testing Plan
Unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
