### PR TITLE
update parsing of chainport status API to new interface

### DIFF
--- a/ironfish-cli/src/utils/chainport/types.ts
+++ b/ironfish-cli/src/utils/chainport/types.ts
@@ -52,15 +52,17 @@ export type ChainportVerifiedToken = {
   is_lifi: boolean
 }
 
-export type ChainportTransactionStatus = {
-  base_network_id?: number
-  base_tx_hash?: string
-  base_tx_status?: number
-  base_token_address?: string
-  target_network_id?: number
-  target_tx_hash?: string
-  target_tx_status?: number
-  target_token_address?: string
-  created_at?: string
-  port_in_ack?: boolean
-}
+export type ChainportTransactionStatus =
+  | Record<string, never> // empty object
+  | {
+      base_network_id: number | null
+      base_tx_hash: string | null
+      base_tx_status: number | null
+      base_token_address: string | null
+      target_network_id: number | null
+      target_tx_hash: string | null
+      target_tx_status: number | null
+      target_token_address: string | null
+      created_at: string | null
+      port_in_ack: boolean | null
+    }

--- a/ironfish-cli/src/utils/chainport/utils.ts
+++ b/ironfish-cli/src/utils/chainport/utils.ts
@@ -152,11 +152,10 @@ Target Network:               ${network.name}
   logger.log(basicInfo)
 
   if (Object.keys(transactionStatus).length === 0) {
-    logger.log(
-      `Transaction status not found on target network.
+    logger.log(`
+Transaction status not found on target network.
 Note: Bridge transactions may take up to 30 minutes to surface on the target network.
-If this issue persists, please contact chainport support: https://helpdesk.chainport.io/`,
-    )
+If this issue persists, please contact chainport support: https://helpdesk.chainport.io/`)
     return
   }
 

--- a/ironfish-cli/src/utils/chainport/utils.ts
+++ b/ironfish-cli/src/utils/chainport/utils.ts
@@ -138,7 +138,7 @@ Target Network:               ${network.name}
        Address:               ${data.address}
        Explorer Account:      ${network.explorer_url + 'address/' + data.address}`
 
-  // We'll wait to show the transaction status if the transaction is still pending
+  // We'll wait to show the transaction status if the transaction is still pending on Ironfish
   if (transaction.status !== TransactionStatus.CONFIRMED) {
     logger.log(basicInfo)
     return
@@ -151,10 +151,12 @@ Target Network:               ${network.name}
 
   logger.log(basicInfo)
 
-  const errorMessage = `\nTransaction status not found on target network. \nNote: Bridge transactions may take up to 30 minutes to surface on the target network. \nIf this issue persists, please contact chainport support: https://helpdesk.chainport.io/`
-
   if (Object.keys(transactionStatus).length === 0) {
-    logger.log(errorMessage)
+    logger.log(
+      `Transaction status not found on target network.
+Note: Bridge transactions may take up to 30 minutes to surface on the target network.
+If this issue persists, please contact chainport support: https://helpdesk.chainport.io/`,
+    )
     return
   }
 
@@ -163,33 +165,19 @@ Target Network:               ${network.name}
     return
   }
 
-  // If the source bridge transaction has reached the minimum confirmation threshold,
-  // but the target bridge transaction hasn't been sent yet -> base_tx_hash is set and
-  // base_tx_status is 1, but target_tx_hash and target_tx_status are null
   if (transactionStatus.target_tx_hash === null) {
     logger.log(`       Transaction Status:    in progress`)
     return
   }
 
-  // If the target bridge transaction was sent, transaction.status
+  if (transactionStatus.target_tx_status === 1) {
+    logger.log(`       Transaction Status:    completed`)
+  } else {
+    logger.log(`       Transaction Status:    in progress`)
+  }
 
