### PR TITLE
moves block connect/disconnect logic into account

### DIFF
--- a/ironfish/src/rpc/routes/wallet/setAccountHead.ts
+++ b/ironfish/src/rpc/routes/wallet/setAccountHead.ts
@@ -130,7 +130,7 @@ routes.register<typeof SetAccountHeadRequestSchema, SetAccountHeadResponse>(
         const header: BlockHeader | null = await context.chain.getHeader(accountHead.hash)
         Assert.isNotNull(header, 'Account head must be in chain')
         const transactions = await context.chain.getBlockTransactions(header)
-        await context.wallet.disconnectBlockForAccount(account, header, transactions)
+        await account.disconnectBlock(header, transactions)
         accountHead = await account.getHead()
       }
     }
@@ -249,18 +249,13 @@ routes.register<typeof SetAccountHeadRequestSchema, SetAccountHeadResponse>(
         return
       }
 
-      await context.wallet.connectBlockForAccount(
-        account,
-        blockTransactions.header,
-        blockTransactions.transactions,
-        true,
-      )
+      await account.connectBlock(blockTransactions.header, blockTransactions.transactions, true)
     }
 
     // If last block isn't end, connect end
     const last = transactionWithNotesList.at(-1)
     if (!last || !last.header.equals(endHeader)) {
-      await context.wallet.connectBlockForAccount(account, endHeader, [], false)
+      await account.connectBlock(endHeader, [], false)
     }
 
     request.end()


### PR DESCRIPTION
## Summary

removes 'connectBlockForAccount' and 'disconnectBlockForAccount' methods from Wallet class and moves that logic to the Account class

delegates management of account data in the walletdb to the account

removes the 'upsertAssetsFromDecryptedNotes' and instead uses the 'backfillAssets' method for each block. this is consistent with how we backfill assets for pending transactions

## Testing Plan

existing unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
