### PR TITLE
Delete WalletBlockHeader and WalletTransaction

### DIFF
--- a/ironfish/src/rpc/routes/chain/serializers.ts
+++ b/ironfish/src/rpc/routes/chain/serializers.ts
@@ -38,6 +38,7 @@ export function deserializeRpcBlockHeader(header: RpcBlockHeader): BlockHeader {
       graffiti: Buffer.from(header.graffiti, 'hex'),
     },
     Buffer.from(header.hash, 'hex'),
+    header.noteSize,
   )
 }
 

--- a/ironfish/src/rpc/routes/chain/serializers.ts
+++ b/ironfish/src/rpc/routes/chain/serializers.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { getBlockSize, getTransactionSize } from '../../../network/utils/serializers'
-import { Block, BlockHeader, Transaction } from '../../../primitives'
+import { Block, BlockHeader, Target, Transaction } from '../../../primitives'
 import { BufferUtils } from '../../../utils'
 import { RpcBlock, RpcBlockHeader, RpcTransaction } from './types'
 
@@ -23,6 +23,22 @@ export function serializeRpcBlockHeader(header: BlockHeader): RpcBlockHeader {
     work: header.work.toString(),
     noteSize: header.noteSize ?? null,
   }
+}
+
+export function deserializeRpcBlockHeader(header: RpcBlockHeader): BlockHeader {
+  return new BlockHeader(
+    {
+      sequence: header.sequence,
+      previousBlockHash: Buffer.from(header.previousBlockHash, 'hex'),
+      noteCommitment: Buffer.from(header.noteCommitment, 'hex'),
+      transactionCommitment: Buffer.from(header.transactionCommitment, 'hex'),
+      target: new Target(header.target),
+      randomness: BigInt(header.randomness),
+      timestamp: new Date(header.timestamp),
+      graffiti: Buffer.from(header.graffiti, 'hex'),
+    },
+    Buffer.from(header.hash, 'hex'),
+  )
 }
 
 export const serializeRpcBlock = (block: Block, serialized?: boolean): RpcBlock => {
@@ -78,4 +94,14 @@ export const serializeRpcTransaction = (
     signature: tx.transactionSignature().toString('hex'),
     ...(serialized ? { serialized: tx.serialize().toString('hex') } : {}),
   }
+}
+
+export const deserializeRpcTransaction = (tx: RpcTransaction): Transaction => {
+  if (tx.serialized) {
+    return new Transaction(Buffer.from(tx.serialized, 'hex'))
+  }
+
+  throw new Error(
+    `Deserializing transactions that are not serialized are currently not supported.`,
+  )
 }

--- a/ironfish/src/wallet/account/account.ts
+++ b/ironfish/src/wallet/account/account.ts
@@ -6,7 +6,7 @@ import { Asset } from '@ironfish/rust-nodejs'
 import { BufferMap, BufferSet } from 'buffer-map'
 import MurmurHash3 from 'imurmurhash'
 import { Assert } from '../../assert'
-import { Transaction } from '../../primitives'
+import { BlockHeader, Transaction } from '../../primitives'
 import { GENESIS_BLOCK_SEQUENCE } from '../../primitives/block'
 import { Note } from '../../primitives/note'
 import { DatabaseKeyRange, IDatabaseTransaction } from '../../storage'
@@ -15,7 +15,6 @@ import { WithNonNull, WithRequired } from '../../utils'
 import { DecryptedNote } from '../../workerPool/tasks/decryptNotes'
 import { AssetBalances } from '../assetBalances'
 import { MultisigKeys, MultisigSigner } from '../interfaces/multisigKeys'
-import { WalletBlockHeader } from '../scanner/remoteChainProcessor'
 import { AccountValue } from '../walletdb/accountValue'
 import { AssetValue } from '../walletdb/assetValue'
 import { BalanceValue } from '../walletdb/balanceValue'
