### PR TITLE
Improve the calculation for the number of workers in the worker pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1298,12 +1298,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.2.6"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
-dependencies = [
- "libc",
-]
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hex"
@@ -1518,6 +1515,7 @@ dependencies = [
  "napi",
  "napi-build",
  "napi-derive",
+ "num_cpus",
  "rand",
 ]
 
@@ -1836,11 +1834,11 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.2.6",
+ "hermit-abi 0.3.9",
  "libc",
 ]
 

--- a/ironfish-rust-nodejs/Cargo.toml
+++ b/ironfish-rust-nodejs/Cargo.toml
@@ -34,6 +34,7 @@ napi = { version = "2.13.2", features = ["napi6"] }
 napi-derive = "2.13.0"
 jubjub = { git = "https://github.com/iron-fish/jubjub.git", branch = "blstrs" }
 rand = "0.8.5"
+num_cpus = "1.16.0"
 
 [build-dependencies]
 napi-build = "2.0.1"

--- a/ironfish-rust-nodejs/index.d.ts
+++ b/ironfish-rust-nodejs/index.d.ts
@@ -72,6 +72,20 @@ export function generatePublicAddressFromIncomingViewKey(ivkString: string): str
 export function generateKeyFromPrivateKey(privateKey: string): Key
 export function initializeSapling(): void
 export function isValidPublicAddress(hexAddress: string): boolean
