### PR TITLE
Change setAccountHead to take blocks instead of transactions

### DIFF
--- a/ironfish/src/rpc/routes/wallet/setAccountHead.test.ts
+++ b/ironfish/src/rpc/routes/wallet/setAccountHead.test.ts
@@ -22,7 +22,12 @@ describe('Route wallet/setAccountHead', () => {
         account: account.name,
         start: routeTest.chain.genesis.hash.toString('hex'),
         end: block.header.hash.toString('hex'),
-        transactions: [{ hash: block.transactions[0].hash().toString('hex') }],
+        blocks: [
+          {
+            hash: block.header.hash.toString('hex'),
+            transactions: [{ hash: block.transactions[0].hash().toString('hex') }],
+          },
+        ],
       })
 
       expect(response.status).toBe(200)
@@ -50,7 +55,12 @@ describe('Route wallet/setAccountHead', () => {
         account: account.name,
         start: block1.header.hash.toString('hex'),
         end: block2.header.hash.toString('hex'),
-        transactions: [{ hash: block2.transactions[0].hash().toString('hex') }],
+        blocks: [
+          {
+            hash: block2.header.hash.toString('hex'),
+            transactions: [{ hash: block2.transactions[0].hash().toString('hex') }],
+          },
+        ],
       })
 
       expect(response.status).toBe(200)
@@ -69,7 +79,7 @@ describe('Route wallet/setAccountHead', () => {
         account: account.name,
         start: 'fff',
         end: 'eee',
-        transactions: [],
+        blocks: [],
       }),
     ).rejects.toThrow('Start block is not on the head chain.')
 
@@ -78,7 +88,7 @@ describe('Route wallet/setAccountHead', () => {
         account: account.name,
         start: routeTest.chain.genesis.hash.toString('hex'),
         end: 'eee',
-        transactions: [],
+        blocks: [],
       }),
     ).rejects.toThrow('End block is not on the head chain.')
   })
@@ -91,7 +101,7 @@ describe('Route wallet/setAccountHead', () => {
         account: account.name,
         start: routeTest.chain.genesis.hash.toString('hex'),
         end: routeTest.chain.genesis.hash.toString('hex'),
-        transactions: [],
+        blocks: [],
       }),
     ).rejects.toThrow('Cannot set account head while account scanning is enabled.')
   })
@@ -111,7 +121,12 @@ describe('Route wallet/setAccountHead', () => {
         account: account.name,
         start: block.header.hash.toString('hex'),
         end: block.header.hash.toString('hex'),
-        transactions: [{ hash: block.transactions[0].hash().toString('hex') }],
+        blocks: [
+          {
+            hash: block.header.hash.toString('hex'),
+            transactions: [{ hash: block.transactions[0].hash().toString('hex') }],
+          },
+        ],
       }),
     ).rejects.toThrow(
       `Start must be ${routeTest.chain.genesis.hash.toString('hex')} if account head is null`,
@@ -136,7 +151,7 @@ describe('Route wallet/setAccountHead', () => {
         account: account.name,
         start: block2.header.hash.toString('hex'),
         end: block2.header.hash.toString('hex'),
-        transactions: [],
+        blocks: [],
       }),
     ).rejects.toThrow(`Start must be ${block1.header.hash.toString('hex')} or earlier`)
   })
@@ -154,7 +169,12 @@ describe('Route wallet/setAccountHead', () => {
       account: account.name,
       start: routeTest.chain.genesis.hash.toString('hex'),
       end: block1.header.hash.toString('hex'),
-      transactions: [{ hash: block1.transactions[0].hash().toString('hex') }],
+      blocks: [
+        {
+          hash: block1.header.hash.toString('hex'),
+          transactions: [{ hash: block1.transactions[0].hash().toString('hex') }],
+        },
+      ],
     })
 
     expect(response.status).toBe(200)
@@ -187,9 +207,15 @@ describe('Route wallet/setAccountHead', () => {
       account: account.name,
       start: node2Block1.header.hash.toString('hex'),
       end: node2Block2.header.hash.toString('hex'),
-      transactions: [
-        { hash: node2Block1.transactions[0].hash().toString('hex') },
-        { hash: node2Block2.transactions[0].hash().toString('hex') },
+      blocks: [
+        {
+          hash: node2Block1.header.hash.toString('hex'),
+          transactions: [{ hash: node2Block1.transactions[0].hash().toString('hex') }],
+        },
+        {
+          hash: node2Block2.header.hash.toString('hex'),
+          transactions: [{ hash: node2Block2.transactions[0].hash().toString('hex') }],
+        },
       ],
     })
 
@@ -213,7 +239,12 @@ describe('Route wallet/setAccountHead', () => {
       account: account.name,
       start: routeTest.chain.genesis.hash.toString('hex'),
       end: block2.header.hash.toString('hex'),
-      transactions: [{ hash: block1.transactions[0].hash().toString('hex') }],
+      blocks: [
+        {
+          hash: block1.header.hash.toString('hex'),
+          transactions: [{ hash: block1.transactions[0].hash().toString('hex') }],
+        },
+      ],
     })
 
     expect(response.status).toBe(200)


### PR DESCRIPTION
## Summary

Updates setAccountHead to take block hashes as well as transaction hashes. This avoids the need to do transaction-to-block lookups and dedupe the block headers when a block includes multiple relevant transactions.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
