### PR TITLE
Rahul/ifl 2638 chainport add utils

### DIFF
--- a/ironfish-cli/src/utils/chainport/config.ts
+++ b/ironfish-cli/src/utils/chainport/config.ts
@@ -8,12 +8,14 @@ const config = {
   [TESTNET.id]: {
     chainportId: 22,
     endpoint: 'https://preprod-api.chainport.io',
-    outgoingAddresses: [
+    outgoingAddresses: new Set([
       '06102d319ab7e77b914a1bd135577f3e266fd82a3e537a02db281421ed8b3d13',
       'db2cf6ec67addde84cc1092378ea22e7bb2eecdeecac5e43febc1cb8fb64b5e5',
       '3bE494deb669ff8d943463bb6042eabcf0c5346cf444d569e07204487716cb85',
-    ],
-    incomingAddresses: ['06102d319ab7e77b914a1bd135577f3e266fd82a3e537a02db281421ed8b3d13'],
+    ]),
+    incomingAddresses: new Set([
+      '06102d319ab7e77b914a1bd135577f3e266fd82a3e537a02db281421ed8b3d13',
+    ]),
   },
 } // MAINNET support to follow
 

--- a/ironfish-cli/src/utils/chainport/utils.test.ts
+++ b/ironfish-cli/src/utils/chainport/utils.test.ts
@@ -11,8 +11,8 @@ jest.mock('./metadata')
 
 describe('isChainportTransaction', () => {
   const mockConfig = {
-    incomingAddresses: ['incoming1', 'incoming2'],
-    outgoingAddresses: ['outgoing1', 'outgoing2'],
+    incomingAddresses: new Set(['incoming1', 'incoming2']),
+    outgoingAddresses: new Set(['outgoing1', 'outgoing2']),
   }
 
   beforeEach(() => {

--- a/ironfish-cli/src/utils/chainport/utils.test.ts
+++ b/ironfish-cli/src/utils/chainport/utils.test.ts
@@ -1,0 +1,112 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { RpcWalletNote, RpcWalletTransaction, TransactionType } from '@ironfish/sdk'
+import { getConfig } from './config'
+import { ChainportMemoMetadata } from './metadata'
+import { extractChainportDataFromTransaction } from './utils'
+
+jest.mock('./config')
+jest.mock('./metadata')
+
+describe('isChainportTransaction', () => {
+  const mockConfig = {
+    incomingAddresses: ['incoming1', 'incoming2'],
+    outgoingAddresses: ['outgoing1', 'outgoing2'],
+  }
+
+  beforeEach(() => {
+    ;(getConfig as jest.Mock).mockReturnValue(mockConfig)
+  })
+
+  it('should return false for non-SEND/RECEIVE transactions', () => {
+    const transaction = { type: TransactionType.MINER } as RpcWalletTransaction
+    const result = extractChainportDataFromTransaction(1, transaction)
+    expect(result).not.toBeDefined()
+  })
+
+  describe('incoming bridge transactions', () => {
+    it('should return false if no notes are present', () => {
+      const transaction = { type: TransactionType.RECEIVE } as RpcWalletTransaction
+      const result = extractChainportDataFromTransaction(1, transaction)
+      expect(result).not.toBeDefined()
+    })
+
+    it('should return false if sender is not in incoming addresses', () => {
+      const transaction = {
+        type: TransactionType.RECEIVE,
+        notes: [{ sender: 'unknown', memoHex: '' }],
+      } as RpcWalletTransaction
+      const result = extractChainportDataFromTransaction(1, transaction)
+      expect(result).not.toBeDefined()
+    })
+
+    it('should return true for valid incoming chainport transaction', () => {
+      ;(ChainportMemoMetadata.decode as jest.Mock).mockReturnValue([1, 'address'])
+
+      const transaction = {
+        type: TransactionType.RECEIVE,
+        notes: [{ sender: 'incoming1', memoHex: 'mockHex' }] as RpcWalletNote[],
+      } as RpcWalletTransaction
+      const result = extractChainportDataFromTransaction(1, transaction)
+      expect(result).toEqual({
+        type: TransactionType.RECEIVE,
+        chainportNetworkId: 1,
+        address: 'address',
+      })
+    })
+  })
+
+  describe('outgoing transactions', () => {
+    it('should return false if less than 2 notes are present', () => {
+      const transaction = {
+        type: TransactionType.SEND,
+        notes: [{ owner: 'outgoing1', memoHex: '' }],
+      } as RpcWalletTransaction
+      const result = extractChainportDataFromTransaction(1, transaction)
+      expect(result).not.toBeDefined()
+    })
+
+    it('should return false if fee payment memo is not present', () => {
+      const transaction = {
+        type: TransactionType.SEND,
+        notes: [
+          { owner: 'outgoing1', memo: '', memoHex: '' },
+          { owner: 'outgoing1', memo: '', memoHex: '' },
+        ],
+      } as RpcWalletTransaction
+      const result = extractChainportDataFromTransaction(1, transaction)
+      expect(result).not.toBeDefined()
+    })
+
+    it('should return false if owner is not in outgoing addresses', () => {
+      const transaction = {
+        type: TransactionType.SEND,
+        notes: [
+          { owner: 'unknown', memo: '{"type": "fee_payment"}', memoHex: '' },
+          { owner: 'unknown', memo: '', memoHex: '' },
+        ],
+      } as RpcWalletTransaction
+      const result = extractChainportDataFromTransaction(1, transaction)
+      expect(result).not.toBeDefined()
+    })
+
+    it('should return true for valid outgoing chainport transaction', () => {
+      ;(ChainportMemoMetadata.decode as jest.Mock).mockReturnValue([1, 'address'])
+      const transaction = {
+        type: TransactionType.SEND,
+        notes: [
+          { owner: 'outgoing1', memo: '{"type": "fee_payment"}', memoHex: 'mockHex' },
+          { owner: 'outgoing1', memo: '', memoHex: 'mockHex' },
+        ],
+      } as RpcWalletTransaction
+      const result = extractChainportDataFromTransaction(1, transaction)
+      expect(result).toBeDefined()
+      expect(result).toEqual({
+        type: TransactionType.SEND,
+        chainportNetworkId: 1,
+        address: 'address',
+      })
+    })
+  })
+})

--- a/ironfish-cli/src/utils/chainport/utils.ts
+++ b/ironfish-cli/src/utils/chainport/utils.ts
@@ -1,0 +1,86 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { RpcWalletTransaction, TransactionType } from '@ironfish/sdk'
+import { getConfig } from './config'
+import { ChainportMemoMetadata } from './metadata'
+
+type ChainportTransactionData =
+  | {
+      type: TransactionType.SEND | TransactionType.RECEIVE
+      chainportNetworkId: number
+      address: string
+    }
+  | undefined
+
+export const extractChainportDataFromTransaction = (
+  networkId: number,
+  transaction: RpcWalletTransaction,
+): ChainportTransactionData => {
+  const config = getConfig(networkId)
+
+  if (transaction.type === TransactionType.SEND) {
+    return getOutgoingChainportTransactionData(transaction, config)
+  }
+  if (transaction.type === TransactionType.RECEIVE) {
+    return getIncomingChainportTransactionData(transaction, config)
+  }
+  return undefined
+}
+
+const getIncomingChainportTransactionData = (
+  transaction: RpcWalletTransaction,
+  config: { incomingAddresses: string[] },
+): ChainportTransactionData => {
+  const bridgeNote = transaction.notes?.[0]
+
+  if (!bridgeNote || !isAddressInList(bridgeNote.sender, config.incomingAddresses)) {
+    return undefined
+  }
+
+  const [sourceNetwork, address, _] = ChainportMemoMetadata.decode(
+    Buffer.from(bridgeNote.memoHex).toString(),
+  )
+
+  return {
+    type: TransactionType.RECEIVE,
+    chainportNetworkId: sourceNetwork,
+    address: address,
+  }
+}
+
+const getOutgoingChainportTransactionData = (
+  transaction: RpcWalletTransaction,
+  config: { outgoingAddresses: string[] },
+): ChainportTransactionData => {
+  if (!transaction.notes || transaction.notes.length < 2) {
+    return undefined
+  }
+
+  if (!transaction.notes.find((note) => note.memo === '{"type": "fee_payment"}')) {
+    return undefined
+  }
+
+  const bridgeNote = transaction.notes.find((note) =>
+    isAddressInList(note.owner, config.outgoingAddresses),
+  )
+
+  if (!bridgeNote) {
+    return undefined
+  }
+
+  const [sourceNetwork, address, _] = ChainportMemoMetadata.decode(
+    Buffer.from(bridgeNote.memoHex).toString(),
+  )
+
+  return {
+    type: TransactionType.SEND,
+    chainportNetworkId: sourceNetwork,
+    address: address,
+  }
+}
+
+const isAddressInList = (address: string, addressList: string[]): boolean => {
+  return addressList.some((addr) => addr.toLowerCase() === address.toLowerCase())
+}

--- a/ironfish-cli/src/utils/chainport/utils.ts
+++ b/ironfish-cli/src/utils/chainport/utils.ts
@@ -39,9 +39,7 @@ const getIncomingChainportTransactionData = (
     return undefined
   }
 
-  const [sourceNetwork, address, _] = ChainportMemoMetadata.decode(
-    Buffer.from(bridgeNote.memoHex).toString(),
-  )
+  const [sourceNetwork, address, _] = ChainportMemoMetadata.decode(bridgeNote.memoHex)
 
   return {
     type: TransactionType.RECEIVE,
@@ -70,9 +68,7 @@ const getOutgoingChainportTransactionData = (
     return undefined
   }
 
-  const [sourceNetwork, address, _] = ChainportMemoMetadata.decode(
-    Buffer.from(bridgeNote.memoHex).toString(),
-  )
+  const [sourceNetwork, address, _] = ChainportMemoMetadata.decode(bridgeNote.memoHex)
 
   return {
     type: TransactionType.SEND,

--- a/ironfish-cli/src/utils/chainport/utils.ts
+++ b/ironfish-cli/src/utils/chainport/utils.ts
@@ -31,11 +31,11 @@ export const extractChainportDataFromTransaction = (
 
 const getIncomingChainportTransactionData = (
   transaction: RpcWalletTransaction,
-  config: { incomingAddresses: string[] },
+  config: { incomingAddresses: Set<string> },
 ): ChainportTransactionData => {
   const bridgeNote = transaction.notes?.[0]
 
-  if (!bridgeNote || !isAddressInList(bridgeNote.sender, config.incomingAddresses)) {
+  if (!bridgeNote || !isAddressInSet(bridgeNote.sender, config.incomingAddresses)) {
     return undefined
   }
 
@@ -52,7 +52,7 @@ const getIncomingChainportTransactionData = (
 
 const getOutgoingChainportTransactionData = (
   transaction: RpcWalletTransaction,
-  config: { outgoingAddresses: string[] },
+  config: { outgoingAddresses: Set<string> },
 ): ChainportTransactionData => {
   if (!transaction.notes || transaction.notes.length < 2) {
     return undefined
@@ -63,7 +63,7 @@ const getOutgoingChainportTransactionData = (
   }
 
   const bridgeNote = transaction.notes.find((note) =>
-    isAddressInList(note.owner, config.outgoingAddresses),
+    isAddressInSet(note.owner, config.outgoingAddresses),
   )
 
   if (!bridgeNote) {
@@ -81,6 +81,6 @@ const getOutgoingChainportTransactionData = (
   }
 }
 
-const isAddressInList = (address: string, addressList: string[]): boolean => {
-  return addressList.some((addr) => addr.toLowerCase() === address.toLowerCase())
+const isAddressInSet = (address: string, addressSet: Set<string>): boolean => {
+  return addressSet.has(address.toLowerCase())
 }


### PR DESCRIPTION
## Summary

Adds a utils file to test whether a transaction is a chainport transaction or not. 

## Testing Plan

Unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
