### PR TITLE
adds feerate to flags of chainport CLI command

### DIFF
--- a/ironfish-cli/src/commands/wallet/chainport/send.ts
+++ b/ironfish-cli/src/commands/wallet/chainport/send.ts
@@ -65,6 +65,12 @@ export class BridgeCommand extends IronfishCommand {
       minimum: 1n,
       flagName: 'fee',
     }),
+    feeRate: IronFlag({
+      char: 'r',
+      description: 'The fee rate amount in IRON/Kilobyte',
+      minimum: 1n,
+      flagName: 'fee rate',
+    }),
     expiration: Flags.integer({
       char: 'e',
       description:
@@ -293,6 +299,7 @@ export class BridgeCommand extends IronfishCommand {
         },
       ],
       fee: flags.fee ? CurrencyUtils.encode(flags.fee) : null,
+      feeRate: flags.feeRate ? CurrencyUtils.encode(flags.feeRate) : null,
       expiration: flags.expiration,
     }
 


### PR DESCRIPTION
## Summary

Adds the feerate flag to this command

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
