### PR TITLE
supports combining notes for custom assets

### DIFF
--- a/ironfish-cli/src/utils/note.ts
+++ b/ironfish-cli/src/utils/note.ts
@@ -1,10 +1,14 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { Asset } from '@ironfish/rust-nodejs'
 import { Assert, RpcClient } from '@ironfish/sdk'
 
-export async function fetchNotes(client: RpcClient, account: string, notesToCombine: number) {
+export async function fetchNotes(
+  client: RpcClient,
+  account: string,
+  assetId: string,
+  notesToCombine: number,
+) {
   const noteSize = await getNoteTreeSize(client)
 
   // TODO(mat): We need to add asset support here for bridges, etc.
@@ -12,7 +16,7 @@ export async function fetchNotes(client: RpcClient, account: string, notesToComb
     account,
     pageSize: notesToCombine,
     filter: {
-      assetId: Asset.nativeId().toString('hex'),
+      assetId,
       spent: false,
     },
   })

--- a/ironfish-cli/src/utils/spendPostTime.ts
+++ b/ironfish-cli/src/utils/spendPostTime.ts
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Asset } from '@ironfish/rust-nodejs'
 import {
   BenchUtils,
   CreateTransactionRequest,
@@ -62,7 +63,7 @@ export async function benchmarkSpendPostTime(
     })
   ).content.publicKey
 
-  const notes = await fetchNotes(client, account, 10)
+  const notes = await fetchNotes(client, account, Asset.nativeId().toString('hex'), 10)
 
   // Not enough notes in the account to measure the time to combine a note
   if (notes.length < 3) {


### PR DESCRIPTION
## Summary

adds an assetId flag to the 'wallet:notes:combine' command

command prompts user to select asset if no asset is specified

displays output notes (including any change note) from the resulting transaction

does not truncate output in table displaying combined notes so that asset information isn't truncated

## Testing Plan

manual testing:
<img width="1181" alt="image" src="https://github.com/iron-fish/ironfish/assets/57735705/17da82d1-a550-4eef-88b2-0afb41d9e542">


## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
