### PR TITLE
adds chainport transaction summary util

### DIFF
--- a/ironfish-cli/src/utils/chainport/utils.ts
+++ b/ironfish-cli/src/utils/chainport/utils.ts
@@ -126,8 +126,6 @@ Target (Ironfish) Network:    ${defaultNetworkName(networkId)}`)
   const transactionStatus = await fetchChainportTransactionStatus(networkId, hash)
   CliUx.ux.action.stop()
 
-  logger.debug(JSON.stringify(transactionStatus, null, 2))
-
   if (Object.keys(transactionStatus).length === 0 || !transactionStatus.target_network_id) {
     logger.log(
       `Transaction status not found on target network.

--- a/ironfish-cli/src/utils/chainport/utils.ts
+++ b/ironfish-cli/src/utils/chainport/utils.ts
@@ -2,9 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { RpcWalletTransaction, TransactionType } from '@ironfish/sdk'
+import {
+  defaultNetworkName,
+  Logger,
+  RpcWalletTransaction,
+  TransactionType,
+} from '@ironfish/sdk'
+import { CliUx } from '@oclif/core'
 import { getConfig } from './config'
 import { ChainportMemoMetadata } from './metadata'
+import { fetchChainportTransactionStatus } from './requests'
+import { ChainportNetwork } from './types'
 
 type ChainportTransactionData =
   | {
@@ -79,4 +87,64 @@ const getOutgoingChainportTransactionData = (
 
 const isAddressInSet = (address: string, addressSet: Set<string>): boolean => {
   return addressSet.has(address.toLowerCase())
+}
+
+export const displayChainportTransactionSummary = async (
+  networkId: number,
+  hash: string,
+  data: ChainportTransactionData,
+  network: ChainportNetwork | undefined,
+  logger: Logger,
+) => {
+  if (!data) {
+    return
+  }
+
+  if (!network) {
+    logger.log(
+      `This transaction is a ${
+        data.type === TransactionType.SEND ? 'outgoing' : 'incoming'
+      } chainport bridge transaction. Error fetching network details.`,
+    )
+    return
+  }
+
+  logger.log(`\n---Chainport Bridge Transaction Details---\n`)
+
+  if (data.type === TransactionType.RECEIVE) {
+    logger.log(`
+Direction:                    Incoming
+Source Network:               ${network.name}
+Source Address:               ${data.address}
+Source Explorer Account:      ${network.explorer_url + 'address/' + data.address}
+Target (Ironfish) Network:    ${defaultNetworkName(networkId)}`)
+
+    return
+  }
+
+  CliUx.ux.action.start('Fetching transaction information on target network')
+  const transactionStatus = await fetchChainportTransactionStatus(networkId, hash)
+  CliUx.ux.action.stop()
+
+  logger.debug(JSON.stringify(transactionStatus, null, 2))
+
+  if (Object.keys(transactionStatus).length === 0 || !transactionStatus.target_network_id) {
+    logger.log(
+      `Transaction status not found on target network.
+Note: Bridge transactions may take up to 30 minutes to surface on the target network.
+If this issue persists, please contact chainport support: https://helpdesk.chainport.io/`,
+    )
+    return
+  }
+
+  logger.log(`
+Direction:                    Outgoing
+Source Network:               ${defaultNetworkName(networkId)}
+Source Transaction Hash:      ${hash}
+Target Network:               ${network.name}
+Target Address:               ${data.address}
+Target Transaction Hash:      ${transactionStatus.target_tx_hash}
+Target Explorer Transaction:  ${
+    network.explorer_url + 'tx/' + transactionStatus.target_tx_hash
+  }`)
 }


### PR DESCRIPTION
## Summary

This summary will be used in the wallet:transaction command

Example output (outgoing transaction): 

![image](https://github.com/iron-fish/ironfish/assets/13268167/27c89983-16b0-457b-8bb5-4ecc0930e894)


## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
