### PR TITLE
Adds ability to filter assets in cli utils

### DIFF
--- a/ironfish-cli/src/utils/asset.ts
+++ b/ironfish-cli/src/utils/asset.ts
@@ -76,6 +76,7 @@ export async function selectAsset(
     showNonCreatorAsset: boolean
     showSingleAssetChoice: boolean
     confirmations?: number
+    filter?: (asset: RpcAsset) => boolean
   },
 ): Promise<
   | {
@@ -121,6 +122,11 @@ export async function selectAsset(
       id: balances[0].assetId,
       name: assetLookup[balances[0].assetId].name,
     }
+  }
+
+  const filter = options.filter
+  if (filter) {
+    balances = balances.filter((balance) => filter(assetLookup[balance.assetId]))
   }
 
   const choices = balances.map((balance) => {


### PR DESCRIPTION
This will be useful for the integration with chainport to only display supported assets as options.

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