+/**
+ * Return the number of processing units available to the system and to the current process.
+ *
+ * Note that the numbers returned by this method may change during the lifetime of the process.
+ * Examples of events that may cause the numbers to change:
+ * - enabling/disabling Simultaneous Multi-Threading (SMT)
+ * - enabling/disabling individual CPU threads or CPU cores
+ * - on Linux, changing CPU affinity masks for the process
+ * - on Linux, changing cgroup quotas for the process
+ *
+ * Also note that these numbers may not be accurate when running in a virtual machine or in a
+ * sandboxed environment.
+ */
+export function getCpuCount(): CpuCount
 export class FishHashContext {
   constructor(full: boolean)
   prebuildDataset(threads: number): void
@@ -229,6 +243,32 @@ export class ThreadPoolHandler {
   pause(): void
   getFoundBlock(): FoundBlockResult | null
   getHashRateSubmission(): number
+}
+export class CpuCount {
+  /**
+   * Estimate of the number of threads that can run simultaneously on the system. This is
+   * usually the same as `logical_count`, but on some systems (e.g. Linux), users can set limits
+   * on individual processes, and so `available_parallelism` may sometimes be lower than
+   * `logical_count`.
+   */
+  availableParallelism: number
+  /**
+   * Total number of 'logical CPUs', or 'virtual CPUs' or 'CPU threads' available on the system.
+   * This number differs from `physical_count` on systems that have Simultaneous Multi-Threading
+   * (SMT) enabled; on systems that do not have SMT enabled, `logical_count` and
+   * `physical_count` should be the same number.
+   *
+   * Note, on some systems and configurations, not all logical CPUs may be available to the
+   * current process, see `available_parallelism`.
+   */
+  logicalCount: number
+  /**
+   * Total number of CPU cores available on the system.
+   *
+   * Note, on some systems and configurations, not all physical CPUs may be available to the
+   * current process, see `available_parallelism`.
+   */
+  physicalCount: number
 }
 export namespace multisig {
   export const IDENTITY_LEN: number

--- a/ironfish-rust-nodejs/index.js
+++ b/ironfish-rust-nodejs/index.js
@@ -252,7 +252,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { FishHashContext, KEY_LENGTH, NONCE_LENGTH, BoxKeyPair, randomBytes, boxMessage, unboxMessage, RollingFilter, initSignalHandler, triggerSegfault, ASSET_ID_LENGTH, ASSET_METADATA_LENGTH, ASSET_NAME_LENGTH, ASSET_LENGTH, Asset, NOTE_ENCRYPTION_KEY_LENGTH, MAC_LENGTH, ENCRYPTED_NOTE_PLAINTEXT_LENGTH, ENCRYPTED_NOTE_LENGTH, NoteEncrypted, PUBLIC_ADDRESS_LENGTH, RANDOMNESS_LENGTH, MEMO_LENGTH, AMOUNT_VALUE_LENGTH, DECRYPTED_NOTE_LENGTH, Note, PROOF_LENGTH, TRANSACTION_SIGNATURE_LENGTH, TRANSACTION_PUBLIC_KEY_RANDOMNESS_LENGTH, TRANSACTION_EXPIRATION_LENGTH, TRANSACTION_FEE_LENGTH, LATEST_TRANSACTION_VERSION, TransactionPosted, Transaction, verifyTransactions, UnsignedTransaction, LanguageCode, generateKey, spendingKeyToWords, wordsToSpendingKey, generatePublicAddressFromIncomingViewKey, generateKeyFromPrivateKey, initializeSapling, FoundBlockResult, ThreadPoolHandler, isValidPublicAddress, multisig } = nativeBinding
+const { FishHashContext, KEY_LENGTH, NONCE_LENGTH, BoxKeyPair, randomBytes, boxMessage, unboxMessage, RollingFilter, initSignalHandler, triggerSegfault, ASSET_ID_LENGTH, ASSET_METADATA_LENGTH, ASSET_NAME_LENGTH, ASSET_LENGTH, Asset, NOTE_ENCRYPTION_KEY_LENGTH, MAC_LENGTH, ENCRYPTED_NOTE_PLAINTEXT_LENGTH, ENCRYPTED_NOTE_LENGTH, NoteEncrypted, PUBLIC_ADDRESS_LENGTH, RANDOMNESS_LENGTH, MEMO_LENGTH, AMOUNT_VALUE_LENGTH, DECRYPTED_NOTE_LENGTH, Note, PROOF_LENGTH, TRANSACTION_SIGNATURE_LENGTH, TRANSACTION_PUBLIC_KEY_RANDOMNESS_LENGTH, TRANSACTION_EXPIRATION_LENGTH, TRANSACTION_FEE_LENGTH, LATEST_TRANSACTION_VERSION, TransactionPosted, Transaction, verifyTransactions, UnsignedTransaction, LanguageCode, generateKey, spendingKeyToWords, wordsToSpendingKey, generatePublicAddressFromIncomingViewKey, generateKeyFromPrivateKey, initializeSapling, FoundBlockResult, ThreadPoolHandler, isValidPublicAddress, CpuCount, getCpuCount, multisig } = nativeBinding
 
 module.exports.FishHashContext = FishHashContext
 module.exports.KEY_LENGTH = KEY_LENGTH
@@ -300,4 +300,6 @@ module.exports.initializeSapling = initializeSapling
 module.exports.FoundBlockResult = FoundBlockResult
 module.exports.ThreadPoolHandler = ThreadPoolHandler
 module.exports.isValidPublicAddress = isValidPublicAddress
+module.exports.CpuCount = CpuCount
+module.exports.getCpuCount = getCpuCount
 module.exports.multisig = multisig

--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -90,13 +90,20 @@ export type ConfigOptions = {
   /**
    * The number of CPU workers to use for long-running node operations, like creating
    * transactions and verifying blocks. 0 disables workers (this is likely to cause
-   * performance issues), and -1 auto-detects based on the number of CPU cores.
+   * performance issues), and -1 auto-detects an optimal value based on the number of
+   * CPU cores (without exceeding `nodeWorkersMax`).
+   *
    * Each worker uses several hundred MB of memory, so try a lower value to reduce memory
    * consumption.
    */
   nodeWorkers: number
   /**
-   * The max number of node workers. See config "nodeWorkers"
+   * The max number of node workers. See also `nodeWorkers". If -1, it defaults to the
+   * number of CPU cores available to the system (capped at 16).
+   *
+   * Note that on system with Simultaneous Multithreading (SMT, also known as
+   * Hyper-Threading on Intel processors), the number of CPU cores is usually half of the
+   * number of virtual CPUs.
    */
   nodeWorkersMax: number
   peerPort: number
@@ -448,7 +455,7 @@ export class Config<
       blockGraffiti: '',
       nodeName: '',
       nodeWorkers: -1,
-      nodeWorkersMax: 6,
+      nodeWorkersMax: -1,
       peerPort: DEFAULT_WEBSOCKET_PORT,
       rpcTcpHost: 'localhost',
       rpcTcpPort: 8020,

--- a/ironfish/src/workerPool/pool.ts
+++ b/ironfish/src/workerPool/pool.ts
@@ -2,9 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { UnsignedTransaction } from '@ironfish/rust-nodejs'
+import { getCpuCount, UnsignedTransaction } from '@ironfish/rust-nodejs'
 import _ from 'lodash'
-import os from 'os'
 import { VerificationResult, VerificationResultReason } from '../consensus'
 import { createRootLogger, Logger } from '../logger'
 import { Meter, MetricsMonitor } from '../metrics'
@@ -321,15 +320,29 @@ export class WorkerPool {
  * Calculates the number of workers to use based on machine's number of cpus
  */
 export function calculateWorkers(nodeWorkers: number, nodeWorkersMax: number): number {
-  let workers = nodeWorkers
-  if (workers === -1) {
-    workers = os.cpus().length - 1
-
-    const maxWorkers = nodeWorkersMax
-    if (maxWorkers !== -1) {
-      workers = Math.min(workers, maxWorkers)
-    }
+  if (nodeWorkers >= 0) {
+    // If `nodeWorkers` is explicitly set, use that. We intentionally ignore
+    // `nodeWorkersMax` because this is the original behavior when
+    // `nodeWorkersMax` was first introduced, and changing that would be a
+    // backwards-incompatible change.
+    return nodeWorkers
   }
 
-  return workers
+  // `nodeWorkers` was not provided. Calculate an optimal value, without
+  // exceeding `nodeWorkersMax` (if provided).
+  //
+  // The -1 in the calculation for both `workers` and `maxWorkers` is to allow
+  // room to the node main process, as well as to reduce the impact on the
+  // user's system responsiveness
+  //
+  // `maxWorkers` is capped at 16 because each worker can consume several MiB
+  // of memory, and this can cause issues on systems with many CPUs but limited
+  // amount of memory. Also, even on systems with enough memory, increasing the
+  // worker pool beyond certain limits is unlikely to improve performance, so
+  // there is no concrete benefit in using as many workers as possible.
+  const { availableParallelism, physicalCount } = getCpuCount()
+  const workers = nodeWorkers >= 0 ? nodeWorkers : availableParallelism - 1
+  const maxWorkers = nodeWorkersMax >= 0 ? nodeWorkersMax : Math.min(physicalCount, 16)
+
+  return Math.min(workers, maxWorkers)
 }

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -50,6 +50,11 @@ who = "Andrea <andrea@iflabs.network>"
 criteria = "safe-to-deploy"
 delta = "0.14.0 -> 0.14.3"
 
+[[audits.hermit-abi]]
+who = "Andrea <andrea@iflabs.network>"
+criteria = "safe-to-deploy"
+delta = "0.2.6 -> 0.3.3"
+
 [[audits.indexmap]]
 who = "Andrea <andrea@iflabs.network>"
 criteria = "safe-to-deploy"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -250,6 +250,12 @@ criteria = "safe-to-deploy"
 version = "0.2.11"
 notes = "build is only looking for environment variables to set cfg. only two minor uses of unsafe,on macos, with ffi bindings to digest primitives and libc atexit. otherwise, this is an abstraction over three very complex systems (schannel, security-framework, and openssl) which may end up having subtle differences, but none of those are apparent from the implementation of this crate"
 
+[[audits.bytecode-alliance.audits.num_cpus]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "1.15.0 -> 1.16.0"
+notes = "Some minor platform updates but no major change to any code."
+
 [[audits.bytecode-alliance.audits.openssl-macros]]
 who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"
@@ -1099,6 +1105,12 @@ There is some additional use of unsafe code but the changes in this crate looked
 There is a new default dependency on the `allocator-api2` crate, which itself has quite a lot of unsafe code.
 Many previously undocumented safety requirements have been documented.
 """
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.hermit-abi]]
+who = "Daira-Emma Hopwood <daira@jacaranda.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.3 -> 0.3.9"
 aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
 
 [[audits.zcash.audits.inout]]


### PR DESCRIPTION
## Summary

This commit changes the default value for `nodeWorkersMax` to the number of CPU cores, minus one, capped at 16. Before this change, `nodeWorkersMax` was hardcoded to 6.

As a consequence of this change, most users with empty configuration will observe a larger number of workers spawned. Users who run on systems with SMT enabled and wi.

For example: on a system with 2 cores, with SMT enabled (4 logical CPUs in total), and empty configuration: before this change, the number of workers would have been .

The rationale behind using the number of CPU cores rather than the number of logical CPUs is that the worker pool should mostly be used for CPU-bound and CPU-intensiv.

This commit also changes the default value for `nodeWorkers` to be based on the number of processing units available to the process, rather than the number of logical.

Some examples to understand the impact of this change:

- users with `nodeWorkers` set in their configuration: no change
- users with `nodeWorkers`/`nodeWorkersMax` not set, 2 CPU cores, SMT enabled (4 CPU threads):
  number of workers before this change = min(4 - 1, 6) = 3
  number of workers after this change = min(4 - 1, 2 - 1, 16) = 1
- users with `nodeWorkers`/`nodeWorkersMax` not set, 8 CPU cores, SMT enabled (16 CPU threads):
  number of workers before this change = min(16 - 1, 6) = 6
  number of workers after this change = min(16 - 1, 8 - 1, 16) = 7
- users with `nodeWorkers`/`nodeWorkersMax` not set, 8 CPU cores, SMT disabled (8 CPU threads):
  number of workers before this change = min(16 - 1, 6) = 6
  number of workers after this change = min(8 - 1, 8 - 1, 16) = 7
- users with `nodeWorkers`/`nodeWorkersMax` not set, 32 CPU cores, SMT enabled (64 CPU threads):
  number of workers before this change = min(64 - 1, 6) = 6
  number of workers after this change = min(64 - 1, 32 - 1, 16) = 16
- users with `nodeWorkers`/`nodeWorkersMax` not set, 32 CPU cores, SMT enabled (64 CPU threads), scheduler affinity set to 4 CPUs:
  number of workers before this change = min(64 - 1, 6) = 6
  number of workers after this change = min(4 - 1, 32 - 1, 16) = 3

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
