### PR TITLE
Automatically start the worker pool if a job is submitted

### DIFF
--- a/ironfish/src/testUtilities/nodeTest.ts
+++ b/ironfish/src/testUtilities/nodeTest.ts
@@ -85,6 +85,7 @@ export class NodeTest {
     sdk.config.setOverride('enableTelemetry', false)
     sdk.config.setOverride('enableAssetVerification', false)
     sdk.config.setOverride('confirmations', 0)
+    sdk.config.setOverride('nodeWorkers', 0)
 
     // Allow tests to override default settings
     if (options?.config) {

--- a/ironfish/src/workerPool/pool.ts
+++ b/ironfish/src/workerPool/pool.ts
@@ -221,12 +221,17 @@ export class WorkerPool {
   }
 
   private execute(request: Readonly<WorkerMessage>): Job {
+    // Ensure that workers are started before handling jobs
+    this.start()
+
     const job = new Job(request)
     job.onEnded.once(this.jobEnded)
     job.onChange.on(this.jobChange)
     job.onChange.emit(job, 'init')
 
-    // If there are no workers, execute in process
+    // If there are no workers, execute in process. The previous call to
+    // start() should ensure that the correct number of workers are started,
+    // but the constructor allows numWorkers to be 0
     if (this.workers.length === 0) {
       void job.execute()
       return job


### PR DESCRIPTION
## Summary

The worker pool is a thread pool that allows multiple jobs to run concurrently. The worker pool is normally started only when a full node is initialized. If a full node is not initialized, then no separate thread is started, and jobs are not run concurrently but sequentially.

This means that the performance of CLI commands that use the worker pool, like `wallet:rescan`, can vary drastically depending on whether a full node is running or not. This behavior is not documented and far from obvious from a user prospective.

To always offer the best performance, this commit changes the worker pool to ensure that threads are always spawned before executing any job.

## Testing Plan

with a node NOT running:
- Run `wallet:rescan` before this change. Observe that the CPU utilization does not exceed 100%
- Run `wallet:rescan` after this change. Observe that the CPU utilization goes well beyond 100%

Alternatively: observe the time that `wallet:rescan` takes when running with/without a node.

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
