### PR TITLE
avoids modifying db in 'shouldDecryptForAccount'

### DIFF
--- a/ironfish/src/wallet/__fixtures__/wallet.test.ts.fixture
+++ b/ironfish/src/wallet/__fixtures__/wallet.test.ts.fixture
@@ -8313,62 +8313,6 @@
       ]
     }
   ],
-  "Wallet shouldDecryptForAccount should set the account createdAt if the account was created on a different chain": [
-    {
-      "value": {
-        "version": 4,
-        "id": "92fbb704-54ee-40cf-8859-bb6d07593f41",
-        "name": "test",
-        "spendingKey": "d64ef0f2414b800f3436fc3aa847fbfe84f88c092396dfe7985b2377dcfcbb03",
-        "viewKey": "a63467df1056011c2d3714477029597ed800ae9a66c9295148138c7a2ba73bb2bde9c89e8cc615a3d782acbb105896926862dd2ea353b26a75d1fc407f6d28a7",
-        "incomingViewKey": "1ce97b3b295420bb75b04a7017dc71b6c7e94e56605232df0550214623fa6b04",
-        "outgoingViewKey": "da37098ee679995765b46e47854922a09b739b1c15d4c580bd31847107980a20",
-        "publicAddress": "6895181f5b40cda36d6c43a1eb705afb7a8676be57a001b4b312cb1337021041",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
-        "scanningEnabled": true,
-        "proofAuthorizingKey": "7b5159ee6bb1a3cf3d6385743ef356e9abf5c1e10a0dce5b9e92a9d660717405"
-      },
-      "head": {
-        "hash": {
-          "type": "Buffer",
-          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-        },
-        "sequence": 1
-      }
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "4791D7AE9F97DF100EF1558E84772D6A09B43762388283F75C6F20A32A88AA86",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:LEQ78rlPDXg2G1nkbH+vmW6+l9vaRqnSKgIJ8qouWgU="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:yO7O5jDWB8T9ToU4g8nlzDAx+hs6a9XELkn7AehcT5k="
-        },
-        "target": "9282972777491357380673661573939192202192629606981189395159182914949423",
-        "randomness": "0",
-        "timestamp": 1717539006874,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAyn99yH93HHJ0ltYcLt8GJdDB8+7bKExm8M/n/QmtdhCAtvzNC5dD+hkYqMVG/nf5KP9LSRnAJLbFIIFffuKBMzc8bKnNaBf6RJHqU1nNTiKrXRWVIuEkBES9Ae6UnPvUEfDn+1LsO2D1IV4zcRuRUU5DeTyI3LAgp8iMdlAwd+oKN6MYP6/dWI6lLmTW3aEiFFDCbZUZb2NpaZYfz2M4KvJXi/agzfcleNBJ8pAL7ECE2o0LPuAPRHNTek0l2+D24wvMSbV5pZupOUvFtxDXYbJJcNBUTjxMM0/MEIdmI1j8vT67RFZXp51bXqFcLF7FpO7N+vkkUD6N6J4ov+miPrNdKRl5W5oEHf+VhT/qZpbnk6yLjPNzufwwQOT5NK8715VYz2wQ0Oshzh2Bq/HpOh2nEn+hnGlOwfBloQpaCGWWx64ZZ7YEtaS7YMVSsd4JvaLobyawzQdjFzSUKyk78KPQGIueg/9owQcKLhUx9OQ/plOp6v5m3+ypEP8nKXgxlrzEXxt807mT22mAFOCnr4gD01kG2CEiXOxrU8PLyDLi838/V4iV0ECxeE1Rn1r+T2pCB7n2SmiIDDVxDEJuSgBGE8jdoN+puJL5OTuugoBIugt41l3t4klyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw4e1Ja1Wt02y3kycLDaK3StMQNcRFuCtmYE+JGN4CTsKSV714eIFcGR3DL7etk6tQlgV3W+O5TvkyCtKATsQ0AA=="
-        }
-      ]
-    }
-  ],
   "Wallet scan should scan until the chain head": [
     {
       "value": {

--- a/ironfish/src/wallet/scanner/walletScanner.ts
+++ b/ironfish/src/wallet/scanner/walletScanner.ts
@@ -150,7 +150,7 @@ export class WalletScanner {
       }
     })
 
-    const shouldDecryptAccounts = await AsyncUtils.filter(accounts, (a) =>
+    const shouldDecryptAccounts = accounts.filter((a) =>
       this.wallet.shouldDecryptForAccount(blockHeader, a),
     )
 

--- a/ironfish/src/wallet/wallet.test.ts
+++ b/ironfish/src/wallet/wallet.test.ts
@@ -2840,9 +2840,7 @@ describe('Wallet', () => {
 
       const block = await useMinerBlockFixture(node.chain, 2)
 
-      await expect(node.wallet.shouldDecryptForAccount(block.header, account)).resolves.toBe(
-        true,
-      )
+      expect(node.wallet.shouldDecryptForAccount(block.header, account)).toBe(true)
     })
 
     it('should return true for an account with createdAt earlier than the header', async () => {
@@ -2854,9 +2852,7 @@ describe('Wallet', () => {
 
       const block = await useMinerBlockFixture(node.chain, 2)
 
-      await expect(node.wallet.shouldDecryptForAccount(block.header, account)).resolves.toBe(
-        true,
-      )
+      expect(node.wallet.shouldDecryptForAccount(block.header, account)).toBe(true)
     })
 
     it('should return false for an account created after the header', async () => {
@@ -2868,9 +2864,7 @@ describe('Wallet', () => {
 
       const block = await useMinerBlockFixture(node.chain, 2)
 
-      await expect(node.wallet.shouldDecryptForAccount(block.header, account)).resolves.toBe(
-        false,
-      )
+      expect(node.wallet.shouldDecryptForAccount(block.header, account)).toBe(false)
     })
 
     it('should return true for an account created at the header', async () => {
@@ -2882,30 +2876,7 @@ describe('Wallet', () => {
 
       await account.updateCreatedAt(block.header)
 
-      await expect(node.wallet.shouldDecryptForAccount(block.header, account)).resolves.toBe(
-        true,
-      )
-    })
-
-    it('should set the account createdAt if the account was created on a different chain', async () => {
-      const { node } = nodeTest
-
-      const account = await useAccountFixture(node.wallet)
-
-      // set createdAt at fake block at sequence 2
-      await account.updateCreatedAt({ hash: Buffer.alloc(32), sequence: 2 })
-
-      const resetAccount = jest.spyOn(node.wallet, 'resetAccount')
-
-      const block = await useMinerBlockFixture(node.chain, 2)
-
-      await expect(node.wallet.shouldDecryptForAccount(block.header, account)).resolves.toBe(
-        false,
-      )
-
-      expect(resetAccount).not.toHaveBeenCalled()
-
-      expect(account.createdAt).toBeNull()
+      expect(node.wallet.shouldDecryptForAccount(block.header, account)).toBe(true)
     })
   })
 })

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -466,25 +466,12 @@ export class Wallet {
     })
   }
 
-  async shouldDecryptForAccount(blockHeader: BlockHeader, account: Account): Promise<boolean> {
+  shouldDecryptForAccount(blockHeader: BlockHeader, account: Account): boolean {
     if (account.createdAt === null) {
       return true
     }
 
     if (account.createdAt.sequence > blockHeader.sequence) {
-      return false
-    }
-
-    if (
-      account.createdAt.sequence === blockHeader.sequence &&
-      !account.createdAt.hash.equals(blockHeader.hash)
-    ) {
-      this.logger.warn(
-        `Account ${account.name} createdAt refers to a block that is not on the node's chain. Stopping scan for this account.`,
-      )
-      await account.updateCreatedAt(null)
-      // Sets head to null to avoid connecting blocks for this account
-      await account.updateHead(null)
       return false
     }
 
@@ -1686,7 +1673,9 @@ export class Wallet {
   }
 
   async chainHasBlock(hash: Buffer): Promise<boolean> {
-    return (await this.chainGetBlock({ hash: hash.toString('hex') })) !== null
+    const block = await this.chainGetBlock({ hash: hash.toString('hex') })
+
+    return block !== null && block.metadata.main
   }
 
   async chainGetBlock(request: GetBlockRequest): Promise<GetBlockResponse | null> {


### PR DESCRIPTION
## Summary

when comparing an account's birthday to the current block during a scan we reset the account birthday and account head if the birthday matches in sequence, but not in hash

the wallet cannot encounter this during a scan because we check account birthdays when the wallet starts and when accounts are imported

makes the check on account birthdays more robust by updating 'chainHasBlock' to return false if the block exists but is not on the main chain

furthermore it is less predictable to modify the db for an account during a filtering operation

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
