### PR TITLE
Removes the ability to import/export AccountImport

### DIFF
--- a/ironfish-cli/src/commands/wallet/export.ts
+++ b/ironfish-cli/src/commands/wallet/export.ts
@@ -74,7 +74,7 @@ export class ExportCommand extends IronfishCommand {
       language: flags.language,
     })
 
-    let output = response.content.account as string
+    let output = response.content.account
     if (color && flags.json && !exportPath) {
       output = jsonColorizer(output)
     }

--- a/ironfish-cli/src/commands/wallet/multisig/dealer/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dealer/create.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { ACCOUNT_SCHEMA_VERSION, RpcClient } from '@ironfish/sdk'
+import { AccountImport } from '@ironfish/sdk/src/wallet/exporter'
 import { Flags, ux } from '@oclif/core'
 import { IronfishCommand } from '../../../../command'
 import { RemoteFlags } from '../../../../flags'
@@ -83,24 +84,26 @@ export class MultisigCreateDealer extends IronfishCommand {
       this.log()
       ux.action.start('Importing the coordinator as a view-only account')
 
-      await client.wallet.importAccount({
-        account: {
-          name,
-          version: ACCOUNT_SCHEMA_VERSION,
-          createdAt: {
-            hash: createdAt.hash.toString('hex'),
-            sequence: createdAt.sequence,
-          },
-          spendingKey: null,
-          viewKey: response.content.viewKey,
-          incomingViewKey: response.content.incomingViewKey,
-          outgoingViewKey: response.content.outgoingViewKey,
-          publicAddress: response.content.publicAddress,
-          proofAuthorizingKey: response.content.proofAuthorizingKey,
-          multisigKeys: {
-            publicKeyPackage: response.content.publicKeyPackage,
-          },
+      const account: AccountImport = {
+        name,
+        version: ACCOUNT_SCHEMA_VERSION,
+        createdAt: {
+          hash: createdAt.hash,
+          sequence: createdAt.sequence,
         },
+        spendingKey: null,
+        viewKey: response.content.viewKey,
+        incomingViewKey: response.content.incomingViewKey,
+        outgoingViewKey: response.content.outgoingViewKey,
+        publicAddress: response.content.publicAddress,
+        proofAuthorizingKey: response.content.proofAuthorizingKey,
+        multisigKeys: {
+          publicKeyPackage: response.content.publicKeyPackage,
+        },
+      }
+
+      await client.wallet.importAccount({
+        account: JSON.stringify(account),
       })
 
       ux.action.stop()

--- a/ironfish/src/rpc/routes/wallet/exportAccount.test.ts
+++ b/ironfish/src/rpc/routes/wallet/exportAccount.test.ts
@@ -22,42 +22,33 @@ describe('Route wallet/exportAccount', () => {
   })
 
   it('should export a default account', async () => {
+    await routeTest.wallet.setDefaultAccount(account.name)
+
     const response = await routeTest.client.wallet.exportAccount({
-      account: account.name,
       viewOnly: false,
+      format: AccountFormat.SpendingKey,
     })
 
     expect(response.status).toBe(200)
-    expect(response.content).toMatchObject({
-      account: {
-        name: account.name,
-        spendingKey: account.spendingKey,
-        viewKey: account.viewKey,
-        incomingViewKey: account.incomingViewKey,
-        outgoingViewKey: account.outgoingViewKey,
-        publicAddress: account.publicAddress,
-        version: account.version,
-      },
-    })
+    expect(response.content.account).toEqual(new SpendingKeyEncoder().encode(account))
   })
 
   it('should omit spending key when view only account is requested', async () => {
     const response = await routeTest.client.wallet.exportAccount({
       account: account.name,
       viewOnly: true,
+      format: AccountFormat.JSON,
     })
 
     expect(response.status).toBe(200)
-    expect(response.content).toMatchObject({
-      account: {
-        name: account.name,
-        spendingKey: null,
-        viewKey: account.viewKey,
-        incomingViewKey: account.incomingViewKey,
-        outgoingViewKey: account.outgoingViewKey,
-        publicAddress: account.publicAddress,
-        version: account.version,
-      },
+    expect(JSON.parse(response.content.account)).toMatchObject({
+      name: account.name,
+      spendingKey: null,
+      viewKey: account.viewKey,
+      incomingViewKey: account.incomingViewKey,
+      outgoingViewKey: account.outgoingViewKey,
+      publicAddress: account.publicAddress,
+      version: account.version,
     })
   })
 
@@ -162,21 +153,20 @@ describe('Route wallet/exportAccount', () => {
     const response = await routeTest.client.wallet.exportAccount({
       account: accountNames[0],
       viewOnly: false,
+      format: AccountFormat.JSON,
     })
 
     expect(response.status).toBe(200)
-    expect(response.content).toMatchObject({
-      account: {
-        name: accountNames[0],
-        spendingKey: null,
-        viewKey: trustedDealerPackage.viewKey,
-        incomingViewKey: trustedDealerPackage.incomingViewKey,
-        outgoingViewKey: trustedDealerPackage.outgoingViewKey,
-        publicAddress: trustedDealerPackage.publicAddress,
-        multisigKeys: {
-          secret: multisigSecret.secret.toString('hex'),
-          publicKeyPackage: trustedDealerPackage.publicKeyPackage,
-        },
+    expect(JSON.parse(response.content.account)).toMatchObject({
+      name: accountNames[0],
+      spendingKey: null,
+      viewKey: trustedDealerPackage.viewKey,
+      incomingViewKey: trustedDealerPackage.incomingViewKey,
+      outgoingViewKey: trustedDealerPackage.outgoingViewKey,
+      publicAddress: trustedDealerPackage.publicAddress,
+      multisigKeys: {
+        secret: multisigSecret.secret.toString('hex'),
+        publicKeyPackage: trustedDealerPackage.publicKeyPackage,
       },
     })
   })
@@ -221,20 +211,19 @@ describe('Route wallet/exportAccount', () => {
     const response = await routeTest.client.wallet.exportAccount({
       account: accountNames[0],
       viewOnly: false,
+      format: AccountFormat.JSON,
     })
 
     expect(response.status).toBe(200)
-    expect(response.content).toMatchObject({
-      account: {
-        name: accountNames[0],
-        spendingKey: null,
-        viewKey: trustedDealerPackage.viewKey,
-        incomingViewKey: trustedDealerPackage.incomingViewKey,
-        outgoingViewKey: trustedDealerPackage.outgoingViewKey,
-        publicAddress: trustedDealerPackage.publicAddress,
-        multisigKeys: {
-          publicKeyPackage: trustedDealerPackage.publicKeyPackage,
-        },
+    expect(JSON.parse(response.content.account)).toMatchObject({
+      name: accountNames[0],
+      spendingKey: null,
+      viewKey: trustedDealerPackage.viewKey,
+      incomingViewKey: trustedDealerPackage.incomingViewKey,
+      outgoingViewKey: trustedDealerPackage.outgoingViewKey,
+      publicAddress: trustedDealerPackage.publicAddress,
+      multisigKeys: {
+        publicKeyPackage: trustedDealerPackage.publicKeyPackage,
       },
     })
   })

--- a/ironfish/src/rpc/routes/wallet/importAccount.test.ts
+++ b/ironfish/src/rpc/routes/wallet/importAccount.test.ts
@@ -24,25 +24,26 @@ describe('Route wallet/importAccount', () => {
   it('should import a view only account that has no spending key', async () => {
     const key = generateKey()
 
-    const accountName = 'foo'
+    const account: AccountImport = {
+      name: 'foo',
+      viewKey: key.viewKey,
+      spendingKey: null,
+      publicAddress: key.publicAddress,
+      incomingViewKey: key.incomingViewKey,
+      outgoingViewKey: key.outgoingViewKey,
+      proofAuthorizingKey: null,
+      version: 1,
+      createdAt: null,
+    }
+
     const response = await routeTest.client.wallet.importAccount({
-      account: {
-        name: accountName,
-        viewKey: key.viewKey,
-        spendingKey: null,
-        publicAddress: key.publicAddress,
-        incomingViewKey: key.incomingViewKey,
-        outgoingViewKey: key.outgoingViewKey,
-        proofAuthorizingKey: null,
-        version: 1,
-        createdAt: null,
-      },
+      account: JSON.stringify(account),
       rescan: false,
     })
 
     expect(response.status).toBe(200)
     expect(response.content).toMatchObject({
-      name: accountName,
+      name: 'foo',
       isDefaultAccount: true,
     })
   })
@@ -50,28 +51,29 @@ describe('Route wallet/importAccount', () => {
   it('should import a multisig account that has no spending key', async () => {
     const trustedDealerPackages = createTrustedDealerKeyPackages()
 
-    const accountName = 'multisig'
-    const response = await routeTest.client.wallet.importAccount({
-      account: {
-        version: 1,
-        name: accountName,
-        viewKey: trustedDealerPackages.viewKey,
-        incomingViewKey: trustedDealerPackages.incomingViewKey,
-        outgoingViewKey: trustedDealerPackages.outgoingViewKey,
-        publicAddress: trustedDealerPackages.publicAddress,
-        spendingKey: null,
-        createdAt: null,
-        proofAuthorizingKey: trustedDealerPackages.proofAuthorizingKey,
-        multisigKeys: {
-          publicKeyPackage: trustedDealerPackages.publicKeyPackage,
-        },
+    const account: AccountImport = {
+      version: 1,
+      name: 'multisig',
+      viewKey: trustedDealerPackages.viewKey,
+      incomingViewKey: trustedDealerPackages.incomingViewKey,
+      outgoingViewKey: trustedDealerPackages.outgoingViewKey,
+      publicAddress: trustedDealerPackages.publicAddress,
+      spendingKey: null,
+      createdAt: null,
+      proofAuthorizingKey: trustedDealerPackages.proofAuthorizingKey,
+      multisigKeys: {
+        publicKeyPackage: trustedDealerPackages.publicKeyPackage,
       },
+    }
+
+    const response = await routeTest.client.wallet.importAccount({
+      account: JSON.stringify(account),
       rescan: false,
     })
 
     expect(response.status).toBe(200)
     expect(response.content).toMatchObject({
-      name: accountName,
+      name: 'multisig',
       isDefaultAccount: false,
     })
   })
@@ -81,7 +83,7 @@ describe('Route wallet/importAccount', () => {
 
     const accountName = 'bar'
     const response = await routeTest.client.wallet.importAccount({
-      account: {
+      account: JSON.stringify({
         name: accountName,
         viewKey: key.viewKey,
         spendingKey: key.spendingKey,
@@ -91,7 +93,7 @@ describe('Route wallet/importAccount', () => {
         proofAuthorizingKey: null,
         version: 1,
         createdAt: null,
-      },
+      }),
       rescan: false,
     })
 
@@ -108,7 +110,7 @@ describe('Route wallet/importAccount', () => {
     const accountName = 'bar'
     const overriddenAccountName = 'not-bar'
     const response = await routeTest.client.wallet.importAccount({
-      account: {
+      account: JSON.stringify({
         name: accountName,
         viewKey: key.viewKey,
         spendingKey: key.spendingKey,
@@ -118,7 +120,7 @@ describe('Route wallet/importAccount', () => {
         proofAuthorizingKey: null,
         version: 1,
         createdAt: null,
-      },
+      }),
       name: overriddenAccountName,
       rescan: false,
     })
@@ -151,18 +153,20 @@ describe('Route wallet/importAccount', () => {
       const skipRescanSpy = jest.spyOn(routeTest.node.wallet, 'skipRescan')
 
       const accountName = 'baz'
+      const account: AccountImport = {
+        name: accountName,
+        viewKey: key.viewKey,
+        spendingKey: key.spendingKey,
+        publicAddress: key.publicAddress,
+        incomingViewKey: key.incomingViewKey,
+        outgoingViewKey: key.outgoingViewKey,
+        proofAuthorizingKey: null,
+        version: 1,
+        createdAt: null,
+      }
+
       const response = await routeTest.client.wallet.importAccount({
-        account: {
-          name: accountName,
-          viewKey: key.viewKey,
-          spendingKey: key.spendingKey,
-          publicAddress: key.publicAddress,
-          incomingViewKey: key.incomingViewKey,
-          outgoingViewKey: key.outgoingViewKey,
-          proofAuthorizingKey: null,
-          version: 1,
-          createdAt: null,
-        },
+        account: JSON.stringify(account),
         // set rescan to true so that skipRescan should not be called
         rescan: true,
       })

--- a/ironfish/src/rpc/routes/wallet/multisig/createSigningCommitment.test.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/createSigningCommitment.test.ts
@@ -5,6 +5,7 @@ import { multisig } from '@ironfish/rust-nodejs'
 import { useAccountAndAddFundsFixture, useUnsignedTxFixture } from '../../../../testUtilities'
 import { createRouteTest } from '../../../../testUtilities/routeTest'
 import { ACCOUNT_SCHEMA_VERSION } from '../../../../wallet'
+import { AccountImport } from '../../../../wallet/exporter'
 
 describe('Route wallet/multisig/createSigningCommitment', () => {
   const routeTest = createRouteTest()
@@ -39,22 +40,24 @@ describe('Route wallet/multisig/createSigningCommitment', () => {
       await routeTest.client.wallet.multisig.createTrustedDealerKeyPackage(request)
     ).content
 
+    const account: AccountImport = {
+      name: 'td',
+      version: ACCOUNT_SCHEMA_VERSION,
+      viewKey: trustedDealerPackage.viewKey,
+      incomingViewKey: trustedDealerPackage.incomingViewKey,
+      outgoingViewKey: trustedDealerPackage.outgoingViewKey,
+      publicAddress: trustedDealerPackage.publicAddress,
+      spendingKey: null,
+      createdAt: null,
+      multisigKeys: {
+        publicKeyPackage: trustedDealerPackage.publicKeyPackage,
+      },
+      proofAuthorizingKey: null,
+    }
+
     const importAccountRequest = {
       name: 'td',
-      account: {
-        name: 'td',
-        version: ACCOUNT_SCHEMA_VERSION,
-        viewKey: trustedDealerPackage.viewKey,
-        incomingViewKey: trustedDealerPackage.incomingViewKey,
-        outgoingViewKey: trustedDealerPackage.outgoingViewKey,
-        publicAddress: trustedDealerPackage.publicAddress,
-        spendingKey: null,
-        createdAt: null,
-        multisigKeys: {
-          publicKeyPackage: trustedDealerPackage.publicKeyPackage,
-        },
-        proofAuthorizingKey: null,
-      },
+      account: JSON.stringify(account),
     }
 
     const importAccountResponse = await routeTest.client.wallet.importAccount(

--- a/ironfish/src/rpc/routes/wallet/multisig/integration.test.slow.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/integration.test.slow.ts
@@ -5,6 +5,7 @@ import { Asset, multisig, verifyTransactions } from '@ironfish/rust-nodejs'
 import { Assert } from '../../../../assert'
 import { createRouteTest } from '../../../../testUtilities/routeTest'
 import { Account, ACCOUNT_SCHEMA_VERSION, AssertMultisigSigner } from '../../../../wallet'
+import { AccountImport } from '../../../../wallet/exporter'
 
 function shuffleArray<T>(array: Array<T>): Array<T> {
   // Durstenfeld shuffle (https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle#The_modern_algorithm)
@@ -149,18 +150,20 @@ describe('multisig RPC integration', () => {
       participantAccounts.push(participantAccount)
     }
 
+    const account: AccountImport = {
+      version: ACCOUNT_SCHEMA_VERSION,
+      name: 'coordinator',
+      spendingKey: null,
+      createdAt: null,
+      multisigKeys: {
+        publicKeyPackage: trustedDealerPackage.publicKeyPackage,
+      },
+      ...trustedDealerPackage,
+    }
+
     // import an account to serve as the coordinator
     await routeTest.client.wallet.importAccount({
-      account: {
-        version: ACCOUNT_SCHEMA_VERSION,
-        name: 'coordinator',
-        spendingKey: null,
-        createdAt: null,
-        multisigKeys: {
-          publicKeyPackage: trustedDealerPackage.publicKeyPackage,
-        },
-        ...trustedDealerPackage,
-      },
+      account: JSON.stringify(account),
       rescan: false,
     })
 


### PR DESCRIPTION
## Summary

For backwards compatability, we used to allow users to import/export AccountImport types instead of strings. Now we only allow importing / exporting encoded accounts.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[x] Yes
```

https://github.com/iron-fish/website/pull/709

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[x] Yes
```

Added to the release draft