### PR TITLE
Separate out account decoding from encrypting

### DIFF
--- a/ironfish/src/rpc/routes/wallet/utils.ts
+++ b/ironfish/src/rpc/routes/wallet/utils.ts
@@ -2,8 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Note } from '../../../primitives'
-import { Account, Base64JsonEncoder, Wallet } from '../../../wallet'
-import { AccountImport } from '../../../wallet/exporter/accountImport'
+import { Account, Wallet } from '../../../wallet'
 import { DecryptedNoteValue } from '../../../wallet/walletdb/decryptedNoteValue'
 import { TransactionValue } from '../../../wallet/walletdb/transactionValue'
 import { WorkerPool } from '../../../workerPool'
@@ -107,22 +106,4 @@ export async function getAccountDecryptedNotes(
   }
 
   return serializedNotes
-}
-
-export async function tryDecodeAccountWithMultisigSecrets(
-  wallet: Wallet,
-  value: string,
-  options?: { name?: string },
-): Promise<AccountImport | undefined> {
-  const encoder = new Base64JsonEncoder()
-
-  for await (const { name, secret } of wallet.walletDb.getMultisigSecrets()) {
-    try {
-      return encoder.decode(value, { name: options?.name ?? name, multisigSecret: secret })
-    } catch (e: unknown) {
-      continue
-    }
-  }
-
-  return undefined
 }

--- a/ironfish/src/testUtilities/matchers/index.ts
+++ b/ironfish/src/testUtilities/matchers/index.ts
@@ -5,3 +5,4 @@
 import './blockchain'
 import './buffer'
 import './merkletree'
+import './string'

--- a/ironfish/src/testUtilities/matchers/string.ts
+++ b/ironfish/src/testUtilities/matchers/string.ts
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { makeResult } from './utils'
+
+// const isBase64 = (s: string): boolean => {
+//   const s === Buffer.from(s, 'base64').toString('base64')
+//   return s === rebuilt
+// }
+
+function toBeBase64(self: string | null | undefined): jest.CustomMatcherResult {
+  const pass = !!self && self === Buffer.from(self, 'base64').toString('base64')
+
+  if (!pass) {
+    return makeResult(false, `expected string to be base64:\n\n${String(self)}`)
+  }
+
+  return makeResult(true, `expected string not to be base64: ${self}`)
+}
+
+expect.extend({ toBeBase64 })
+
+declare global {
+  namespace jest {
+    interface Matchers<R> {
+      toBeBase64(): R
+    }
+  }
+}

--- a/ironfish/src/testUtilities/matchers/string.ts
+++ b/ironfish/src/testUtilities/matchers/string.ts
@@ -4,11 +4,6 @@
 
 import { makeResult } from './utils'
 
