### PR TITLE
Rahul/ifl 2643 add explorer url to transaction command

### DIFF
--- a/ironfish-cli/src/utils/chainport/utils.ts
+++ b/ironfish-cli/src/utils/chainport/utils.ts
@@ -113,8 +113,6 @@ export const displayChainportTransactionSummary = async (
     return
   }
 
-  logger.log(`\n---Chainport Bridge Transaction Details---\n`)
-
   if (data.type === TransactionType.RECEIVE) {
     logger.log(`
 Direction:                    Incoming


### PR DESCRIPTION
## Summary

Depends on #5012 

Example for outgoing bridge transaction: 

![image](https://github.com/iron-fish/ironfish/assets/13268167/e07d468f-dc30-4ef0-ae7f-b1982b316503)

Example for incoming bridge transaction: 

![image](https://github.com/iron-fish/ironfish/assets/13268167/d3105ddb-3a68-476c-9689-17e34e8ebea8)


## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
