### PR TITLE
Rename isHexEncoding to be more clear

### DIFF
--- a/ironfish/src/wallet/validator.ts
+++ b/ironfish/src/wallet/validator.ts
@@ -18,21 +18,15 @@ export function isValidPublicAddress(publicAddress: string): boolean {
 }
 
 export function isValidSpendingKey(spendingKey: string): boolean {
-  return spendingKey.length === SPENDING_KEY_LENGTH && haveAllowedCharacters(spendingKey)
+  return spendingKey.length === SPENDING_KEY_LENGTH && isHexEncoding(spendingKey)
 }
 
 export function isValidIncomingViewKey(incomingViewKey: string): boolean {
-  return (
-    incomingViewKey.length === INCOMING_VIEW_KEY_LENGTH &&
-    haveAllowedCharacters(incomingViewKey)
-  )
+  return incomingViewKey.length === INCOMING_VIEW_KEY_LENGTH && isHexEncoding(incomingViewKey)
 }
 
 export function isValidOutgoingViewKey(outgoingViewKey: string): boolean {
-  return (
-    outgoingViewKey.length === OUTGOING_VIEW_KEY_LENGTH &&
-    haveAllowedCharacters(outgoingViewKey)
-  )
+  return outgoingViewKey.length === OUTGOING_VIEW_KEY_LENGTH && isHexEncoding(outgoingViewKey)
 }
 
 export function isValidIVKAndPublicAddressPair(ivk: string, publicAddress: string): boolean {
@@ -40,7 +34,7 @@ export function isValidIVKAndPublicAddressPair(ivk: string, publicAddress: strin
 }
 
 export function isValidViewKey(viewKey: string): boolean {
-  return viewKey.length === VIEW_KEY_LENGTH && haveAllowedCharacters(viewKey)
+  return viewKey.length === VIEW_KEY_LENGTH && isHexEncoding(viewKey)
 }
 
 export function validateAccount(toImport: Partial<AccountValue>): void {
@@ -94,7 +88,7 @@ export function validateAccount(toImport: Partial<AccountValue>): void {
   }
 }
 
-function haveAllowedCharacters(text: string): boolean {
+function isHexEncoding(text: string): boolean {
   const validInputRegex = /^[0-9a-f]+$/
   return validInputRegex.exec(text.toLowerCase()) != null
 }


### PR DESCRIPTION
## Summary

This function isn't checking if you have allowed characters, its specifically checking if a string is hex encoded. This makes it more clear.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
