### PR TITLE
Remove the `fishHashContext` argument from `sdk.node()`

### DIFF
--- a/ironfish/src/sdk.ts
+++ b/ironfish/src/sdk.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { BoxKeyPair, FishHashContext } from '@ironfish/rust-nodejs'
+import { BoxKeyPair } from '@ironfish/rust-nodejs'
 import {
   Config,
   ConfigOptions,
@@ -179,7 +179,6 @@ export class IronfishSdk {
   }: {
     autoSeed?: boolean
     privateIdentity?: PrivateIdentity
-    fishHashContext?: FishHashContext
     customNetworkPath?: string
     networkId?: number
   } = {}): Promise<FullNode> {

--- a/ironfish/src/testUtilities/nodeTest.ts
+++ b/ironfish/src/testUtilities/nodeTest.ts
@@ -107,7 +107,6 @@ export class NodeTest {
 
     const node = await sdk.node({
       autoSeed: this.options?.autoSeed,
-      fishHashContext: FISH_HASH_CONTEXT,
       ...networkOptions,
     })
 


### PR DESCRIPTION
## Summary

This argument was unused.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