-  if (transactionStatus.target_tx_hash) {
-    // When the port is confirmed to be complete on the target chain target_tx_status is 1
-    if (transactionStatus.target_tx_status === 1) {
-      logger.log(`       Transaction Status:    completed`)
-    }
-    // if the port is still in progress target_tx_status is null
-    else {
-      logger.log(`       Transaction Status:    in progress`)
-    }
-
-    logger.log(`       Transaction Hash:      ${transactionStatus.target_tx_hash}
+  logger.log(`       Transaction Hash:      ${transactionStatus.target_tx_hash}
        Explorer Transaction:  ${
          network.explorer_url + 'tx/' + transactionStatus.target_tx_hash
        }`)
-
-    return
-  }
-
-  logger.error(errorMessage)
 }

--- a/ironfish-cli/src/utils/chainport/utils.ts
+++ b/ironfish-cli/src/utils/chainport/utils.ts
@@ -6,6 +6,7 @@ import {
   defaultNetworkName,
   Logger,
   RpcWalletTransaction,
+  TransactionStatus,
   TransactionType,
 } from '@ironfish/sdk'
 import { ux } from '@oclif/core'
@@ -95,7 +96,7 @@ const isAddressInSet = (address: string, addressSet: Set<string>): boolean => {
 
 export const displayChainportTransactionSummary = async (
   networkId: number,
-  hash: string,
+  transaction: RpcWalletTransaction,
   data: ChainportTransactionData,
   network: ChainportNetwork | undefined,
   logger: Logger,
@@ -113,38 +114,82 @@ export const displayChainportTransactionSummary = async (
     return
   }
 
+  // Chainport does not give us a way to determine the source transaction hash of an incoming bridge transaction
+  // So we can only display the source network and address
   if (data.type === TransactionType.RECEIVE) {
     logger.log(`
 Direction:                    Incoming
 Source Network:               ${network.name}
-Source Address:               ${data.address}
-Source Explorer Account:      ${network.explorer_url + 'address/' + data.address}
+       Address:               ${data.address}
+       Explorer Account:      ${network.explorer_url + 'address/' + data.address}
 Target (Ironfish) Network:    ${defaultNetworkName(networkId)}`)
 
     return
   }
 
-  ux.action.start('Fetching transaction information on target network')
-  const transactionStatus = await fetchChainportTransactionStatus(networkId, hash)
-  ux.action.stop()
+  const basicInfo = `
+Direction:                    Outgoing
+==============================================
+Source Network:               ${defaultNetworkName(networkId)}
+       Transaction Status:    ${transaction.status}
+       Transaction Hash:      ${transaction.hash}
+==============================================
+Target Network:               ${network.name}
+       Address:               ${data.address}
+       Explorer Account:      ${network.explorer_url + 'address/' + data.address}`
 
-  if (Object.keys(transactionStatus).length === 0 || !transactionStatus.target_network_id) {
-    logger.log(
-      `Transaction status not found on target network.
-Note: Bridge transactions may take up to 30 minutes to surface on the target network.
-If this issue persists, please contact chainport support: https://helpdesk.chainport.io/`,
-    )
+  // We'll wait to show the transaction status if the transaction is still pending
+  if (transaction.status !== TransactionStatus.CONFIRMED) {
+    logger.log(basicInfo)
     return
   }
 
-  logger.log(`
-Direction:                    Outgoing
-Source Network:               ${defaultNetworkName(networkId)}
-Source Transaction Hash:      ${hash}
-Target Network:               ${network.name}
-Target Address:               ${data.address}
-Target Transaction Hash:      ${transactionStatus.target_tx_hash}
-Target Explorer Transaction:  ${
-    network.explorer_url + 'tx/' + transactionStatus.target_tx_hash
-  }`)
+  ux.action.start('Fetching transaction information on target network')
+  const transactionStatus = await fetchChainportTransactionStatus(networkId, transaction.hash)
+  logger.log(`Transaction status fetched`)
+  ux.action.stop()
+
+  logger.log(basicInfo)
+
+  const errorMessage = `\nTransaction status not found on target network. \nNote: Bridge transactions may take up to 30 minutes to surface on the target network. \nIf this issue persists, please contact chainport support: https://helpdesk.chainport.io/`
+
+  if (Object.keys(transactionStatus).length === 0) {
+    logger.log(errorMessage)
+    return
+  }
+
+  if (!transactionStatus.base_tx_hash || !transactionStatus.base_tx_status) {
+    logger.log(`       Transaction Status:    in progress`)
+    return
+  }
+
+  // If the source bridge transaction has reached the minimum confirmation threshold,
+  // but the target bridge transaction hasn't been sent yet -> base_tx_hash is set and
+  // base_tx_status is 1, but target_tx_hash and target_tx_status are null
+  if (transactionStatus.target_tx_hash === null) {
+    logger.log(`       Transaction Status:    in progress`)
+    return
+  }
+
+  // If the target bridge transaction was sent, transaction.status
+
+  if (transactionStatus.target_tx_hash) {
+    // When the port is confirmed to be complete on the target chain target_tx_status is 1
+    if (transactionStatus.target_tx_status === 1) {
+      logger.log(`       Transaction Status:    completed`)
+    }
+    // if the port is still in progress target_tx_status is null
+    else {
+      logger.log(`       Transaction Status:    in progress`)
+    }
+
+    logger.log(`       Transaction Hash:      ${transactionStatus.target_tx_hash}
+       Explorer Transaction:  ${
+         network.explorer_url + 'tx/' + transactionStatus.target_tx_hash
+       }`)
+
+    return
+  }
+
+  logger.error(errorMessage)
 }

--- a/ironfish-cli/src/utils/chainport/utils.ts
+++ b/ironfish-cli/src/utils/chainport/utils.ts
@@ -161,12 +161,12 @@ If this issue persists, please contact chainport support: https://helpdesk.chain
   }
 
   if (!transactionStatus.base_tx_hash || !transactionStatus.base_tx_status) {
-    logger.log(`       Transaction Status:    in progress`)
+    logger.log(`       Transaction Status:    pending`)
     return
   }
 
   if (transactionStatus.target_tx_hash === null) {
-    logger.log(`       Transaction Status:    in progress`)
+    logger.log(`       Transaction Status:    pending`)
     return
   }
 


### PR DESCRIPTION
## Summary

Chainport just sent us some new information about how to use the transaction status API. These changes reflect the new interaction. 

There is also a difference in types. Chainport either sends us an empty object or a body with all keys that either have a type of string or null. 

Examples below: 

Pending transaction: 

![image](https://github.com/iron-fish/ironfish/assets/13268167/17b7d1ee-abe2-4de3-ab39-6eaef370e480)

Confirmed transaction: 

![image](https://github.com/iron-fish/ironfish/assets/13268167/35b6ce49-2a29-43d3-bafd-f3c41a79de8f)

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