@@ -174,7 +173,7 @@ export class Account {
   }
 
   async connectTransaction(
-    blockHeader: WalletBlockHeader,
+    blockHeader: BlockHeader,
     transaction: Transaction,
     decryptedNotes: Array<DecryptedNote>,
     tx?: IDatabaseTransaction,
@@ -488,7 +487,7 @@ export class Account {
   }
 
   private async deleteDisconnectedMintsFromAssetsStore(
-    blockHeader: WalletBlockHeader,
+    blockHeader: BlockHeader,
     transaction: Transaction,
     receivedAssets: BufferSet | null,
     tx: IDatabaseTransaction,
@@ -643,7 +642,7 @@ export class Account {
   }
 
   async disconnectTransaction(
-    blockHeader: WalletBlockHeader,
+    blockHeader: BlockHeader,
     transaction: Transaction,
     tx?: IDatabaseTransaction,
   ): Promise<AssetBalances> {

--- a/ironfish/src/wallet/scanner/remoteChainProcessor.test.ts
+++ b/ironfish/src/wallet/scanner/remoteChainProcessor.test.ts
@@ -5,18 +5,18 @@
 import { BlockHeader } from '../../primitives'
 import { ALL_API_NAMESPACES, RpcMemoryClient } from '../../rpc'
 import { createNodeTest, useMinerBlockFixture } from '../../testUtilities'
-import { RemoteChainProcessor, WalletBlockHeader } from './remoteChainProcessor'
+import { RemoteChainProcessor } from './remoteChainProcessor'
 
 describe('RemoteChainProcessor', () => {
   const nodeTest = createNodeTest()
 
-  function getWalletBlockHeader(blockHeader: BlockHeader): WalletBlockHeader {
-    return {
+  function getExpectingHeader(blockHeader: BlockHeader): unknown {
+    return expect.objectContaining({
       hash: blockHeader.hash,
       previousBlockHash: blockHeader.previousBlockHash,
       sequence: blockHeader.sequence,
       timestamp: blockHeader.timestamp,
-    }
+    })
   }
 
   it('processes chain', async () => {
@@ -46,7 +46,7 @@ describe('RemoteChainProcessor', () => {
       maxQueueSize: 10,
     })
 
-    const onEvent: jest.Mock<void, [WalletBlockHeader, 'add' | 'remove']> = jest.fn()
+    const onEvent: jest.Mock<void, [BlockHeader, 'add' | 'remove']> = jest.fn()
     processor.onAdd.on((block) => onEvent(block.header, 'add'))
     processor.onRemove.on((block) => onEvent(block.header, 'remove'))
 
@@ -58,7 +58,7 @@ describe('RemoteChainProcessor', () => {
 
     await processor.update()
     expect(processor.hash?.equals(blockA1.header.hash)).toBe(true)
-    expect(onEvent).toHaveBeenNthCalledWith(1, getWalletBlockHeader(blockA1.header), 'add')
+    expect(onEvent).toHaveBeenNthCalledWith(1, getExpectingHeader(blockA1.header), 'add')
     expect(onEvent).toHaveBeenCalledTimes(1)
 
     // G -> A1
@@ -68,9 +68,9 @@ describe('RemoteChainProcessor', () => {
 
     await processor.update()
     expect(processor.hash?.equals(blockB2.header.hash)).toBe(true)
-    expect(onEvent).toHaveBeenNthCalledWith(2, getWalletBlockHeader(blockA1.header), 'remove')
-    expect(onEvent).toHaveBeenNthCalledWith(3, getWalletBlockHeader(blockB1.header), 'add')
-    expect(onEvent).toHaveBeenNthCalledWith(4, getWalletBlockHeader(blockB2.header), 'add')
+    expect(onEvent).toHaveBeenNthCalledWith(2, getExpectingHeader(blockA1.header), 'remove')
+    expect(onEvent).toHaveBeenNthCalledWith(3, getExpectingHeader(blockB1.header), 'add')
+    expect(onEvent).toHaveBeenNthCalledWith(4, getExpectingHeader(blockB2.header), 'add')
     expect(onEvent).toHaveBeenCalledTimes(4)
 
     // G -> A1 -> A2 -> A3
@@ -80,11 +80,11 @@ describe('RemoteChainProcessor', () => {
 
     await processor.update()
     expect(processor.hash?.equals(blockA3.header.hash)).toBe(true)
-    expect(onEvent).toHaveBeenNthCalledWith(5, getWalletBlockHeader(blockB2.header), 'remove')
-    expect(onEvent).toHaveBeenNthCalledWith(6, getWalletBlockHeader(blockB1.header), 'remove')
-    expect(onEvent).toHaveBeenNthCalledWith(7, getWalletBlockHeader(blockA1.header), 'add')
-    expect(onEvent).toHaveBeenNthCalledWith(8, getWalletBlockHeader(blockA2.header), 'add')
-    expect(onEvent).toHaveBeenNthCalledWith(9, getWalletBlockHeader(blockA3.header), 'add')
+    expect(onEvent).toHaveBeenNthCalledWith(5, getExpectingHeader(blockB2.header), 'remove')
+    expect(onEvent).toHaveBeenNthCalledWith(6, getExpectingHeader(blockB1.header), 'remove')
+    expect(onEvent).toHaveBeenNthCalledWith(7, getExpectingHeader(blockA1.header), 'add')
+    expect(onEvent).toHaveBeenNthCalledWith(8, getExpectingHeader(blockA2.header), 'add')
+    expect(onEvent).toHaveBeenNthCalledWith(9, getExpectingHeader(blockA3.header), 'add')
     expect(onEvent).toHaveBeenCalledTimes(9)
   })
 
@@ -101,7 +101,7 @@ describe('RemoteChainProcessor', () => {
       maxQueueSize: 10,
     })
 
-    const onEvent: jest.Mock<void, [WalletBlockHeader, 'add' | 'remove']> = jest.fn()
+    const onEvent: jest.Mock<void, [BlockHeader, 'add' | 'remove']> = jest.fn()
     processor.onAdd.on((block) => onEvent(block.header, 'add'))
     processor.onRemove.on((block) => onEvent(block.header, 'remove'))
 
@@ -128,8 +128,8 @@ describe('RemoteChainProcessor', () => {
 
     await processor.update()
     expect(processor.hash?.equals(blockA1.header.hash)).toBe(true)
-    expect(onEvent).toHaveBeenNthCalledWith(4, getWalletBlockHeader(blockA3.header), 'remove')
-    expect(onEvent).toHaveBeenNthCalledWith(5, getWalletBlockHeader(blockA2.header), 'remove')
+    expect(onEvent).toHaveBeenNthCalledWith(4, getExpectingHeader(blockA3.header), 'remove')
+    expect(onEvent).toHaveBeenNthCalledWith(5, getExpectingHeader(blockA2.header), 'remove')
   })
 
   it('cancels updates when abort signal is triggered', async () => {

--- a/ironfish/src/wallet/scanner/scanState.ts
+++ b/ironfish/src/wallet/scanner/scanState.ts
@@ -4,9 +4,9 @@
 
 import { Event } from '../../event'
 import { Meter } from '../../metrics'
+import { BlockHeader } from '../../primitives'
 import { PromiseResolve, PromiseUtils } from '../../utils'
 import { HeadValue } from '../walletdb/headValue'
-import { WalletBlockHeader } from './remoteChainProcessor'
 
 export class ScanState {
   hash: Buffer | null = null
@@ -43,7 +43,7 @@ export class ScanState {
     return (remaining / this.speed.rate1m) * 1000
   }
 
-  signal(header: WalletBlockHeader): void {
+  signal(header: BlockHeader): void {
     this.hash = header.hash
     this.sequence = header.sequence
     this.speed.add(1)

--- a/ironfish/src/wallet/scanner/walletScanner.ts
+++ b/ironfish/src/wallet/scanner/walletScanner.ts
@@ -7,14 +7,11 @@ import { BufferMap } from 'buffer-map'
 import { Config } from '../../fileStores'
 import { Logger } from '../../logger'
 import { Mutex } from '../../mutex'
+import { BlockHeader, Transaction } from '../../primitives'
 import { RpcClient } from '../../rpc'
 import { AsyncUtils, BufferUtils, HashUtils } from '../../utils'
 import { DecryptedNote } from '../../workerPool/tasks/decryptNotes'
-import {
-  RemoteChainProcessor,
-  WalletBlockHeader,
-  WalletBlockTransaction,
-} from './remoteChainProcessor'
+import { RemoteChainProcessor } from './remoteChainProcessor'
 import { ScanState } from './scanState'
 
 export class WalletScanner {
@@ -127,8 +124,8 @@ export class WalletScanner {
   }
 
   async connectBlock(
-    blockHeader: WalletBlockHeader,
-    transactions: WalletBlockTransaction[],
+    blockHeader: BlockHeader,
+    transactions: { transaction: Transaction; initialNoteIndex: number }[],
     abort?: AbortController,
   ): Promise<void> {
     if (blockHeader.sequence % 100 === 0) {
@@ -202,8 +199,8 @@ export class WalletScanner {
   }
 
   async disconnectBlock(
-    header: WalletBlockHeader,
-    transactions: WalletBlockTransaction[],
+    header: BlockHeader,
+    transactions: { transaction: Transaction; initialNoteIndex: number }[],
     abort?: AbortController,
   ): Promise<void> {
     this.logger.debug(`AccountHead DEL: ${header.sequence} => ${Number(header.sequence) - 1}`)

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -21,6 +21,7 @@ import { NoteHasher } from '../merkletree'
 import { Side } from '../merkletree/merkletree'
 import { Witness } from '../merkletree/witness'
 import { Mutex } from '../mutex'
+import { BlockHeader } from '../primitives'
 import { GENESIS_BLOCK_PREVIOUS, GENESIS_BLOCK_SEQUENCE } from '../primitives/block'
 import { BurnDescription } from '../primitives/burnDescription'
 import { MintDescription } from '../primitives/mintDescription'
@@ -50,7 +51,6 @@ import {
 import { AccountImport } from './exporter/accountImport'
 import { isMultisigSignerTrustedDealerImport } from './exporter/multisig'
 import { MintAssetOptions } from './interfaces/mintAssetOptions'
-import { WalletBlockHeader, WalletBlockTransaction } from './scanner/remoteChainProcessor'
 import { ScanState } from './scanner/scanState'
 import { WalletScanner } from './scanner/walletScanner'
 import { validateAccount } from './validator'
@@ -431,7 +431,7 @@ export class Wallet {
 
   async connectBlockForAccount(
     account: Account,
-    blockHeader: WalletBlockHeader,
+    blockHeader: BlockHeader,
     transactions: { transaction: Transaction; decryptedNotes: DecryptedNote[] }[],
     shouldDecrypt: boolean,
   ): Promise<void> {
@@ -466,10 +466,7 @@ export class Wallet {
     })
   }
 
-  async shouldDecryptForAccount(
-    blockHeader: WalletBlockHeader,
-    account: Account,
-  ): Promise<boolean> {
+  async shouldDecryptForAccount(blockHeader: BlockHeader, account: Account): Promise<boolean> {
     if (account.createdAt === null) {
       return true
     }
@@ -495,7 +492,7 @@ export class Wallet {
   }
 
   private async connectBlockTransactions(
-    blockHeader: WalletBlockHeader,
+    blockHeader: BlockHeader,
     transactions: Array<{ transaction: Transaction; decryptedNotes: Array<DecryptedNote> }>,
     account: Account,
     tx?: IDatabaseTransaction,
@@ -521,7 +518,7 @@ export class Wallet {
   private async upsertAssetsFromDecryptedNotes(
     account: Account,
     decryptedNotes: DecryptedNote[],
-    blockHeader: WalletBlockHeader,
+    blockHeader: BlockHeader,
     tx?: IDatabaseTransaction,
   ): Promise<void> {
     for (const { serializedNote } of decryptedNotes) {
@@ -605,8 +602,8 @@ export class Wallet {
 
   async disconnectBlockForAccount(
     account: Account,
-    header: WalletBlockHeader,
-    transactions: WalletBlockTransaction[],
+    header: BlockHeader,
+    transactions: { transaction: Transaction; initialNoteIndex: number }[],
   ) {
     const assetBalanceDeltas = new AssetBalances()
 


### PR DESCRIPTION
## Summary

I have no idea why these types were introduced, but they were not necessary. You can just use the basic primitives we already have and not introduce brand new types to the code base.

There will be further changes to delete the initial index calculation and push it further down to the place where you actually loop over the transactions.

## Testing Plan
Existing tests cover the scanning and chain processor.

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