-// const isBase64 = (s: string): boolean => {
-//   const s === Buffer.from(s, 'base64').toString('base64')
-//   return s === rebuilt
-// }
-
 function toBeBase64(self: string | null | undefined): jest.CustomMatcherResult {
   const pass = !!self && self === Buffer.from(self, 'base64').toString('base64')
 

--- a/ironfish/src/wallet/exporter/account.ts
+++ b/ironfish/src/wallet/exporter/account.ts
@@ -36,7 +36,7 @@ export function encodeAccountImport(
     case AccountFormat.JSON:
       return new JsonEncoder().encode(value)
     case AccountFormat.Base64Json:
-      return new Base64JsonEncoder().encode(value, options)
+      return new Base64JsonEncoder().encode(value)
     case AccountFormat.SpendingKey:
       return new SpendingKeyEncoder().encode(value)
     case AccountFormat.Mnemonic:

--- a/ironfish/src/wallet/exporter/encoder.ts
+++ b/ironfish/src/wallet/exporter/encoder.ts
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { multisig } from '@ironfish/rust-nodejs'
 import { LanguageKey } from '../../utils'
 import { AccountImport } from './accountImport'
 
@@ -20,36 +19,12 @@ export class DecodeFailed extends Error {
   }
 }
 
-export class MultisigSecretNotFound extends DecodeInvalid {
-  name = this.constructor.name
-}
-
-export interface MultisigIdentityEncryption {
-  kind: 'MultisigIdentity'
-  identity: multisig.ParticipantIdentity | Buffer
-}
-
-// This is meant to be a tagged union type: `AccountEncryptionMethod = Method1 | Method2 | Method3 | ...`
-export type AccountEncryptionMethod = MultisigIdentityEncryption
-
-export function isMultisigIdentityEncryption(
-  method: AccountEncryptionMethod,
-): method is MultisigIdentityEncryption {
-  return 'kind' in method && method.kind === 'MultisigIdentity'
-}
-
 export type AccountEncodingOptions = {
   language?: LanguageKey
-  encryptWith?: AccountEncryptionMethod
 }
 
 export type AccountDecodingOptions = {
   name?: string
-  // It would have been nice to have a `wallet?: Wallet` field and let the
-  // encoders extract all the decryption information they needed from it, but
-  // sadly interacting with the wallet DB is an asynchronous operation, and
-  // decoders are all synchronous
-  multisigSecret?: multisig.ParticipantSecret | Buffer
 }
 
 export type AccountEncoder = {

--- a/ironfish/src/wallet/exporter/encoders/base64json.test.ts
+++ b/ironfish/src/wallet/exporter/encoders/base64json.test.ts
@@ -1,15 +1,11 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import '../../../testUtilities'
 import { generateKey } from '@ironfish/rust-nodejs'
 import { ACCOUNT_SCHEMA_VERSION } from '../../account/account'
 import { AccountImport } from '../accountImport'
 import { BASE64_JSON_ACCOUNT_PREFIX, Base64JsonEncoder } from './base64json'
-
-const isBase64 = (s: string): boolean => {
-  const rebuilt = Buffer.from(s, 'base64').toString('base64')
-  return s === rebuilt
-}
 
 describe('Base64JsonEncoder', () => {
   const key = generateKey()
@@ -30,7 +26,7 @@ describe('Base64JsonEncoder', () => {
 
     const encoded = encoder.encode(accountImport)
     expect(encoded.startsWith(BASE64_JSON_ACCOUNT_PREFIX)).toBe(true)
-    expect(isBase64(encoded.slice(BASE64_JSON_ACCOUNT_PREFIX.length))).toBe(true)
+    expect(encoded.slice(BASE64_JSON_ACCOUNT_PREFIX.length)).toBeBase64()
   })
 
   it('renames account when name is passed', () => {

--- a/ironfish/src/wallet/exporter/encoders/base64json.test.ts
+++ b/ironfish/src/wallet/exporter/encoders/base64json.test.ts
@@ -1,14 +1,10 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { generateKey, multisig } from '@ironfish/rust-nodejs'
+import { generateKey } from '@ironfish/rust-nodejs'
 import { ACCOUNT_SCHEMA_VERSION } from '../../account/account'
 import { AccountImport } from '../accountImport'
-import {
-  BASE64_JSON_ACCOUNT_PREFIX,
-  BASE64_JSON_MULTISIG_ENCRYPTED_ACCOUNT_PREFIX,
-  Base64JsonEncoder,
-} from './base64json'
+import { BASE64_JSON_ACCOUNT_PREFIX, Base64JsonEncoder } from './base64json'
 
 const isBase64 = (s: string): boolean => {
   const rebuilt = Buffer.from(s, 'base64').toString('base64')
@@ -199,126 +195,5 @@ describe('Base64JsonEncoder', () => {
     const encoded = 'ifaccountnot base64'
 
     expect(() => encoder.decode(encoded)).toThrow()
-  })
-
-  describe('with multisig encryption', () => {
-    const multisigSecret = multisig.ParticipantSecret.random()
-    const identity = multisigSecret.toIdentity()
-
-    it(`produces a base64 blob with the ${BASE64_JSON_MULTISIG_ENCRYPTED_ACCOUNT_PREFIX} prefix`, () => {
-      const accountImport: AccountImport = {
-        version: ACCOUNT_SCHEMA_VERSION,
-        name: 'test',
-        spendingKey: key.spendingKey,
-        viewKey: key.viewKey,
-        incomingViewKey: key.incomingViewKey,
-        outgoingViewKey: key.outgoingViewKey,
-        publicAddress: key.publicAddress,
-        createdAt: null,
-        proofAuthorizingKey: key.proofAuthorizingKey,
-      }
-
-      const encoded = encoder.encode(accountImport, {
-        encryptWith: { kind: 'MultisigIdentity', identity },
-      })
-      expect(encoded.startsWith(BASE64_JSON_MULTISIG_ENCRYPTED_ACCOUNT_PREFIX)).toBe(true)
-      expect(
-        isBase64(encoded.slice(BASE64_JSON_MULTISIG_ENCRYPTED_ACCOUNT_PREFIX.length)),
-      ).toBe(true)
-    })
-
-    it('encodes an account and decodes the string', () => {
-      const accountImport: AccountImport = {
-        version: ACCOUNT_SCHEMA_VERSION,
-        name: 'test',
-        spendingKey: key.spendingKey,
-        viewKey: key.viewKey,
-        incomingViewKey: key.incomingViewKey,
-        outgoingViewKey: key.outgoingViewKey,
-        publicAddress: key.publicAddress,
-        createdAt: null,
-        proofAuthorizingKey: key.proofAuthorizingKey,
-      }
-
-      const encoded = encoder.encode(accountImport, {
-        encryptWith: { kind: 'MultisigIdentity', identity },
-      })
-      expect(encoded.startsWith(BASE64_JSON_MULTISIG_ENCRYPTED_ACCOUNT_PREFIX)).toBe(true)
-
-      const decoded = encoder.decode(encoded, { multisigSecret })
-      expect(decoded).toMatchObject(accountImport)
-    })
-
-    it('throws an error when decoding without a secret', () => {
-      const accountImport: AccountImport = {
-        version: ACCOUNT_SCHEMA_VERSION,
-        name: 'test',
-        spendingKey: key.spendingKey,
-        viewKey: key.viewKey,
-        incomingViewKey: key.incomingViewKey,
-        outgoingViewKey: key.outgoingViewKey,
-        publicAddress: key.publicAddress,
-        createdAt: null,
-        proofAuthorizingKey: key.proofAuthorizingKey,
-      }
-
-      const encoded = encoder.encode(accountImport, {
-        encryptWith: { kind: 'MultisigIdentity', identity },
-      })
-      expect(() => encoder.decode(encoded)).toThrow()
-    })
-
-    it('throws an error when decoding with the wrong secret', () => {
-      const accountImport: AccountImport = {
-        version: ACCOUNT_SCHEMA_VERSION,
-        name: 'test',
-        spendingKey: key.spendingKey,
-        viewKey: key.viewKey,
-        incomingViewKey: key.incomingViewKey,
-        outgoingViewKey: key.outgoingViewKey,
-        publicAddress: key.publicAddress,
-        createdAt: null,
-        proofAuthorizingKey: key.proofAuthorizingKey,
-      }
-
-      const encoded = encoder.encode(accountImport, {
-        encryptWith: { kind: 'MultisigIdentity', identity },
-      })
-      const wrongSecret = multisig.ParticipantSecret.random()
-      expect(() => encoder.decode(encoded, { multisigSecret: wrongSecret })).toThrow()
-    })
-
-    it('does not expose account information in cleartext', () => {
-      const accountImport: AccountImport = {
-        version: ACCOUNT_SCHEMA_VERSION,
-        name: 'test',
-        spendingKey: key.spendingKey,
-        viewKey: key.viewKey,
-        incomingViewKey: key.incomingViewKey,
-        outgoingViewKey: key.outgoingViewKey,
-        publicAddress: key.publicAddress,
-        createdAt: null,
-        proofAuthorizingKey: key.proofAuthorizingKey,
-      }
-
-      const encoded = encoder.encode(accountImport, {
-        encryptWith: { kind: 'MultisigIdentity', identity },
-      })
-      expect(encoded.startsWith(BASE64_JSON_MULTISIG_ENCRYPTED_ACCOUNT_PREFIX)).toBe(true)
-      expect(
-        isBase64(encoded.slice(BASE64_JSON_MULTISIG_ENCRYPTED_ACCOUNT_PREFIX.length)),
-      ).toBe(true)
-
-      const binary = Buffer.from(
-        encoded.slice(BASE64_JSON_MULTISIG_ENCRYPTED_ACCOUNT_PREFIX.length),
-        'base64',
-      )
-
-      for (const [_key, value] of Object.entries(accountImport)) {
-        if (typeof value === 'string') {
-          expect(binary.includes(value)).toBe(false)
-        }
-      }
-    })
   })
 })

--- a/ironfish/src/wallet/exporter/encoders/base64json.ts
+++ b/ironfish/src/wallet/exporter/encoders/base64json.ts
@@ -2,46 +2,19 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { AccountImport } from '../accountImport'
-import {
-  AccountDecodingOptions,
-  AccountEncoder,
-  AccountEncodingOptions,
-  DecodeFailed,
-  isMultisigIdentityEncryption,
-} from '../encoder'
-import { decodeEncryptedMultisigAccount, encodeEncryptedMultisigAccount } from '../multisig'
+import { AccountDecodingOptions, AccountEncoder, DecodeFailed } from '../encoder'
 import { JsonEncoder } from './json'
 
 export const BASE64_JSON_ACCOUNT_PREFIX = 'ifaccount'
 
-export const BASE64_JSON_MULTISIG_ENCRYPTED_ACCOUNT_PREFIX = 'ifmsaccount'
-
 export class Base64JsonEncoder implements AccountEncoder {
-  encode(value: AccountImport, options?: AccountEncodingOptions): string {
+  encode(value: AccountImport): string {
     const binary = Buffer.from(new JsonEncoder().encode(value))
-
-    if (options?.encryptWith) {
-      if (isMultisigIdentityEncryption(options.encryptWith)) {
-        const encrypted = encodeEncryptedMultisigAccount(binary, options.encryptWith)
-        const encoded = encrypted.toString('base64')
-        return `${BASE64_JSON_MULTISIG_ENCRYPTED_ACCOUNT_PREFIX}${encoded}`
-      }
-
-      throw new Error('Unknown encryption method requested')
-    }
-
     const encoded = binary.toString('base64')
     return `${BASE64_JSON_ACCOUNT_PREFIX}${encoded}`
   }
 
   decode(value: string, options?: AccountDecodingOptions): AccountImport {
-    if (value.startsWith(BASE64_JSON_MULTISIG_ENCRYPTED_ACCOUNT_PREFIX)) {
-      const encoded = value.slice(BASE64_JSON_MULTISIG_ENCRYPTED_ACCOUNT_PREFIX.length)
-      const encrypted = Buffer.from(encoded, 'base64')
-      const json = decodeEncryptedMultisigAccount(encrypted, options).toString()
-      return new JsonEncoder().decode(json, options)
-    }
-
     if (value.startsWith(BASE64_JSON_ACCOUNT_PREFIX)) {
       const encoded = value.slice(BASE64_JSON_ACCOUNT_PREFIX.length)
       const json = Buffer.from(encoded, 'base64').toString()

--- a/ironfish/src/wallet/exporter/encryption.test.ts
+++ b/ironfish/src/wallet/exporter/encryption.test.ts
@@ -1,0 +1,97 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { generateKey, multisig } from '@ironfish/rust-nodejs'
+import { createNodeTest } from '../../testUtilities'
+import { ACCOUNT_SCHEMA_VERSION } from '../account/account'
+import { AccountImport } from './accountImport'
+import { JsonEncoder } from './encoders/json'
+import {
+  BASE64_JSON_MULTISIG_ENCRYPTED_ACCOUNT_PREFIX,
+  decryptEncodedAccount,
+  decryptEncodedAccountWithMultisigSecret,
+  encryptEncodedAccount,
+} from './encryption'
+
+describe('Wallet Export Encryption', () => {
+  const nodeTest = createNodeTest()
+  const key = generateKey()
+
+  const account: AccountImport = {
+    version: ACCOUNT_SCHEMA_VERSION,
+    name: 'test',
+    spendingKey: key.spendingKey,
+    viewKey: key.viewKey,
+    incomingViewKey: key.incomingViewKey,
+    outgoingViewKey: key.outgoingViewKey,
+    publicAddress: key.publicAddress,
+    createdAt: null,
+    proofAuthorizingKey: key.proofAuthorizingKey,
+  }
+
+  const secret = multisig.ParticipantSecret.random()
+  const identity = secret.toIdentity()
+
+  it('encodes an account and decodes the string', () => {
+    const encoded = new JsonEncoder().encode(account)
+    const encrypted = encryptEncodedAccount(encoded, {
+      kind: 'MultisigIdentity',
+      identity: identity,
+    })
+
+    const decrypted = decryptEncodedAccountWithMultisigSecret(encrypted, secret)
+    expect(decrypted).toEqual(encoded)
+  })
+
+  it('returns null when decoding with the wrong secret', () => {
+    const wrongSecret = multisig.ParticipantSecret.random()
+
+    const encoded = new JsonEncoder().encode(account)
+    const encrypted = encryptEncodedAccount(encoded, {
+      kind: 'MultisigIdentity',
+      identity: identity,
+    })
+
+    const decrypted = decryptEncodedAccountWithMultisigSecret(encrypted, wrongSecret)
+    expect(decrypted).toBeNull()
+  })
+
+  it('does not expose account information in cleartext', () => {
+    const encoded = new JsonEncoder().encode(account)
+    const encrypted = encryptEncodedAccount(encoded, {
+      kind: 'MultisigIdentity',
+      identity: identity,
+    })
+
+    for (const value of Object.values(account)) {
+      if (typeof value === 'string') {
+        expect(encrypted.includes(value)).toBe(false)
+      }
+    }
+  })
+
+  it('encodes in base64 with prefix', () => {
+    const encoded = new JsonEncoder().encode(account)
+    const encrypted = encryptEncodedAccount(encoded, {
+      kind: 'MultisigIdentity',
+      identity: identity,
+    })
+
+    expect(encrypted.startsWith(BASE64_JSON_MULTISIG_ENCRYPTED_ACCOUNT_PREFIX)).toBe(true)
+    expect(encrypted.slice(BASE64_JSON_MULTISIG_ENCRYPTED_ACCOUNT_PREFIX.length)).toBeBase64()
+  })
+
+  it('should decrypt an account using wallet secrets', async () => {
+    const identity = await nodeTest.wallet.createMultisigSecret('foo')
+
+    const encoded = new JsonEncoder().encode(account)
+
+    const encrypted = encryptEncodedAccount(encoded, {
+      kind: 'MultisigIdentity',
+      identity: new multisig.ParticipantIdentity(identity),
+    })
+
+    const decrypted = await decryptEncodedAccount(encrypted, nodeTest.wallet)
+    expect(decrypted).toEqual(encoded)
+  })
+})

--- a/ironfish/src/wallet/exporter/encryption.ts
+++ b/ironfish/src/wallet/exporter/encryption.ts
@@ -22,7 +22,7 @@ export const BASE64_JSON_MULTISIG_ENCRYPTED_ACCOUNT_PREFIX = 'ifmsaccount'
 
 /**
  * This returns the decrypted account if decryption was successful
- * or returns the original unnecrypted input if encryption was not
+ * or returns the original unencrypted input if encryption was not
  * successful
  */
 export async function decryptEncodedAccount(

--- a/ironfish/src/wallet/exporter/encryption.ts
+++ b/ironfish/src/wallet/exporter/encryption.ts
@@ -1,0 +1,81 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { multisig } from '@ironfish/rust-nodejs'
+import { Wallet } from '../wallet'
+
+interface MultisigIdentityEncryption {
+  kind: 'MultisigIdentity'
+  identity: multisig.ParticipantIdentity
+}
+
+// This is meant to be a tagged union type: `AccountEncryptionMethod = Method1 | Method2 | Method3 | ...`
+export type AccountEncryptionMethod = MultisigIdentityEncryption
+
+function isMultisigIdentityEncryption(
+  method: AccountEncryptionMethod,
+): method is MultisigIdentityEncryption {
+  return 'kind' in method && method.kind === 'MultisigIdentity'
+}
+
+export const BASE64_JSON_MULTISIG_ENCRYPTED_ACCOUNT_PREFIX = 'ifmsaccount'
+
+/**
+ * This returns the decrypted account if decryption was successful
+ * or returns the original unnecrypted input if encryption was not
+ * successful
+ */
+export async function decryptEncodedAccount(
+  encrypted: string,
+  wallet: Wallet,
+): Promise<string> {
+  // Try multisig secrets in the wallet
+  if (encrypted.startsWith(BASE64_JSON_MULTISIG_ENCRYPTED_ACCOUNT_PREFIX)) {
+    const encoded = encrypted.slice(BASE64_JSON_MULTISIG_ENCRYPTED_ACCOUNT_PREFIX.length)
+
+    for await (const { secret: secretBuffer } of wallet.walletDb.getMultisigSecrets()) {
+      const secret = new multisig.ParticipantSecret(secretBuffer)
+      const decrypted = decryptEncodedAccountWithMultisigSecret(encoded, secret)
+
+      if (decrypted) {
+        return decrypted
+      }
+    }
+  }
+
+  return encrypted
+}
+
+export function decryptEncodedAccountWithMultisigSecret(
+  encrypted: string,
+  secret: multisig.ParticipantSecret,
+): string | null {
+  if (encrypted.startsWith(BASE64_JSON_MULTISIG_ENCRYPTED_ACCOUNT_PREFIX)) {
+    encrypted = encrypted.slice(BASE64_JSON_MULTISIG_ENCRYPTED_ACCOUNT_PREFIX.length)
+  }
+
+  const encoded = Buffer.from(encrypted, 'base64')
+
+  try {
+    return secret.decryptData(encoded).toString('utf8')
+  } catch (e: unknown) {
+    return null
+  }
+}
+
+/**
+ * This will encrypt and encode the account with the given encryption scheme
+ */
+export function encryptEncodedAccount(
+  encoded: string,
+  encryption: AccountEncryptionMethod,
+): string {
+  if (isMultisigIdentityEncryption(encryption)) {
+    const binary = Buffer.from(encoded)
+    const encrypted = encryption.identity.encryptData(binary)
+    const base64 = encrypted.toString('base64')
+    return BASE64_JSON_MULTISIG_ENCRYPTED_ACCOUNT_PREFIX + base64
+  }
+
+  throw new Error('Unknown encryption method requested')
+}

--- a/ironfish/src/wallet/exporter/multisig.ts
+++ b/ironfish/src/wallet/exporter/multisig.ts
@@ -1,54 +1,18 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { multisig } from '@ironfish/rust-nodejs'
 import { MultisigKeys, MultisigSigner } from '../interfaces/multisigKeys'
-import {
-  AccountDecodingOptions,
-  MultisigIdentityEncryption,
-  MultisigSecretNotFound,
-} from './encoder'
-
-export function encodeEncryptedMultisigAccount(
-  value: Buffer,
-  options: MultisigIdentityEncryption,
-): Buffer {
-  const identity = Buffer.isBuffer(options.identity)
-    ? new multisig.ParticipantIdentity(options.identity)
-    : options.identity
-
-  return identity.encryptData(value)
-}
-
-export function decodeEncryptedMultisigAccount(
-  value: Buffer,
-  options?: AccountDecodingOptions,
-): Buffer {
-  if (!options?.multisigSecret) {
-    throw new MultisigSecretNotFound(
-      'Encrypted multisig account cannot be decrypted without a corresponding multisig secret',
-    )
-  }
-  const secret = Buffer.isBuffer(options.multisigSecret)
-    ? new multisig.ParticipantSecret(options.multisigSecret)
-    : options.multisigSecret
-  try {
-    return secret.decryptData(value)
-  } catch (e) {
-    throw new Error(`Failed to decrypt multisig account: ${String(e)}`)
-  }
-}
-
-// Multisig signing data can come from:
-// 1. Regular account export and imported which will have the secret
-// 2. Import from a trusted dealer, which will only have the identity
-export type MultisigKeysImport = MultisigKeys | MultisigSignerTrustedDealerImport
 
 export interface MultisigSignerTrustedDealerImport {
   identity: string
   keyPackage: string
   publicKeyPackage: string
 }
+
+// Multisig signing data can come from:
+// 1. Regular account export and imported which will have the secret
+// 2. Import from a trusted dealer, which will only have the identity
+export type MultisigKeysImport = MultisigKeys | MultisigSignerTrustedDealerImport
 
 export function isMultisigSignerImport(data: MultisigKeysImport): data is MultisigSigner {
   return 'secret' in data


### PR DESCRIPTION
## Summary

This fixes the fact that we attempted to add encryption to our encoder
itself, but it was nerver fully inserted into the encoding because the
decoding flow never used the wallet to try all the secrets. This means
the encryption of an encoded account was only half in the encoding
system, and half out.

This introduces a very clear separate module at
Wallet/Exporter/Encryption which has all the methods to handle
encryption.

## Testing Plan
- Added new tests
- Revised old tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
