### PR TITLE
Remove Wallet.getLatestHeadHash()

### DIFF
--- a/ironfish-cli/src/commands/chain/rewind.ts
+++ b/ironfish-cli/src/commands/chain/rewind.ts
@@ -118,10 +118,10 @@ async function rewindWalletHead(
   wallet: Wallet,
   sequence: number,
 ): Promise<void> {
-  const walletHeadHash = await wallet.getLatestHeadHash()
+  const latestHead = await wallet.getLatestHead()
 
-  if (walletHeadHash) {
-    const walletHead = await chain.getHeader(walletHeadHash)
+  if (latestHead) {
+    const walletHead = await chain.getHeader(latestHead.hash)
 
     if (walletHead && walletHead.sequence > sequence) {
       const bar = getProgressBar('Rewiding wallet')

--- a/ironfish/src/wallet/__fixtures__/wallet.test.ts.fixture
+++ b/ironfish/src/wallet/__fixtures__/wallet.test.ts.fixture
@@ -1769,7 +1769,7 @@
       ]
     }
   ],
-  "Wallet getLatestHeadHash should return the latest head hash": [
+  "Wallet getLatestHead should return the latest head": [
     {
       "value": {
         "version": 4,
@@ -1935,7 +1935,7 @@
       ]
     }
   ],
-  "Wallet getLatestHeadHash should skip accounts with scanning disabled": [
+  "Wallet getLatestHead should skip accounts with scanning disabled": [
     {
       "value": {
         "version": 4,

--- a/ironfish/src/wallet/wallet.test.ts
+++ b/ironfish/src/wallet/wallet.test.ts
@@ -618,8 +618,8 @@ describe('Wallet', () => {
     })
   })
 
-  describe('getLatestHeadHash', () => {
-    it('should return the latest head hash', async () => {
+  describe('getLatestHead', () => {
+    it('should return the latest head', async () => {
       const { node } = nodeTest
 
       const accountA = await useAccountFixture(node.wallet, 'accountA')
@@ -636,7 +636,9 @@ describe('Wallet', () => {
       await accountB.updateHead(blockB.header)
       await accountC.updateHead(null)
 
-      expect(await node.wallet.getLatestHeadHash()).toEqual(blockB.header.hash)
+      const head = await node.wallet.getLatestHead()
+      expect(head?.hash).toEqualBuffer(blockB.header.hash)
+      expect(head?.sequence).toEqual(blockB.header.sequence)
     })
 
     it('should skip accounts with scanning disabled', async () => {
@@ -661,11 +663,13 @@ describe('Wallet', () => {
       expect((await accountA.getHead())?.sequence).toBe(2)
       expect((await accountB.getHead())?.sequence).toBe(3)
 
-      expect(await node.wallet.getLatestHeadHash()).toEqual(blockA.header.hash)
+      const head = await node.wallet.getLatestHead()
+      expect(head?.hash).toEqualBuffer(blockA.header.hash)
+      expect(head?.sequence).toEqual(blockA.header.sequence)
 
       await accountA.updateScanningEnabled(false)
 
-      expect(await node.wallet.getLatestHeadHash()).toBeNull()
+      expect(await node.wallet.getLatestHead()).toBeNull()
     })
   })
 

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -1662,12 +1662,6 @@ export class Wallet {
     return latestHead
   }
 
-  async getLatestHeadHash(): Promise<Buffer | null> {
-    const latestHead = await this.getLatestHead()
-
-    return latestHead ? latestHead.hash : null
-  }
-
   async isAccountUpToDate(account: Account, confirmations?: number): Promise<boolean> {
     const head = await account.getHead()
 


### PR DESCRIPTION
## Summary

This function is just a projection of a more generalized function and doesn't need to exist.

## Testing Plan

Updated tests

## Documentation

```
[x] Yes
```

Added to release docs

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
