### PR TITLE
Remove unnecessary trims from CLI commands

### DIFF
--- a/ironfish-cli/src/args.ts
+++ b/ironfish-cli/src/args.ts
@@ -12,7 +12,7 @@ type Url = {
 }
 
 export function parseUrl(input: string): Promise<Url> {
-  const parsed = parseUrlSdk(input.trim())
+  const parsed = parseUrlSdk(input)
   if (parsed.hostname != null) {
     return Promise.resolve(parsed as Url)
   } else {

--- a/ironfish-cli/src/commands/blocks/show.ts
+++ b/ironfish-cli/src/commands/blocks/show.ts
@@ -10,7 +10,6 @@ export default class ShowBlock extends IronfishCommand {
 
   static args = {
     search: Args.string({
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: true,
       description: 'The hash or sequence of the block to look at',
     }),

--- a/ironfish-cli/src/commands/chain/asset.ts
+++ b/ironfish-cli/src/commands/chain/asset.ts
@@ -11,7 +11,6 @@ export default class Asset extends IronfishCommand {
 
   static args = {
     id: Args.string({
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: true,
       description: 'The identifier of the asset',
     }),

--- a/ironfish-cli/src/commands/chain/benchmark.ts
+++ b/ironfish-cli/src/commands/chain/benchmark.ts
@@ -20,7 +20,6 @@ export default class Benchmark extends IronfishCommand {
     ...LocalFlags,
     targetdir: Flags.string({
       char: 't',
-      parse: (input: string) => Promise.resolve(input.trim()),
       required: false,
       description: 'Path to the temporary directory to use to test',
     }),

--- a/ironfish-cli/src/commands/chain/download.ts
+++ b/ironfish-cli/src/commands/chain/download.ts
@@ -18,18 +18,15 @@ export default class Download extends IronfishCommand {
     ...LocalFlags,
     manifestUrl: Flags.string({
       char: 'm',
-      parse: (input: string) => Promise.resolve(input.trim()),
       description: 'Manifest url to download snapshot from',
     }),
     path: Flags.string({
       char: 'p',
-      parse: (input: string) => Promise.resolve(input.trim()),
       required: false,
       description: 'Path to a downloaded snapshot file to import',
     }),
     output: Flags.string({
       char: 'o',
-      parse: (input: string) => Promise.resolve(input.trim()),
       required: false,
       description: 'Output folder to download the snapshot file to',
     }),

--- a/ironfish-cli/src/commands/chain/export.ts
+++ b/ironfish-cli/src/commands/chain/export.ts
@@ -15,7 +15,6 @@ export default class Export extends IronfishCommand {
     ...RemoteFlags,
     path: Flags.string({
       char: 'p',
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: false,
       description: 'The path to export the chain to',
     }),

--- a/ironfish-cli/src/commands/chain/readd-block.ts
+++ b/ironfish-cli/src/commands/chain/readd-block.ts
@@ -17,7 +17,6 @@ export default class ReAddBlock extends IronfishCommand {
 
   static args = {
     hash: Args.string({
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: true,
       description: 'The hash of the block in hex format',
     }),

--- a/ironfish-cli/src/commands/chain/rewind.ts
+++ b/ironfish-cli/src/commands/chain/rewind.ts
@@ -21,12 +21,10 @@ export default class Rewind extends IronfishCommand {
 
   static args = {
     to: Args.string({
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: true,
       description: 'The block sequence to rewind to',
     }),
     from: Args.string({
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: false,
       description: 'The sequence to start removing blocks from',
     }),

--- a/ironfish-cli/src/commands/config/get.ts
+++ b/ironfish-cli/src/commands/config/get.ts
@@ -12,7 +12,6 @@ export class GetCommand extends IronfishCommand {
 
   static args = {
     name: Args.string({
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: true,
       description: 'Name of the config item',
     }),
@@ -41,7 +40,7 @@ export class GetCommand extends IronfishCommand {
 
   async start(): Promise<void> {
     const { args, flags } = await this.parse(GetCommand)
-    const name = args.name.trim()
+    const name = args.name
 
     const client = await this.sdk.connectRpc(flags.local)
 

--- a/ironfish-cli/src/commands/config/set.ts
+++ b/ironfish-cli/src/commands/config/set.ts
@@ -10,12 +10,10 @@ export class SetCommand extends IronfishCommand {
 
   static args = {
     name: Args.string({
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: true,
       description: 'Name of the config item',
     }),
     value: Args.string({
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: true,
       description: 'Value of the config item',
     }),

--- a/ironfish-cli/src/commands/config/unset.ts
+++ b/ironfish-cli/src/commands/config/unset.ts
@@ -10,7 +10,6 @@ export class UnsetCommand extends IronfishCommand {
 
   static args = {
     name: Args.string({
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: true,
       description: 'Name of the config item',
     }),

--- a/ironfish-cli/src/commands/peers/show.ts
+++ b/ironfish-cli/src/commands/peers/show.ts
@@ -26,9 +26,7 @@ export class ShowCommand extends IronfishCommand {
 
   async start(): Promise<void> {
     const { args } = await this.parse(ShowCommand)
-
-    // TODO(mat): Move trim into parse function like the others
-    const identity = args.identity.trim()
+    const identity = args.identity
 
     await this.sdk.client.connect()
     const [peer, messages] = await Promise.all([

--- a/ironfish-cli/src/commands/rpc/token.ts
+++ b/ironfish-cli/src/commands/rpc/token.ts
@@ -11,7 +11,6 @@ export default class Token extends IronfishCommand {
   static flags = {
     ...LocalFlags,
     token: Flags.string({
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: false,
       description: 'Set the RPC auth token to <value>',
     }),

--- a/ironfish-cli/src/commands/wallet/chainport/send.ts
+++ b/ironfish-cli/src/commands/wallet/chainport/send.ts
@@ -153,8 +153,8 @@ export class BridgeCommand extends IronfishCommand {
   private async getAndValidateInputs(client: RpcClient, networkId: number) {
     const { flags } = await this.parse(BridgeCommand)
 
-    let from = flags.account?.trim()
-    let to = flags.to?.trim()
+    let from = flags.account
+    let to = flags.to
     let assetId = flags.assetId
 
     if (!from) {

--- a/ironfish-cli/src/commands/wallet/delete.ts
+++ b/ironfish-cli/src/commands/wallet/delete.ts
@@ -11,7 +11,6 @@ export class DeleteCommand extends IronfishCommand {
 
   static args = {
     account: Args.string({
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: true,
       description: 'Name of the account',
     }),

--- a/ironfish-cli/src/commands/wallet/import.ts
+++ b/ironfish-cli/src/commands/wallet/import.ts
@@ -27,7 +27,6 @@ export class ImportCommand extends IronfishCommand {
 
   static args = {
     blob: Args.string({
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: false,
       description: 'The copy-pasted output of wallet:export; or, a raw spending key',
     }),

--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -288,8 +288,7 @@ export class CombineNotesCommand extends IronfishCommand {
     const totalAmount = notes.reduce((acc, note) => acc + BigInt(note.value), 0n)
 
     const memo =
-      flags.memo?.trim() ??
-      (await ux.prompt('Enter the memo (or leave blank)', { required: false }))
+      flags.memo ?? (await ux.prompt('Enter the memo (or leave blank)', { required: false }))
 
     const expiration = await this.calculateExpiration(client, spendPostTime, numberOfNotes)
 

--- a/ironfish-cli/src/commands/wallet/send.ts
+++ b/ironfish-cli/src/commands/wallet/send.ts
@@ -116,8 +116,8 @@ export class Send extends IronfishCommand {
   async start(): Promise<void> {
     const { flags } = await this.parse(Send)
     let assetId = flags.assetId
-    let to = flags.to?.trim()
-    let from = flags.account?.trim()
+    let to = flags.to
+    let from = flags.account
 
     const client = await this.sdk.connectRpc()
 
@@ -206,8 +206,7 @@ export class Send extends IronfishCommand {
     }
 
     const memo =
-      flags.memo?.trim() ??
-      (await ux.prompt('Enter the memo (or leave blank)', { required: false }))
+      flags.memo ?? (await ux.prompt('Enter the memo (or leave blank)', { required: false }))
 
     if (!isValidPublicAddress(to)) {
       this.log(`A valid public address is required`)

--- a/ironfish-cli/src/commands/wallet/transaction/import.ts
+++ b/ironfish-cli/src/commands/wallet/transaction/import.ts
@@ -26,7 +26,6 @@ export class TransactionImportCommand extends IronfishCommand {
   static args = {
     transaction: Args.string({
       required: false,
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       description: 'The transaction in hex encoding',
     }),
   }

--- a/ironfish-cli/src/commands/wallet/transaction/index.ts
+++ b/ironfish-cli/src/commands/wallet/transaction/index.ts
@@ -33,7 +33,6 @@ export class TransactionCommand extends IronfishCommand {
 
   static args = {
     hash: Args.string({
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: true,
       description: 'Hash of the transaction',
     }),

--- a/ironfish-cli/src/commands/wallet/transaction/watch.ts
+++ b/ironfish-cli/src/commands/wallet/transaction/watch.ts
@@ -23,7 +23,6 @@ export class WatchTxCommand extends IronfishCommand {
 
   static args = {
     hash: Args.string({
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: true,
       description: 'Hash of the transaction',
     }),


### PR DESCRIPTION
## Summary

oclif already trims by default. By adding these trims, we're overriding the behavior of oclif and closing unintentional escape hatches for cases where a leading/trailing space might be intended when wrapping the arg or flag in quotation marks.

There are a few more places where `trim` is being used in the CLI commands, but they are generally being used as part of more complex split functions, or are deep enough down the call stack that I didn't want to potentially cause issues for now.

## Testing Plan

## Documentation

N/A

## Breaking Change

N/A