### PR TITLE
oclif 1.23.1 -> 3.27.0

### DIFF
--- a/ironfish-cli/package.json
+++ b/ironfish-cli/package.json
@@ -60,7 +60,7 @@
   "dependencies": {
     "@ironfish/rust-nodejs": "2.3.0",
     "@ironfish/sdk": "2.3.0",
-    "@oclif/core": "1.23.1",
+    "@oclif/core": "1.26.0",
     "@oclif/plugin-autocomplete": "1.3.10",
     "@oclif/plugin-help": "5.1.12",
     "@oclif/plugin-not-found": "2.3.1",

--- a/ironfish-cli/package.json
+++ b/ironfish-cli/package.json
@@ -60,7 +60,7 @@
   "dependencies": {
     "@ironfish/rust-nodejs": "2.3.0",
     "@ironfish/sdk": "2.3.0",
-    "@oclif/core": "2.16.0",
+    "@oclif/core": "3.27.0",
     "@oclif/plugin-autocomplete": "1.3.10",
     "@oclif/plugin-help": "5.1.12",
     "@oclif/plugin-not-found": "2.3.1",

--- a/ironfish-cli/package.json
+++ b/ironfish-cli/package.json
@@ -60,7 +60,7 @@
   "dependencies": {
     "@ironfish/rust-nodejs": "2.3.0",
     "@ironfish/sdk": "2.3.0",
-    "@oclif/core": "1.26.0",
+    "@oclif/core": "2.16.0",
     "@oclif/plugin-autocomplete": "1.3.10",
     "@oclif/plugin-help": "5.1.12",
     "@oclif/plugin-not-found": "2.3.1",

--- a/ironfish-cli/src/args.ts
+++ b/ironfish-cli/src/args.ts
@@ -2,9 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-export function parseNumber(input: string): number | null {
+export function parseNumber(input: string): Promise<number> {
   const parsed = Number(input)
-  return isNaN(parsed) ? null : parsed
+  if (isNaN(parsed)) {
+    return Promise.reject(`Invalid number: ${input}`)
+  } else {
+    return Promise.resolve(parsed)
+  }
 }
 
 /**

--- a/ironfish-cli/src/args.ts
+++ b/ironfish-cli/src/args.ts
@@ -2,15 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-export function parseNumber(input: string): Promise<number> {
-  const parsed = Number(input)
-  if (isNaN(parsed)) {
-    return Promise.reject(`Invalid number: ${input}`)
-  } else {
-    return Promise.resolve(parsed)
-  }
-}
-
 // TODO(mat): No idea if this remotely works the way I expect yet
 export function parseUrl(input: string): Promise<URL> {
   const parsed = new URL(input)

--- a/ironfish-cli/src/args.ts
+++ b/ironfish-cli/src/args.ts
@@ -2,13 +2,21 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-// TODO(mat): No idea if this remotely works the way I expect yet
-export function parseUrl(input: string): Promise<URL> {
-  const parsed = new URL(input)
-  if (parsed.hostname == null || parsed.port == null || parsed.protocol == null) {
-    return Promise.reject(`Invalid URL: ${input}`)
+import { parseUrl as parseUrlSdk } from '@ironfish/sdk'
+import { Args } from '@oclif/core'
+
+type Url = {
+  protocol: string | null
+  hostname: string
+  port: number | null
+}
+
+export function parseUrl(input: string): Promise<Url> {
+  const parsed = parseUrlSdk(input.trim())
+  if (parsed.hostname != null) {
+    return Promise.resolve(parsed as Url)
   } else {
-    return Promise.resolve(parsed)
+    return Promise.reject(new Error(`Invalid URL: ${input}`))
   }
 }
 
@@ -24,3 +32,7 @@ export function parseBoolean(input: string): 'true' | 'false' | null {
   }
   return null
 }
+
+export const UrlArg = Args.custom<Url>({
+  parse: async (input: string) => parseUrl(input),
+})

--- a/ironfish-cli/src/args.ts
+++ b/ironfish-cli/src/args.ts
@@ -11,6 +11,16 @@ export function parseNumber(input: string): Promise<number> {
   }
 }
 
+// TODO(mat): No idea if this remotely works the way I expect yet
+export function parseUrl(input: string): Promise<URL> {
+  const parsed = new URL(input)
+  if (parsed.hostname == null || parsed.port == null || parsed.protocol == null) {
+    return Promise.reject(`Invalid URL: ${input}`)
+  } else {
+    return Promise.resolve(parsed)
+  }
+}
+
 /**
  * Oclif currently rejects falsy args as if they weren't included,
  * so this function returns the strings 'true' or 'false' instead. This

--- a/ironfish-cli/src/commands/blocks/show.ts
+++ b/ironfish-cli/src/commands/blocks/show.ts
@@ -1,20 +1,20 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Args } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { LocalFlags } from '../../flags'
 
 export default class ShowBlock extends IronfishCommand {
   static description = 'Show the block header of a requested hash or sequence'
 
-  static args = [
-    {
-      name: 'search',
+  static args = {
+    search: Args.string({
       parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: true,
       description: 'The hash or sequence of the block to look at',
-    },
-  ]
+    }),
+  }
 
   static flags = {
     ...LocalFlags,
@@ -22,7 +22,7 @@ export default class ShowBlock extends IronfishCommand {
 
   async start(): Promise<void> {
     const { args } = await this.parse(ShowBlock)
-    const search = args.search as string
+    const search = args.search
 
     const client = await this.sdk.connectRpc()
     const data = await client.chain.getBlock({ search })

--- a/ironfish-cli/src/commands/chain/asset.ts
+++ b/ironfish-cli/src/commands/chain/asset.ts
@@ -2,20 +2,21 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Assert, BufferUtils } from '@ironfish/sdk'
+import { Args } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 
 export default class Asset extends IronfishCommand {
   static description = 'Get the asset info'
 
-  static args = [
-    {
-      name: 'id',
+  static args = {
+    id: Args.string({
+      // TODO(mat): Do we still need these parse functions? Revisit once we can build..
       parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: true,
       description: 'The identifier of the asset',
-    },
-  ]
+    }),
+  }
 
   static flags = {
     ...RemoteFlags,

--- a/ironfish-cli/src/commands/chain/asset.ts
+++ b/ironfish-cli/src/commands/chain/asset.ts
@@ -11,7 +11,6 @@ export default class Asset extends IronfishCommand {
 
   static args = {
     id: Args.string({
-      // TODO(mat): Do we still need these parse functions? Revisit once we can build..
       parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: true,
       description: 'The identifier of the asset',

--- a/ironfish-cli/src/commands/chain/benchmark.ts
+++ b/ironfish-cli/src/commands/chain/benchmark.ts
@@ -32,8 +32,6 @@ export default class Benchmark extends IronfishCommand {
     }),
   }
 
-  static args = []
-
   async start(): Promise<void> {
     const { flags } = await this.parse(Benchmark)
     const { blocks } = flags

--- a/ironfish-cli/src/commands/chain/benchmark.ts
+++ b/ironfish-cli/src/commands/chain/benchmark.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { BenchUtils, IronfishSdk, NodeUtils } from '@ironfish/sdk'
-import { CliUx, Flags } from '@oclif/core'
+import { Flags, ux } from '@oclif/core'
 import blessed from 'blessed'
 import fs from 'fs/promises'
 import path from 'path'
@@ -38,10 +38,10 @@ export default class Benchmark extends IronfishCommand {
     const { flags } = await this.parse(Benchmark)
     const { blocks } = flags
 
-    CliUx.ux.action.start(`Opening node`)
+    ux.action.start(`Opening node`)
     const node = await this.sdk.node()
     await NodeUtils.waitForOpen(node)
-    CliUx.ux.action.stop('done.')
+    ux.action.stop('done.')
 
     let targetDirectory
     if (!flags.targetdir) {
@@ -51,7 +51,7 @@ export default class Benchmark extends IronfishCommand {
       targetDirectory = path.join(flags.targetdir)
     }
 
-    CliUx.ux.action.start(`Opening node in ${targetDirectory}`)
+    ux.action.start(`Opening node in ${targetDirectory}`)
 
     const noLoggingConfig = Object.assign({}, this.sdk.config.overrides)
     noLoggingConfig.logLevel = '*:error'
@@ -65,7 +65,7 @@ export default class Benchmark extends IronfishCommand {
     const tempNode = await tmpSdk.node()
     await NodeUtils.waitForOpen(tempNode)
     tempNode.workerPool.start()
-    CliUx.ux.action.stop('done.')
+    ux.action.stop('done.')
 
     const startingSequence = tempNode.chain.head.sequence
     const startingHeader = await node.chain.getHeaderAtSequence(startingSequence)

--- a/ironfish-cli/src/commands/chain/broadcast.ts
+++ b/ironfish-cli/src/commands/chain/broadcast.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { ux } from '@oclif/core'
+import { Args, ux } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 
@@ -12,17 +12,16 @@ export class BroadcastCommand extends IronfishCommand {
     ...RemoteFlags,
   }
 
-  static args = [
-    {
-      name: 'transaction',
+  static args = {
+    transaction: Args.string({
       required: true,
       description: 'The transaction in hex encoding',
-    },
-  ]
+    }),
+  }
 
   async start(): Promise<void> {
     const { args } = await this.parse(BroadcastCommand)
-    const transaction = args.transaction as string
+    const transaction = args.transaction
 
     ux.action.start(`Broadcasting transaction`)
     const client = await this.sdk.connectRpc()

--- a/ironfish-cli/src/commands/chain/broadcast.ts
+++ b/ironfish-cli/src/commands/chain/broadcast.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { CliUx } from '@oclif/core'
+import { ux } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 
@@ -24,11 +24,11 @@ export class BroadcastCommand extends IronfishCommand {
     const { args } = await this.parse(BroadcastCommand)
     const transaction = args.transaction as string
 
-    CliUx.ux.action.start(`Broadcasting transaction`)
+    ux.action.start(`Broadcasting transaction`)
     const client = await this.sdk.connectRpc()
     const response = await client.chain.broadcastTransaction({ transaction })
     if (response.content) {
-      CliUx.ux.action.stop(`Transaction broadcasted: ${response.content.hash}`)
+      ux.action.stop(`Transaction broadcasted: ${response.content.hash}`)
     }
   }
 }

--- a/ironfish-cli/src/commands/chain/download.ts
+++ b/ironfish-cli/src/commands/chain/download.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { ErrorUtils, FileUtils, Meter, NodeUtils, TimeUtils } from '@ironfish/sdk'
-import { CliUx, Flags } from '@oclif/core'
+import { Flags, ux } from '@oclif/core'
 import fsAsync from 'fs/promises'
 import { IronfishCommand } from '../../command'
 import { LocalFlags } from '../../flags'
@@ -79,7 +79,7 @@ export default class Download extends IronfishCommand {
       const spaceRequired = FileUtils.formatFileSize(manifest.file_size * 2)
 
       if (!flags.confirm) {
-        const confirm = await CliUx.ux.confirm(
+        const confirm = await ux.confirm(
           `Download ${fileSize} snapshot to update from block ${headSequence} to ${manifest.block_sequence}? ` +
             `\nAt least ${spaceRequired} of free disk space is required to download and unzip the snapshot file.` +
             `\nAre you sure? (Y)es / (N)o`,
@@ -94,7 +94,7 @@ export default class Download extends IronfishCommand {
       const snapshotPath = await Downloader.snapshotPath()
       this.log(`Downloading snapshot from ${snapshotUrl} to ${snapshotPath}`)
 
-      const bar = CliUx.ux.progress({
+      const bar = ux.progress({
         barCompleteChar: '\u2588',
         barIncompleteChar: '\u2591',
         format:
@@ -136,7 +136,7 @@ export default class Download extends IronfishCommand {
       downloadedSnapshot = new DownloadedSnapshot(this.sdk, path)
     }
 
-    const progressBar = CliUx.ux.progress({
+    const progressBar = ux.progress({
       barCompleteChar: '\u2588',
       barIncompleteChar: '\u2591',
       format:
@@ -162,18 +162,18 @@ export default class Download extends IronfishCommand {
       },
     )
 
-    CliUx.ux.action.start(
+    ux.action.start(
       `Replacing existing chain data at ${downloadedSnapshot.chainDatabasePath} before importing snapshot`,
     )
 
     await downloadedSnapshot.replaceDatabase()
 
-    CliUx.ux.action.stop('done')
+    ux.action.stop('done')
 
     if (flags.cleanup) {
-      CliUx.ux.action.start(`Cleaning up snapshot file at ${downloadedSnapshot.file}`)
+      ux.action.start(`Cleaning up snapshot file at ${downloadedSnapshot.file}`)
       await fsAsync.rm(downloadedSnapshot.file)
-      CliUx.ux.action.stop('done')
+      ux.action.stop('done')
     }
   }
 }

--- a/ironfish-cli/src/commands/chain/export.ts
+++ b/ironfish-cli/src/commands/chain/export.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { AsyncUtils, GENESIS_BLOCK_SEQUENCE } from '@ironfish/sdk'
-import { CliUx, Flags } from '@oclif/core'
+import { Flags, ux } from '@oclif/core'
 import fs from 'fs'
 import { parseNumber } from '../../args'
 import { IronfishCommand } from '../../command'
@@ -57,7 +57,7 @@ export default class Export extends IronfishCommand {
     const { start, stop } = await AsyncUtils.first(stream.contentStream())
     this.log(`Exporting chain from ${start} -> ${stop} to ${exportPath}`)
 
-    const progress = CliUx.ux.progress({
+    const progress = ux.progress({
       format: 'Exporting blocks: [{bar}] {value}/{total} {percentage}% | ETA: {eta}s',
     }) as ProgressBar
 

--- a/ironfish-cli/src/commands/chain/export.ts
+++ b/ironfish-cli/src/commands/chain/export.ts
@@ -4,7 +4,6 @@
 import { AsyncUtils, GENESIS_BLOCK_SEQUENCE } from '@ironfish/sdk'
 import { Args, Flags, ux } from '@oclif/core'
 import fs from 'fs'
-import { parseNumber } from '../../args'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 import { ProgressBar } from '../../types'
@@ -23,17 +22,12 @@ export default class Export extends IronfishCommand {
   }
 
   static args = {
-    // TODO(mat): Verify these new parse methods function about the same. We
-    // also shouldn't need to be doing verification of this nullable number type
-    // in the logic anymore, so remove that too
     start: Args.integer({
-      parse: (input: string): Promise<number> => parseNumber(input),
       default: Number(GENESIS_BLOCK_SEQUENCE),
       required: false,
       description: 'The sequence to start at (inclusive, genesis block is 1)',
     }),
     stop: Args.integer({
-      parse: (input: string): Promise<number> => parseNumber(input),
       required: false,
       description: 'The sequence to end at (inclusive)',
     }),

--- a/ironfish-cli/src/commands/chain/export.ts
+++ b/ironfish-cli/src/commands/chain/export.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { AsyncUtils, GENESIS_BLOCK_SEQUENCE } from '@ironfish/sdk'
-import { Flags, ux } from '@oclif/core'
+import { Args, Flags, ux } from '@oclif/core'
 import fs from 'fs'
 import { parseNumber } from '../../args'
 import { IronfishCommand } from '../../command'
@@ -22,21 +22,22 @@ export default class Export extends IronfishCommand {
     }),
   }
 
-  static args = [
-    {
-      name: 'start',
-      parse: (input: string): Promise<number | null> => Promise.resolve(parseNumber(input)),
+  static args = {
+    // TODO(mat): Verify these new parse methods function about the same. We
+    // also shouldn't need to be doing verification of this nullable number type
+    // in the logic anymore, so remove that too
+    start: Args.integer({
+      parse: (input: string): Promise<number> => parseNumber(input),
       default: Number(GENESIS_BLOCK_SEQUENCE),
       required: false,
       description: 'The sequence to start at (inclusive, genesis block is 1)',
-    },
-    {
-      name: 'stop',
-      parse: (input: string): Promise<number | null> => Promise.resolve(parseNumber(input)),
+    }),
+    stop: Args.integer({
+      parse: (input: string): Promise<number> => parseNumber(input),
       required: false,
       description: 'The sequence to end at (inclusive)',
-    },
-  ]
+    }),
+  }
 
   async start(): Promise<void> {
     const { flags, args } = await this.parse(Export)

--- a/ironfish-cli/src/commands/chain/genesisadd.ts
+++ b/ironfish-cli/src/commands/chain/genesisadd.ts
@@ -10,7 +10,7 @@ import {
   IJSON,
   isValidPublicAddress,
 } from '@ironfish/sdk'
-import { CliUx, Flags } from '@oclif/core'
+import { Flags, ux } from '@oclif/core'
 import fs from 'fs/promises'
 import { IronfishCommand } from '../../command'
 import { LocalFlags } from '../../flags'
@@ -79,7 +79,7 @@ export default class GenesisAddCommand extends IronfishCommand {
     // Log genesis block info
     this.log(`Genesis block will be modified with the following values in a new transaction:`)
     this.log(`Allocations:`)
-    const columns: CliUx.Table.table.Columns<GenesisBlockAllocation> = {
+    const columns: ux.Table.table.Columns<GenesisBlockAllocation> = {
       identity: {
         header: 'ADDRESS',
         get: (row: GenesisBlockAllocation) => row.publicAddress,
@@ -96,7 +96,7 @@ export default class GenesisAddCommand extends IronfishCommand {
       },
     }
 
-    CliUx.ux.table(allocations, columns, {
+    ux.table(allocations, columns, {
       printLine: this.log.bind(this),
     })
 
@@ -116,7 +116,7 @@ export default class GenesisAddCommand extends IronfishCommand {
     if (flags.dry) {
       this.exit(0)
     } else {
-      const result = await CliUx.ux.confirm('\nCreate new genesis block? (y)es / (n)o')
+      const result = await ux.confirm('\nCreate new genesis block? (y)es / (n)o')
       if (!result) {
         this.exit(0)
       }

--- a/ironfish-cli/src/commands/chain/genesisblock.ts
+++ b/ironfish-cli/src/commands/chain/genesisblock.ts
@@ -12,7 +12,7 @@ import {
   makeGenesisBlock,
   Target,
 } from '@ironfish/sdk'
-import { CliUx, Flags } from '@oclif/core'
+import { Flags, ux } from '@oclif/core'
 import fs from 'fs/promises'
 import { IronfishCommand } from '../../command'
 import { LocalFlags } from '../../flags'
@@ -134,7 +134,7 @@ export default class GenesisBlockCommand extends IronfishCommand {
     this.log(`Genesis block will be created with the following values:`)
     this.log(`\nDifficulty: ${target.toDifficulty()}\n`)
     this.log(`Allocations:`)
-    const columns: CliUx.Table.table.Columns<GenesisBlockAllocation> = {
+    const columns: ux.Table.table.Columns<GenesisBlockAllocation> = {
       identity: {
         header: 'ADDRESS',
         get: (row: GenesisBlockAllocation) => row.publicAddress,
@@ -151,7 +151,7 @@ export default class GenesisBlockCommand extends IronfishCommand {
       },
     }
 
-    CliUx.ux.table(info.allocations, columns, {
+    ux.table(info.allocations, columns, {
       printLine: this.log.bind(this),
     })
 
@@ -171,7 +171,7 @@ export default class GenesisBlockCommand extends IronfishCommand {
     if (flags.dry) {
       this.exit(0)
     } else {
-      const result = await CliUx.ux.confirm('\nCreate the genesis block? (y)es / (n)o')
+      const result = await ux.confirm('\nCreate the genesis block? (y)es / (n)o')
       if (!result) {
         this.exit(0)
       }

--- a/ironfish-cli/src/commands/chain/power.ts
+++ b/ironfish-cli/src/commands/chain/power.ts
@@ -3,7 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { FileUtils } from '@ironfish/sdk'
 import { Args, Flags } from '@oclif/core'
-import { parseNumber } from '../../args'
 import { IronfishCommand } from '../../command'
 import { LocalFlags } from '../../flags'
 
@@ -21,7 +20,6 @@ export default class Power extends IronfishCommand {
 
   static args = {
     block: Args.integer({
-      parse: (input: string): Promise<number> => parseNumber(input),
       required: false,
       description: 'The sequence of the block to estimate network speed for',
     }),

--- a/ironfish-cli/src/commands/chain/power.ts
+++ b/ironfish-cli/src/commands/chain/power.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { FileUtils } from '@ironfish/sdk'
-import { Flags } from '@oclif/core'
+import { Args, Flags } from '@oclif/core'
 import { parseNumber } from '../../args'
 import { IronfishCommand } from '../../command'
 import { LocalFlags } from '../../flags'
@@ -19,14 +19,13 @@ export default class Power extends IronfishCommand {
     }),
   }
 
-  static args = [
-    {
-      name: 'block',
-      parse: (input: string): Promise<number | null> => Promise.resolve(parseNumber(input)),
+  static args = {
+    block: Args.integer({
+      parse: (input: string): Promise<number> => parseNumber(input),
       required: false,
       description: 'The sequence of the block to estimate network speed for',
-    },
-  ]
+    }),
+  }
 
   async start(): Promise<void> {
     const { flags, args } = await this.parse(Power)

--- a/ironfish-cli/src/commands/chain/prune.ts
+++ b/ironfish-cli/src/commands/chain/prune.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { BlockchainUtils } from '@ironfish/sdk'
-import { CliUx, Flags } from '@oclif/core'
+import { Flags, ux } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { LocalFlags } from '../../flags'
 
@@ -34,11 +34,11 @@ export default class Prune extends IronfishCommand {
   async start(): Promise<void> {
     const { flags } = await this.parse(Prune)
 
-    CliUx.ux.action.start(`Opening node`)
+    ux.action.start(`Opening node`)
     const node = await this.sdk.node()
     await node.openDB()
     await node.chain.open()
-    CliUx.ux.action.stop('done.')
+    ux.action.stop('done.')
 
     if (flags.prune) {
       const { start, stop } = BlockchainUtils.getBlockRange(node.chain, {
@@ -77,9 +77,9 @@ export default class Prune extends IronfishCommand {
     }
 
     if (flags.compact) {
-      CliUx.ux.action.start(`Compacting Database`)
+      ux.action.start(`Compacting Database`)
       await node.chain.blockchainDb.compact()
-      CliUx.ux.action.stop()
+      ux.action.stop()
     }
 
     await node.chain.close()

--- a/ironfish-cli/src/commands/chain/readd-block.ts
+++ b/ironfish-cli/src/commands/chain/readd-block.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { ux } from '@oclif/core'
+import { Args, ux } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { LocalFlags } from '../../flags'
 
@@ -15,18 +15,17 @@ export default class ReAddBlock extends IronfishCommand {
     ...LocalFlags,
   }
 
-  static args = [
-    {
-      name: 'hash',
+  static args = {
+    hash: Args.string({
       parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: true,
       description: 'The hash of the block in hex format',
-    },
-  ]
+    }),
+  }
 
   async start(): Promise<void> {
     const { args } = await this.parse(ReAddBlock)
-    const hash = Buffer.from(args.hash as string, 'hex')
+    const hash = Buffer.from(args.hash, 'hex')
 
     ux.action.start(`Opening node`)
     const node = await this.sdk.node()

--- a/ironfish-cli/src/commands/chain/readd-block.ts
+++ b/ironfish-cli/src/commands/chain/readd-block.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { CliUx } from '@oclif/core'
+import { ux } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { LocalFlags } from '../../flags'
 
@@ -28,11 +28,11 @@ export default class ReAddBlock extends IronfishCommand {
     const { args } = await this.parse(ReAddBlock)
     const hash = Buffer.from(args.hash as string, 'hex')
 
-    CliUx.ux.action.start(`Opening node`)
+    ux.action.start(`Opening node`)
     const node = await this.sdk.node()
     await node.openDB()
     await node.chain.open()
-    CliUx.ux.action.stop('done.')
+    ux.action.stop('done.')
 
     const block = await node.chain.getBlock(hash)
 

--- a/ironfish-cli/src/commands/chain/repair.ts
+++ b/ironfish-cli/src/commands/chain/repair.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Assert, BlockHeader, FullNode, IDatabaseTransaction, TimeUtils } from '@ironfish/sdk'
 import { Meter } from '@ironfish/sdk'
-import { CliUx, Flags } from '@oclif/core'
+import { Flags, ux } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { LocalFlags } from '../../flags'
 import { ProgressBar } from '../../types'
@@ -38,15 +38,15 @@ export default class RepairChain extends IronfishCommand {
     const { flags } = await this.parse(RepairChain)
 
     const speed = new Meter()
-    const progress = CliUx.ux.progress({
+    const progress = ux.progress({
       format: '{title}: [{bar}] {value}/{total} {percentage}% {speed}/sec | {estimate}',
     }) as ProgressBar
 
-    CliUx.ux.action.start(`Opening node`)
+    ux.action.start(`Opening node`)
     const node = await this.sdk.node()
     await node.openDB()
     await node.chain.open()
-    CliUx.ux.action.stop('done.')
+    ux.action.stop('done.')
 
     if (node.chain.isEmpty) {
       this.log(`Chain is too corrupt. Delete your DB at ${node.config.chainDatabasePath}`)
@@ -59,7 +59,7 @@ export default class RepairChain extends IronfishCommand {
 
     const confirmed =
       flags.confirm ||
-      (await CliUx.ux.confirm(
+      (await ux.confirm(
         `\n⚠️ If you start repairing your database, you MUST finish the\n` +
           `process or your database will be in a corrupt state. Repairing\n` +
           `may take ${estimate} or longer.\n\n` +
@@ -79,13 +79,13 @@ export default class RepairChain extends IronfishCommand {
   async repairChain(node: FullNode, speed: Meter, progress: ProgressBar): Promise<void> {
     Assert.isNotNull(node.chain.head)
 
-    CliUx.ux.action.start('Clearing hash to next hash table')
+    ux.action.start('Clearing hash to next hash table')
     await node.chain.clearHashToNextHash()
-    CliUx.ux.action.stop()
+    ux.action.stop()
 
-    CliUx.ux.action.start('Clearing Sequence to hash table')
+    ux.action.start('Clearing Sequence to hash table')
     await node.chain.clearSequenceToHash()
-    CliUx.ux.action.stop()
+    ux.action.stop()
 
     const total = Number(node.chain.head.sequence)
     let done = 0
@@ -148,14 +148,14 @@ export default class RepairChain extends IronfishCommand {
     let prev = await node.chain.getHeaderAtSequence(TREE_START - 1)
     const noteSize = prev && prev.noteSize !== null ? prev.noteSize : 0
 
-    CliUx.ux.action.start('Clearing notes MerkleTree')
+    ux.action.start('Clearing notes MerkleTree')
     await node.chain.notes.truncate(noteSize)
-    CliUx.ux.action.stop()
+    ux.action.stop()
 
-    CliUx.ux.action.start('Clearing nullifier set')
+    ux.action.start('Clearing nullifier set')
     await node.chain.nullifiers.clear()
 
-    CliUx.ux.action.stop()
+    ux.action.stop()
 
     speed.reset()
     progress.start(total, TREE_START, {

--- a/ironfish-cli/src/commands/chain/rewind.ts
+++ b/ironfish-cli/src/commands/chain/rewind.ts
@@ -10,7 +10,7 @@ import {
   TimeUtils,
   Wallet,
 } from '@ironfish/sdk'
-import { CliUx, Command } from '@oclif/core'
+import { Command, ux } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { LocalFlags } from '../../flags'
 import { ProgressBar } from '../../types'
@@ -192,7 +192,7 @@ async function removeBlocks(
 }
 
 function getProgressBar(label: string): ProgressBar {
-  return CliUx.ux.progress({
+  return ux.progress({
     barCompleteChar: '\u2588',
     barIncompleteChar: '\u2591',
     format: `${label}: [{bar}] {percentage}% | {value} / {total} blocks | {speed}/s | ETA: {estimate}`,

--- a/ironfish-cli/src/commands/chain/rewind.ts
+++ b/ironfish-cli/src/commands/chain/rewind.ts
@@ -10,7 +10,7 @@ import {
   TimeUtils,
   Wallet,
 } from '@ironfish/sdk'
-import { Command, ux } from '@oclif/core'
+import { Args, Command, ux } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { LocalFlags } from '../../flags'
 import { ProgressBar } from '../../types'
@@ -19,20 +19,18 @@ export default class Rewind extends IronfishCommand {
   static description =
     'Rewind the chain database to the given sequence by deleting all blocks with greater sequences'
 
-  static args = [
-    {
-      name: 'to',
+  static args = {
+    to: Args.string({
       parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: true,
       description: 'The block sequence to rewind to',
-    },
-    {
-      name: 'from',
+    }),
+    from: Args.string({
       parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: false,
       description: 'The sequence to start removing blocks from',
-    },
-  ]
+    }),
+  }
 
   static flags = {
     ...LocalFlags,

--- a/ironfish-cli/src/commands/chain/show.ts
+++ b/ironfish-cli/src/commands/chain/show.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Args } from '@oclif/core'
-import { parseNumber } from '../../args'
 import { IronfishCommand } from '../../command'
 import { LocalFlags } from '../../flags'
 
@@ -15,13 +14,11 @@ export default class Show extends IronfishCommand {
 
   static args = {
     start: Args.integer({
-      parse: (input: string): Promise<number> => parseNumber(input),
       default: -50,
       required: false,
       description: 'The sequence to start at (inclusive, genesis block is 1)',
     }),
     stop: Args.integer({
-      parse: (input: string): Promise<number> => parseNumber(input),
       required: false,
       description: 'The sequence to end at (inclusive)',
     }),

--- a/ironfish-cli/src/commands/chain/show.ts
+++ b/ironfish-cli/src/commands/chain/show.ts
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Args } from '@oclif/core'
 import { parseNumber } from '../../args'
 import { IronfishCommand } from '../../command'
 import { LocalFlags } from '../../flags'
@@ -12,21 +13,19 @@ export default class Show extends IronfishCommand {
     ...LocalFlags,
   }
 
-  static args = [
-    {
-      name: 'start',
-      parse: (input: string): Promise<number | null> => Promise.resolve(parseNumber(input)),
+  static args = {
+    start: Args.integer({
+      parse: (input: string): Promise<number> => parseNumber(input),
       default: -50,
       required: false,
       description: 'The sequence to start at (inclusive, genesis block is 1)',
-    },
-    {
-      name: 'stop',
-      parse: (input: string): Promise<number | null> => Promise.resolve(parseNumber(input)),
+    }),
+    stop: Args.integer({
+      parse: (input: string): Promise<number> => parseNumber(input),
       required: false,
       description: 'The sequence to end at (inclusive)',
-    },
-  ]
+    }),
+  }
 
   async start(): Promise<void> {
     const { args } = await this.parse(Show)

--- a/ironfish-cli/src/commands/config/get.ts
+++ b/ironfish-cli/src/commands/config/get.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { ConfigOptions } from '@ironfish/sdk'
-import { Flags } from '@oclif/core'
+import { Args, Flags } from '@oclif/core'
 import jsonColorizer from 'json-colorizer'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
@@ -10,14 +10,13 @@ import { RemoteFlags } from '../../flags'
 export class GetCommand extends IronfishCommand {
   static description = `Print out one config value`
 
-  static args = [
-    {
-      name: 'name',
+  static args = {
+    name: Args.string({
       parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: true,
       description: 'Name of the config item',
-    },
-  ]
+    }),
+  }
 
   static flags = {
     ...RemoteFlags,
@@ -42,7 +41,7 @@ export class GetCommand extends IronfishCommand {
 
   async start(): Promise<void> {
     const { args, flags } = await this.parse(GetCommand)
-    const name = (args.name as string).trim()
+    const name = args.name.trim()
 
     const client = await this.sdk.connectRpc(flags.local)
 

--- a/ironfish-cli/src/commands/config/set.ts
+++ b/ironfish-cli/src/commands/config/set.ts
@@ -1,27 +1,25 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { Flags } from '@oclif/core'
+import { Args, Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 
 export class SetCommand extends IronfishCommand {
   static description = `Set a value in the config`
 
-  static args = [
-    {
-      name: 'name',
+  static args = {
+    name: Args.string({
       parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: true,
       description: 'Name of the config item',
-    },
-    {
-      name: 'value',
+    }),
+    value: Args.string({
       parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: true,
       description: 'Value of the config item',
-    },
-  ]
+    }),
+  }
 
   static flags = {
     ...RemoteFlags,
@@ -37,8 +35,8 @@ export class SetCommand extends IronfishCommand {
 
   async start(): Promise<void> {
     const { args, flags } = await this.parse(SetCommand)
-    const name = args.name as string
-    const value = args.value as string
+    const name = args.name
+    const value = args.value
 
     const client = await this.sdk.connectRpc(flags.local)
     await client.config.setConfig({ name, value })

--- a/ironfish-cli/src/commands/config/unset.ts
+++ b/ironfish-cli/src/commands/config/unset.ts
@@ -1,21 +1,20 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { Flags } from '@oclif/core'
+import { Args, Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 
 export class UnsetCommand extends IronfishCommand {
   static description = `Unset a value in the config and fall back to default`
 
-  static args = [
-    {
-      name: 'name',
+  static args = {
+    name: Args.string({
       parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: true,
       description: 'Name of the config item',
-    },
-  ]
+    }),
+  }
 
   static flags = {
     ...RemoteFlags,
@@ -29,7 +28,7 @@ export class UnsetCommand extends IronfishCommand {
 
   async start(): Promise<void> {
     const { args, flags } = await this.parse(UnsetCommand)
-    const name = args.name as string
+    const name = args.name
 
     const client = await this.sdk.connectRpc(flags.local)
     await client.config.unsetConfig({ name })

--- a/ironfish-cli/src/commands/faucet.ts
+++ b/ironfish-cli/src/commands/faucet.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { DEFAULT_DISCORD_INVITE, RpcRequestError } from '@ironfish/sdk'
-import { CliUx, Flags } from '@oclif/core'
+import { Flags, ux } from '@oclif/core'
 import { IronfishCommand } from '../command'
 import { RemoteFlags } from '../flags'
 import { ONE_FISH_IMAGE, TWO_FISH_IMAGE } from '../images'
@@ -47,7 +47,7 @@ export class FaucetCommand extends IronfishCommand {
 
     if (!email) {
       email =
-        (await CliUx.ux.prompt('Enter your email to stay updated with Iron Fish', {
+        (await ux.prompt('Enter your email to stay updated with Iron Fish', {
           required: false,
         })) || undefined
     }
@@ -59,20 +59,16 @@ export class FaucetCommand extends IronfishCommand {
     if (!accountName) {
       this.log(`You don't have a default account set up yet. Let's create one first!`)
       accountName =
-        (await CliUx.ux.prompt('Please enter the name of your new Iron Fish account', {
+        (await ux.prompt('Please enter the name of your new Iron Fish account', {
           required: false,
         })) || 'default'
 
       await client.wallet.createAccount({ name: accountName, default: true })
     }
 
-    CliUx.ux.action.start(
-      'Collecting your funds',
-      'Sending a request to the Iron Fish network',
-      {
-        stdout: true,
-      },
-    )
+    ux.action.start('Collecting your funds', 'Sending a request to the Iron Fish network', {
+      stdout: true,
+    })
 
     try {
       await client.faucet.getFunds({
@@ -81,17 +77,15 @@ export class FaucetCommand extends IronfishCommand {
       })
     } catch (error: unknown) {
       if (error instanceof RpcRequestError) {
-        CliUx.ux.action.stop(error.codeMessage)
+        ux.action.stop(error.codeMessage)
       } else {
-        CliUx.ux.action.stop(
-          'Unfortunately, the faucet request failed. Please try again later.',
-        )
+        ux.action.stop('Unfortunately, the faucet request failed. Please try again later.')
       }
 
       this.exit(1)
     }
 
-    CliUx.ux.action.stop('Success')
+    ux.action.stop('Success')
     this.log(
       `
 

--- a/ironfish-cli/src/commands/mempool/transactions.ts
+++ b/ironfish-cli/src/commands/mempool/transactions.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { getFeeRate, GetMempoolTransactionResponse, MinMax, Transaction } from '@ironfish/sdk'
-import { CliUx, Flags } from '@oclif/core'
+import { Flags, ux } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 import { CommandFlags } from '../../types'
@@ -154,7 +154,7 @@ function renderTable(
   response: GetMempoolTransactionResponse[],
   flags: CommandFlags<typeof TransactionsCommand>,
 ): string {
-  const columns: CliUx.Table.table.Columns<TransactionRow> = {
+  const columns: ux.Table.table.Columns<TransactionRow> = {
     position: {
       header: 'POSITION',
       minWidth: 4,
@@ -210,7 +210,7 @@ function renderTable(
   let result = ''
 
   const limit = flags.csv ? 0 : flags.show
-  CliUx.ux.table(getRows(response, limit), columns, {
+  ux.table(getRows(response, limit), columns, {
     printLine: (line) => (result += `${String(line)}\n`),
     ...flags,
   })

--- a/ironfish-cli/src/commands/mempool/transactions.ts
+++ b/ironfish-cli/src/commands/mempool/transactions.ts
@@ -3,9 +3,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { getFeeRate, GetMempoolTransactionResponse, MinMax, Transaction } from '@ironfish/sdk'
 import { Flags, ux } from '@oclif/core'
+import { InferredFlags } from '@oclif/core/lib/interfaces'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
-import { CommandFlags } from '../../types'
 import { TableFlags } from '../../utils/table'
 
 const { sort: _, ...tableFlags } = TableFlags
@@ -152,7 +152,7 @@ type TransactionRow = {
 
 function renderTable(
   response: GetMempoolTransactionResponse[],
-  flags: CommandFlags<typeof TransactionsCommand>,
+  flags: InferredFlags<typeof TransactionsCommand.flags>,
 ): string {
   const columns: ux.Table.table.Columns<TransactionRow> = {
     position: {

--- a/ironfish-cli/src/commands/miners/start.ts
+++ b/ironfish-cli/src/commands/miners/start.ts
@@ -12,7 +12,7 @@ import {
   StratumTcpClient,
   StratumTlsClient,
 } from '@ironfish/sdk'
-import { CliUx, Flags } from '@oclif/core'
+import { Flags, ux } from '@oclif/core'
 import dns from 'dns'
 import os from 'os'
 import { IronfishCommand } from '../../command'
@@ -174,12 +174,12 @@ export class Miner extends IronfishCommand {
   }
 
   displayHashrate(miner: MiningPoolMiner | MiningSoloMiner): void {
-    CliUx.ux.action.start(`Hashrate`)
+    ux.action.start(`Hashrate`)
 
     const updateHashPower = () => {
       const rate = Math.max(0, Math.floor(miner.hashRate.rate5s))
       const formatted = `${FileUtils.formatHashRate(rate)}/s (${rate})`
-      CliUx.ux.action.status = formatted
+      ux.action.status = formatted
     }
 
     this.updateInterval = setInterval(updateHashPower, 1000)

--- a/ironfish-cli/src/commands/peers/add.ts
+++ b/ironfish-cli/src/commands/peers/add.ts
@@ -2,23 +2,24 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { DEFAULT_WEBSOCKET_PORT, parseUrl } from '@ironfish/sdk'
+import { Args } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 
 export class AddCommand extends IronfishCommand {
   static description = `Attempt to connect to a peer through websockets`
 
-  static args = [
-    {
-      name: 'address',
+  static args = {
+    // TODO(mat): Verify usage of url flag here.. Either need built in URL type or Args.custom
+    address: Args.url({
       parse: (
         input: string,
       ): Promise<{ protocol: string | null; hostname: string | null; port: number | null }> =>
         Promise.resolve(parseUrl(input.trim())),
       required: true,
       description: `The address of the peer to connect to in the form {host}:{port}`,
-    },
-  ]
+    }),
+  }
 
   static flags = {
     ...RemoteFlags,

--- a/ironfish-cli/src/commands/peers/add.ts
+++ b/ironfish-cli/src/commands/peers/add.ts
@@ -2,8 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { DEFAULT_WEBSOCKET_PORT } from '@ironfish/sdk'
-import { Args } from '@oclif/core'
-import { parseUrl } from '../../args'
+import { UrlArg } from '../../args'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 
@@ -11,9 +10,7 @@ export class AddCommand extends IronfishCommand {
   static description = `Attempt to connect to a peer through websockets`
 
   static args = {
-    // TODO(mat): Verify usage of url flag here.. Either need built in URL type or Args.custom
-    address: Args.url({
-      parse: (input: string): Promise<URL> => parseUrl(input),
+    address: UrlArg({
       required: true,
       description: `The address of the peer to connect to in the form {host}:{port}`,
     }),
@@ -30,10 +27,6 @@ export class AddCommand extends IronfishCommand {
     if (!connected) {
       this.log('Could not connect to node')
       this.exit(0)
-    }
-
-    if (!args.address.hostname) {
-      this.error(`Could not parse the given url`)
     }
 
     const request = {

--- a/ironfish-cli/src/commands/peers/banned.ts
+++ b/ironfish-cli/src/commands/peers/banned.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { BannedPeerResponse, GetBannedPeersResponse, PromiseUtils } from '@ironfish/sdk'
-import { CliUx, Flags } from '@oclif/core'
+import { Flags, ux } from '@oclif/core'
 import blessed from 'blessed'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
@@ -67,7 +67,7 @@ export class BannedCommand extends IronfishCommand {
 }
 
 function renderTable(content: GetBannedPeersResponse): string {
-  const columns: CliUx.Table.table.Columns<BannedPeerResponse> = {
+  const columns: ux.Table.table.Columns<BannedPeerResponse> = {
     identity: {
       minWidth: 45,
       header: 'IDENTITY',
@@ -86,7 +86,7 @@ function renderTable(content: GetBannedPeersResponse): string {
 
   let result = ''
 
-  CliUx.ux.table(content.peers, columns, {
+  ux.table(content.peers, columns, {
     printLine: (line) => (result += `${String(line)}\n`),
   })
 

--- a/ironfish-cli/src/commands/peers/index.ts
+++ b/ironfish-cli/src/commands/peers/index.ts
@@ -3,10 +3,10 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { GetPeersResponse, PromiseUtils } from '@ironfish/sdk'
 import { Flags, ux } from '@oclif/core'
+import { InferredFlags } from '@oclif/core/lib/interfaces'
 import blessed from 'blessed'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
-import { CommandFlags } from '../../types'
 import { TableFlags } from '../../utils/table'
 
 type GetPeerResponsePeer = GetPeersResponse['peers'][0]
@@ -94,7 +94,7 @@ export class ListCommand extends IronfishCommand {
 
 function renderTable(
   content: GetPeersResponse,
-  flags: CommandFlags<typeof ListCommand>,
+  flags: InferredFlags<typeof ListCommand.flags>,
 ): string {
   let columns: ux.Table.table.Columns<GetPeerResponsePeer> = {
     identity: {

--- a/ironfish-cli/src/commands/peers/index.ts
+++ b/ironfish-cli/src/commands/peers/index.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { GetPeersResponse, PromiseUtils } from '@ironfish/sdk'
-import { CliUx, Flags } from '@oclif/core'
+import { Flags, ux } from '@oclif/core'
 import blessed from 'blessed'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
@@ -96,7 +96,7 @@ function renderTable(
   content: GetPeersResponse,
   flags: CommandFlags<typeof ListCommand>,
 ): string {
-  let columns: CliUx.Table.table.Columns<GetPeerResponsePeer> = {
+  let columns: ux.Table.table.Columns<GetPeerResponsePeer> = {
     identity: {
       header: 'IDENTITY',
       get: (row: GetPeerResponsePeer) => {
@@ -224,7 +224,7 @@ function renderTable(
 
   let result = ''
 
-  CliUx.ux.table(peers, columns, {
+  ux.table(peers, columns, {
     printLine: (line) => (result += `${String(line)}\n`),
     ...flags,
   })

--- a/ironfish-cli/src/commands/peers/show.ts
+++ b/ironfish-cli/src/commands/peers/show.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { GetPeerMessagesResponse, GetPeerResponse, TimeUtils } from '@ironfish/sdk'
+import { Args } from '@oclif/core'
 import colors from 'colors/safe'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
@@ -12,13 +13,12 @@ type GetPeerMessagesResponseMessages = GetPeerMessagesResponse['messages'][0]
 export class ShowCommand extends IronfishCommand {
   static description = `Display info about a peer`
 
-  static args = [
-    {
-      name: 'identity',
+  static args = {
+    identity: Args.string({
       required: true,
       description: 'Identity of the peer',
-    },
-  ]
+    }),
+  }
 
   static flags = {
     ...RemoteFlags,
@@ -27,7 +27,8 @@ export class ShowCommand extends IronfishCommand {
   async start(): Promise<void> {
     const { args } = await this.parse(ShowCommand)
 
-    const identity = (args.identity as string).trim()
+    // TODO(mat): Move trim into parse function like the others
+    const identity = args.identity.trim()
 
     await this.sdk.client.connect()
     const [peer, messages] = await Promise.all([

--- a/ironfish-cli/src/commands/reset.ts
+++ b/ironfish-cli/src/commands/reset.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { FullNode, PEER_STORE_FILE_NAME } from '@ironfish/sdk'
-import { CliUx, Flags } from '@oclif/core'
+import { Flags, ux } from '@oclif/core'
 import fsAsync from 'fs/promises'
 import { IronfishCommand } from '../command'
 import {
@@ -67,7 +67,7 @@ export default class Reset extends IronfishCommand {
       cancelledMessage: 'Reset aborted.',
     })
 
-    CliUx.ux.action.start('Deleting databases...')
+    ux.action.start('Deleting databases...')
 
     await Promise.all([
       fsAsync.rm(chainDatabasePath, { recursive: true, force: true }),
@@ -86,6 +86,6 @@ export default class Reset extends IronfishCommand {
     await node.wallet.open()
     await node.wallet.reset({ resetCreatedAt: networkChanged })
 
-    CliUx.ux.action.stop('Databases deleted successfully')
+    ux.action.stop('Databases deleted successfully')
   }
 }

--- a/ironfish-cli/src/commands/stop.ts
+++ b/ironfish-cli/src/commands/stop.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { FullNode } from '@ironfish/sdk'
-import { CliUx } from '@oclif/core'
+import { ux } from '@oclif/core'
 import { IronfishCommand } from '../command'
 import { RemoteFlags } from '../flags'
 
@@ -20,10 +20,10 @@ export default class StopCommand extends IronfishCommand {
 
     await this.sdk.client.connect()
 
-    CliUx.ux.action.start('Asking node to shut down...')
+    ux.action.start('Asking node to shut down...')
 
     await this.sdk.client.node.stopNode()
 
-    CliUx.ux.action.stop('done.')
+    ux.action.stop('done.')
   }
 }

--- a/ironfish-cli/src/commands/swim.ts
+++ b/ironfish-cli/src/commands/swim.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { CliUx } from '@oclif/core'
+import { ux } from '@oclif/core'
 import { IronfishCommand } from '../command'
 import { ONE_FISH_IMAGE, TWO_FISH_IMAGE } from '../images'
 
@@ -40,7 +40,7 @@ export default class SwimCommand extends IronfishCommand {
       console.clear()
       this.renderPixels(pixels)
       this.log('The hex fish are coming...')
-      await CliUx.ux.wait(32)
+      await ux.wait(32)
     }
 
     // eslint-disable-next-line no-console

--- a/ironfish-cli/src/commands/wallet/address.ts
+++ b/ironfish-cli/src/commands/wallet/address.ts
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Args } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 
@@ -13,17 +14,16 @@ export class AddressCommand extends IronfishCommand {
     ...RemoteFlags,
   }
 
-  static args = [
-    {
-      name: 'account',
+  static args = {
+    account: Args.string({
       required: false,
       description: 'Name of the account to get the address for',
-    },
-  ]
+    }),
+  }
 
   async start(): Promise<void> {
     const { args } = await this.parse(AddressCommand)
-    const account = args.account as string | undefined
+    const account = args.account
 
     const client = await this.sdk.connectRpc()
 

--- a/ironfish-cli/src/commands/wallet/assets.ts
+++ b/ironfish-cli/src/commands/wallet/assets.ts
@@ -9,7 +9,7 @@ import {
   PUBLIC_ADDRESS_LENGTH,
 } from '@ironfish/rust-nodejs'
 import { BufferUtils } from '@ironfish/sdk'
-import { Flags, ux } from '@oclif/core'
+import { Args, Flags, ux } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 import { renderAssetWithVerificationStatus } from '../../utils'
@@ -33,18 +33,17 @@ export class AssetsCommand extends IronfishCommand {
     }),
   }
 
-  static args = [
-    {
-      name: 'account',
+  static args = {
+    account: Args.string({
       required: false,
       description: 'Name of the account. DEPRECATED: use --account flag',
-    },
-  ]
+    }),
+  }
 
   async start(): Promise<void> {
     const { flags, args } = await this.parse(AssetsCommand)
     // TODO: remove account arg
-    const account = flags.account ? flags.account : (args.account as string | undefined)
+    const account = flags.account ? flags.account : args.account
 
     const client = await this.sdk.connectRpc()
     const response = client.wallet.getAssets({

--- a/ironfish-cli/src/commands/wallet/assets.ts
+++ b/ironfish-cli/src/commands/wallet/assets.ts
@@ -9,7 +9,7 @@ import {
   PUBLIC_ADDRESS_LENGTH,
 } from '@ironfish/rust-nodejs'
 import { BufferUtils } from '@ironfish/sdk'
-import { CliUx, Flags } from '@oclif/core'
+import { Flags, ux } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 import { renderAssetWithVerificationStatus } from '../../utils'
@@ -60,7 +60,7 @@ export class AssetsCommand extends IronfishCommand {
     let showHeader = !flags['no-header']
 
     for await (const asset of response.contentStream()) {
-      CliUx.ux.table(
+      ux.table(
         [asset],
         {
           name: TableCols.fixedWidth({

--- a/ironfish-cli/src/commands/wallet/balance.ts
+++ b/ironfish-cli/src/commands/wallet/balance.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { CurrencyUtils, GetBalanceResponse, isNativeIdentifier, RpcAsset } from '@ironfish/sdk'
-import { Flags } from '@oclif/core'
+import { Args, Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 import { renderAssetWithVerificationStatus } from '../../utils'
@@ -38,18 +38,17 @@ export class BalanceCommand extends IronfishCommand {
     }),
   }
 
-  static args = [
-    {
-      name: 'account',
+  static args = {
+    account: Args.string({
       required: false,
       description: 'Name of the account to get balance for. DEPRECATED: use --account flag',
-    },
-  ]
+    }),
+  }
 
   async start(): Promise<void> {
     const { flags, args } = await this.parse(BalanceCommand)
     // TODO: remove account arg
-    const account = flags.account ? flags.account : (args.account as string | undefined)
+    const account = flags.account ? flags.account : args.account
 
     const client = await this.sdk.connectRpc()
 

--- a/ironfish-cli/src/commands/wallet/balances.ts
+++ b/ironfish-cli/src/commands/wallet/balances.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { BufferUtils, CurrencyUtils, GetBalancesResponse, RpcAsset } from '@ironfish/sdk'
-import { Flags, ux } from '@oclif/core'
+import { Args, Flags, ux } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 import { compareAssets, renderAssetWithVerificationStatus } from '../../utils'
@@ -30,20 +30,19 @@ export class BalancesCommand extends IronfishCommand {
     }),
   }
 
-  static args = [
-    {
-      name: 'account',
+  static args = {
+    account: Args.string({
       required: false,
       description: 'Name of the account to get balances for. DEPRECATED: use --account flag',
-    },
-  ]
+    }),
+  }
 
   async start(): Promise<void> {
     const { flags, args } = await this.parse(BalancesCommand)
     const client = await this.sdk.connectRpc()
 
     // TODO: remove account arg
-    const account = flags.account ? flags.account : (args.account as string | undefined)
+    const account = flags.account ? flags.account : args.account
     const response = await client.wallet.getAccountBalances({
       account,
       confirmations: flags.confirmations,

--- a/ironfish-cli/src/commands/wallet/balances.ts
+++ b/ironfish-cli/src/commands/wallet/balances.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { BufferUtils, CurrencyUtils, GetBalancesResponse, RpcAsset } from '@ironfish/sdk'
-import { CliUx, Flags } from '@oclif/core'
+import { Flags, ux } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 import { compareAssets, renderAssetWithVerificationStatus } from '../../utils'
@@ -65,7 +65,7 @@ export class BalancesCommand extends IronfishCommand {
       })
     }
 
-    let columns: CliUx.Table.table.Columns<AssetBalancePairs> = {
+    let columns: ux.Table.table.Columns<AssetBalancePairs> = {
       assetName: {
         header: 'Asset Name',
         get: ({ asset }) =>
@@ -130,6 +130,6 @@ export class BalancesCommand extends IronfishCommand {
       ),
     )
 
-    CliUx.ux.table(assetBalancePairs, columns, { ...flags })
+    ux.table(assetBalancePairs, columns, { ...flags })
   }
 }

--- a/ironfish-cli/src/commands/wallet/burn.ts
+++ b/ironfish-cli/src/commands/wallet/burn.ts
@@ -10,7 +10,7 @@ import {
   RpcAsset,
   Transaction,
 } from '@ironfish/sdk'
-import { CliUx, Flags } from '@oclif/core'
+import { Flags, ux } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { IronFlag, RemoteFlags, ValueFlag } from '../../flags'
 import { confirmOperation } from '../../utils'
@@ -221,7 +221,7 @@ export class Burn extends IronfishCommand {
 
     await this.confirm(assetData, amount, raw.fee, account, flags.confirm)
 
-    CliUx.ux.action.start('Sending the transaction')
+    ux.action.start('Sending the transaction')
 
     const response = await client.wallet.postTransaction({
       transaction: RawTransactionSerde.serialize(raw).toString('hex'),
@@ -231,7 +231,7 @@ export class Burn extends IronfishCommand {
     const bytes = Buffer.from(response.content.transaction, 'hex')
     const transaction = new Transaction(bytes)
 
-    CliUx.ux.action.stop()
+    ux.action.stop()
 
     if (response.content.accepted === false) {
       this.warn(

--- a/ironfish-cli/src/commands/wallet/chainport/send.ts
+++ b/ironfish-cli/src/commands/wallet/chainport/send.ts
@@ -13,7 +13,7 @@ import {
   TESTNET,
   Transaction,
 } from '@ironfish/sdk'
-import { CliUx, Flags } from '@oclif/core'
+import { Flags, ux } from '@oclif/core'
 import inquirer from 'inquirer'
 import * as validator from 'web3-validator'
 import { IronfishCommand } from '../../../command'
@@ -171,7 +171,7 @@ export class BridgeCommand extends IronfishCommand {
     }
 
     if (!to) {
-      to = await CliUx.ux.prompt('Enter the public address of the recipient', {
+      to = await ux.prompt('Enter the public address of the recipient', {
         required: true,
       })
     }
@@ -370,17 +370,17 @@ export class BridgeCommand extends IronfishCommand {
 
     const summary = `\
  \nBRIDGE TRANSACTION SUMMARY:
- 
+
  From                           ${from}
  To                             ${to}
  Target Network                 ${network.name}
  Estimated Amount Received      ${bridgeAmount}
- 
+
  Fees:
  Chainport Fee                  ${chainportFee}
  Target Network Fee             ${targetNetworkFee}
  Ironfish Network Fee           ${ironfishNetworkFee}
- 
+
  Outputs                        ${raw.outputs.length}
  Spends                         ${raw.spends.length}
  Expiration                     ${raw.expiration ? raw.expiration.toString() : ''}
@@ -393,9 +393,9 @@ export class BridgeCommand extends IronfishCommand {
     targetNetworks: number[],
     asset: ChainportVerifiedToken,
   ): Promise<ChainportNetwork> {
-    CliUx.ux.action.start('Fetching available networks')
+    ux.action.start('Fetching available networks')
     const networks = await fetchChainportNetworkMap(networkId)
-    CliUx.ux.action.stop()
+    ux.action.stop()
 
     const choices = Object.keys(networks).map((key) => {
       return {

--- a/ironfish-cli/src/commands/wallet/create.ts
+++ b/ironfish-cli/src/commands/wallet/create.ts
@@ -2,20 +2,19 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { ux } from '@oclif/core'
+import { Args, ux } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 
 export class CreateCommand extends IronfishCommand {
   static description = `Create a new account for sending and receiving coins`
 
-  static args = [
-    {
-      name: 'account',
+  static args = {
+    account: Args.string({
       required: false,
       description: 'Name of the account',
-    },
-  ]
+    }),
+  }
 
   static flags = {
     ...RemoteFlags,

--- a/ironfish-cli/src/commands/wallet/create.ts
+++ b/ironfish-cli/src/commands/wallet/create.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { CliUx } from '@oclif/core'
+import { ux } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 
@@ -26,7 +26,7 @@ export class CreateCommand extends IronfishCommand {
     let name = args.account as string
 
     if (!name) {
-      name = await CliUx.ux.prompt('Enter the name of the account', {
+      name = await ux.prompt('Enter the name of the account', {
         required: true,
       })
     }

--- a/ironfish-cli/src/commands/wallet/delete.ts
+++ b/ironfish-cli/src/commands/wallet/delete.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { CliUx, Flags } from '@oclif/core'
+import { Flags, ux } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 
@@ -37,21 +37,21 @@ export class DeleteCommand extends IronfishCommand {
 
     const client = await this.sdk.connectRpc()
 
-    CliUx.ux.action.start(`Deleting account '${account}'`)
+    ux.action.start(`Deleting account '${account}'`)
     const response = await client.wallet.removeAccount({ account, confirm, wait })
-    CliUx.ux.action.stop()
+    ux.action.stop()
 
     if (response.content.needsConfirm) {
-      const value = await CliUx.ux.prompt(`Are you sure? Type ${account} to confirm`)
+      const value = await ux.prompt(`Are you sure? Type ${account} to confirm`)
 
       if (value !== account) {
         this.log(`Aborting: ${value} did not match ${account}`)
         this.exit(1)
       }
 
-      CliUx.ux.action.start(`Deleting account '${account}'`)
+      ux.action.start(`Deleting account '${account}'`)
       await client.wallet.removeAccount({ account, confirm: true, wait })
-      CliUx.ux.action.stop()
+      ux.action.stop()
     }
 
     this.log(`Account '${account}' successfully deleted.`)

--- a/ironfish-cli/src/commands/wallet/delete.ts
+++ b/ironfish-cli/src/commands/wallet/delete.ts
@@ -2,21 +2,20 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { Flags, ux } from '@oclif/core'
+import { Args, Flags, ux } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 
 export class DeleteCommand extends IronfishCommand {
   static description = `Permanently delete an account`
 
-  static args = [
-    {
-      name: 'account',
+  static args = {
+    account: Args.string({
       parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: true,
       description: 'Name of the account',
-    },
-  ]
+    }),
+  }
 
   static flags = {
     ...RemoteFlags,
@@ -33,7 +32,7 @@ export class DeleteCommand extends IronfishCommand {
     const { args, flags } = await this.parse(DeleteCommand)
     const confirm = flags.confirm
     const wait = flags.wait
-    const account = args.account as string
+    const account = args.account
 
     const client = await this.sdk.connectRpc()
 

--- a/ironfish-cli/src/commands/wallet/export.ts
+++ b/ironfish-cli/src/commands/wallet/export.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { AccountFormat, ErrorUtils, LanguageUtils } from '@ironfish/sdk'
-import { CliUx, Flags } from '@oclif/core'
+import { Flags, ux } from '@oclif/core'
 import fs from 'fs'
 import jsonColorizer from 'json-colorizer'
 import path from 'path'
@@ -93,7 +93,7 @@ export class ExportCommand extends IronfishCommand {
         if (fs.existsSync(resolved)) {
           this.log(`There is already an account backup at ${exportPath}`)
 
-          const confirmed = await CliUx.ux.confirm(
+          const confirmed = await ux.confirm(
             `\nOverwrite the account backup with new file?\nAre you sure? (Y)es / (N)o`,
           )
 

--- a/ironfish-cli/src/commands/wallet/export.ts
+++ b/ironfish-cli/src/commands/wallet/export.ts
@@ -7,7 +7,7 @@ import fs from 'fs'
 import jsonColorizer from 'json-colorizer'
 import path from 'path'
 import { IronfishCommand } from '../../command'
-import { ColorFlag, ColorFlagKey, RemoteFlags } from '../../flags'
+import { ColorFlag, ColorFlagKey, EnumLanguageKeyFlag, RemoteFlags } from '../../flags'
 
 export class ExportCommand extends IronfishCommand {
   static description = `Export an account`
@@ -23,10 +23,10 @@ export class ExportCommand extends IronfishCommand {
       default: false,
       description: 'Export an account to a mnemonic 24 word phrase',
     }),
-    language: Flags.enum({
+    language: EnumLanguageKeyFlag({
       description: 'Language to use for mnemonic export',
       required: false,
-      options: LanguageUtils.LANGUAGE_KEYS,
+      choices: LanguageUtils.LANGUAGE_KEYS,
     }),
     json: Flags.boolean({
       default: false,

--- a/ironfish-cli/src/commands/wallet/export.ts
+++ b/ironfish-cli/src/commands/wallet/export.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { AccountFormat, ErrorUtils, LanguageUtils } from '@ironfish/sdk'
-import { Flags, ux } from '@oclif/core'
+import { Args, Flags, ux } from '@oclif/core'
 import fs from 'fs'
 import jsonColorizer from 'json-colorizer'
 import path from 'path'
@@ -42,13 +42,12 @@ export class ExportCommand extends IronfishCommand {
     }),
   }
 
-  static args = [
-    {
-      name: 'account',
+  static args = {
+    account: Args.string({
       required: false,
       description: 'Name of the account to export',
-    },
-  ]
+    }),
+  }
 
   async start(): Promise<void> {
     const { flags, args } = await this.parse(ExportCommand)

--- a/ironfish-cli/src/commands/wallet/import.ts
+++ b/ironfish-cli/src/commands/wallet/import.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { RPC_ERROR_CODES, RpcRequestError } from '@ironfish/sdk'
-import { Flags, ux } from '@oclif/core'
+import { Args, Flags, ux } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 import { importFile, importPipe, longPrompt } from '../../utils/input'
@@ -25,18 +25,17 @@ export class ImportCommand extends IronfishCommand {
     }),
   }
 
-  static args = [
-    {
-      name: 'blob',
+  static args = {
+    blob: Args.string({
       parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: false,
       description: 'The copy-pasted output of wallet:export; or, a raw spending key',
-    },
-  ]
+    }),
+  }
 
   async start(): Promise<void> {
     const { flags, args } = await this.parse(ImportCommand)
-    const blob = args.blob as string | undefined
+    const blob = args.blob
 
     const client = await this.sdk.connectRpc()
 

--- a/ironfish-cli/src/commands/wallet/import.ts
+++ b/ironfish-cli/src/commands/wallet/import.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { RPC_ERROR_CODES, RpcRequestError } from '@ironfish/sdk'
-import { CliUx, Flags } from '@oclif/core'
+import { Flags, ux } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 import { importFile, importPipe, longPrompt } from '../../utils/input'
@@ -59,7 +59,7 @@ export class ImportCommand extends IronfishCommand {
     } else if (!process.stdin.isTTY) {
       account = await importPipe()
     } else {
-      CliUx.ux.error(`Invalid import type`)
+      ux.error(`Invalid import type`)
     }
 
     const accountsResponse = await client.wallet.getAccounts()
@@ -71,7 +71,7 @@ export class ImportCommand extends IronfishCommand {
       this.log()
       this.log(`Found existing account with name '${flags.name}'`)
 
-      const name = await CliUx.ux.prompt('Enter a different name for the account', {
+      const name = await ux.prompt('Enter a different name for the account', {
         required: true,
       })
       if (name === flags.name) {
@@ -103,7 +103,7 @@ export class ImportCommand extends IronfishCommand {
             this.log(e.codeMessage)
           }
 
-          const name = await CliUx.ux.prompt(message, {
+          const name = await ux.prompt(message, {
             required: true,
           })
           if (name === flags.name) {

--- a/ironfish-cli/src/commands/wallet/mint.ts
+++ b/ironfish-cli/src/commands/wallet/mint.ts
@@ -14,7 +14,7 @@ import {
   RpcRequestError,
   Transaction,
 } from '@ironfish/sdk'
-import { CliUx, Flags } from '@oclif/core'
+import { Flags, ux } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { IronFlag, RemoteFlags, ValueFlag } from '../../flags'
 import { confirmOperation } from '../../utils'
@@ -147,18 +147,18 @@ export class Mint extends IronfishCommand {
     // name is provided
     let isMintingNewAsset = Boolean(name || metadata)
     if (!assetId && !metadata && !name) {
-      isMintingNewAsset = await CliUx.ux.confirm('Do you want to create a new asset (Y/N)?')
+      isMintingNewAsset = await ux.confirm('Do you want to create a new asset (Y/N)?')
     }
 
     if (isMintingNewAsset) {
       if (!name) {
-        name = await CliUx.ux.prompt('Enter the name for the new asset', {
+        name = await ux.prompt('Enter the name for the new asset', {
           required: true,
         })
       }
 
       if (!metadata) {
-        metadata = await CliUx.ux.prompt('Enter metadata for the new asset', {
+        metadata = await ux.prompt('Enter metadata for the new asset', {
           default: '',
           required: false,
         })
@@ -296,7 +296,7 @@ export class Mint extends IronfishCommand {
       assetData,
     )
 
-    CliUx.ux.action.start('Sending the transaction')
+    ux.action.start('Sending the transaction')
 
     const response = await client.wallet.postTransaction({
       transaction: RawTransactionSerde.serialize(raw).toString('hex'),
@@ -306,7 +306,7 @@ export class Mint extends IronfishCommand {
     const bytes = Buffer.from(response.content.transaction, 'hex')
     const transaction = new Transaction(bytes)
 
-    CliUx.ux.action.stop()
+    ux.action.stop()
 
     const minted = transaction.mints[0]
 

--- a/ironfish-cli/src/commands/wallet/multisig/commitment/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/commitment/create.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { UnsignedTransaction } from '@ironfish/sdk'
-import { CliUx, Flags } from '@oclif/core'
+import { Flags, ux } from '@oclif/core'
 import { IronfishCommand } from '../../../../command'
 import { RemoteFlags } from '../../../../flags'
 import { longPrompt } from '../../../../utils/input'
@@ -81,7 +81,7 @@ export class CreateSigningCommitmentCommand extends IronfishCommand {
     )
 
     if (!flags.confirm) {
-      const confirmed = await CliUx.ux.confirm('Confirm signing commitment creation (Y/N)')
+      const confirmed = await ux.confirm('Confirm signing commitment creation (Y/N)')
       if (!confirmed) {
         this.error('Creating signing commitment aborted')
       }

--- a/ironfish-cli/src/commands/wallet/multisig/dealer/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dealer/create.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { ACCOUNT_SCHEMA_VERSION, RpcClient } from '@ironfish/sdk'
-import { CliUx, Flags } from '@oclif/core'
+import { Flags, ux } from '@oclif/core'
 import { IronfishCommand } from '../../../../command'
 import { RemoteFlags } from '../../../../flags'
 import { longPrompt } from '../../../../utils/input'
@@ -53,7 +53,7 @@ export class MultisigCreateDealer extends IronfishCommand {
 
     let minSigners = flags.minSigners
     if (!minSigners) {
-      const input = await CliUx.ux.prompt('Enter the number of minimum signers', {
+      const input = await ux.prompt('Enter the number of minimum signers', {
         required: true,
       })
       minSigners = parseInt(input)
@@ -81,7 +81,7 @@ export class MultisigCreateDealer extends IronfishCommand {
 
     if (flags.importCoordinator) {
       this.log()
-      CliUx.ux.action.start('Importing the coordinator as a view-only account')
+      ux.action.start('Importing the coordinator as a view-only account')
 
       await client.wallet.importAccount({
         account: {
@@ -103,7 +103,7 @@ export class MultisigCreateDealer extends IronfishCommand {
         },
       })
 
-      CliUx.ux.action.stop()
+      ux.action.stop()
     }
 
     for (const [i, { identity, account }] of response.content.participantAccounts.entries()) {
@@ -128,8 +128,7 @@ export class MultisigCreateDealer extends IronfishCommand {
 
     let name = inputName
     do {
-      name =
-        name ?? (await CliUx.ux.prompt('Enter a name for the coordinator', { required: true }))
+      name = name ?? (await ux.prompt('Enter a name for the coordinator', { required: true }))
 
       if (accountNames.has(name)) {
         this.log(`Account with name ${name} already exists`)

--- a/ironfish-cli/src/commands/wallet/multisig/dkg/round1.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/round1.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { CliUx, Flags } from '@oclif/core'
+import { Flags, ux } from '@oclif/core'
 import { IronfishCommand } from '../../../../command'
 import { RemoteFlags } from '../../../../flags'
 import { longPrompt } from '../../../../utils/input'
@@ -57,7 +57,7 @@ export class DkgRound1Command extends IronfishCommand {
 
     let minSigners = flags.minSigners
     if (!minSigners) {
-      const input = await CliUx.ux.prompt('Enter the number of minimum signers', {
+      const input = await ux.prompt('Enter the number of minimum signers', {
         required: true,
       })
       minSigners = parseInt(input)

--- a/ironfish-cli/src/commands/wallet/multisig/dkg/round2.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/round2.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { CliUx, Flags } from '@oclif/core'
+import { Flags, ux } from '@oclif/core'
 import { IronfishCommand } from '../../../../command'
 import { RemoteFlags } from '../../../../flags'
 import { longPrompt } from '../../../../utils/input'
@@ -41,7 +41,7 @@ export class DkgRound2Command extends IronfishCommand {
 
     let round1SecretPackage = flags.round1SecretPackage
     if (!round1SecretPackage) {
-      round1SecretPackage = await CliUx.ux.prompt(
+      round1SecretPackage = await ux.prompt(
         `Enter the round 1 secret package for participant ${participantName}`,
         { required: true },
       )

--- a/ironfish-cli/src/commands/wallet/multisig/dkg/round3.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/round3.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { CliUx, Flags } from '@oclif/core'
+import { Flags, ux } from '@oclif/core'
 import { IronfishCommand } from '../../../../command'
 import { RemoteFlags } from '../../../../flags'
 import { longPrompt } from '../../../../utils/input'
@@ -51,7 +51,7 @@ export class DkgRound3Command extends IronfishCommand {
 
     let round2SecretPackage = flags.round2SecretPackage
     if (!round2SecretPackage) {
-      round2SecretPackage = await CliUx.ux.prompt(
+      round2SecretPackage = await ux.prompt(
         `Enter the encrypted secret package for participant ${participantName}`,
         {
           required: true,

--- a/ironfish-cli/src/commands/wallet/multisig/participant/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/participant/create.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { RPC_ERROR_CODES, RpcRequestError } from '@ironfish/sdk'
-import { CliUx, Flags } from '@oclif/core'
+import { Flags, ux } from '@oclif/core'
 import { IronfishCommand } from '../../../../command'
 import { RemoteFlags } from '../../../../flags'
 
@@ -21,7 +21,7 @@ export class MultisigIdentityCreate extends IronfishCommand {
     const { flags } = await this.parse(MultisigIdentityCreate)
     let name = flags.name
     if (!name) {
-      name = await CliUx.ux.prompt('Enter a name for the identity', {
+      name = await ux.prompt('Enter a name for the identity', {
         required: true,
       })
     }
@@ -38,7 +38,7 @@ export class MultisigIdentityCreate extends IronfishCommand {
         ) {
           this.log()
           this.log(e.codeMessage)
-          name = await CliUx.ux.prompt('Enter a new name for the identity', {
+          name = await ux.prompt('Enter a new name for the identity', {
             required: true,
           })
         } else {

--- a/ironfish-cli/src/commands/wallet/multisig/participants/index.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/participants/index.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { CliUx } from '@oclif/core'
+import { ux } from '@oclif/core'
 import { IronfishCommand } from '../../../../command'
 import { RemoteFlags } from '../../../../flags'
 
@@ -27,7 +27,7 @@ export class MultisigParticipants extends IronfishCommand {
     // sort identities by name
     participants.sort((a, b) => a.name.localeCompare(b.name))
 
-    CliUx.ux.table(
+    ux.table(
       participants,
       {
         name: {

--- a/ironfish-cli/src/commands/wallet/multisig/signature/aggregate.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/signature/aggregate.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { CurrencyUtils, Transaction } from '@ironfish/sdk'
-import { CliUx, Flags } from '@oclif/core'
+import { Flags, ux } from '@oclif/core'
 import { IronfishCommand } from '../../../../command'
 import { RemoteFlags } from '../../../../flags'
 import { longPrompt } from '../../../../utils/input'
@@ -62,7 +62,7 @@ export class MultisigSign extends IronfishCommand {
     }
     signatureShares = signatureShares.map((s) => s.trim())
 
-    CliUx.ux.action.start('Signing the multisig transaction')
+    ux.action.start('Signing the multisig transaction')
 
     const client = await this.sdk.connectRpc()
 
@@ -76,7 +76,7 @@ export class MultisigSign extends IronfishCommand {
     const bytes = Buffer.from(response.content.transaction, 'hex')
     const transaction = new Transaction(bytes)
 
-    CliUx.ux.action.stop()
+    ux.action.stop()
 
     if (flags.broadcast && response.content.accepted === false) {
       this.warn(

--- a/ironfish-cli/src/commands/wallet/multisig/signature/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/signature/create.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { multisig } from '@ironfish/rust-nodejs'
 import { UnsignedTransaction } from '@ironfish/sdk'
-import { CliUx, Flags } from '@oclif/core'
+import { Flags, ux } from '@oclif/core'
 import { IronfishCommand } from '../../../../command'
 import { RemoteFlags } from '../../../../flags'
 import { longPrompt } from '../../../../utils/input'
@@ -62,7 +62,7 @@ export class CreateSignatureShareCommand extends IronfishCommand {
     )
 
     if (!flags.confirm) {
-      const confirmed = await CliUx.ux.confirm('Confirm new signature share creation (Y/N)')
+      const confirmed = await ux.confirm('Confirm new signature share creation (Y/N)')
       if (!confirmed) {
         this.error('Creating signature share aborted')
       }

--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -12,7 +12,7 @@ import {
   TimeUtils,
   Transaction,
 } from '@ironfish/sdk'
-import { CliUx, Flags } from '@oclif/core'
+import { Flags, ux } from '@oclif/core'
 import inquirer from 'inquirer'
 import { IronfishCommand } from '../../../command'
 import { HexFlag, IronFlag, RemoteFlags } from '../../../flags'
@@ -131,7 +131,7 @@ export class CombineNotesCommand extends IronfishCommand {
 
     // eslint-disable-next-line no-constant-condition
     while (true) {
-      const result = await CliUx.ux.prompt('Enter the number of notes', {
+      const result = await ux.prompt('Enter the number of notes', {
         required: true,
       })
 
@@ -289,7 +289,7 @@ export class CombineNotesCommand extends IronfishCommand {
 
     const memo =
       flags.memo?.trim() ??
-      (await CliUx.ux.prompt('Enter the memo (or leave blank)', { required: false }))
+      (await ux.prompt('Enter the memo (or leave blank)', { required: false }))
 
     const expiration = await this.calculateExpiration(client, spendPostTime, numberOfNotes)
 
@@ -455,7 +455,7 @@ export class CombineNotesCommand extends IronfishCommand {
 
     if (resultingNotes) {
       this.log('')
-      CliUx.ux.table(
+      ux.table(
         resultingNotes,
         {
           hash: {

--- a/ironfish-cli/src/commands/wallet/notes/index.ts
+++ b/ironfish-cli/src/commands/wallet/notes/index.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { CurrencyUtils, RpcAsset } from '@ironfish/sdk'
-import { Flags, ux } from '@oclif/core'
+import { Args, Flags, ux } from '@oclif/core'
 import { IronfishCommand } from '../../../command'
 import { RemoteFlags } from '../../../flags'
 import { TableCols, TableFlags } from '../../../utils/table'
@@ -20,18 +20,17 @@ export class NotesCommand extends IronfishCommand {
     }),
   }
 
-  static args = [
-    {
-      name: 'account',
+  static args = {
+    account: Args.string({
       required: false,
       description: 'Name of the account to get notes for. DEPRECATED: use --account flag',
-    },
-  ]
+    }),
+  }
 
   async start(): Promise<void> {
     const { flags, args } = await this.parse(NotesCommand)
     // TODO: remove account arg
-    const account = flags.account ? flags.account : (args.account as string | undefined)
+    const account = flags.account ? flags.account : args.account
 
     const assetLookup: Map<string, RpcAsset> = new Map()
 

--- a/ironfish-cli/src/commands/wallet/notes/index.ts
+++ b/ironfish-cli/src/commands/wallet/notes/index.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { CurrencyUtils, RpcAsset } from '@ironfish/sdk'
-import { CliUx, Flags } from '@oclif/core'
+import { Flags, ux } from '@oclif/core'
 import { IronfishCommand } from '../../../command'
 import { RemoteFlags } from '../../../flags'
 import { TableCols, TableFlags } from '../../../utils/table'
@@ -49,7 +49,7 @@ export class NotesCommand extends IronfishCommand {
         )
       }
 
-      CliUx.ux.table(
+      ux.table(
         [note],
         {
           memo: {

--- a/ironfish-cli/src/commands/wallet/post.ts
+++ b/ironfish-cli/src/commands/wallet/post.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { RawTransaction, RawTransactionSerde, RpcClient, Transaction } from '@ironfish/sdk'
-import { Flags, ux } from '@oclif/core'
+import { Args, Flags, ux } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 import { longPrompt } from '../../utils/input'
@@ -37,16 +37,15 @@ export class PostCommand extends IronfishCommand {
     }),
   }
 
-  static args = [
-    {
-      name: 'transaction',
+  static args = {
+    transaction: Args.string({
       description: 'The raw transaction in hex encoding',
-    },
-  ]
+    }),
+  }
 
   async start(): Promise<void> {
     const { flags, args } = await this.parse(PostCommand)
-    let transaction = args.transaction as string | undefined
+    let transaction = args.transaction
 
     if (!transaction) {
       transaction = await longPrompt('Enter the raw transaction in hex encoding', {

--- a/ironfish-cli/src/commands/wallet/post.ts
+++ b/ironfish-cli/src/commands/wallet/post.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { RawTransaction, RawTransactionSerde, RpcClient, Transaction } from '@ironfish/sdk'
-import { CliUx, Flags } from '@oclif/core'
+import { Flags, ux } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 import { longPrompt } from '../../utils/input'
@@ -67,14 +67,14 @@ export class PostCommand extends IronfishCommand {
       }
     }
 
-    CliUx.ux.action.start(`Posting the transaction`)
+    ux.action.start(`Posting the transaction`)
 
     const response = await client.wallet.postTransaction({
       transaction,
       broadcast: flags.broadcast,
     })
 
-    CliUx.ux.action.stop()
+    ux.action.stop()
 
     const posted = new Transaction(Buffer.from(response.content.transaction, 'hex'))
 
@@ -113,7 +113,7 @@ export class PostCommand extends IronfishCommand {
 
     await renderRawTransactionDetails(client, raw, account, this.logger)
 
-    return CliUx.ux.confirm('Do you want to post this (Y/N)?')
+    return ux.confirm('Do you want to post this (Y/N)?')
   }
 
   async getAccountName(

--- a/ironfish-cli/src/commands/wallet/prune.ts
+++ b/ironfish-cli/src/commands/wallet/prune.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { NodeUtils, TransactionStatus } from '@ironfish/sdk'
-import { CliUx, Flags } from '@oclif/core'
+import { Flags, ux } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { LocalFlags } from '../../flags'
 
@@ -39,10 +39,10 @@ export default class PruneCommand extends IronfishCommand {
   async start(): Promise<void> {
     const { flags } = await this.parse(PruneCommand)
 
-    CliUx.ux.action.start(`Opening node`)
+    ux.action.start(`Opening node`)
     const node = await this.sdk.node()
     await NodeUtils.waitForOpen(node)
-    CliUx.ux.action.stop('Done.')
+    ux.action.stop('Done.')
 
     let accounts
     if (flags.account) {
@@ -83,14 +83,14 @@ export default class PruneCommand extends IronfishCommand {
       }
     }
 
-    CliUx.ux.action.start(`Cleaning up deleted accounts`)
+    ux.action.start(`Cleaning up deleted accounts`)
     await node.wallet.forceCleanupDeletedAccounts()
-    CliUx.ux.action.stop()
+    ux.action.stop()
 
     if (flags.compact) {
-      CliUx.ux.action.start(`Compacting wallet database`)
+      ux.action.start(`Compacting wallet database`)
       await node.wallet.walletDb.db.compact()
-      CliUx.ux.action.stop()
+      ux.action.stop()
     }
 
     await node.closeDB()

--- a/ironfish-cli/src/commands/wallet/rename.ts
+++ b/ironfish-cli/src/commands/wallet/rename.ts
@@ -13,8 +13,7 @@ export class RenameCommand extends IronfishCommand {
       required: true,
       description: 'Name of the account to rename',
     }),
-    // TODO(mat): Do we need to do 'new-name', or does oclif do some magic like flags now?
-    'new-name': Args.string({
+    newName: Args.string({
       required: true,
       description: 'New name to assign to the account',
     }),
@@ -26,8 +25,7 @@ export class RenameCommand extends IronfishCommand {
 
   async start(): Promise<void> {
     const { args } = await this.parse(RenameCommand)
-    const account = args.account
-    const newName = args['new-name']
+    const { account, newName } = args
 
     const client = await this.sdk.connectRpc()
     await client.wallet.renameAccount({ account, newName })

--- a/ironfish-cli/src/commands/wallet/rename.ts
+++ b/ironfish-cli/src/commands/wallet/rename.ts
@@ -1,24 +1,24 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Args } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 
 export class RenameCommand extends IronfishCommand {
   static description = 'Change the name of an account'
 
-  static args = [
-    {
-      name: 'account',
+  static args = {
+    account: Args.string({
       required: true,
       description: 'Name of the account to rename',
-    },
-    {
-      name: 'new-name',
+    }),
+    // TODO(mat): Do we need to do 'new-name', or does oclif do some magic like flags now?
+    'new-name': Args.string({
       required: true,
       description: 'New name to assign to the account',
-    },
-  ]
+    }),
+  }
 
   static flags = {
     ...RemoteFlags,
@@ -26,8 +26,8 @@ export class RenameCommand extends IronfishCommand {
 
   async start(): Promise<void> {
     const { args } = await this.parse(RenameCommand)
-    const account = args.account as string
-    const newName = args['new-name'] as string
+    const account = args.account
+    const newName = args['new-name']
 
     const client = await this.sdk.connectRpc()
     await client.wallet.renameAccount({ account, newName })

--- a/ironfish-cli/src/commands/wallet/rescan.ts
+++ b/ironfish-cli/src/commands/wallet/rescan.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { Meter, TimeUtils } from '@ironfish/sdk'
-import { CliUx, Flags } from '@oclif/core'
+import { Flags, ux } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 import { ProgressBar } from '../../types'
@@ -36,7 +36,7 @@ export class RescanCommand extends IronfishCommand {
 
     const client = await this.sdk.connectRpc(local)
 
-    CliUx.ux.action.start('Asking node to start scanning', undefined, {
+    ux.action.start('Asking node to start scanning', undefined, {
       stdout: true,
     })
 
@@ -44,7 +44,7 @@ export class RescanCommand extends IronfishCommand {
 
     const speed = new Meter()
 
-    const progress = CliUx.ux.progress({
+    const progress = ux.progress({
       format: 'Scanning Blocks: [{bar}] {value}/{total} {percentage}% {speed}/sec | {estimate}',
     }) as ProgressBar
 
@@ -54,7 +54,7 @@ export class RescanCommand extends IronfishCommand {
     try {
       for await (const { endSequence, sequence } of response.contentStream()) {
         if (!started) {
-          CliUx.ux.action.stop()
+          ux.action.stop()
           speed.start()
           progress.start(endSequence, 0)
           started = true

--- a/ironfish-cli/src/commands/wallet/reset.ts
+++ b/ironfish-cli/src/commands/wallet/reset.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { Flags, ux } from '@oclif/core'
+import { Args, Flags, ux } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 
@@ -25,17 +25,16 @@ export class ResetCommand extends IronfishCommand {
     }),
   }
 
-  static args = [
-    {
-      name: 'account',
+  static args = {
+    account: Args.string({
       required: true,
       description: 'Name of the account to reset',
-    },
-  ]
+    }),
+  }
 
   async start(): Promise<void> {
     const { args, flags } = await this.parse(ResetCommand)
-    const account = args.account as string
+    const account = args.account
 
     if (!flags.confirm) {
       const confirm = await ux.confirm(

--- a/ironfish-cli/src/commands/wallet/reset.ts
+++ b/ironfish-cli/src/commands/wallet/reset.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { CliUx, Flags } from '@oclif/core'
+import { Flags, ux } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 
@@ -38,7 +38,7 @@ export class ResetCommand extends IronfishCommand {
     const account = args.account as string
 
     if (!flags.confirm) {
-      const confirm = await CliUx.ux.confirm(
+      const confirm = await ux.confirm(
         `Are you sure you want to reset the account ${account}` +
           `\nThis will delete your transactions.` +
           `\nYour keys will not be deleted.` +

--- a/ironfish-cli/src/commands/wallet/scanning/off.ts
+++ b/ironfish-cli/src/commands/wallet/scanning/off.ts
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Args } from '@oclif/core'
 import { IronfishCommand } from '../../../command'
 import { RemoteFlags } from '../../../flags'
 
@@ -11,17 +12,16 @@ export class ScanningOffCommand extends IronfishCommand {
     ...RemoteFlags,
   }
 
-  static args = [
-    {
-      name: 'account',
+  static args = {
+    account: Args.string({
       required: true,
       description: 'Name of the account to update',
-    },
-  ]
+    }),
+  }
 
   async start(): Promise<void> {
     const { args } = await this.parse(ScanningOffCommand)
-    const account = args.account as string
+    const account = args.account
 
     const client = await this.sdk.connectRpc()
 

--- a/ironfish-cli/src/commands/wallet/scanning/on.ts
+++ b/ironfish-cli/src/commands/wallet/scanning/on.ts
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Args } from '@oclif/core'
 import { IronfishCommand } from '../../../command'
 import { RemoteFlags } from '../../../flags'
 
@@ -11,17 +12,16 @@ export class ScanningOnCommand extends IronfishCommand {
     ...RemoteFlags,
   }
 
-  static args = [
-    {
-      name: 'account',
+  static args = {
+    account: Args.string({
       required: true,
       description: 'Name of the account to update',
-    },
-  ]
+    }),
+  }
 
   async start(): Promise<void> {
     const { args } = await this.parse(ScanningOnCommand)
-    const account = args.account as string
+    const account = args.account
 
     const client = await this.sdk.connectRpc()
 

--- a/ironfish-cli/src/commands/wallet/send.ts
+++ b/ironfish-cli/src/commands/wallet/send.ts
@@ -11,7 +11,7 @@ import {
   TimeUtils,
   Transaction,
 } from '@ironfish/sdk'
-import { CliUx, Flags } from '@oclif/core'
+import { Flags, ux } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { HexFlag, IronFlag, RemoteFlags, ValueFlag } from '../../flags'
 import { confirmOperation } from '../../utils'
@@ -200,14 +200,14 @@ export class Send extends IronfishCommand {
     }
 
     if (!to) {
-      to = await CliUx.ux.prompt('Enter the public address of the recipient', {
+      to = await ux.prompt('Enter the public address of the recipient', {
         required: true,
       })
     }
 
     const memo =
       flags.memo?.trim() ??
-      (await CliUx.ux.prompt('Enter the memo (or leave blank)', { required: false }))
+      (await ux.prompt('Enter the memo (or leave blank)', { required: false }))
 
     if (!isValidPublicAddress(to)) {
       this.log(`A valid public address is required`)

--- a/ironfish-cli/src/commands/wallet/status.ts
+++ b/ironfish-cli/src/commands/wallet/status.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { CliUx } from '@oclif/core'
+import { ux } from '@oclif/core'
 import chalk from 'chalk'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
@@ -22,7 +22,7 @@ export class StatusCommand extends IronfishCommand {
 
     const response = await client.wallet.getAccountsStatus()
 
-    CliUx.ux.table(
+    ux.table(
       response.content.accounts,
       {
         name: {

--- a/ironfish-cli/src/commands/wallet/transaction/import.ts
+++ b/ironfish-cli/src/commands/wallet/transaction/import.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { Flags, ux } from '@oclif/core'
+import { Args, Flags, ux } from '@oclif/core'
 import { IronfishCommand } from '../../../command'
 import { RemoteFlags } from '../../../flags'
 import { importFile, importPipe, longPrompt } from '../../../utils/input'
@@ -23,18 +23,17 @@ export class TransactionImportCommand extends IronfishCommand {
     }),
   }
 
-  static args = [
-    {
-      name: 'transaction',
+  static args = {
+    transaction: Args.string({
       required: false,
       parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       description: 'The transaction in hex encoding',
-    },
-  ]
+    }),
+  }
 
   async start(): Promise<void> {
     const { flags, args } = await this.parse(TransactionImportCommand)
-    const txArg = args.transaction as string | undefined
+    const txArg = args.transaction
 
     let transaction
 

--- a/ironfish-cli/src/commands/wallet/transaction/import.ts
+++ b/ironfish-cli/src/commands/wallet/transaction/import.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { CliUx, Flags } from '@oclif/core'
+import { Flags, ux } from '@oclif/core'
 import { IronfishCommand } from '../../../command'
 import { RemoteFlags } from '../../../flags'
 import { importFile, importPipe, longPrompt } from '../../../utils/input'
@@ -55,16 +55,16 @@ export class TransactionImportCommand extends IronfishCommand {
     } else if (!process.stdin.isTTY) {
       transaction = await importPipe()
     } else {
-      CliUx.ux.error(`Invalid import type`)
+      ux.error(`Invalid import type`)
     }
 
-    CliUx.ux.action.start(`Importing transaction`)
+    ux.action.start(`Importing transaction`)
     const client = await this.sdk.connectRpc()
     const response = await client.wallet.addTransaction({
       transaction,
       broadcast: flags.broadcast,
     })
-    CliUx.ux.action.stop()
+    ux.action.stop()
 
     this.log(`Transaction imported for accounts: ${response.content.accounts.join(', ')}`)
   }

--- a/ironfish-cli/src/commands/wallet/transaction/index.ts
+++ b/ironfish-cli/src/commands/wallet/transaction/index.ts
@@ -9,7 +9,7 @@ import {
   RpcWalletNote,
   TimeUtils,
 } from '@ironfish/sdk'
-import { CliUx, Flags } from '@oclif/core'
+import { Flags, ux } from '@oclif/core'
 import { IronfishCommand } from '../../../command'
 import { RemoteFlags } from '../../../flags'
 import {
@@ -98,9 +98,9 @@ export class TransactionCommand extends IronfishCommand {
     if (chainportTxnDetails) {
       this.log(`\n---Chainport Bridge Transaction Summary---\n`)
 
-      CliUx.ux.action.start('Fetching network details')
+      ux.action.start('Fetching network details')
       const chainportNetworks = await fetchChainportNetworkMap(networkId)
-      CliUx.ux.action.stop()
+      ux.action.stop()
 
       await displayChainportTransactionSummary(
         networkId,
@@ -130,7 +130,7 @@ export class TransactionCommand extends IronfishCommand {
         })
       }
 
-      CliUx.ux.table(noteAssetPairs, {
+      ux.table(noteAssetPairs, {
         amount: {
           header: 'Amount',
           get: ({ asset, note }) =>
@@ -161,7 +161,7 @@ export class TransactionCommand extends IronfishCommand {
 
     if (response.content.transaction.spends.length > 0) {
       this.log(`\n---Spends---\n`)
-      CliUx.ux.table(response.content.transaction.spends, {
+      ux.table(response.content.transaction.spends, {
         size: {
           header: 'Size',
           get: (spend) => spend.size,
@@ -187,7 +187,7 @@ export class TransactionCommand extends IronfishCommand {
       )
 
       this.log(`\n---Asset Balance Deltas---\n`)
-      CliUx.ux.table(assetBalanceDeltas, {
+      ux.table(assetBalanceDeltas, {
         assetId: {
           header: 'Asset ID',
         },

--- a/ironfish-cli/src/commands/wallet/transaction/index.ts
+++ b/ironfish-cli/src/commands/wallet/transaction/index.ts
@@ -9,7 +9,7 @@ import {
   RpcWalletNote,
   TimeUtils,
 } from '@ironfish/sdk'
-import { Flags, ux } from '@oclif/core'
+import { Args, Flags, ux } from '@oclif/core'
 import { IronfishCommand } from '../../../command'
 import { RemoteFlags } from '../../../flags'
 import {
@@ -31,25 +31,23 @@ export class TransactionCommand extends IronfishCommand {
     }),
   }
 
-  static args = [
-    {
-      name: 'hash',
+  static args = {
+    hash: Args.string({
       parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: true,
       description: 'Hash of the transaction',
-    },
-    {
-      name: 'account',
+    }),
+    account: Args.string({
       required: false,
       description: 'Name of the account. DEPRECATED: use --account flag',
-    },
-  ]
+    }),
+  }
 
   async start(): Promise<void> {
     const { flags, args } = await this.parse(TransactionCommand)
-    const hash = args.hash as string
+    const hash = args.hash
     // TODO: remove account arg
-    const account = flags.account ? flags.account : (args.account as string | undefined)
+    const account = flags.account ? flags.account : args.account
 
     const client = await this.sdk.connectRpc()
     const networkId = (await client.chain.getNetworkInfo()).content.networkId

--- a/ironfish-cli/src/commands/wallet/transaction/watch.ts
+++ b/ironfish-cli/src/commands/wallet/transaction/watch.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { Flags } from '@oclif/core'
+import { Args, Flags } from '@oclif/core'
 import { IronfishCommand } from '../../../command'
 import { RemoteFlags } from '../../../flags'
 import { watchTransaction } from '../../../utils/transaction'
@@ -21,25 +21,23 @@ export class WatchTxCommand extends IronfishCommand {
     }),
   }
 
-  static args = [
-    {
-      name: 'hash',
+  static args = {
+    hash: Args.string({
       parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: true,
       description: 'Hash of the transaction',
-    },
-    {
-      name: 'account',
+    }),
+    account: Args.string({
       required: false,
       description: 'Name of the account. DEPRECATED: use --account flag',
-    },
-  ]
+    }),
+  }
 
   async start(): Promise<void> {
     const { flags, args } = await this.parse(WatchTxCommand)
-    const hash = args.hash as string
+    const hash = args.hash
     // TODO: remove account arg
-    const account = flags.account ? flags.account : (args.account as string | undefined)
+    const account = flags.account ? flags.account : args.account
 
     const client = await this.sdk.connectRpc()
 

--- a/ironfish-cli/src/commands/wallet/transactions.ts
+++ b/ironfish-cli/src/commands/wallet/transactions.ts
@@ -10,7 +10,7 @@ import {
   RpcAsset,
   TransactionType,
 } from '@ironfish/sdk'
-import { Flags, ux } from '@oclif/core'
+import { Args, Flags, ux } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 import { getAssetsByIDs } from '../../utils'
@@ -51,18 +51,17 @@ export class TransactionsCommand extends IronfishCommand {
     }),
   }
 
-  static args = [
-    {
-      name: 'account',
+  static args = {
+    account: Args.string({
       required: false,
       description: 'Name of the account. DEPRECATED: use --account flag',
-    },
-  ]
+    }),
+  }
 
   async start(): Promise<void> {
     const { flags, args } = await this.parse(TransactionsCommand)
     // TODO: remove account arg
-    const account = flags.account ? flags.account : (args.account as string | undefined)
+    const account = flags.account ? flags.account : args.account
 
     const format: Format =
       flags.csv || flags.output === 'csv'

--- a/ironfish-cli/src/commands/wallet/transactions.ts
+++ b/ironfish-cli/src/commands/wallet/transactions.ts
@@ -10,7 +10,7 @@ import {
   RpcAsset,
   TransactionType,
 } from '@ironfish/sdk'
-import { CliUx, Flags } from '@oclif/core'
+import { Flags, ux } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 import { getAssetsByIDs } from '../../utils'
@@ -119,7 +119,7 @@ export class TransactionsCommand extends IronfishCommand {
         transactionRows = this.getTransactionRows(assetLookup, transaction, format)
       }
 
-      CliUx.ux.table(transactionRows, columns, {
+      ux.table(transactionRows, columns, {
         printLine: this.log.bind(this),
         ...flags,
         'no-header': !showHeader,
@@ -259,8 +259,8 @@ export class TransactionsCommand extends IronfishCommand {
     extended: boolean,
     notes: boolean,
     format: Format,
-  ): CliUx.Table.table.Columns<PartialRecursive<TransactionRow>> {
-    let columns: CliUx.Table.table.Columns<PartialRecursive<TransactionRow>> = {
+  ): ux.Table.table.Columns<PartialRecursive<TransactionRow>> {
+    let columns: ux.Table.table.Columns<PartialRecursive<TransactionRow>> = {
       timestamp: TableCols.timestamp({
         streaming: true,
       }),

--- a/ironfish-cli/src/commands/wallet/use.ts
+++ b/ironfish-cli/src/commands/wallet/use.ts
@@ -1,19 +1,19 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Args } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 
 export class UseCommand extends IronfishCommand {
   static description = 'Change the default account used by all commands'
 
-  static args = [
-    {
-      name: 'account',
+  static args = {
+    account: Args.string({
       required: true,
       description: 'Name of the account',
-    },
-  ]
+    }),
+  }
 
   static flags = {
     ...RemoteFlags,
@@ -21,7 +21,7 @@ export class UseCommand extends IronfishCommand {
 
   async start(): Promise<void> {
     const { args } = await this.parse(UseCommand)
-    const account = args.account as string
+    const account = args.account
 
     const client = await this.sdk.connectRpc()
     await client.wallet.useAccount({ account })

--- a/ironfish-cli/src/flags.ts
+++ b/ironfish-cli/src/flags.ts
@@ -188,11 +188,11 @@ export const HexFlag = Flags.custom<string>({
 
 export const EnumLanguageKeyFlag = Flags.custom<LanguageKey, { choices: Array<LanguageKey> }>({
   parse: async (input, _ctx, opts) => {
-    const parsed = opts.choices.find((valid) => valid === input)
+    const parsed = opts.choices.find((valid) => valid.toLowerCase() === input.toLowerCase())
     if (parsed) {
       return Promise.resolve(parsed)
     } else {
-      return Promise.reject(`Invalid choice: ${input}`)
+      return Promise.reject(new Error(`Invalid choice: ${input}`))
     }
   },
 })

--- a/ironfish-cli/src/flags.ts
+++ b/ironfish-cli/src/flags.ts
@@ -10,6 +10,7 @@ import {
   DEFAULT_USE_RPC_IPC,
   DEFAULT_USE_RPC_TCP,
   DEFAULT_USE_RPC_TLS,
+  LanguageKey,
   MAXIMUM_ORE_AMOUNT,
   MINIMUM_ORE_AMOUNT,
 } from '@ironfish/sdk'
@@ -186,5 +187,16 @@ export const HexFlag = Flags.custom<string>({
     }
 
     return Promise.resolve(input)
+  },
+})
+
+export const EnumLanguageKeyFlag = Flags.custom<LanguageKey, { choices: Array<LanguageKey> }>({
+  parse: async (input, _ctx, opts) => {
+    const parsed = opts.choices.find((valid) => valid === input)
+    if (parsed) {
+      return Promise.resolve(parsed)
+    } else {
+      return Promise.reject(`Invalid choice: ${input}`)
+    }
   },
 })

--- a/ironfish-cli/src/flags.ts
+++ b/ironfish-cli/src/flags.ts
@@ -14,9 +14,7 @@ import {
   MAXIMUM_ORE_AMOUNT,
   MINIMUM_ORE_AMOUNT,
 } from '@ironfish/sdk'
-import { Flags, Interfaces } from '@oclif/core'
-
-type CompletableOptionFlag = Interfaces.CompletableOptionFlag<unknown>
+import { Flags } from '@oclif/core'
 
 export const VerboseFlagKey = 'verbose'
 export const ConfigFlagKey = 'config'
@@ -98,36 +96,34 @@ export const RpcUseHttpFlag = Flags.boolean({
   allowNo: true,
 })
 
-const localFlags: Record<string, CompletableOptionFlag> = {}
-localFlags[VerboseFlagKey] = VerboseFlag as unknown as CompletableOptionFlag
-localFlags[ConfigFlagKey] = ConfigFlag as unknown as CompletableOptionFlag
-localFlags[DataDirFlagKey] = DataDirFlag as unknown as CompletableOptionFlag
-
 /**
  * These flags should usually be used on any command that starts a node,
  * or uses a database to execute the command
  */
-export const LocalFlags = localFlags
-
-const remoteFlags: Record<string, CompletableOptionFlag> = {}
-remoteFlags[VerboseFlagKey] = VerboseFlag as unknown as CompletableOptionFlag
-remoteFlags[ConfigFlagKey] = ConfigFlag as unknown as CompletableOptionFlag
-remoteFlags[DataDirFlagKey] = DataDirFlag as unknown as CompletableOptionFlag
-remoteFlags[RpcUseTcpFlagKey] = RpcUseTcpFlag as unknown as CompletableOptionFlag
-remoteFlags[RpcUseIpcFlagKey] = RpcUseIpcFlag as unknown as CompletableOptionFlag
-remoteFlags[RpcTcpHostFlagKey] = RpcTcpHostFlag as unknown as CompletableOptionFlag
-remoteFlags[RpcTcpPortFlagKey] = RpcTcpPortFlag as unknown as CompletableOptionFlag
-remoteFlags[RpcHttpHostFlagKey] = RpcHttpHostFlag as unknown as CompletableOptionFlag
-remoteFlags[RpcHttpPortFlagKey] = RpcHttpPortFlag as unknown as CompletableOptionFlag
-remoteFlags[RpcUseHttpFlagKey] = RpcUseHttpFlag as unknown as CompletableOptionFlag
-remoteFlags[RpcTcpTlsFlagKey] = RpcTcpTlsFlag as unknown as CompletableOptionFlag
-remoteFlags[RpcAuthFlagKey] = RpcAuthFlag as unknown as CompletableOptionFlag
+export const LocalFlags = {
+  [VerboseFlagKey]: VerboseFlag,
+  [ConfigFlagKey]: ConfigFlag,
+  [DataDirFlagKey]: DataDirFlag,
+}
 
 /**
  * These flags should usually be used on any command that uses an
  * RPC client to connect to a node to run the command
  */
-export const RemoteFlags = remoteFlags
+export const RemoteFlags = {
+  [VerboseFlagKey]: VerboseFlag,
+  [ConfigFlagKey]: ConfigFlag,
+  [DataDirFlagKey]: DataDirFlag,
+  [RpcUseTcpFlagKey]: RpcUseTcpFlag,
+  [RpcUseIpcFlagKey]: RpcUseIpcFlag,
+  [RpcTcpHostFlagKey]: RpcTcpHostFlag,
+  [RpcTcpPortFlagKey]: RpcTcpPortFlag,
+  [RpcHttpHostFlagKey]: RpcHttpHostFlag,
+  [RpcHttpPortFlagKey]: RpcHttpPortFlag,
+  [RpcUseHttpFlagKey]: RpcUseHttpFlag,
+  [RpcTcpTlsFlagKey]: RpcTcpTlsFlag,
+  [RpcAuthFlagKey]: RpcAuthFlag,
+}
 
 export type IronOpts = { minimum?: bigint; flagName: string }
 

--- a/ironfish-cli/src/types.ts
+++ b/ironfish-cli/src/types.ts
@@ -5,7 +5,6 @@
 import { Interfaces } from '@oclif/core'
 
 export interface ProgressBar {
-  progress: () => void
   getTotal(): number
   setTotal(totalValue: number): void
   start(totalValue?: number, startValue?: number, payload?: Record<string, unknown>): void

--- a/ironfish-cli/src/types.ts
+++ b/ironfish-cli/src/types.ts
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { Interfaces } from '@oclif/core'
-
 export interface ProgressBar {
   getTotal(): number
   setTotal(totalValue: number): void
@@ -14,7 +12,3 @@ export interface ProgressBar {
   increment(delta?: number, payload?: Record<string, unknown>): void
   increment(payload?: Record<string, unknown>): void
 }
-
-export type CommandFlags<T> = T extends Interfaces.Input<infer TFlags, infer GFlags>
-  ? Interfaces.ParserOutput<TFlags, GFlags>['flags']
-  : never

--- a/ironfish-cli/src/utils/chainport/utils.ts
+++ b/ironfish-cli/src/utils/chainport/utils.ts
@@ -8,7 +8,7 @@ import {
   RpcWalletTransaction,
   TransactionType,
 } from '@ironfish/sdk'
-import { CliUx } from '@oclif/core'
+import { ux } from '@oclif/core'
 import { getConfig, isNetworkSupportedByChainport } from './config'
 import { ChainportMemoMetadata } from './metadata'
 import { fetchChainportTransactionStatus } from './requests'
@@ -124,9 +124,9 @@ Target (Ironfish) Network:    ${defaultNetworkName(networkId)}`)
     return
   }
 
-  CliUx.ux.action.start('Fetching transaction information on target network')
+  ux.action.start('Fetching transaction information on target network')
   const transactionStatus = await fetchChainportTransactionStatus(networkId, hash)
-  CliUx.ux.action.stop()
+  ux.action.stop()
 
   if (Object.keys(transactionStatus).length === 0 || !transactionStatus.target_network_id) {
     logger.log(

--- a/ironfish-cli/src/utils/confirm.ts
+++ b/ironfish-cli/src/utils/confirm.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { CliUx } from '@oclif/core'
+import { ux } from '@oclif/core'
 
 export const confirmOperation = async (options: {
   confirmMessage?: string
@@ -14,10 +14,10 @@ export const confirmOperation = async (options: {
     return true
   }
 
-  const confirmed = await CliUx.ux.confirm(confirmMessage || 'Do you confirm (Y/N)?')
+  const confirmed = await ux.confirm(confirmMessage || 'Do you confirm (Y/N)?')
 
   if (!confirmed) {
-    CliUx.ux.log(cancelledMessage || 'Operation aborted.')
-    CliUx.ux.exit(0)
+    ux.log(cancelledMessage || 'Operation aborted.')
+    ux.exit(0)
   }
 }

--- a/ironfish-cli/src/utils/currency.ts
+++ b/ironfish-cli/src/utils/currency.ts
@@ -4,7 +4,7 @@
 
 import { Asset } from '@ironfish/rust-nodejs'
 import { Assert, CurrencyUtils, Logger, RpcAssetVerification, RpcClient } from '@ironfish/sdk'
-import { CliUx } from '@oclif/core'
+import { ux } from '@oclif/core'
 
 /**
  * This prompts the user to enter an amount of currency in the major
@@ -57,7 +57,7 @@ export async function promptCurrency(options: {
 
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const input = await CliUx.ux.prompt(text, {
+    const input = await ux.prompt(text, {
       required: options.required,
     })
 

--- a/ironfish-cli/src/utils/expiration.ts
+++ b/ironfish-cli/src/utils/expiration.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { Logger, RpcClient } from '@ironfish/sdk'
-import { CliUx } from '@oclif/core'
+import { ux } from '@oclif/core'
 
 export async function promptExpiration(options: {
   client: RpcClient
@@ -17,7 +17,7 @@ export async function promptExpiration(options: {
 
     const prompt = `Enter an expiration block sequence for the transaction. You can also enter 0 for no expiration, or leave blank to use the default. The current chain head is ${headSequence}`
 
-    const input = await CliUx.ux.prompt(prompt, { required: false })
+    const input = await ux.prompt(prompt, { required: false })
     if (!input) {
       return
     }

--- a/ironfish-cli/src/utils/fees.ts
+++ b/ironfish-cli/src/utils/fees.ts
@@ -13,7 +13,7 @@ import {
   RpcClient,
   RpcRequestError,
 } from '@ironfish/sdk'
-import { CliUx } from '@oclif/core'
+import { ux } from '@oclif/core'
 import inquirer from 'inquirer'
 import { promptCurrency } from './currency'
 
@@ -24,7 +24,7 @@ export async function selectFee(options: {
   confirmations?: number
   logger: Logger
 }): Promise<RawTransaction> {
-  CliUx.ux.action.start('Calculating fees')
+  ux.action.start('Calculating fees')
 
   const feeRates = await options.client.wallet.estimateFeeRates()
 
@@ -58,7 +58,7 @@ export async function selectFee(options: {
     },
   ]
 
-  CliUx.ux.action.stop()
+  ux.action.stop()
 
   const result = await inquirer.prompt<{
     selection: RawTransaction | null

--- a/ironfish-cli/src/utils/spendPostTime.ts
+++ b/ironfish-cli/src/utils/spendPostTime.ts
@@ -14,7 +14,7 @@ import {
   RpcResponseEnded,
   TimeUtils,
 } from '@ironfish/sdk'
-import { CliUx } from '@oclif/core'
+import { ux } from '@oclif/core'
 import { fetchNotes } from './note'
 
 /**
@@ -55,7 +55,7 @@ export async function benchmarkSpendPostTime(
   client: RpcClient,
   account: string,
 ): Promise<number> {
-  CliUx.ux.action.start('Measuring time to combine 1 note')
+  ux.action.start('Measuring time to combine 1 note')
 
   const publicKey = (
     await client.wallet.getAccountPublicKey({
@@ -67,7 +67,7 @@ export async function benchmarkSpendPostTime(
 
   // Not enough notes in the account to measure the time to combine a note
   if (notes.length < 3) {
-    CliUx.ux.error('Not enough notes.')
+    ux.error('Not enough notes.')
   }
 
   const feeRates = await client.wallet.estimateFeeRates()
@@ -122,10 +122,10 @@ export async function benchmarkSpendPostTime(
   )
 
   if (spendPostTime <= 0) {
-    CliUx.ux.error('Error calculating spendPostTime. Please try again.')
+    ux.error('Error calculating spendPostTime. Please try again.')
   }
 
-  CliUx.ux.action.stop(TimeUtils.renderSpan(spendPostTime))
+  ux.action.stop(TimeUtils.renderSpan(spendPostTime))
   sdk.internal.set('spendPostTime', spendPostTime)
   sdk.internal.set('spendPostTimeMeasurements', 1)
   await sdk.internal.save()

--- a/ironfish-cli/src/utils/table.ts
+++ b/ironfish-cli/src/utils/table.ts
@@ -4,7 +4,7 @@
 
 import { ASSET_NAME_LENGTH } from '@ironfish/rust-nodejs'
 import { Assert, BufferUtils, TimeUtils } from '@ironfish/sdk'
-import { CliUx, Flags } from '@oclif/core'
+import { Flags, ux } from '@oclif/core'
 import { table } from '@oclif/core/lib/cli-ux/styled/table'
 
 /**
@@ -134,7 +134,7 @@ export enum Format {
 
 export const TableCols = { timestamp, asset, fixedWidth }
 
-const { 'no-truncate': _, ...tableFlags } = CliUx.ux.table.flags()
+const { 'no-truncate': _, ...tableFlags } = ux.table.flags()
 
 export const TableFlags = {
   ...tableFlags,

--- a/ironfish-cli/src/utils/transaction.ts
+++ b/ironfish-cli/src/utils/transaction.ts
@@ -21,7 +21,7 @@ import {
 } from '@ironfish/sdk'
 import { BurnDescription } from '@ironfish/sdk/src/primitives/burnDescription'
 import { MintDescription } from '@ironfish/sdk/src/primitives/mintDescription'
-import { CliUx } from '@oclif/core'
+import { ux } from '@oclif/core'
 import { ProgressBar } from '../types'
 import { getAssetsByIDs, getAssetVerificationByIds } from './asset'
 
@@ -61,11 +61,11 @@ export class TransactionTimer {
     this.startTime = performance.now()
 
     if (this.estimateInMs <= 0) {
-      CliUx.ux.action.start('Sending the transaction')
+      ux.action.start('Sending the transaction')
       return
     }
 
-    this.progressBar = CliUx.ux.progress({
+    this.progressBar = ux.progress({
       format: '{title}: [{bar}] {percentage}% | {estimate}',
     }) as ProgressBar
 
@@ -97,7 +97,7 @@ export class TransactionTimer {
     this.endTime = performance.now()
 
     if (!this.progressBar || !this.timer || this.estimateInMs <= 0) {
-      CliUx.ux.action.stop()
+      ux.action.stop()
       return
     }
 
@@ -498,9 +498,9 @@ export async function watchTransaction(options: {
 
   logger.log(`Watching transaction ${options.hash}`)
 
-  CliUx.ux.action.start(`Current Status`)
+  ux.action.start(`Current Status`)
   const span = TimeUtils.renderSpan(0, { hideMilliseconds: true })
-  CliUx.ux.action.status = `${currentStatus} ${span}`
+  ux.action.status = `${currentStatus} ${span}`
 
   // eslint-disable-next-line no-constant-condition
   while (true) {
@@ -513,14 +513,14 @@ export async function watchTransaction(options: {
     currentStatus = response?.content.transaction?.status ?? 'not found'
 
     if (prevStatus !== 'not found' && currentStatus === 'not found') {
-      CliUx.ux.action.stop(`Transaction ${options.hash} deleted while watching it.`)
+      ux.action.stop(`Transaction ${options.hash} deleted while watching it.`)
       break
     }
 
     if (currentStatus === prevStatus) {
       const duration = Date.now() - lastTime
       const span = TimeUtils.renderSpan(duration, { hideMilliseconds: true })
-      CliUx.ux.action.status = `${currentStatus} ${span}`
+      ux.action.status = `${currentStatus} ${span}`
       await PromiseUtils.sleep(pollFrequencyMs)
       continue
     }
@@ -530,7 +530,7 @@ export async function watchTransaction(options: {
     const duration = now - lastTime
     lastTime = now
 
-    CliUx.ux.action.stop(
+    ux.action.stop(
       `${prevStatus} -> ${currentStatus}: ${TimeUtils.renderSpan(duration, {
         hideMilliseconds: true,
       })}`,
@@ -539,14 +539,14 @@ export async function watchTransaction(options: {
     last = response
     prevStatus = currentStatus
 
-    CliUx.ux.action.start(`Current Status`)
+    ux.action.start(`Current Status`)
     const span = TimeUtils.renderSpan(0, { hideMilliseconds: true })
-    CliUx.ux.action.status = `${currentStatus} ${span}`
+    ux.action.status = `${currentStatus} ${span}`
 
     if (currentStatus !== 'not found' && waitUntil.includes(currentStatus)) {
       const duration = now - startTime
       const span = TimeUtils.renderSpan(duration, { hideMilliseconds: true })
-      CliUx.ux.action.stop(`done after ${span}`)
+      ux.action.stop(`done after ${span}`)
       break
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1899,22 +1899,20 @@
     supports-color "^8.1.1"
     tslib "^2"
 
-"@oclif/core@1.26.0":
-  version "1.26.0"
-  resolved "https://registry.yarnpkg.com/@oclif/core/-/core-1.26.0.tgz#35f2e913e2d533d5384b88e5cdb02dc8158ebfd9"
-  integrity sha512-VzvxKsFOLSlmAPloeLAQHGbOe3o2eP+/T7czf5WsBS69GrsIMYHSNnOXbYoKozbpkFUX9xe1Moc2j2g3s9OmWw==
+"@oclif/core@2.16.0":
+  version "2.16.0"
+  resolved "https://registry.yarnpkg.com/@oclif/core/-/core-2.16.0.tgz#e6f3c6c359d4313a15403d8652bbdd0e99ce4b3a"
+  integrity sha512-dL6atBH0zCZl1A1IXCKJgLPrM/wR7K+Wi401E/IvqsK8m2iCHW+0TEOGrans/cuN3oTW+uxIyJFHJ8Im0k4qBw==
   dependencies:
-    "@oclif/linewrap" "^1.0.0"
-    "@oclif/screen" "^3.0.4"
+    "@types/cli-progress" "^3.11.0"
     ansi-escapes "^4.3.2"
     ansi-styles "^4.3.0"
     cardinal "^2.1.1"
     chalk "^4.1.2"
     clean-stack "^3.0.1"
-    cli-progress "^3.10.0"
+    cli-progress "^3.12.0"
     debug "^4.3.4"
-    ejs "^3.1.6"
-    fs-extra "^9.1.0"
+    ejs "^3.1.8"
     get-package-type "^0.1.0"
     globby "^11.1.0"
     hyperlinker "^1.0.0"
@@ -1924,13 +1922,15 @@
     natural-orderby "^2.0.3"
     object-treeify "^1.1.33"
     password-prompt "^1.1.2"
-    semver "^7.3.7"
+    slice-ansi "^4.0.0"
     string-width "^4.2.3"
     strip-ansi "^6.0.1"
     supports-color "^8.1.1"
     supports-hyperlinks "^2.2.0"
-    tslib "^2.4.1"
+    ts-node "^10.9.1"
+    tslib "^2.5.0"
     widest-line "^3.1.0"
+    wordwrap "^1.0.0"
     wrap-ansi "^7.0.0"
 
 "@oclif/core@^1.0.8", "@oclif/core@^1.2.1", "@oclif/core@^1.3.0", "@oclif/core@^1.3.6":
@@ -3374,6 +3374,11 @@ assertion-error@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
   integrity sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==
+
+astral-regex@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
+  integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
 
 async@^3.2.3:
   version "3.2.4"
@@ -9210,6 +9215,15 @@ slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
+
+slice-ansi@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-4.0.0.tgz#500e8dd0fd55b05815086255b3195adf2a45fe6b"
+  integrity sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==
+  dependencies:
+    ansi-styles "^4.0.0"
+    astral-regex "^2.0.0"
+    is-fullwidth-code-point "^3.0.0"
 
 smart-buffer@^4.1.0, smart-buffer@^4.2.0:
   version "4.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1899,13 +1899,13 @@
     supports-color "^8.1.1"
     tslib "^2"
 
-"@oclif/core@1.23.1":
-  version "1.23.1"
-  resolved "https://registry.yarnpkg.com/@oclif/core/-/core-1.23.1.tgz#bebbbc4e02a4c1a4216d64165f892037f8a1e14a"
-  integrity sha512-nz7wVGesJ1Qg74p1KNKluZpQ3Z042mqdaRlczEI4Xwqj5s9jjdDBCDHNkiGzV4UAKzicVzipNj6qqhyUWKYnaA==
+"@oclif/core@1.26.0":
+  version "1.26.0"
+  resolved "https://registry.yarnpkg.com/@oclif/core/-/core-1.26.0.tgz#35f2e913e2d533d5384b88e5cdb02dc8158ebfd9"
+  integrity sha512-VzvxKsFOLSlmAPloeLAQHGbOe3o2eP+/T7czf5WsBS69GrsIMYHSNnOXbYoKozbpkFUX9xe1Moc2j2g3s9OmWw==
   dependencies:
     "@oclif/linewrap" "^1.0.0"
-    "@oclif/screen" "^3.0.3"
+    "@oclif/screen" "^3.0.4"
     ansi-escapes "^4.3.2"
     ansi-styles "^4.3.0"
     cardinal "^2.1.1"
@@ -2134,11 +2134,6 @@
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@oclif/screen/-/screen-3.0.2.tgz#969054308fe98d130c02844a45cc792199b75670"
   integrity sha512-S/SF/XYJeevwIgHFmVDAFRUvM3m+OjhvCAYMk78ZJQCYCQ5wS7j+LTt1ZEv2jpEEGg2tx/F6TYYWxddNAYHrFQ==
-
-"@oclif/screen@^3.0.3":
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/@oclif/screen/-/screen-3.0.4.tgz#663db0ecaf23f3184e7f01886ed578060e4a7f1c"
-  integrity sha512-IMsTN1dXEXaOSre27j/ywGbBjrzx0FNd1XmuhCWCB9NTPrhWI1Ifbz+YLSEcstfQfocYsrbrIessxXb2oon4lA==
 
 "@oclif/screen@^3.0.4":
   version "3.0.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1899,36 +1899,36 @@
     supports-color "^8.1.1"
     tslib "^2"
 
-"@oclif/core@2.16.0":
-  version "2.16.0"
-  resolved "https://registry.yarnpkg.com/@oclif/core/-/core-2.16.0.tgz#e6f3c6c359d4313a15403d8652bbdd0e99ce4b3a"
-  integrity sha512-dL6atBH0zCZl1A1IXCKJgLPrM/wR7K+Wi401E/IvqsK8m2iCHW+0TEOGrans/cuN3oTW+uxIyJFHJ8Im0k4qBw==
+"@oclif/core@3.27.0":
+  version "3.27.0"
+  resolved "https://registry.yarnpkg.com/@oclif/core/-/core-3.27.0.tgz#a22a4ff4e5811db7a182b1687302237a57802381"
+  integrity sha512-Fg93aNFvXzBq5L7ztVHFP2nYwWU1oTCq48G0TjF/qC1UN36KWa2H5Hsm72kERd5x/sjy2M2Tn4kDEorUlpXOlw==
   dependencies:
-    "@types/cli-progress" "^3.11.0"
+    "@types/cli-progress" "^3.11.5"
     ansi-escapes "^4.3.2"
     ansi-styles "^4.3.0"
     cardinal "^2.1.1"
     chalk "^4.1.2"
     clean-stack "^3.0.1"
     cli-progress "^3.12.0"
-    debug "^4.3.4"
-    ejs "^3.1.8"
+    color "^4.2.3"
+    debug "^4.3.5"
+    ejs "^3.1.10"
     get-package-type "^0.1.0"
     globby "^11.1.0"
     hyperlinker "^1.0.0"
     indent-string "^4.0.0"
     is-wsl "^2.2.0"
     js-yaml "^3.14.1"
+    minimatch "^9.0.4"
     natural-orderby "^2.0.3"
     object-treeify "^1.1.33"
-    password-prompt "^1.1.2"
+    password-prompt "^1.1.3"
     slice-ansi "^4.0.0"
     string-width "^4.2.3"
     strip-ansi "^6.0.1"
     supports-color "^8.1.1"
     supports-hyperlinks "^2.2.0"
-    ts-node "^10.9.1"
-    tslib "^2.5.0"
     widest-line "^3.1.0"
     wordwrap "^1.0.0"
     wrap-ansi "^7.0.0"
@@ -2594,6 +2594,13 @@
   version "3.11.0"
   resolved "https://registry.yarnpkg.com/@types/cli-progress/-/cli-progress-3.11.0.tgz#ec79df99b26757c3d1c7170af8422e0fc95eef7e"
   integrity sha512-XhXhBv1R/q2ahF3BM7qT5HLzJNlIL0wbcGyZVjqOTqAybAnsLisd7gy1UCyIqpL+5Iv6XhlSyzjLCnI2sIdbCg==
+  dependencies:
+    "@types/node" "*"
+
+"@types/cli-progress@^3.11.5":
+  version "3.11.5"
+  resolved "https://registry.yarnpkg.com/@types/cli-progress/-/cli-progress-3.11.5.tgz#9518c745e78557efda057e3f96a5990c717268c3"
+  integrity sha512-D4PbNRbviKyppS5ivBGyFO29POlySLmA2HyUFE4p5QGazAMM3CwkKWcvTl8gvElSuxRh6FPKL8XmidX873ou4g==
   dependencies:
     "@types/node" "*"
 
@@ -4037,15 +4044,31 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
-color-name@~1.1.4:
+color-name@^1.0.0, color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+color-string@^1.9.0:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.9.1.tgz#4467f9146f036f855b764dfb5bf8582bf342c7a4"
+  integrity sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==
+  dependencies:
+    color-name "^1.0.0"
+    simple-swizzle "^0.2.2"
 
 color-support@^1.1.2, color-support@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-support/-/color-support-1.1.3.tgz#93834379a1cc9a0c61f82f52f0d04322251bd5a2"
   integrity sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==
+
+color@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/color/-/color-4.2.3.tgz#d781ecb5e57224ee43ea9627560107c0e0c6463a"
+  integrity sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==
+  dependencies:
+    color-convert "^2.0.1"
+    color-string "^1.9.0"
 
 colors@*, colors@1.4.0:
   version "1.4.0"
@@ -4355,6 +4378,13 @@ debug@^4.3.4:
   dependencies:
     ms "2.1.2"
 
+debug@^4.3.5:
+  version "4.3.5"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.5.tgz#e83444eceb9fedd4a1da56d671ae2446a01a6e1e"
+  integrity sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==
+  dependencies:
+    ms "2.1.2"
+
 debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
@@ -4566,7 +4596,7 @@ duplexer@^0.1.1, duplexer@~0.1.1:
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.2.tgz#3abe43aef3835f8ae077d136ddce0f276b0400e6"
   integrity sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==
 
-ejs@^3.1.6, ejs@^3.1.7, ejs@^3.1.8:
+ejs@^3.1.10, ejs@^3.1.6, ejs@^3.1.7, ejs@^3.1.8:
   version "3.1.8"
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-3.1.8.tgz#758d32910c78047585c7ef1f92f9ee041c1c190b"
   integrity sha512-/sXZeMlhS0ArkfX2Aw780gJzXSMPnKjtspYZv+f3NiKLlubezAHDU5+9xz6gd3/NhG3txQCo6xlglmTS+oTGEQ==
@@ -6038,6 +6068,11 @@ is-arrayish@^0.2.1:
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=
 
+is-arrayish@^0.3.1:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.3.2.tgz#4574a2ae56f7ab206896fb431eaeed066fdf8f03"
+  integrity sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==
+
 is-bigint@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/is-bigint/-/is-bigint-1.0.4.tgz#08147a1875bc2b32005d41ccd8291dffc6691df3"
@@ -7478,6 +7513,13 @@ minimatch@^5.0.1:
   dependencies:
     brace-expansion "^2.0.1"
 
+minimatch@^9.0.4:
+  version "9.0.4"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.4.tgz#8e49c731d1749cbec05050ee5145147b32496a51"
+  integrity sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==
+  dependencies:
+    brace-expansion "^2.0.1"
+
 minimist-options@4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/minimist-options/-/minimist-options-4.1.0.tgz#c0655713c53a8a2ebd77ffa247d342c40f010619"
@@ -8422,6 +8464,14 @@ password-prompt@^1.1.2:
     ansi-escapes "^3.1.0"
     cross-spawn "^6.0.5"
 
+password-prompt@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/password-prompt/-/password-prompt-1.1.3.tgz#05e539f4e7ca4d6c865d479313f10eb9db63ee5f"
+  integrity sha512-HkrjG2aJlvF0t2BMH0e2LB/EHf3Lcq3fNMzy4GYHcQblAvOl+QQji1Lx7WRBMqpVK8p+KR7bCg7oqAMXtdgqyw==
+  dependencies:
+    ansi-escapes "^4.3.2"
+    cross-spawn "^7.0.3"
+
 path-exists@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
@@ -9205,6 +9255,13 @@ simple-get@^4.0.0:
     decompress-response "^6.0.0"
     once "^1.3.1"
     simple-concat "^1.0.0"
+
+simple-swizzle@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/simple-swizzle/-/simple-swizzle-0.2.2.tgz#a4da6b635ffcccca33f70d17cb92592de95e557a"
+  integrity sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==
+  dependencies:
+    is-arrayish "^0.3.1"
 
 sisteransi@^1.0.5:
   version "1.0.5"


### PR DESCRIPTION
## Summary

Upgrades `@oclif/core` from 1.23.1 to 3.27.0. The latest version is 4.0.3, however the transition to 4.0 is going to be very substantial, and will basically require us to build our own CLI UX library so I am going to do this piece first.

There is a good amount of cleanup that can be done now also, but I wanted to keep this PR relatively small, and can followup with more cleanup PRs.

The biggest win here is the typed args. We can treat them like Flags now, which means we can make them more usable, more re-usable, and with better type safety.

## Testing Plan

Manual 💀 

## Documentation

N/A

## Breaking Change

N/A