### PR TITLE
detect bridge transactions in wallet:transactions command

### DIFF
--- a/ironfish-cli/src/utils/chainport/config.ts
+++ b/ironfish-cli/src/utils/chainport/config.ts
@@ -11,13 +11,17 @@ const config = {
     outgoingAddresses: new Set([
       '06102d319ab7e77b914a1bd135577f3e266fd82a3e537a02db281421ed8b3d13',
       'db2cf6ec67addde84cc1092378ea22e7bb2eecdeecac5e43febc1cb8fb64b5e5',
-      '3bE494deb669ff8d943463bb6042eabcf0c5346cf444d569e07204487716cb85',
+      '3be494deb669ff8d943463bb6042eabcf0c5346cf444d569e07204487716cb85',
     ]),
     incomingAddresses: new Set([
       '06102d319ab7e77b914a1bd135577f3e266fd82a3e537a02db281421ed8b3d13',
     ]),
   },
 } // MAINNET support to follow
+
+export const isNetworkSupportedByChainport = (networkId: number) => {
+  return !!config[networkId]
+}
 
 export const getConfig = (networkId: number) => {
   if (!config[networkId]) {

--- a/ironfish-cli/src/utils/chainport/index.ts
+++ b/ironfish-cli/src/utils/chainport/index.ts
@@ -4,3 +4,4 @@
 
 export * from './metadata'
 export * from './requests'
+export * from './utils'

--- a/ironfish-cli/src/utils/chainport/utils.ts
+++ b/ironfish-cli/src/utils/chainport/utils.ts
@@ -9,12 +9,12 @@ import {
   TransactionType,
 } from '@ironfish/sdk'
 import { CliUx } from '@oclif/core'
-import { getConfig } from './config'
+import { getConfig, isNetworkSupportedByChainport } from './config'
 import { ChainportMemoMetadata } from './metadata'
 import { fetchChainportTransactionStatus } from './requests'
 import { ChainportNetwork } from './types'
 
-type ChainportTransactionData =
+export type ChainportTransactionData =
   | {
       type: TransactionType.SEND | TransactionType.RECEIVE
       chainportNetworkId: number
@@ -26,6 +26,10 @@ export const extractChainportDataFromTransaction = (
   networkId: number,
   transaction: RpcWalletTransaction,
 ): ChainportTransactionData => {
+  if (isNetworkSupportedByChainport(networkId) === false) {
+    return undefined
+  }
+
   const config = getConfig(networkId)
 
   if (transaction.type === TransactionType.SEND) {

--- a/ironfish-cli/src/utils/index.ts
+++ b/ironfish-cli/src/utils/index.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 export * from './asset'
+export * from './chainport'
 export * from './confirm'
 export * from './editor'
 export * from './platform'


### PR DESCRIPTION
## Summary

Detects bridge transactions in the transactions command. Example output: 

![image](https://github.com/iron-fish/ironfish/assets/13268167/703fea0f-962a-4e05-b745-9c186612bc90)

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
