### PR TITLE
removes hash from  account createdAt

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/dealer/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dealer/create.ts
@@ -73,12 +73,7 @@ export class MultisigCreateDealer extends IronfishCommand {
     })
 
     const chainResponse = await client.chain.getChainInfo()
-    const hash = Buffer.from(chainResponse.content.currentBlockIdentifier.hash, 'hex')
-    const sequence = Number(chainResponse.content.currentBlockIdentifier.index)
-    const createdAt = {
-      hash,
-      sequence,
-    }
+    const createdAt = Number(chainResponse.content.currentBlockIdentifier.index)
 
     if (flags.importCoordinator) {
       this.log()
@@ -87,10 +82,7 @@ export class MultisigCreateDealer extends IronfishCommand {
       const account: AccountImport = {
         name,
         version: ACCOUNT_SCHEMA_VERSION,
-        createdAt: {
-          hash: createdAt.hash,
-          sequence: createdAt.sequence,
-        },
+        createdAt,
         spendingKey: null,
         viewKey: response.content.viewKey,
         incomingViewKey: response.content.incomingViewKey,

--- a/ironfish-cli/src/commands/wallet/multisig/dealer/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dealer/create.ts
@@ -72,10 +72,14 @@ export class MultisigCreateDealer extends IronfishCommand {
       participants: identities.map((identity) => ({ identity })),
     })
 
-    const chainResponse = await client.chain.getChainInfo()
-    const createdAt = { sequence: Number(chainResponse.content.currentBlockIdentifier.index) }
-
     if (flags.importCoordinator) {
+      const chainResponse = await client.chain.getChainInfo()
+      const networkResponse = await client.chain.getNetworkInfo()
+      const createdAt = {
+        sequence: Number(chainResponse.content.currentBlockIdentifier.index),
+        networkId: networkResponse.content.networkId,
+      }
+
       this.log()
       ux.action.start('Importing the coordinator as a view-only account')
 

--- a/ironfish-cli/src/commands/wallet/multisig/dealer/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dealer/create.ts
@@ -73,7 +73,7 @@ export class MultisigCreateDealer extends IronfishCommand {
     })
 
     const chainResponse = await client.chain.getChainInfo()
-    const createdAt = Number(chainResponse.content.currentBlockIdentifier.index)
+    const createdAt = { sequence: Number(chainResponse.content.currentBlockIdentifier.index) }
 
     if (flags.importCoordinator) {
       this.log()

--- a/ironfish/src/blockchain/__fixtures__/blockchain.test.perf.ts.fixture
+++ b/ironfish/src/blockchain/__fixtures__/blockchain.test.perf.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "28b0f8b4679473d9c9adad455494caeabf0ead48caea86db99bcc2425e82740f",
         "publicAddress": "c99fce0caf37289e0b5d9ff1b896cd6381688ff97e2a4c1a74be726dcbbcaaeb",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -39,10 +35,6 @@
         "outgoingViewKey": "261b0e6b4252bdd3c27677e1f7fdf1d2bd2db39e19290e6fd0e1d65f2965ad27",
         "publicAddress": "85a057d38b8e0272a3bb97f5da2e526f2c997e8a708cf051982993e33f1fc9bb",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/blockchain/__fixtures__/blockchain.test.ts.fixture
+++ b/ironfish/src/blockchain/__fixtures__/blockchain.test.ts.fixture
@@ -1143,10 +1143,6 @@
         "outgoingViewKey": "0406f204ff132ae168783c8af1a4dcd82f45e7c271dc4e04e168a26fb936aa1d",
         "publicAddress": "ddebcac61504e6d2f39effc355270bb0aab239277293361e794e6ef6ab777051",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1171,10 +1167,6 @@
         "outgoingViewKey": "1cd881299d0f9b63f8eda5ac55235b4687d95dca4aca55228f0300de867f79fe",
         "publicAddress": "6f45ef61b28a39668ad24dc9b5e5b94a4f98c7173ef6af473d07e00ccc57ca00",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1339,10 +1331,6 @@
         "outgoingViewKey": "6bb9bab5d445aa4632018b15507411a369dcf2c265b27cce3300a285818e9a3a",
         "publicAddress": "77292e480846943968dffc2318a891f98bc2c0e3b976bf5dace782dcdbbcc0a7",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1399,10 +1387,6 @@
         "outgoingViewKey": "3930eef29048ee6b82c71ad473de272fac4a66c5252c90c07b1c53a06cc221c0",
         "publicAddress": "155bf6feb8c76630cd3d9b925c8ee6516acc612ad3c1333bf03fd4cae8803fd2",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1433,10 +1417,6 @@
         "outgoingViewKey": "758d5d4f9f7f76150b0602878adf8474692753908d26facfd32bc45c3dc93867",
         "publicAddress": "d0b3c7671b495a8c6ff89f7c82fb3bf98c9850bbf667d7a1ee2318778f147ed5",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1647,10 +1627,6 @@
         "outgoingViewKey": "fe2776db23240c1d27393f1fb83e0b83d176a7078e8f248f679fedc043315723",
         "publicAddress": "2ec32245f13b501b11e83ba0ef9a8b541a2619235299e5f2ca91ebcf2907a424",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:kticrtSfaYHaDuXgxReIYTT3i/0dSNeRtLS24Y3FTRA="
-          },
           "sequence": 3
         },
         "scanningEnabled": true,
@@ -1811,10 +1787,6 @@
         "outgoingViewKey": "67981a5887f9d75ea342a56425e7f985b7a305037c96051b70663bf2f6d80d25",
         "publicAddress": "cb5f0e2d214e2f08143200850d8bb4f8f6239a26a7ae15e1ffdb4bb71750eb5f",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1925,10 +1897,6 @@
         "outgoingViewKey": "ecb1fc7bc28e2edd443e8b85e95f898fa20f04881df9c04e0400d8adeba38d3d",
         "publicAddress": "5b6139ccda5772ea9f51b20a436fbcb81c51d5ae4e44ee5c0192f61a1fe47beb",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1989,10 +1957,6 @@
         "outgoingViewKey": "cbd178f77d6a3517119ffedc29815b755f7bdcf94a9e10d9affddff40eda29ac",
         "publicAddress": "10fda5ded70e0befe7471324f91334d0527e0ccf0e96a3fdbecfa152979fa61c",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2053,10 +2017,6 @@
         "outgoingViewKey": "d952c3c3df01f15fa0b2d9297fae0581a0f6365983f9985610b7a8afb94a4699",
         "publicAddress": "2496bb01bd1b2fe33f39b0d866e6203b86d32154d3082ec7b82ff91addc39aaa",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2173,10 +2133,6 @@
         "outgoingViewKey": "3800a2f30ad6a6ded383ecd4afd2e3f951a6cdea13c2f39a605e5ad90e64dce2",
         "publicAddress": "246ff23fe4ad29a4fa0611ffbe33fec63b0dbe1c6be319ac0fa5d25ab80f4321",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2201,10 +2157,6 @@
         "outgoingViewKey": "1134745b2631e17988272cdb21d14beb8b7d1aaf456f03007364c7cf9865e069",
         "publicAddress": "44288a1c8aaec069ea59742149a148ba1a3aacf19eb910431105e2881b246212",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2321,10 +2273,6 @@
         "outgoingViewKey": "6f0e8a67f2b4dd6a86e0364459bf1593a3c469a32b70c60caafcace0b4facfa0",
         "publicAddress": "c836c91cb3670772e9d008bd2cd6a956d8757013f0599920e58e048141a0606a",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2441,10 +2389,6 @@
         "outgoingViewKey": "d3489f54cb693d8f576801e37608f20012e95ba07f82644db223b0d53c76f12f",
         "publicAddress": "46a254523ff1188292eec63dde55b63c5c7d8fc1a55125366abd629e9304f720",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2505,10 +2449,6 @@
         "outgoingViewKey": "f5d4e9944c90d10bf54129d19e11da8fe37808bbe6e96f8653e3102d87f0388f",
         "publicAddress": "ae83e265d6f62f93026e22c77b8ba297e57a32734278dd0abae4e4ef55c872df",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2599,10 +2539,6 @@
         "outgoingViewKey": "5b77aade0039c3c2a5cc0f555346b61834cdd28e95306c89eaf71e37be149898",
         "publicAddress": "c7c479c0f57e61d20973f200f3e4eddfd7c277d874e74c486413c76499e5b286",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2849,10 +2785,6 @@
         "outgoingViewKey": "0216cad9e92dacd253ba540bf7ac80ac41be0cdcb731d4afd12abced48ff506d",
         "publicAddress": "32e83a3893a10fb54039beff28054ff2b85a7ae5d3e92367e0b79eba29523ab5",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2877,10 +2809,6 @@
         "outgoingViewKey": "b57e43e1d424a1bc6658e0736ea827bad3e52c33942c5c9d5bc5f543242147de",
         "publicAddress": "819a2f570116dbf53f98bb3658932a439eec9dded6e136bfeb81927cbdb3e113",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -3049,10 +2977,6 @@
         "outgoingViewKey": "013ded83f42a33245ea4d6e3ec2ba1311a7c9f553c47822fac809ff9e824566f",
         "publicAddress": "0a2d4727d753bc9d223873ecbddf8768eff52b301c7a6598ee509ad45c3d9f35",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -3113,10 +3037,6 @@
         "outgoingViewKey": "62d82b21577a8a8ca4ecac65096f2590b936cb167111d8f20049e1d4010f0f67",
         "publicAddress": "d2a69e3ec5414ef142d65a62b7d5efb438a17baf10ce2a51856691dbd5dd0862",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -3141,10 +3061,6 @@
         "outgoingViewKey": "46ad4c45ea0decc4e18fee0b52fe1c731175e8025b67aff7440bbcb0b9f6a5fa",
         "publicAddress": "b37f7ce956725aa2706e8a34922427a160af35bbc84f60ce958da8ccbddb5ca9",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -3239,10 +3155,6 @@
         "outgoingViewKey": "9a79d2dd34c9890205e268f7ad073b2bc23d7e7d66bb61671c7af7d6d6e311d8",
         "publicAddress": "8c25c7893a851c5eb2d4d6fa288a99f390becc20d8a04f5e69279d44a82f531b",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -3333,10 +3245,6 @@
         "outgoingViewKey": "ee447f81042b8fc38ea46521099d26dfdf458159893931e98afb65a9252b8edf",
         "publicAddress": "e15e6e9d7666f68e50be1fc087d880a2d0caa6e378de19c67e3f65bbfb61b60e",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -3431,10 +3339,6 @@
         "outgoingViewKey": "45f83a764d77b1f761840a2cb3412c5a7ad4fa3cb98b2d88520973cae87405a1",
         "publicAddress": "9acf0d928a4cdc334d01c2de26fdc824824287a21338b00507cccc5f783633ab",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -3495,10 +3399,6 @@
         "outgoingViewKey": "e7d4ff4e20699155e3829cfc073ddac74aea8e1550c56e6c818758c262354e4a",
         "publicAddress": "fd99dbb1b010f76f583c9ff06054c489d22394dd5f7dd635234f1a67df46b3cd",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -3593,10 +3493,6 @@
         "outgoingViewKey": "2de94163df57d42c44abc57907456832266ec5ee23e5b654fe1360bc3a0b8a07",
         "publicAddress": "51cc1d523d1554480bcad269de9c9d0eab068e9fa2e902c68f9b38c28a5b385b",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -3621,10 +3517,6 @@
         "outgoingViewKey": "77474eccfb163f56742eb2420d04b3cf22053fc22dcf79176987b0a93e697256",
         "publicAddress": "01cc134518b1016fa0215c1993238b8854df51b46540f1bf10d48ef222592299",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -3719,10 +3611,6 @@
         "outgoingViewKey": "d0eee74a254f7c1ae83930a46bc7d566c694c32e0c17186d79a7da7a501d3cf3",
         "publicAddress": "5748c722c5752dfef22b821f040d858e64138f6602ec396ba317f22d23f999ce",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -3813,10 +3701,6 @@
         "outgoingViewKey": "464e0cdcd91bebbf29a7a8648e8933cb197833fd6949a8be6c35b7d5076c7bf1",
         "publicAddress": "9d199f4c23b779aa11ee7ad9e7123230263f93bf89032a83eeecae5cb6c192b3",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -3907,10 +3791,6 @@
         "outgoingViewKey": "740a2581c7677ef86753e3abd977607f692d0d95fe11e69f922ebca7d8df6264",
         "publicAddress": "5e7e4bc375a05259b5ad097fac428a243d90ab5b13db87bdf85fe8e50be2b6c2",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -4001,10 +3881,6 @@
         "outgoingViewKey": "26918cc68c2948a21431e7e991df7f02c5b59c2d8e5ebc2e4b94a8b139cdda94",
         "publicAddress": "e393c3d8d772199a47b3542ca35b1ecc8788cda2f77ceb1e9395818ac4b0ebdb",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -4193,10 +4069,6 @@
         "outgoingViewKey": "36ee95982dcf313c71e436e329a26a407f66bd482c3cd124562701e69d676fd5",
         "publicAddress": "aad8f18c9653bf56712cd7c6bed8b2f779599cf5db11ca111035fcb84cca87e7",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -4221,10 +4093,6 @@
         "outgoingViewKey": "e2c49209cda2d1656fe0c21dec6bf13d86df28cbbe546c3303cc1aa44bd23ede",
         "publicAddress": "2bd265d684d2861de86a7d9d7fda26039c33ae31a275ba61952645a242262d4a",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -4337,10 +4205,6 @@
         "outgoingViewKey": "588b74d56e7f2981effc0bd7ee93e0c3a43df72226b44fd6f60bd83ffa8f7f8c",
         "publicAddress": "204575129e8f222d722b9ccc281d872fd0d9ce11ae03466ac62aa5fde6c01247",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -4435,10 +4299,6 @@
         "outgoingViewKey": "71506fca3186274adf5e156db4c86eaeaab8e1d6488938e14f7528c81ef7d5d9",
         "publicAddress": "d1609d40d8a86e88b54fcc5eb794d24e1557d8b31ae8ccddb6415bf81d203fde",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -4463,10 +4323,6 @@
         "outgoingViewKey": "7a2e3d0c095077c66e746923138d6ce94669f638d8eeeefdbf8c1ed3611ac4b2",
         "publicAddress": "9728a8201f9eeae43ee332377b964eafaa99975eec2a6e8670c40abebc0f28e6",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -4577,10 +4433,6 @@
         "outgoingViewKey": "dbf66108ed861f923be539fdb8f26e0e267fafacdda8cdde966f30f4c7d6ee65",
         "publicAddress": "32c7547ffe1dd0d7e38bcd3fe00f0792a8c665ac89960d5cd09f9038343bfedd",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/blockchain/database/__fixtures__/assetValue.test.ts.fixture
+++ b/ironfish/src/blockchain/database/__fixtures__/assetValue.test.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "de67a5e14b8911282873502631d9f7449c37ace371e6bc757847251544f7f225",
         "publicAddress": "107ad9374229cbb43a822f9b617658e06432dec804a4ddee38835a014e6d1865",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/blockchain/nullifierSet/__fixtures__/nullifierSet.test.ts.fixture
+++ b/ironfish/src/blockchain/nullifierSet/__fixtures__/nullifierSet.test.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "faa66599ee577712eac1a8f41d287ac15b117bcd15ab57e47268f145e06bf2dc",
         "publicAddress": "afdbe0aa15787f2ae6c74a217190470ed623199f16d79aa83afa3af467f8415c",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/consensus/__fixtures__/verifier.test.perf.ts.fixture
+++ b/ironfish/src/consensus/__fixtures__/verifier.test.perf.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "c5b5d8116e04c506ec577bea28eb190e7896259c3e11c7787b5af0da2a8cd159",
         "publicAddress": "ba1ded13a19a4baa5f5f8dd8ea39956b5d3c91b68092d2226e308765df4c1023",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/consensus/__fixtures__/verifier.test.ts.fixture
+++ b/ironfish/src/consensus/__fixtures__/verifier.test.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "ecde93dc29e9a17e90961784bda44e8aed456968d26d63422cecc33da6ec9239",
         "publicAddress": "7f29e9c467f443e3ca7ea1395f8e1ffad524081ec14409d5f38702311c2f2491",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -71,10 +67,6 @@
         "outgoingViewKey": "b4b237e29a99971eefdbef25047ab4ef48aef714d1c7d972ee5e2fae6f20dd24",
         "publicAddress": "7124fdcc974220f7fc2772b58c2b5c15d674a1d7205054e7c3c0c7d5146b7f4f",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -105,10 +97,6 @@
         "outgoingViewKey": "b7f82711e405a6c6a8ad76c74142417d7d0f4cff39cddbe732c31defd9c25a2b",
         "publicAddress": "f1cb1874a36ce65cfc2db424e98c72d601baa54ffa0d87f256d743c1660ea25a",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -169,10 +157,6 @@
         "outgoingViewKey": "0eba0a0a9568c45bb4721f9d68c36d8c6f1b53c830ee7b5c34b5dd3c670f6fa0",
         "publicAddress": "70ede7ea540538c4e16e843c706f2f825869267fd59b4bacf223d38cf820d070",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -229,10 +213,6 @@
         "outgoingViewKey": "0a909b83d368efb395f7f761e1b0c1ef825c2377dc2512a5e66b81ab0d39fefe",
         "publicAddress": "8c76d32ba57fdcbccf511958c41db71aaca7a27e5e846b7295baf05e0ddd8fda",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -263,10 +243,6 @@
         "outgoingViewKey": "54c6bcb374fb2975f5e2942e0a91eb9eb550e312709581e99b6ca3e312b4723e",
         "publicAddress": "4bdad1bb20555a78ce0e9555b25ff747b4d65198812091cf3059db450d2bfa4f",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -323,10 +299,6 @@
         "outgoingViewKey": "7cae38872ad370f6dd25a4fe04bc2001c9f0fe74fcd597d8d0664e4a3caa2e20",
         "publicAddress": "aed34e1c94c9eae5deac9436e9f0ef320f2e3111903aa491bf00d7b36dc599dc",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -413,10 +385,6 @@
         "outgoingViewKey": "7a9ca683f55187e4634f78eded9a0656d8631359be216f907d447e9d13267391",
         "publicAddress": "66c7c26ed5a646293f9dafbc187401b51733f5d18170507169764e9f2d9a1ca3",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -499,10 +467,6 @@
         "outgoingViewKey": "a9854cad1f275e7158c06bf5e92747bed7ef1e24917d26ddec158122d2696122",
         "publicAddress": "1d19330ea917ec33be82f2a764ee05018a9006def2ee45d304348a07200c2a3c",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -527,10 +491,6 @@
         "outgoingViewKey": "8ffb3442445891812d57a11b1063ea22b84479799ac03cd465cddb85e64146d4",
         "publicAddress": "7c71323eec3e68841305002f45eba2aab6e1a94f9c17ab936bf34bbb70c968d6",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -677,10 +637,6 @@
         "outgoingViewKey": "7abb14f5e6b25d121338a479168a38e2dc669d33159dc115af6e0a5f2a8dfe0b",
         "publicAddress": "d5f9171338b1a5ece3d76d7a5bb654257fecd43a76b912f0940d82b8bfb9731c",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -795,10 +751,6 @@
         "outgoingViewKey": "bcb883306988931bec27a6acafd688557bbbe8f6973db5e5788f35c715173b5b",
         "publicAddress": "71e8ccd429955cae33a7e15cc475d0d9eff743a2359642cce31784eafdb4b856",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -881,10 +833,6 @@
         "outgoingViewKey": "e4bed26ec0899d93eababaf73599317292f2050ddfb7f71652dca998c61491d7",
         "publicAddress": "cd94f660430ad1edce7d3a60cddb9ac7c6e3b09da3787d820763e9990615e6b6",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -945,10 +893,6 @@
         "outgoingViewKey": "b83441141f939a4cfe8b6c7d2812b247b8069a7ba0b99d83ea99c6da343e752c",
         "publicAddress": "7f5fee4c7c073e6ff3cd63f4556acb6a10225e192381b9ecfe999030890180bc",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1069,10 +1013,6 @@
         "outgoingViewKey": "b8df0986bc5ed0def61abbb32f47e025344a2e1d54de661cc064e5d8e0d7a56a",
         "publicAddress": "ab6eb06a17dea02eae6862157a044473bf8fe0ce564b73e0334036f5e093da98",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1097,10 +1037,6 @@
         "outgoingViewKey": "a021f6eec58b386beaf9840c42902ff7499d9d720debd76e845b746bd91d680b",
         "publicAddress": "711f5ba34f987e8c4b0e248a3b89d0055c959b3b4654ba3c67248847ce6b45ee",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1413,10 +1349,6 @@
         "outgoingViewKey": "c8dd3c4b169ebac8948edd779b715c27916d71ccc7e3fb20dae1a6adbde89add",
         "publicAddress": "a7f6c66015f082e9ee9de917c189e55c9583b42e6ee29b390fe50c1973966d15",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1499,10 +1431,6 @@
         "outgoingViewKey": "47283a69c3bc0880a99c775bd32e3a630498e8b0bc39168927abe53bba53f1ba",
         "publicAddress": "8fe526922e2e677deaafedcafbc2b786771c26634462affb1c0016f34ede6f06",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1585,10 +1513,6 @@
         "outgoingViewKey": "fc75a8e79a7530542881ce59a1009b39624b7a11c567d0da854ae6d8880ee5d7",
         "publicAddress": "51fdfd1efb467981e723832e5fbf1de39e8d2b4bfeb34cec5fd50535a86202bf",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1671,10 +1595,6 @@
         "outgoingViewKey": "770106e259d4fe448b1920fcd63f16fe8bbd83a55bc414d5e237b8831dd537db",
         "publicAddress": "20c7acc5e0412f515491c3e9c4a2c6dcb5580d03b1bdbc39c4075ea66fab9be0",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1949,10 +1869,6 @@
         "outgoingViewKey": "84cf5eb773da4bd017f1e2eea9972481f525fcd847731c50392ef70191591eaa",
         "publicAddress": "37c8773f95df6967ac8c5e123e12553036cd0961b5380154e0a0015a6b8c136f",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1977,10 +1893,6 @@
         "outgoingViewKey": "2e26c08f65dd416695bdd9f95f9cd3bfa8a2f1854ca7177853412b2d4ae77dbf",
         "publicAddress": "f89bcaf5fd2bfa4ceed864d279c3ff70732aeae44d35755a9fca84106d0b8293",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2007,10 +1919,6 @@
         "outgoingViewKey": "0a6acb3680b47dd8e69496c6fcb286feaf0485652e9aca25a1bbcdcbb148ffd5",
         "publicAddress": "4b0e91aeb323136f341acfe193cbd43557f6295864f5e670e088745d3bb92cd1",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2035,10 +1943,6 @@
         "outgoingViewKey": "6f0b0614303951de1fa7fefb160d710b1c2a2f8984075b0f6b5b94aeb94722c1",
         "publicAddress": "d1ff7d7868191a6dd89355cd9f930a5ab5b2280a73e0b9f6eaa9ba32a70a114f",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2065,10 +1969,6 @@
         "outgoingViewKey": "d3a00cecdcbad383ba8b8b8aab5f51f006a69c22d22b8479ac706dab80573b06",
         "publicAddress": "7e88808b1ca170bb3926f534efd70677717df27e9d729c53369b6420345d8b8b",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2093,10 +1993,6 @@
         "outgoingViewKey": "42a399587b610fdcd02140cfd4944cabd5b71b0ef5c020444980f2c4456a214f",
         "publicAddress": "ff463649184ff49b39a7a195731d8f606b9e2b8a949cb4a3d882d14307fb0f64",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2123,10 +2019,6 @@
         "outgoingViewKey": "79ebbf16c18e5b86436c7482649274f4869265a7255171dca89bdfbfa5ad9670",
         "publicAddress": "f789aadc287507187246f9731c3122e7af3e7b697109fe4443e3a09864070cae",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2151,10 +2043,6 @@
         "outgoingViewKey": "c93149335d41ae231a99a30d15769541fc2708c8207747d9a4d6f457b0cb87e8",
         "publicAddress": "28202a50127334119acc98209a5a08328abd7e399b4406c47d34ef03268a5896",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2181,10 +2069,6 @@
         "outgoingViewKey": "aaf6f6ad8eeb1b77800a3c946b6c65a492603bbd7da1d5f9e2619a14e2d65692",
         "publicAddress": "ba1cba2e35cdadcfdd3affa15cc0f5fafaf9f8e6a37c9d82e693e68a5963c398",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2209,10 +2093,6 @@
         "outgoingViewKey": "0b0d3c6b1597114c8077817401533baa7b1b47b9aa51006ee04cc102efe16a87",
         "publicAddress": "8df2f5a580da1ff8d41c7688b8e39e5028b08ca447f6ed50e727b317dfc3f42d",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2239,10 +2119,6 @@
         "outgoingViewKey": "20bdfaaa561602a2db98c7c2f21155a8ba092712ef3a54cf077a3f98a374b406",
         "publicAddress": "f75074765e2fb180b8c799b2be7398928aa508a2267ee5ca60aacdf2c96af463",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2267,10 +2143,6 @@
         "outgoingViewKey": "dda91c1f7063e561dbb64d4163ffc0e8350d751048f630ed27be721819002871",
         "publicAddress": "a64e2c0ac1d2835e2f6e3e01b4ffbd404c5cf8017e41d5c2ab16be451c31d1ed",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2297,10 +2169,6 @@
         "outgoingViewKey": "c92ad7dc39266eb6ea98b5907d091db749e6ca98c0f4073d81b45011f7ad86c1",
         "publicAddress": "e42242f29d95e598b3a5cb12a8dc61cdd534e61ba679db9b13c15a9345d5b113",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2325,10 +2193,6 @@
         "outgoingViewKey": "a9eba4f5ab1eb7cec4802ad2abd018aaf49c51e885f244327a7c02e414b20d5a",
         "publicAddress": "ddf65ec4caabfc49385311309c8afa7fe39ab8d9a49a6e433c6d2fab28ce9892",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2355,10 +2219,6 @@
         "outgoingViewKey": "01c2545ec2a99a96395b1faaf1be094e2dba1bf7185d34c4617458a5c80a7c84",
         "publicAddress": "a4d74e0e0adb703bdfef767de0690724542e893501324fd9762cd4a30f583dd1",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2383,10 +2243,6 @@
         "outgoingViewKey": "8b95e6c693c0baa8cbb2a0dd7afb0efcaa1790bcb1d0356a3fe3dd50996f63e1",
         "publicAddress": "6348ce922027226e7ccfced229d705c14609e0e390f81299419f253e988a7be2",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2413,10 +2269,6 @@
         "outgoingViewKey": "41426e6ea1df42791c0b07f37eff83aa5706e96bab2746538a0bdb5245134c57",
         "publicAddress": "7b386f3eee9eb5155510ffede2781ed290c8b87e1d8df88d9d4aa9a300a24d73",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2441,10 +2293,6 @@
         "outgoingViewKey": "da11b38c1ab00df81953a372eb3da7ad29cecb20eda8aaf2c76702fa990e0f4b",
         "publicAddress": "0456ebefb54269cd4f547236cd05e39fec9c88dfcc900f911ec2b3be52e9cb60",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2471,10 +2319,6 @@
         "outgoingViewKey": "fd1c610f476df0d7a1b72d0b092404b64c039d71ba4cef4b2029ffffc3d6d640",
         "publicAddress": "905e6fd5c79387def3f5f7fe5f6891b7d24bd36c56343380c736514b4df41428",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2499,10 +2343,6 @@
         "outgoingViewKey": "636f43db6c93acce26c4a6ef9c316e68f0ab5dc72c4d9a3fe756e9d26802df4e",
         "publicAddress": "b37c83e546ece1a245863a605b995632e0369fc9e46840ce8f0812a7b9613142",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2529,10 +2369,6 @@
         "outgoingViewKey": "60efabb0facf30a1378bb43494153e37caca0442725aac757ce75b6f49183190",
         "publicAddress": "46a7c021aaa49997795caca0775df8eca8e44e42b355a0b44009299d837b974a",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2557,10 +2393,6 @@
         "outgoingViewKey": "cce166aeaa25b4ff185565b8377873e4d9f1bba1cf206eeeeeee907d1cab7ff1",
         "publicAddress": "c25fd22518a8bc4e11d2eed44ee10f72c49d4769621a72a4189f66eceba56110",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/memPool/__fixtures__/feeEstimator.test.ts.fixture
+++ b/ironfish/src/memPool/__fixtures__/feeEstimator.test.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "82218bdf824381b43c0bb1352c1409b0975b87da61c443a3548da26a89ca6115",
         "publicAddress": "2f1814f0578635fa8e605c6ca54e9ecc5a0a7dfb4a9a34dd926a5f206f61de42",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -97,10 +93,6 @@
         "outgoingViewKey": "77d9692805dd28e274a58db0f9830085906c067a96e2f2f1abe3644cde10cf1a",
         "publicAddress": "736cac369c1e219734eafbb4500fd04fefa678bf6d3a90775b39495fe9a991b7",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -239,10 +231,6 @@
         "outgoingViewKey": "4df413af5e4a983c087e4237a68ba282c301699a660916feda7d5266332515fb",
         "publicAddress": "83b9dc3a6d1d19ad4c5b8d3696fa75bd496f4bc7516a273f2d0c857988592b9a",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -355,10 +343,6 @@
         "outgoingViewKey": "03233166b2d682ad442151bd28abd6100be387455939a4b6016f39669e6114df",
         "publicAddress": "f250a45968cb7da493d62d00d01b982dda31a626eb86d0c4291da577a623710e",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -441,10 +425,6 @@
         "outgoingViewKey": "13420c8038195cff809733cf626d8c2c97343dd80f7ae37eb4d736087b8fa81c",
         "publicAddress": "6046dc21627f05e32c55a702e9a16813832de37f342884aa740c6ad3ed714a6b",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -527,10 +507,6 @@
         "outgoingViewKey": "4179903a187bac37bffd51e6af5c852613a1f90436066502aecf594e8799f6f6",
         "publicAddress": "ef6287403eb37f87f1e5121c5cc0a16e6047defc8ea1dcce850d2bab2e27ba1b",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -555,10 +531,6 @@
         "outgoingViewKey": "851820d48c509e1ae6d6fdb3e23ea222a98d763601d627c4fac11db86a838378",
         "publicAddress": "1c82e02713d3e036ac76e3f3071f58c002800e8ae4cc5fc3a44b45e84853435b",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -697,10 +669,6 @@
         "outgoingViewKey": "d4377a747984cf25b2c58c64e058a94a58c72c300f69b11025628529eaec183a",
         "publicAddress": "088e264b5f8da6892bee00468520820cd50cb0d99750de0ba8a5b96362a8e08f",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -725,10 +693,6 @@
         "outgoingViewKey": "ac01df2759956114959c7ed77f128d69f0ea2ff12f3939e2f05979a7f4ecdd87",
         "publicAddress": "3331b4cdeb6c0fef9fe6b3ff270896b8611fed9989e84263eedd08f24491cc98",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -867,10 +831,6 @@
         "outgoingViewKey": "4622cea6bd701dd409bf927c94b862cec1c86b91f23b0406a437e1f3a4487711",
         "publicAddress": "3a72bf39ccaf5aba947a9faf81394e4da234fb9575226580a4f069de29cb6eb6",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -895,10 +855,6 @@
         "outgoingViewKey": "a9bd7b167e788f1bc39733800bea04adac971e2158fea0ae82e65640b9fa0837",
         "publicAddress": "15221c9c95d09d878d41d9714511101c915d9e50c1f379442b30c1cc93c55b52",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1097,10 +1053,6 @@
         "outgoingViewKey": "4d46bae1833e1696fcadac245701b398dba6be66ed698bdb828479ac80dd1ef4",
         "publicAddress": "e39903d026ffeb33540ed7db02f9b07aea2afee1247cb4084be99a3f3459a955",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1183,10 +1135,6 @@
         "outgoingViewKey": "425adae5816587b57583885a86e95f1f0105b9c3c13b5271ed68a0c36252624f",
         "publicAddress": "0dc9db820b8cb02ee878beaa5be61cb666fc0a0d4d877738780ee5cd304474e9",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1211,10 +1159,6 @@
         "outgoingViewKey": "3f8c53841e345422f6d05ad3962d90c23b28ac141d8f3a145398529a8c0daa4c",
         "publicAddress": "505fd6c795345cd2a04d308f822c7639288843b2ca4e706dd74d37116377a345",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/memPool/__fixtures__/memPool.test.ts.fixture
+++ b/ironfish/src/memPool/__fixtures__/memPool.test.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "daf301cceb5ec5658fa53e7244fc869caa7fdb74ea3054d58b2f5f2a0c6f9be5",
         "publicAddress": "7192694fb7ccc63ff5699771d78e889072ad6041c712bb71d7f5c7529df15984",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -39,10 +35,6 @@
         "outgoingViewKey": "01ce04649e0f0d629e6453823b12d9b41845656dfc6d6845f1424244d1094827",
         "publicAddress": "721586be843a666358f8cac7e22a99b84c655c8c084e044e3eb3521e9ccb769b",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -125,10 +117,6 @@
         "outgoingViewKey": "a0cf6e62c8943e0d57f6a7b2cfe827147c008a9764072332e06c243548d8186b",
         "publicAddress": "d83159a913219b8007d766f50b79665deb91b21836d69c7363aa6110fff99c31",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -153,10 +141,6 @@
         "outgoingViewKey": "67f4582e2760ad5e40ff1544bbc7b099c40c23f404cae502b4a05cadaed845f6",
         "publicAddress": "2d07a874dbafb7a02f9ebd700717238b5a6a4fac4234d104ef679be0d5437edb",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -181,10 +165,6 @@
         "outgoingViewKey": "7620bb440371d14e1a4156247db75a142b0d3d63177ea0ab8c11d911075cd1af",
         "publicAddress": "4a04f7d127b00d2e4dd828daf441b5d37c7a70d1633eab42236f7dc2eb1bcae3",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -209,10 +189,6 @@
         "outgoingViewKey": "5bd04f6ab19e894739ef441e0b2fd7e0e7c4356be078d9af435d2ee951851f2d",
         "publicAddress": "7e9941fd061f20083a12c4aa65810c384324a35ce75bd46ad22e812e6203ebcb",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -351,10 +327,6 @@
         "outgoingViewKey": "95a209ea3951a031622e0e72e0b776c5c64b53a60d4c57ca1a44899ab923ec86",
         "publicAddress": "d82442e947345cc9c38a7652683eeb613917cf58044942fcc6055c20a560d283",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -379,10 +351,6 @@
         "outgoingViewKey": "829fabaebf89e4e2f7dc758b26d61aa057a746d8f3f015f7c714d494d3bca4fa",
         "publicAddress": "53670de254b300e195a889836ada74abeb41eff7f59a6de5fede88d539653267",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -465,10 +433,6 @@
         "outgoingViewKey": "2b8ef0388019488fdeb4d00eabddbc690d09c301e0e90be8e6c701577554cf37",
         "publicAddress": "da176c1e458faab66ba6d6b7ff39f497b4637ccd03ee39aeed90cc88ace9e3af",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -493,10 +457,6 @@
         "outgoingViewKey": "068578bd5b4f27c496b8d6a791dfe0480ff6a28de798db1434e5c41df4b6590b",
         "publicAddress": "c136564cb097edf4625906e6686d503b123d3ec3d19b71fe79f03c90bb121651",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -579,10 +539,6 @@
         "outgoingViewKey": "720ef147eb7faa4e508eea66fd248fc0533c9e59db634bdf1db40333b344fc01",
         "publicAddress": "e15568163b1c191943ef89ddbe9561e93e1730d1de5f1096375890b4587189af",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -755,10 +711,6 @@
         "outgoingViewKey": "f57f314b9e022eb37024e8dbd42fb1dfccc558cb522166a1afb10d133af55160",
         "publicAddress": "473cea5671c29f2ac391f16a1c16b1a0cbf51a98c1dde852f51c49e20f56dda3",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -783,10 +735,6 @@
         "outgoingViewKey": "265e67d1878418298d8fa81492d1d1873173d7c964abed6a96087fada9f8f9e8",
         "publicAddress": "47ff8b79a88aa105c968d3bccb3686be3f8960856c1e1d98c07307eefe63689c",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -981,10 +929,6 @@
         "outgoingViewKey": "e745673b69941fe4b9cd1d86b6a1de78f2f5ee0f62e49392f9fbdd84013df5c9",
         "publicAddress": "2e9a8a5e423854c35b3ac5f40b6c851d3014b05a8b80adeff2659d1e58301dc3",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1009,10 +953,6 @@
         "outgoingViewKey": "950b03c9528d2075b3f93197a0ac8201c64c462028ae12fc703ba2111b66ab63",
         "publicAddress": "22d0eedaa722d7f8123d09d5f904a6e59ed33b1509e3592c8bddb5def4148649",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1151,10 +1091,6 @@
         "outgoingViewKey": "d0fd9c8672cfda8feebdd523cc84b0138c95c96663fd3beba142583e2744dc79",
         "publicAddress": "c5cc07f1f87f31ecb74ecf0cd3b9f01b52ddc3287b5d9a8447d2003500071939",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1179,10 +1115,6 @@
         "outgoingViewKey": "504edc04aafb532170295f21160cb16933fb5d4930c5c88f8d043dabdb64d2dc",
         "publicAddress": "0a24c6ce4247f1e4070f3ae5de4d3c81b568878c0a46e45037c0d27d957ef241",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1265,10 +1197,6 @@
         "outgoingViewKey": "7e532b745be8557f01dc7c8533b2cfbd2f135d07c26a7bd6757b345b90122d3b",
         "publicAddress": "8fd1a2499485f89f74121f8e7b2a0913fc317186d8075beda1bbe32b1421b1bf",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1293,10 +1221,6 @@
         "outgoingViewKey": "5e88e0d3591059cf37da564801b1fa658ae7d505fa0fc4b91ef27e98ee854b07",
         "publicAddress": "7b9e1691ea5d8ba0d0c5f04429b969c675c6634554feaa38d9caf52724cf180d",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1379,10 +1303,6 @@
         "outgoingViewKey": "bdbb0e5cc4f2f02ed9e51876f04a6d011074eb02461f2b2a91b5b55ced75889f",
         "publicAddress": "a58bbb300a29e9d78168e95c88cf1bf7e377f0e9938a9ce5d1535d8bae8ac589",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1465,10 +1385,6 @@
         "outgoingViewKey": "11dbcbb85f76c21696f77f0c813911bc35a482b4fadcb4cda6996ba7ba23ae79",
         "publicAddress": "4c1bc554bc1d517512f0b6c26c8bf0d09ce1efb6ea20824f85cab4d0bf97b8d9",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1493,10 +1409,6 @@
         "outgoingViewKey": "960438a3f741640293a832fb275126fb557b3132761417f9cacddf9f7667af5a",
         "publicAddress": "b641285bfce03f4d6fa0d6956400d55f6e96db233e924a953d416e5016a1c13f",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1609,10 +1521,6 @@
         "outgoingViewKey": "358d1049003a1490c5ba95e4011ea4dd6fdf8a8c9e84c049a83b7bd59bc7681a",
         "publicAddress": "aa210f7cdd8aa4a1781a853211df0e37cbec63cc4ac65891f342da8527d0c54b",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1637,10 +1545,6 @@
         "outgoingViewKey": "9abcd66810df732896e0c55d58606b3918936b019ee33f6b1f7b75dbf5d495f1",
         "publicAddress": "ce3bc1e3670260e4087b77e61902215b6fdbe608526fab3e48f3e33696e935d9",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1753,10 +1657,6 @@
         "outgoingViewKey": "447b2593c4d3659cb400e5a00ecb41bb84cb615509fb27fc669175f750c669e0",
         "publicAddress": "f4a6daa32d460b6f72530b6e6ab8c3d8a80c63e1b37dded04856d36ede83609a",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1843,10 +1743,6 @@
         "outgoingViewKey": "4cbfd6ff9d2df9bf48ca80e15cf886ef0d6a64d2ac85931194aba636b7f3d281",
         "publicAddress": "512d108e5dd3c25a308e023a889784f5418583bbc51afe46e055c2abec87dd53",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1871,10 +1767,6 @@
         "outgoingViewKey": "ba27ab9108f05c16d23b6efda8c93acf2357fe9639d76a8c32afaaae516043d5",
         "publicAddress": "2a0b03a2ccd104a9a7c5a0cc94a0f1da16ae32c78d11b79604efa3850e7a69ca",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1957,10 +1849,6 @@
         "outgoingViewKey": "9a93a9bbfac0f46c956405edd73d5765567b0b48c10a802371adc93d92b4234d",
         "publicAddress": "9c97781e8658f5f07739e75c0c10c3ba17dd54e4ae982021ec59cbfad1ea2713",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1985,10 +1873,6 @@
         "outgoingViewKey": "b3a2601b8f3fac989d56bbcf384222f89d22c2564322dcce07386f7fd072c132",
         "publicAddress": "19bedc7ffa953add8d056cb5cef4cc5f084c7ca031135ea2b2ee8e0caead6502",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2071,10 +1955,6 @@
         "outgoingViewKey": "3494d8bd135989e36ca313189fdf79f8e1570608388f6512ded229125cc3fdd5",
         "publicAddress": "0951dd7e4cb1d2db8da5d49ca0c6da4669e525d66c99f3e1915d23e02fc89a36",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2157,10 +2037,6 @@
         "outgoingViewKey": "9041dea07bfc8828676f31100eda630be08a94592025994d06c425d8ee5bb74e",
         "publicAddress": "71cf65e974256158585bd31067cbde1031ec7f71490d2e1333d6665d850d9e81",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2185,10 +2061,6 @@
         "outgoingViewKey": "3ab3efcd24074ede53ebe3228de58023c5276393ea855089ff4f8561fc10a76a",
         "publicAddress": "6a28bb9390dc017a462ee796158fa4e04cc96fbd6c0712bbdffd4ddf614991a2",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2327,10 +2199,6 @@
         "outgoingViewKey": "9668f954988f2e47eb5d3bdd1aaba61274ce2510f24fde13217fa7815e7321f8",
         "publicAddress": "690c60e41efa3fc768e70160fb48bbd66888903e4c9712c7da9911e756dd7271",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2355,10 +2223,6 @@
         "outgoingViewKey": "3e0a3958147123cb50e28d266e6680161873d70f8851932ef2fa7d63a2db1470",
         "publicAddress": "64b1a7eeda653cb27670fabe81b6a3281933af9bce8b872ae89b021d7ddf5e13",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2523,10 +2387,6 @@
         "outgoingViewKey": "6c4cc4a6c03572c45cca0c6e78c193e0bb4c8644ce0a48d0d7a41646c83fc452",
         "publicAddress": "95ffd9e349e6f187942dbcf0412b893ff37bba6e865d79d64ed61a035d9aa867",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2639,10 +2499,6 @@
         "outgoingViewKey": "e0155800089a1023de15045897a728c94d016a072fd624f8c4ca60ff948bc389",
         "publicAddress": "7e590291a050dfa4bb00d5a59dc734292abae44aa6562c873c078a2789b51b16",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2667,10 +2523,6 @@
         "outgoingViewKey": "6df008ca674b739f399170a996c01ce7239308da5debf73c66fec34374e86987",
         "publicAddress": "c89a82dfd4454a2e98db0a227f8e9f98cc88c826746b0e20a6c7fe784fd66682",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2753,10 +2605,6 @@
         "outgoingViewKey": "d8e10b89b51c0f5afb8a267c460d3d48ab98f483d64414b3c00cb4a725f192f9",
         "publicAddress": "912e957ddd5dcd94ec0aad4f923d81a012a6715200f799138974044393a1f08a",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2781,10 +2629,6 @@
         "outgoingViewKey": "b8547abe29aee4817946ddb6e0c092e853d64d7975185a56749cd26922b0cfc2",
         "publicAddress": "10b777e1f04c64019b8e20097a20fa9cce9b172c781d1b00bf2443a428011acb",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2875,10 +2719,6 @@
         "outgoingViewKey": "63069e2d6d54aed1771398a90c780eae1e6bf99ff49d3b8f61d7c34992c15b7c",
         "publicAddress": "a6b7103e4a5873b9499e54bed34553918fc76bdb922d213dfa62ad25d13426ec",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2903,10 +2743,6 @@
         "outgoingViewKey": "76f90cae362f8d1fff903cc6bdf0e7be4b4f3a48d724773640aac4250238688e",
         "publicAddress": "acf86aa92aade18b5f3bf259805c369bc8d83f1df26ab412ba4bb33c9f9bf468",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2997,10 +2833,6 @@
         "outgoingViewKey": "cc468ab5a269706c3f1bf901f7f481f37ca0d2a4869d96ba180723befe9f0a61",
         "publicAddress": "7e5c4234ff179a5651233e5d28dfa8e317914507b1e13d25449cd2bb5d06a6e1",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -3025,10 +2857,6 @@
         "outgoingViewKey": "3af84f09abe4c8d05be010a399c0c1ceba7836e11be39dcf96f0c29e35137287",
         "publicAddress": "651edb139cc2b2d3f2af1c021fb7d07568f11872123f18a5c5f876009e169d54",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/migrations/data/033-account-created-at-sequence.ts
+++ b/ironfish/src/migrations/data/033-account-created-at-sequence.ts
@@ -1,0 +1,56 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Logger } from '../../logger'
+import { IDatabase, IDatabaseTransaction } from '../../storage'
+import { createDB } from '../../storage/utils'
+import { Database, Migration, MigrationContext } from '../migration'
+import { GetStores } from './033-account-created-at-sequence/stores'
+
+export class Migration033 extends Migration {
+  path = __filename
+  database = Database.WALLET
+
+  prepare(context: MigrationContext): IDatabase {
+    return createDB({ location: context.config.walletDatabasePath })
+  }
+
+  async forward(
+    context: MigrationContext,
+    db: IDatabase,
+    tx: IDatabaseTransaction | undefined,
+    logger: Logger,
+  ): Promise<void> {
+    const stores = GetStores(db)
+
+    const confirmations = context.config.get('confirmations')
+
+    for await (const accountValue of stores.old.accounts.getAllValuesIter(tx)) {
+      logger.debug(` Migrating account ${accountValue.name}`)
+
+      const createdAt = accountValue.createdAt
+        ? { sequence: Math.max(1, accountValue.createdAt.sequence - confirmations) }
+        : null
+
+      const migrated = {
+        ...accountValue,
+        createdAt,
+        scanningEnabled: true,
+      }
+
+      await stores.new.accounts.put(accountValue.id, migrated, tx)
+    }
+  }
+
+  async backward(
+    _context: MigrationContext,
+    db: IDatabase,
+    tx: IDatabaseTransaction | undefined,
+  ): Promise<void> {
+    const stores = GetStores(db)
+
+    for await (const accountValue of stores.new.accounts.getAllValuesIter(tx)) {
+      await stores.old.accounts.put(accountValue.id, { ...accountValue, createdAt: null }, tx)
+    }
+  }
+}

--- a/ironfish/src/migrations/data/033-account-created-at-sequence/new/AccountValue.ts
+++ b/ironfish/src/migrations/data/033-account-created-at-sequence/new/AccountValue.ts
@@ -1,0 +1,146 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { PUBLIC_ADDRESS_LENGTH } from '@ironfish/rust-nodejs'
+import bufio from 'bufio'
+import { IDatabaseEncoding } from '../../../../storage'
+import { MultisigKeys, MultisigKeysEncoding } from './MultisigKeys'
+
+export const KEY_LENGTH = 32
+export const VIEW_KEY_LENGTH = 64
+const VERSION_LENGTH = 2
+
+export interface AccountValue {
+  version: number
+  id: string
+  name: string
+  spendingKey: string | null
+  viewKey: string
+  incomingViewKey: string
+  outgoingViewKey: string
+  publicAddress: string
+  createdAt: { sequence: number } | null
+  scanningEnabled: boolean
+  multisigKeys?: MultisigKeys
+  proofAuthorizingKey: string | null
+}
+
+export class AccountValueEncoding implements IDatabaseEncoding<AccountValue> {
+  serialize(value: AccountValue): Buffer {
+    const bw = bufio.write(this.getSize(value))
+    let flags = 0
+    flags |= Number(!!value.spendingKey) << 0
+    flags |= Number(!!value.createdAt) << 1
+    flags |= Number(!!value.multisigKeys) << 2
+    flags |= Number(!!value.proofAuthorizingKey) << 3
+    flags |= Number(!!value.scanningEnabled) << 4
+    bw.writeU8(flags)
+    bw.writeU16(value.version)
+    bw.writeVarString(value.id, 'utf8')
+    bw.writeVarString(value.name, 'utf8')
+
+    if (value.spendingKey) {
+      bw.writeBytes(Buffer.from(value.spendingKey, 'hex'))
+    }
+
+    bw.writeBytes(Buffer.from(value.viewKey, 'hex'))
+    bw.writeBytes(Buffer.from(value.incomingViewKey, 'hex'))
+    bw.writeBytes(Buffer.from(value.outgoingViewKey, 'hex'))
+    bw.writeBytes(Buffer.from(value.publicAddress, 'hex'))
+
+    if (value.createdAt) {
+      bw.writeU32(value.createdAt.sequence)
+    }
+
+    if (value.multisigKeys) {
+      const encoding = new MultisigKeysEncoding()
+      bw.writeU64(encoding.getSize(value.multisigKeys))
+      bw.writeBytes(encoding.serialize(value.multisigKeys))
+    }
+
+    if (value.proofAuthorizingKey) {
+      bw.writeBytes(Buffer.from(value.proofAuthorizingKey, 'hex'))
+    }
+
+    return bw.render()
+  }
+
+  deserialize(buffer: Buffer): AccountValue {
+    const reader = bufio.read(buffer, true)
+    const flags = reader.readU8()
+    const version = reader.readU16()
+    const hasSpendingKey = flags & (1 << 0)
+    const hasCreatedAt = flags & (1 << 1)
+    const hasMultisigKeys = flags & (1 << 2)
+    const hasProofAuthorizingKey = flags & (1 << 3)
+    const scanningEnabled = Boolean(flags & (1 << 4))
+    const id = reader.readVarString('utf8')
+    const name = reader.readVarString('utf8')
+    const spendingKey = hasSpendingKey ? reader.readBytes(KEY_LENGTH).toString('hex') : null
+    const viewKey = reader.readBytes(VIEW_KEY_LENGTH).toString('hex')
+    const incomingViewKey = reader.readBytes(KEY_LENGTH).toString('hex')
+    const outgoingViewKey = reader.readBytes(KEY_LENGTH).toString('hex')
+    const publicAddress = reader.readBytes(PUBLIC_ADDRESS_LENGTH).toString('hex')
+
+    let createdAt = null
+    if (hasCreatedAt) {
+      createdAt = { sequence: reader.readU32() }
+    }
+
+    let multisigKeys = undefined
+    if (hasMultisigKeys) {
+      const multisigKeysLength = reader.readU64()
+      const encoding = new MultisigKeysEncoding()
+      multisigKeys = encoding.deserialize(reader.readBytes(multisigKeysLength))
+    }
+
+    const proofAuthorizingKey = hasProofAuthorizingKey
+      ? reader.readBytes(KEY_LENGTH).toString('hex')
+      : null
+
+    return {
+      version,
+      id,
+      name,
+      viewKey,
+      incomingViewKey,
+      outgoingViewKey,
+      spendingKey,
+      publicAddress,
+      createdAt,
+      scanningEnabled,
+      multisigKeys,
+      proofAuthorizingKey,
+    }
+  }
+
+  getSize(value: AccountValue): number {
+    let size = 0
+    size += 1 // flags
+    size += VERSION_LENGTH
+    size += bufio.sizeVarString(value.id, 'utf8')
+    size += bufio.sizeVarString(value.name, 'utf8')
+    if (value.spendingKey) {
+      size += KEY_LENGTH
+    }
+    size += VIEW_KEY_LENGTH
+    size += KEY_LENGTH
+    size += KEY_LENGTH
+    size += PUBLIC_ADDRESS_LENGTH
+
+    if (value.createdAt) {
+      size += 4
+    }
+
+    if (value.multisigKeys) {
+      const encoding = new MultisigKeysEncoding()
+      size += 8 // size of multi sig keys
+      size += encoding.getSize(value.multisigKeys)
+    }
+    if (value.proofAuthorizingKey) {
+      size += KEY_LENGTH
+    }
+
+    return size
+  }
+}

--- a/ironfish/src/migrations/data/033-account-created-at-sequence/new/MultisigKeys.ts
+++ b/ironfish/src/migrations/data/033-account-created-at-sequence/new/MultisigKeys.ts
@@ -1,0 +1,74 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import bufio from 'bufio'
+import { IDatabaseEncoding } from '../../../../storage'
+
+export class MultisigKeysEncoding implements IDatabaseEncoding<MultisigKeys> {
+  serialize(value: MultisigKeys): Buffer {
+    const bw = bufio.write(this.getSize(value))
+
+    let flags = 0
+    flags |= Number(!!isSignerMultisig(value)) << 0
+    bw.writeU8(flags)
+
+    bw.writeVarBytes(Buffer.from(value.publicKeyPackage, 'hex'))
+    if (isSignerMultisig(value)) {
+      bw.writeVarBytes(Buffer.from(value.secret, 'hex'))
+      bw.writeVarBytes(Buffer.from(value.keyPackage, 'hex'))
+    }
+
+    return bw.render()
+  }
+
+  deserialize(buffer: Buffer): MultisigKeys {
+    const reader = bufio.read(buffer, true)
+
+    const flags = reader.readU8()
+    const isSigner = flags & (1 << 0)
+
+    const publicKeyPackage = reader.readVarBytes().toString('hex')
+    if (isSigner) {
+      const secret = reader.readVarBytes().toString('hex')
+      const keyPackage = reader.readVarBytes().toString('hex')
+      return {
+        publicKeyPackage,
+        secret,
+        keyPackage,
+      }
+    }
+
+    return {
+      publicKeyPackage,
+    }
+  }
+
+  getSize(value: MultisigKeys): number {
+    let size = 0
+    size += 1 // flags
+
+    size += bufio.sizeVarString(value.publicKeyPackage, 'hex')
+    if (isSignerMultisig(value)) {
+      size += bufio.sizeVarString(value.secret, 'hex')
+      size += bufio.sizeVarString(value.keyPackage, 'hex')
+    }
+
+    return size
+  }
+}
+
+export interface MultisigSigner {
+  secret: string
+  keyPackage: string
+  publicKeyPackage: string
+}
+
+export interface MultisigCoordinator {
+  publicKeyPackage: string
+}
+
+export type MultisigKeys = MultisigSigner | MultisigCoordinator
+
+export function isSignerMultisig(multisigKeys: MultisigKeys): multisigKeys is MultisigSigner {
+  return 'keyPackage' in multisigKeys && 'secret' in multisigKeys
+}

--- a/ironfish/src/migrations/data/033-account-created-at-sequence/new/index.ts
+++ b/ironfish/src/migrations/data/033-account-created-at-sequence/new/index.ts
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { IDatabase, IDatabaseStore, StringEncoding } from '../../../../storage'
+import { AccountValue, AccountValueEncoding } from './AccountValue'
+
+export function GetNewStores(db: IDatabase): {
+  accounts: IDatabaseStore<{ key: string; value: AccountValue }>
+} {
+  const accounts: IDatabaseStore<{ key: string; value: AccountValue }> = db.addStore(
+    {
+      name: 'a',
+      keyEncoding: new StringEncoding(),
+      valueEncoding: new AccountValueEncoding(),
+    },
+    false,
+  )
+
+  return { accounts }
+}

--- a/ironfish/src/migrations/data/033-account-created-at-sequence/old/AccountValue.ts
+++ b/ironfish/src/migrations/data/033-account-created-at-sequence/old/AccountValue.ts
@@ -1,0 +1,150 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { PUBLIC_ADDRESS_LENGTH } from '@ironfish/rust-nodejs'
+import bufio from 'bufio'
+import { IDatabaseEncoding } from '../../../../storage'
+import { HeadValue, NullableHeadValueEncoding } from './HeadValue'
+import { MultisigKeys, MultisigKeysEncoding } from './MultisigKeys'
+
+const KEY_LENGTH = 32
+export const VIEW_KEY_LENGTH = 64
+const VERSION_LENGTH = 2
+
+export interface AccountValue {
+  version: number
+  id: string
+  name: string
+  spendingKey: string | null
+  viewKey: string
+  incomingViewKey: string
+  outgoingViewKey: string
+  publicAddress: string
+  createdAt: HeadValue | null
+  scanningEnabled: boolean
+  multisigKeys?: MultisigKeys
+  proofAuthorizingKey: string | null
+}
+
+export class AccountValueEncoding implements IDatabaseEncoding<AccountValue> {
+  serialize(value: AccountValue): Buffer {
+    const bw = bufio.write(this.getSize(value))
+    let flags = 0
+    flags |= Number(!!value.spendingKey) << 0
+    flags |= Number(!!value.createdAt) << 1
+    flags |= Number(!!value.multisigKeys) << 2
+    flags |= Number(!!value.proofAuthorizingKey) << 3
+    flags |= Number(!!value.scanningEnabled) << 4
+    bw.writeU8(flags)
+    bw.writeU16(value.version)
+    bw.writeVarString(value.id, 'utf8')
+    bw.writeVarString(value.name, 'utf8')
+
+    if (value.spendingKey) {
+      bw.writeBytes(Buffer.from(value.spendingKey, 'hex'))
+    }
+
+    bw.writeBytes(Buffer.from(value.viewKey, 'hex'))
+    bw.writeBytes(Buffer.from(value.incomingViewKey, 'hex'))
+    bw.writeBytes(Buffer.from(value.outgoingViewKey, 'hex'))
+    bw.writeBytes(Buffer.from(value.publicAddress, 'hex'))
+
+    if (value.createdAt) {
+      const encoding = new NullableHeadValueEncoding()
+      bw.writeBytes(encoding.serialize(value.createdAt))
+    }
+
+    if (value.multisigKeys) {
+      const encoding = new MultisigKeysEncoding()
+      bw.writeU64(encoding.getSize(value.multisigKeys))
+      bw.writeBytes(encoding.serialize(value.multisigKeys))
+    }
+
+    if (value.proofAuthorizingKey) {
+      bw.writeBytes(Buffer.from(value.proofAuthorizingKey, 'hex'))
+    }
+
+    return bw.render()
+  }
+
+  deserialize(buffer: Buffer): AccountValue {
+    const reader = bufio.read(buffer, true)
+    const flags = reader.readU8()
+    const version = reader.readU16()
+    const hasSpendingKey = flags & (1 << 0)
+    const hasCreatedAt = flags & (1 << 1)
+    const hasMultisigKeys = flags & (1 << 2)
+    const hasProofAuthorizingKey = flags & (1 << 3)
+    const scanningEnabled = Boolean(flags & (1 << 4))
+    const id = reader.readVarString('utf8')
+    const name = reader.readVarString('utf8')
+    const spendingKey = hasSpendingKey ? reader.readBytes(KEY_LENGTH).toString('hex') : null
+    const viewKey = reader.readBytes(VIEW_KEY_LENGTH).toString('hex')
+    const incomingViewKey = reader.readBytes(KEY_LENGTH).toString('hex')
+    const outgoingViewKey = reader.readBytes(KEY_LENGTH).toString('hex')
+    const publicAddress = reader.readBytes(PUBLIC_ADDRESS_LENGTH).toString('hex')
+
+    let createdAt = null
+    if (hasCreatedAt) {
+      const encoding = new NullableHeadValueEncoding()
+      createdAt = encoding.deserialize(reader.readBytes(encoding.nonNullSize))
+    }
+
+    let multisigKeys = undefined
+    if (hasMultisigKeys) {
+      const multisigKeysLength = reader.readU64()
+      const encoding = new MultisigKeysEncoding()
+      multisigKeys = encoding.deserialize(reader.readBytes(multisigKeysLength))
+    }
+
+    const proofAuthorizingKey = hasProofAuthorizingKey
+      ? reader.readBytes(KEY_LENGTH).toString('hex')
+      : null
+
+    return {
+      version,
+      id,
+      name,
+      viewKey,
+      incomingViewKey,
+      outgoingViewKey,
+      spendingKey,
+      publicAddress,
+      createdAt,
+      scanningEnabled,
+      multisigKeys,
+      proofAuthorizingKey,
+    }
+  }
+
+  getSize(value: AccountValue): number {
+    let size = 0
+    size += 1 // flags
+    size += VERSION_LENGTH
+    size += bufio.sizeVarString(value.id, 'utf8')
+    size += bufio.sizeVarString(value.name, 'utf8')
+    if (value.spendingKey) {
+      size += KEY_LENGTH
+    }
+    size += VIEW_KEY_LENGTH
+    size += KEY_LENGTH
+    size += KEY_LENGTH
+    size += PUBLIC_ADDRESS_LENGTH
+
+    if (value.createdAt) {
+      const encoding = new NullableHeadValueEncoding()
+      size += encoding.nonNullSize
+    }
+
+    if (value.multisigKeys) {
+      const encoding = new MultisigKeysEncoding()
+      size += 8 // size of multi sig keys
+      size += encoding.getSize(value.multisigKeys)
+    }
+    if (value.proofAuthorizingKey) {
+      size += KEY_LENGTH
+    }
+
+    return size
+  }
+}

--- a/ironfish/src/migrations/data/033-account-created-at-sequence/old/HeadValue.ts
+++ b/ironfish/src/migrations/data/033-account-created-at-sequence/old/HeadValue.ts
@@ -1,0 +1,41 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import bufio from 'bufio'
+import { IDatabaseEncoding } from '../../../../storage'
+
+export type HeadValue = {
+  hash: Buffer
+  sequence: number
+}
+
+export class NullableHeadValueEncoding implements IDatabaseEncoding<HeadValue | null> {
+  readonly nonNullSize = 32 + 4 // 256-bit block hash + 32-bit integer
+
+  serialize(value: HeadValue | null): Buffer {
+    const bw = bufio.write(this.getSize(value))
+
+    if (value) {
+      bw.writeHash(value.hash)
+      bw.writeU32(value.sequence)
+    }
+
+    return bw.render()
+  }
+
+  deserialize(buffer: Buffer): HeadValue | null {
+    const reader = bufio.read(buffer, true)
+
+    if (reader.left()) {
+      const hash = reader.readHash()
+      const sequence = reader.readU32()
+      return { hash, sequence }
+    }
+
+    return null
+  }
+
+  getSize(value: HeadValue | null): number {
+    return value ? this.nonNullSize : 0
+  }
+}

--- a/ironfish/src/migrations/data/033-account-created-at-sequence/old/MultisigKeys.ts
+++ b/ironfish/src/migrations/data/033-account-created-at-sequence/old/MultisigKeys.ts
@@ -1,0 +1,74 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import bufio from 'bufio'
+import { IDatabaseEncoding } from '../../../../storage'
+
+export class MultisigKeysEncoding implements IDatabaseEncoding<MultisigKeys> {
+  serialize(value: MultisigKeys): Buffer {
+    const bw = bufio.write(this.getSize(value))
+
+    let flags = 0
+    flags |= Number(!!isSignerMultisig(value)) << 0
+    bw.writeU8(flags)
+
+    bw.writeVarBytes(Buffer.from(value.publicKeyPackage, 'hex'))
+    if (isSignerMultisig(value)) {
+      bw.writeVarBytes(Buffer.from(value.secret, 'hex'))
+      bw.writeVarBytes(Buffer.from(value.keyPackage, 'hex'))
+    }
+
+    return bw.render()
+  }
+
+  deserialize(buffer: Buffer): MultisigKeys {
+    const reader = bufio.read(buffer, true)
+
+    const flags = reader.readU8()
+    const isSigner = flags & (1 << 0)
+
+    const publicKeyPackage = reader.readVarBytes().toString('hex')
+    if (isSigner) {
+      const secret = reader.readVarBytes().toString('hex')
+      const keyPackage = reader.readVarBytes().toString('hex')
+      return {
+        publicKeyPackage,
+        secret,
+        keyPackage,
+      }
+    }
+
+    return {
+      publicKeyPackage,
+    }
+  }
+
+  getSize(value: MultisigKeys): number {
+    let size = 0
+    size += 1 // flags
+
+    size += bufio.sizeVarString(value.publicKeyPackage, 'hex')
+    if (isSignerMultisig(value)) {
+      size += bufio.sizeVarString(value.secret, 'hex')
+      size += bufio.sizeVarString(value.keyPackage, 'hex')
+    }
+
+    return size
+  }
+}
+
+export interface MultisigSigner {
+  secret: string
+  keyPackage: string
+  publicKeyPackage: string
+}
+
+export interface MultisigCoordinator {
+  publicKeyPackage: string
+}
+
+export type MultisigKeys = MultisigSigner | MultisigCoordinator
+
+export function isSignerMultisig(multisigKeys: MultisigKeys): multisigKeys is MultisigSigner {
+  return 'keyPackage' in multisigKeys && 'secret' in multisigKeys
+}

--- a/ironfish/src/migrations/data/033-account-created-at-sequence/old/index.ts
+++ b/ironfish/src/migrations/data/033-account-created-at-sequence/old/index.ts
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { IDatabase, IDatabaseStore, StringEncoding } from '../../../../storage'
+import { AccountValue, AccountValueEncoding } from './AccountValue'
+
+export function GetOldStores(db: IDatabase): {
+  accounts: IDatabaseStore<{ key: string; value: AccountValue }>
+} {
+  const accounts: IDatabaseStore<{ key: string; value: AccountValue }> = db.addStore(
+    {
+      name: 'a',
+      keyEncoding: new StringEncoding(),
+      valueEncoding: new AccountValueEncoding(),
+    },
+    false,
+  )
+
+  return { accounts }
+}

--- a/ironfish/src/migrations/data/033-account-created-at-sequence/stores.ts
+++ b/ironfish/src/migrations/data/033-account-created-at-sequence/stores.ts
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { IDatabase } from '../../../storage'
+import { GetNewStores } from './new'
+import { GetOldStores } from './old'
+
+export function GetStores(db: IDatabase): {
+  old: ReturnType<typeof GetOldStores>
+  new: ReturnType<typeof GetNewStores>
+} {
+  const oldStores = GetOldStores(db)
+  const newStores = GetNewStores(db)
+
+  return { old: oldStores, new: newStores }
+}

--- a/ironfish/src/migrations/data/index.ts
+++ b/ironfish/src/migrations/data/index.ts
@@ -21,6 +21,7 @@ import { Migration029 } from './029-backfill-assets-owner-wallet'
 import { Migration030 } from './030-value-to-unspent-note'
 import { Migration031 } from './031-add-pak-to-account'
 import { Migration032 } from './032-add-account-scanning'
+import { Migration033 } from './033-account-created-at-sequence'
 
 export const MIGRATIONS = [
   Migration014,
@@ -42,4 +43,5 @@ export const MIGRATIONS = [
   Migration030,
   Migration031,
   Migration032,
+  Migration033,
 ]

--- a/ironfish/src/mining/__fixtures__/manager.test.perf.ts.fixture
+++ b/ironfish/src/mining/__fixtures__/manager.test.perf.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "6f5862f6ed322d5bafd757a792a13442e5dd666492b6ea0dcf89732d78256e70",
         "publicAddress": "a805c8549eb4942bdcbcdc56c8c83881ed924b1341c44d0456dc27152e3e3a89",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/mining/__fixtures__/manager.test.slow.ts.fixture
+++ b/ironfish/src/mining/__fixtures__/manager.test.slow.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "9b2a1a4c088b8b62eaa1e7f4bd49ddb1e190cf99e802e0195aca0b16f7370e00",
         "publicAddress": "cbb56c58e51a1591bcb08942c579e6e9c8f9e94e45f53aa9a9eccf8676f6f2f0",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -67,10 +63,6 @@
         "outgoingViewKey": "7b9d6518f475b94399d835c63b6e11f10626d7168168a09237a9445e3a0a90df",
         "publicAddress": "695c8e40505b64b4f15fc6b787c9a186bc8b70bfa95fce6cf1b389a96d52056f",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -153,10 +145,6 @@
         "outgoingViewKey": "f986b6064dc98d6b835365cdf1f1966b7f4823af2edabebf5ea0eb72f8b93c9b",
         "publicAddress": "2bd459634e51037ebe4db46272bfbfc86c14b4d4ca195ee805a4bf5762d8e318",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -181,10 +169,6 @@
         "outgoingViewKey": "ea891d1a0338cce986cbed80ab69ee848497b34952ca17834ae260f4be8c5791",
         "publicAddress": "238b6f085a5a773a07d1df2c1302a52969c9e6bd219269a62a5ba8baa0cfb2c3",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -293,10 +277,6 @@
         "outgoingViewKey": "5c0430ed1990827380f72e7217d0b2263d3c243762cf20236e621d30e12786c5",
         "publicAddress": "d784b46c3836343c6e904d010ef2b0ac5f8600b0892a7df075b5e639cbeac3f1",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -379,10 +359,6 @@
         "outgoingViewKey": "d02b576cc5b6681de96a1a8484411890155e85ace5cf0b40677684f8d63f27fa",
         "publicAddress": "d996d974b9d8c4fc05b69f64665b0fc198efc61de791904cce8ae31639fb5cbc",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -407,10 +383,6 @@
         "outgoingViewKey": "373a4fc3c1be7acf23aca5ab1df77e55e20330b8cf7b5ff05552b08bc5d7eb43",
         "publicAddress": "6c0486933c3fad366c5156d2c18e02da687b04c8de0d5aa54d04fb9434538f17",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -557,10 +529,6 @@
         "outgoingViewKey": "3ba811363532f0a28ab5244b221b02b420e13f9c079d7255ccfab0421bfafa69",
         "publicAddress": "797d6d0c12c85fe780c9c7fcf50290c3f1c8cdc5a308826d01071d96ebcb6ea8",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -647,10 +615,6 @@
         "outgoingViewKey": "684c980dbaae846dabbaeb7fb8d7ae8774c4c6d88184425f9b182860babdeebd",
         "publicAddress": "33c3f078a9a3346d0c4a935c6d8a88071cf2ab6ee0a89e962e6aa24e86161785",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -707,10 +671,6 @@
         "outgoingViewKey": "f70f52e58cad6ec93207a5348ea2d430d8b36d60585b9df9d7328a27f6a040e6",
         "publicAddress": "6a4eb1097f36a2327e18f4181b069f927c8d9d888d29fbd18aff30c5aba3f76d",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -763,10 +723,6 @@
         "outgoingViewKey": "3f43351ac0d7d88e0a1c27b3f9fb536ef88a17f9779bea008967279a31cd2cfe",
         "publicAddress": "ee3175d7bab913d324c80845a9ff59c9da837b99c83e05662fbbb80020afa411",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -845,10 +801,6 @@
         "outgoingViewKey": "b80e978779e60f325a8ddc11f9ad92d3758e69579f9f8510b13ed8f4582ecb9b",
         "publicAddress": "dda970d64a5c91b473ddf82e18a00c73cca788e22d8a13d586e0809558c872aa",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -901,10 +853,6 @@
         "outgoingViewKey": "7bea1974bf9d0fe8b1a98d2b8f281ef5e9f4d1cf58491f679265ec433c677a5f",
         "publicAddress": "6c430d95525b74ad7487b627940648bb28fc255888532f4639af0b2c349f9a87",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -961,10 +909,6 @@
         "outgoingViewKey": "610fb80345e49120544db4436aef8312f1f2507b6f1f1cea5d110b22c9ed38cc",
         "publicAddress": "55f7cc929b6884788023c361e76637295919340a86bdc08f0c88071deb0aa493",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1047,10 +991,6 @@
         "outgoingViewKey": "781c6ed5b802ad44c684101316280c804a87f2d6c2e847e137c122665388b72d",
         "publicAddress": "b112e3c21782a754d6b8538f7801cea3b48abff7c0a4e10dcd4e782b2274efac",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1129,10 +1069,6 @@
         "outgoingViewKey": "cc5f82d9ebc69620fbb04bbd632c7787a0e98dd1f811d11a064bc3c33231684a",
         "publicAddress": "97a1311968bf528bf86c5fe358fa3f2beee08b2cf77702378ea67772deb5220d",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1159,10 +1095,6 @@
         "outgoingViewKey": "4334f7dd081b19c82f2c90f80aa54df19325a51bbd15cded22affb889dfc43bd",
         "publicAddress": "de96c980112bfa57aa9dfff2db522823bf5fa0acf139b6ea4daa38ce2838ae64",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1189,10 +1121,6 @@
         "outgoingViewKey": "986bd0df24967e1070df691754c28889bc9a50422f27c4b335574d77f28281f3",
         "publicAddress": "a360a2128cbf850d03940b5d4f0477f58ce28738cb9dafebe68b84f468530c88",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1219,10 +1147,6 @@
         "outgoingViewKey": "1cae03e46ab1bf87aa5b4ebfc033636709ea99f701bb9d9abad7579afbcafacf",
         "publicAddress": "10e22b4cad2ad004d904d3aa8ca29b16b40e154a470902ffcdb8500b53487fea",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1301,10 +1225,6 @@
         "outgoingViewKey": "daa113143e69223aa5a11afb1c73f67cc477cff8946e021c940f189b79faa674",
         "publicAddress": "391ed9950b53b4a6fa26a4cae4f4a7ab4bc891f3ccc3f3366f10b840dd6d8639",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/mining/__fixtures__/poolShares.test.ts.fixture
+++ b/ironfish/src/mining/__fixtures__/poolShares.test.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "d3f1c7d7c9a6e3955b8d7ec4450fd702f92bafff6c21bda57e9718507c25730b",
         "publicAddress": "5027b5e54378805079d897b7e91c4a6e2a675336f051d3ad5c8d2ce6c123602e",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -41,10 +37,6 @@
         "outgoingViewKey": "a6c9ecfccb11d543bdce4479fe5d29547c36bbc882e17f1066982d7aca9ffc98",
         "publicAddress": "59b6001e83fd3a6b80daedf3ab1ad67f496806bad088ceb43248fb45481e0c6d",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -71,10 +63,6 @@
         "outgoingViewKey": "ea4e8f4d3cb8d7194434449d6ef1efd34f1151bc1a234ebfc97fbd8d9fac57fb",
         "publicAddress": "c31f7d5cddf9f7b6f128994bb177df7337909a02abc80eea9a2c44c0b0894fe8",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -101,10 +89,6 @@
         "outgoingViewKey": "47676f95061e5e707ecd16782f8645fb36ef16a794bf0f24950b0fc01d80aaaa",
         "publicAddress": "4d45c3aea5a48a6894e6308c5d589609a8aff83aab6904ad7d292870db743ecd",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -131,10 +115,6 @@
         "outgoingViewKey": "5d3c66ea054912516a3550e37274f30508ddc4e19d23642e37a8d96a9d050675",
         "publicAddress": "8c7579199c84c07df79808b7ea99d7a6a7ea22d75e250be8882ed63e5ca9c280",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -161,10 +141,6 @@
         "outgoingViewKey": "cf431b5ad0fc17afacba829cdab91aa9ba7edd2b4f9185f5c0e0a8dc322b34d7",
         "publicAddress": "b96df9d9a26a555ae9885b6654a08844dd2eb4f4243bd1d3e2be8b569feaa604",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -191,10 +167,6 @@
         "outgoingViewKey": "1d0bd639631318ddc6c0eea6eb706a61ca7b39cb38adca32ba6fbfba2fba76c7",
         "publicAddress": "0a0fce51eb25432cd813ef2ba136fcdb3faab1cf0fa5533ff50b40e942777fbe",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -221,10 +193,6 @@
         "outgoingViewKey": "fac7695f687c20bf5f30097822871d0e105d6923354c80e01c53702843998f28",
         "publicAddress": "0c0765adce3b83ce0d5079bf1ca4a6f55e0e808cf45da5ffca38c397da571035",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -251,10 +219,6 @@
         "outgoingViewKey": "e88079cd703323c773801344df8a0d1033f51d0453158da397469f1fa146c3d9",
         "publicAddress": "a50e88a71199085a5e4cc22da74e2b8920bed8b2a0176c2287f9193dad78b11e",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -281,10 +245,6 @@
         "outgoingViewKey": "0352e1e8550063c44db4650d1b6c41bbac14006b7bf70e2cb1a0345faad610b0",
         "publicAddress": "ab9581ef2e7da183ffc59800f1f4a46b53f76453af231fd2a387e8986f8be433",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -311,10 +271,6 @@
         "outgoingViewKey": "a9eb8ca8bfc8800c1f6f17ba3dec7cd5f2339e50bd3437793cfb111c98006ba8",
         "publicAddress": "87a83a757a57f39b7ea8068f719424841683f54979e1f8d67e931e6f1d34ad29",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/network/__fixtures__/blockFetcher.test.ts.fixture
+++ b/ironfish/src/network/__fixtures__/blockFetcher.test.ts.fixture
@@ -95,10 +95,6 @@
         "outgoingViewKey": "e69ddffb85a833ec79cd5f4d2615375c50de94fed57d011372f164c9371aacd2",
         "publicAddress": "4f7dc6759c617fe1b59f864616b3d938732ac50ce62ba46da55caaba6108c319",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -301,10 +297,6 @@
         "outgoingViewKey": "5ee34b7f0b8be796a120f7765788973fe6165da3b94c930f23b32fa35c623a67",
         "publicAddress": "28471a17d96dd72d0b43525f6fa29d1c17a403dd494825d0717d1ff15d6740ef",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -507,10 +499,6 @@
         "outgoingViewKey": "ade7f214edf2ad5513975301f7bb3b1a2bf43dd34abd203aa78c30b5db5f0536",
         "publicAddress": "c9a1de564f8a313eba285f349bba8dcc3ab71195c32ebef7773b5e22cffcb48d",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/network/__fixtures__/peerNetwork.test.ts.fixture
+++ b/ironfish/src/network/__fixtures__/peerNetwork.test.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "d9977fb0bc5c2d6fb5b346abe12c41cabc7c5ff5fa19ffd36b8992a9e76be168",
         "publicAddress": "b071dcdaf075f82e732732f63aba0165ffa2773142d83a67db52d44055da565a",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -75,10 +71,6 @@
         "outgoingViewKey": "b8e4479493a7557b92b5d1dff598a084a27de4eb5aa8bc173c982a93dbc8f4c6",
         "publicAddress": "8c0f1d88d1fdc18bd937670c42fa531ad6414838d0a38e9146ab54eafc137044",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -261,10 +253,6 @@
         "outgoingViewKey": "5d602e7ba6aa86560819d39631d12a4748340c459b33a19fe8f1775c20dd2507",
         "publicAddress": "75a7b9c0af881a7d23caef89bc8f5c95fd27b736a9a070ccde463b8896bfc336",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -325,10 +313,6 @@
         "outgoingViewKey": "e8ae2564c73dee0c18c57099bea5382a293342c8d4e90e61dd52466cff685592",
         "publicAddress": "eb20966c088d3836693de19f0d536ab469a9185cd8a0b7f8d0bcdf33e42fd7bd",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2019,10 +2003,6 @@
         "outgoingViewKey": "086ab5643922cb88f52f3b8d0b57ad73f233d82a52390ea178b4176c20f29ebd",
         "publicAddress": "1d125fc892d45354b912cc02d0041ff5c7ec0fca1f635e3a9baead2a9cb55457",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2047,10 +2027,6 @@
         "outgoingViewKey": "a88f2fd557404bdf89a318e44156f8f2c4c9470559638d24c349fb311bcf0959",
         "publicAddress": "2b2a69d27cb5204605025a40633c4f25cf94b5444b390cb0885fa57a1143398e",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2133,10 +2109,6 @@
         "outgoingViewKey": "fa65ba5e47b43d7edb43e1a7d1d31bf36b9cc98c633a38734b8d9b261aee4b89",
         "publicAddress": "eb4cc0fdd088df117392bc43792f9ffd0d6bee45752c27d56f20a3f1d557d1a6",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2161,10 +2133,6 @@
         "outgoingViewKey": "3fa8d0b1fa350115bbf2c4c02f6cc851cd8cab137a0777d6dc81b9c14eb9de5f",
         "publicAddress": "ceed0308fee361d0d97bbf9b748ce923a6ceecdfeaffab38ee414f53f0c050c2",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2247,10 +2215,6 @@
         "outgoingViewKey": "fd0ae817ac451ef961928795f50955cd12d4844e5f5582f7dbd763c4dc4b609a",
         "publicAddress": "9ace7ba7c5b7f855179dc24b6fd0d21ec75901c41c2194c29ca47ec8391c9038",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2275,10 +2239,6 @@
         "outgoingViewKey": "3aa8f61ec1d62237410a2f2c60221e817df74ab6bae89ca141f9137ab8b0c23b",
         "publicAddress": "905b72876b75c49450b4d4af514709338ae0bb981aadf16d4c2a2bf1e3bf2ec6",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2361,10 +2321,6 @@
         "outgoingViewKey": "a31869184b83845840a172c72d3cf7f2b27b4e9bcf4432ceea044a1ee693f2bc",
         "publicAddress": "d6cb525c8d2f48d0a6f33bfabb75d9b74725eb078344e8e180c8a1aa21490d5d",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2389,10 +2345,6 @@
         "outgoingViewKey": "3a5cee62e67fcd4f71978633b1335120361580dfacd6939b3074c426cf1a4d80",
         "publicAddress": "adcc88dcd41afc5694085432e6831ff7dad1a48168c173a0409aa06b7fc0eba7",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2475,10 +2427,6 @@
         "outgoingViewKey": "131e8ff48484453f07f14e0bbffdc9510effe3d2eb5364a1235000b4ae53d662",
         "publicAddress": "8dc1c9fbb82f357a75f1a5698ba856c99db955e1772a37f14f304a81c8062c15",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2503,10 +2451,6 @@
         "outgoingViewKey": "a84c67e5475289b8146d375aac69796712d9be275048db6401b09c492b7e3fb6",
         "publicAddress": "256b3ad7ecb3c852426bc41391a8b223caf9e8e1ae1d0cd3009b5ba2d5593d82",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2589,10 +2533,6 @@
         "outgoingViewKey": "e328042580ffb69cab0c538c93fc465350165889ac703b0fd126f6c99d5f0bf8",
         "publicAddress": "fbb13149a0580d4106624154bae645dc257f84da38fff69c38c91d9909125762",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2679,10 +2619,6 @@
         "outgoingViewKey": "d3e1f69e4b8ac467d030573b52f576d8e224b4f75c070386c5458a5e8ec3df27",
         "publicAddress": "580a88393d5526f01e8bcb2d942c3ade396667b19c4b3d3f9d6988eae117c0ce",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2707,10 +2643,6 @@
         "outgoingViewKey": "b84230a63de95d5d8a956a6e851335189fcbf29b5ab8a86ed5a71281113576ed",
         "publicAddress": "e43f433f9a4618d0749f8a8b6af6b3d697539b6c623d54c1a645a281b58d886a",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2793,10 +2725,6 @@
         "outgoingViewKey": "edbcbbd08e3311f03a8388774d450b95947338b786189cef2ab5e2b8b7f9fa0d",
         "publicAddress": "eee443c63a6c2be7f8f4632f4d1323fa4f424e4188a8036b5569ec51b1b0f3c8",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2821,10 +2749,6 @@
         "outgoingViewKey": "9d7775a3f8b62ea31b8cc7f7b465f2136aabbed734a1d47715dc848bf07f6b6e",
         "publicAddress": "c10e9b0e0b43f9b9124c9cb68e95152ab16d2274182cb101101099f22648631c",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2933,10 +2857,6 @@
         "outgoingViewKey": "c4405147fb3fcf863134e5f539f6f66679746220532c366fe7d700c03fe06eaa",
         "publicAddress": "d23368835d4bf19be83ea2f35f331b7fe42ce3f4abadd0dba8549fedaa72c955",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2961,10 +2881,6 @@
         "outgoingViewKey": "1931a64a7e728f4613d89b21cb12a6f463d51742694e763a3d29687e426044b6",
         "publicAddress": "3ec1f268a725e4bb18ef4600343dbd2f12b4a8beb6d0cd2527b46eacb0a22adb",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -3047,10 +2963,6 @@
         "outgoingViewKey": "3294c70f28ca96a54dd250ac8828a76eebccf6b042eedceccb4c222a9cad99d9",
         "publicAddress": "f4a0909de6f424ed8f421842fb53f7dc7e36e78529ebf2e8228e7c11b3a3b2b1",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -3075,10 +2987,6 @@
         "outgoingViewKey": "3db32f45180abae8d4ed1def454c014731a75be3d428a435b8135affaa617092",
         "publicAddress": "7c82563017fd87ef92007216bac6822414755f37091a727740501a362bf20d11",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -3189,10 +3097,6 @@
         "outgoingViewKey": "f5d47b6fc4021e82c9a64bfaeb3fc107ef9b34227b7c9d012ae42827b8b9de5c",
         "publicAddress": "97ba6f73e2f4c8916db3bd06c234a4cf640b4fce0de05d69f846ff9ec0934bc2",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -3217,10 +3121,6 @@
         "outgoingViewKey": "0229dee182057254ea827e0f5e8a80e4b1b3596325fd699f23debc5df8703ded",
         "publicAddress": "ca1a07da7ba050c080fde8adc8d20462372f7d9d2a479c99c722f2dbce665b0f",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/network/__fixtures__/transactionFetcher.test.ts.fixture
+++ b/ironfish/src/network/__fixtures__/transactionFetcher.test.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "4fe4e24ace26ce0ef198a206c9f76e510b836a8705769fc4ac7b9293e3b380cc",
         "publicAddress": "d48aae40b11f6a36345090e8acb99e477165d95cd847e6e61c18e25bbdbbeb5a",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -39,10 +35,6 @@
         "outgoingViewKey": "486b92d8bec1cb0361fa534a8f8d62e2b7b14a53fdb5fe1b7054e01b328b289b",
         "publicAddress": "998d3f3840e6998931e41531ecc61811160f7256b2bf488d3e94c48764b01117",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -125,10 +117,6 @@
         "outgoingViewKey": "709fb4a434097bc617325e58dbc962e4b16e58541947d472424efe29d1799382",
         "publicAddress": "7e8eaa6d90e0ef3281d03bdaa0eff16bf76841d98446fc7238f787bafa8c572e",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -153,10 +141,6 @@
         "outgoingViewKey": "d0895aab83bd2dd86069804f369b19ff40ef6c16c7a9c883414b8c2475d010d5",
         "publicAddress": "f71a47c668e06f559cb689ec177672ddfa07a43bdfaf137a3729f459efe57a1a",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -239,10 +223,6 @@
         "outgoingViewKey": "8258c135399f31049d561ee5d90dd21f8d020ae64ea436407f0629a9a2eb31c6",
         "publicAddress": "b1fd3e52b001724b5ffd7fad71a92213f212f1aca48df81a729dfac3483fcc0f",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -267,10 +247,6 @@
         "outgoingViewKey": "1a7388c2aaefb3dc41dad8802a150c24faae1bb18ea207ea043074a8f8439b51",
         "publicAddress": "59d754a28bc85d0682f9b58074ba58e60db6f816229a8edc22ac71ad48546e73",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -353,10 +329,6 @@
         "outgoingViewKey": "b85cb3a8372b94f93424e24f2ecfd0c4a99fdb30f5a13abcf513dd61edf64941",
         "publicAddress": "33e194acacbbba6a8352e7a8302ca05175e4e6ef496eec5826a05abf61eddbe4",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -381,10 +353,6 @@
         "outgoingViewKey": "5717e95165731eacc45224783b0940507a6e0a45101766c6dfcef3674aa861eb",
         "publicAddress": "ce93e8ec32f81174cae3b5172089f0ec4be948b827072c26a3ad82641a69aeaa",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -467,10 +435,6 @@
         "outgoingViewKey": "cd68f41469e10fe3da512c38cca0ed61c2e06050fee925406e861fcd5d893014",
         "publicAddress": "88080af53d7db6d73a6edeedb50e4b7812b7aa222997e7c448a931ac8da57a3c",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -495,10 +459,6 @@
         "outgoingViewKey": "7eb00d68f2b137e325cccef011f5b3ccc3e87fbf54f384752a161f0266e8fd90",
         "publicAddress": "106bd9ca646878acd64006ab9f6a672680455df8d1890c64cbf8bd8abf80e1dd",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -581,10 +541,6 @@
         "outgoingViewKey": "cd0ef3feac1f0971823c6545541447e339e0511a15b75339ba7569025be77b1b",
         "publicAddress": "e15d5a1f07e7760c0de873fcf45181b6dcf923be9879851d4546ccc6993d250c",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -609,10 +565,6 @@
         "outgoingViewKey": "9f60af88258f6d413b1a0f5aa681f51ffb7835d3f8d0ff5fe94a6294b783c48a",
         "publicAddress": "96e4691cba4791c0ad48d6e433049916bd7541633b0751509b301ad9e6e4e311",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -695,10 +647,6 @@
         "outgoingViewKey": "5066933d19ab16d4143a428c930d1a9d8589ef8d64e9848fda4a02f66c128359",
         "publicAddress": "9187e5cd3dabfebbbee0031407683c5691f129a134e825a888193c58a58b0d03",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -723,10 +671,6 @@
         "outgoingViewKey": "c17441172bdc407d211a66dc2f28c4fc7f1a3818b7ff4da14567309b09fde482",
         "publicAddress": "e58c63d4528d14c9b03dfc50af696c9e5d21af82f13d245e724a1e2d0bdb3521",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/network/messages/__fixtures__/getBlockTransactions.test.ts.fixture
+++ b/ironfish/src/network/messages/__fixtures__/getBlockTransactions.test.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "81ae666494f863ffea0fcdffbd0f33ef7b5615f71c4ec3a6ef69dceb3918f0c1",
         "publicAddress": "79b81bfd6088f276291d595dbc20368d3f590ea090e0b8374d4e3e0639624266",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/network/messages/__fixtures__/getBlocks.test.ts.fixture
+++ b/ironfish/src/network/messages/__fixtures__/getBlocks.test.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "b75446854bab30c717f322b4feabc9296522d9a134686db7d5da1983df964db5",
         "publicAddress": "25e53d32c286a95ac67d4efbcd35ca0841757d7c1be5be333c59ec5d2c1a4f47",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/network/messages/__fixtures__/getCompactBlock.test.ts.fixture
+++ b/ironfish/src/network/messages/__fixtures__/getCompactBlock.test.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "4f51f09d539d6ba2b91c42bae6466b81bdb564e07cc2242fbbf5abe7e95d2748",
         "publicAddress": "ae560a6703321aff5697ee2c47be33f340738ace5755cf09d678caffbf0fa105",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/network/messages/__fixtures__/newCompactBlock.test.ts.fixture
+++ b/ironfish/src/network/messages/__fixtures__/newCompactBlock.test.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "5cdccbdb899c1e30d0260153f1f827f6607bd4839cee9204d996c0aabce61b71",
         "publicAddress": "4cdcca459b02c986234b95b946c1126e6411b356af0ead539604a6a18230d42f",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/network/messages/__fixtures__/newTransactions.test.ts.fixture
+++ b/ironfish/src/network/messages/__fixtures__/newTransactions.test.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "a2fe285ad3467f77656bdeab488d33c24255ff0b00724eca76c1a0078402a38e",
         "publicAddress": "9d7fe5704bd95292092514cfe05139ac0eabbab59c6523bfb79e2c1e49cd6744",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/network/messages/__fixtures__/pooledTransactions.test.ts.fixture
+++ b/ironfish/src/network/messages/__fixtures__/pooledTransactions.test.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "f94d2a4183be7a144decc1e19e4b4a2007f4a985c56e5b6e9962cfcc159f35ca",
         "publicAddress": "e651cd078d5bdebd637738a63b39e87b7f2f56c8f90631ef91f29e0277306671",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/primitives/__fixtures__/block.test.ts.fixture
+++ b/ironfish/src/primitives/__fixtures__/block.test.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "8e145fbf7cff75d28029cd6d64ae8593be6d2a0c84ffe9c6af5e7d670b13476c",
         "publicAddress": "b2c930b390f58849daac00853aeb483661eea0a7c08f9e651ad5f49395c007c1",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -39,10 +35,6 @@
         "outgoingViewKey": "0f9917d0d7f02c7903b1b0baefa0f365c3abbf134beb33298786d75d063b2271",
         "publicAddress": "923ba3629a36f3b36d0de2784a5d3929c32032ae28fe98d9e787e6cbf2e2c566",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -153,10 +145,6 @@
         "outgoingViewKey": "a391670c08a40a52c8d182336ae1911928412ffaf109c6a48dd2600f0e06ed62",
         "publicAddress": "a0671795b5771637ac17d07d92b7f3f57659186168b4374dd394f07dcb48372d",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -243,10 +231,6 @@
         "outgoingViewKey": "793d58d941683407aa13f034bcec86387985ad4ffeb5860969e1aaa319cc7105",
         "publicAddress": "9093d4c52c741d2e9a90de2a639be1d6b239aefdfa43176959189471ae042531",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -357,10 +341,6 @@
         "outgoingViewKey": "d0f9b35210d145b36bdfedca31b0db0f934f475bf49db0c6bb1a88798e5a1d2a",
         "publicAddress": "1356f7e0b6fc6dec3a5d57a8cb86fd8b529811a6ba1e2a1ed5d1299c239dfed7",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/primitives/__fixtures__/note.test.ts.fixture
+++ b/ironfish/src/primitives/__fixtures__/note.test.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "b21a3c72aae7b27c3617103365378f48eff2c0bb1d0a3449f3240b15e0af93a0",
         "publicAddress": "a007411ad315ddaabd22545187241b37b46e1176d7fd6bdc4f33182b839f0907",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -67,10 +63,6 @@
         "outgoingViewKey": "4795c829d68e5dc83eeee8fafb7ce3a79dae1f3bdb97404a43565a2f6ddf187e",
         "publicAddress": "57e217fb045825ef5b7008cded044e6848f15b83d9f34c35e9c7252f6c4325d3",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/primitives/__fixtures__/rawTransaction.test.slow.ts.fixture
+++ b/ironfish/src/primitives/__fixtures__/rawTransaction.test.slow.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "4e79b4081ef66e6d0de284c14529294bc8ed69ea737a19ec54d22f26c9e8dc52",
         "publicAddress": "ca6e5a2ae955a027a2d75bb38962f68b06f6985d8a362d5f4a393090b1a73653",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -45,10 +41,6 @@
         "outgoingViewKey": "b007fed4cba0e5ae21800d64f358ab434097a19dc2fcb1dbf4a15bb39ed4d013",
         "publicAddress": "0a3440a7c169322f4682ada244b24e763c0fc0a5737708436fcf8e6a4608baaf",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -79,10 +71,6 @@
         "outgoingViewKey": "cc15d7e8764cfc37d78e9878c7742758ac5e48f36ed71c3a939db9e0f2a39208",
         "publicAddress": "4fd817b6404e2b3e93f58d9d7da03a92beadcf6e5ecc18310c9d3bd1d7f4866c",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -113,10 +101,6 @@
         "outgoingViewKey": "a5e92be651be199aa528d5cb31fccfcc6ecfeb5d6da97b04982f33e3a1ee619b",
         "publicAddress": "d1b8044eea25cd37bc39d1fe17b4fde08b15d43d0c0ab3ed01efc79b55505ca2",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -147,10 +131,6 @@
         "outgoingViewKey": "a18f6a40d2f78af1c56aab5c08e65c8f7112369584d4058aa084722bdf6f88e0",
         "publicAddress": "6c7ff7c6e7d1a7ef888e8421d9cf90491c96f3c2f19af07a6ced3bad76c0956d",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -181,10 +161,6 @@
         "outgoingViewKey": "5b131060e3658049c7f7d39b58cb918d24f03830258ed5e5a5fdfa9ad814d869",
         "publicAddress": "cc17d9b164c5e2033697fe183e1b1a99e5bdadca2082e26d43c1d9ee160a1e18",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -215,10 +191,6 @@
         "outgoingViewKey": "ef6856043de1e273dca61b355cafc173e93cdbd9fa10b4bf7684b2e3599b3952",
         "publicAddress": "70e012e4d5e777e8ac5a527774853bce642aa7f99d3b14bf521975ab062a9e21",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -249,10 +221,6 @@
         "outgoingViewKey": "0fb9ee5f055ee7809130e28a625f6aa39699c7f877100e5b3171a02ee988ff89",
         "publicAddress": "e013322320fe32337166f6aada1fb4ee5e95b2d71bac2f065dfeac59a152643a",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -283,10 +251,6 @@
         "outgoingViewKey": "f30d86cc97a4454aa5ab7b3a4339e54967c2da291b047f9bf069d9a7a1e366e6",
         "publicAddress": "6816b1e2c09126d8b9f32ba9b606c78f9ad7534256f72733df079eb6c682bb3e",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -317,10 +281,6 @@
         "outgoingViewKey": "1d952a75f9c63972b1e4370ec4b995bbec090a09f7904d72e633d1aac3683013",
         "publicAddress": "6b48ef5542540f0a0681babf80b39131ea8a7982ba2d69e950763cd976edc64c",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -351,10 +311,6 @@
         "outgoingViewKey": "f3d56fb4838671f31aff88c12ddf06f96663c46322f7c61f517192db815b366f",
         "publicAddress": "30fc42ed6a433c3e0a885175f549cedc1b2dcbe03698615f92534c877e31a1d1",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -385,10 +341,6 @@
         "outgoingViewKey": "7002087cd2a6fb128d0f35fe1ffd60d86372ebb4d8bfd7a078081988b7f11744",
         "publicAddress": "1666f1e9ec2f42e4ca445195384d8d35228024d00e855bc3f5763f12c50747ee",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -419,10 +371,6 @@
         "outgoingViewKey": "0cfeef3959fed1d155711dba2e5797050cb95c1d9103f778f51c13272aed6b73",
         "publicAddress": "bebdacdc831f4506de8b290de10cacd10e8833d975148583865871cea5d1dc81",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -453,10 +401,6 @@
         "outgoingViewKey": "af900ddefba91a5fe6389b45305f8b6c3fd74ba05c25b519aec6978a859b8337",
         "publicAddress": "bcb78f55eae6a038c966b541f98fa493c57c730f414f51a84a935303acfb63e1",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -487,10 +431,6 @@
         "outgoingViewKey": "1d50d55d63a4b007f85320ba587a051ecf0e5a5de174fa69d4a13f4d8eadc20a",
         "publicAddress": "ac43ef3843cf1c122ae6a18170e0a4e9ef90ab51fb8d859e4be7cee6b040b009",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -521,10 +461,6 @@
         "outgoingViewKey": "d05cc682a102b20d7c57f916998a94399afa8c4dd2615a2a1d7e84f51c46e237",
         "publicAddress": "6fb8049625fe64d89ddd6981ae12460b094387f8dae77bf32ab4c54752e90221",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -555,10 +491,6 @@
         "outgoingViewKey": "3be4d4cf1f59e83b461bff561c3a7bd4aaaf29925b0142e6a5127b985975daa2",
         "publicAddress": "d6aac67b54c9cc543493b83eb5ae6e841ca12188d8c6e213be353bd6e93bcd6a",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -589,10 +521,6 @@
         "outgoingViewKey": "3d5d0cc06fbc7c59caac83b64e9b3caa744954843fb9100855f6ea856bf81b60",
         "publicAddress": "a86c714cbe4c1377e3e6754703d06d338cc347cf753fe7ee9d8e33d3b8da1696",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -623,10 +551,6 @@
         "outgoingViewKey": "b07aa7ffe7e1bbf41bc46f61d758883a6b90bd5eca6ad7524357074d8a84e20e",
         "publicAddress": "04259b1f6440a16e5e8a1b6d7399799a1460006b76fff6c5d4179beabf6df095",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -657,10 +581,6 @@
         "outgoingViewKey": "ba8479a03f6a4c5fce0fbbe6585df3d25904b61f13a280d6d14a8e0704e70e8d",
         "publicAddress": "a29dacf3e67ff866e0d3f372b1932d71a979285382ee2ce89b4d27e2f7cf06cb",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -691,10 +611,6 @@
         "outgoingViewKey": "fc11999036e0f6ef20d9edeb9cbb30e026402444c1db70458fdec0912c6d1df3",
         "publicAddress": "e0280e43942ff26cc1dbbafae5e82de07daaec6695769fbf0e3a54dd7da15554",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -725,10 +641,6 @@
         "outgoingViewKey": "4579246868c7e0dd16ed65e5b01f87c15485e3c33d171903c4ad53d2b454ad8e",
         "publicAddress": "d93b2a777b4769c67383299e6628f77e2a4f38d8d6240fb51d01d08249aa172d",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -759,10 +671,6 @@
         "outgoingViewKey": "e124df489ce109c0e38a86d1282e9032c483c06e11fc8645e1aae2deac5ad08b",
         "publicAddress": "996b2ac3cf84b5c7568a995b758c3021819e27cf3d73d582092cc4712e9bcf6e",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -793,10 +701,6 @@
         "outgoingViewKey": "60a121ac254b1955d7d402f914e211727bc5f08d8be57326e52472ae4671aa29",
         "publicAddress": "a9f5650f69edda9ec8c40867a4aab3d5d428ddb864e161d52bdfe902aa7cb3b2",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -827,10 +731,6 @@
         "outgoingViewKey": "2d5ac34d8bdb136677596800d32b49810d539dc250276e5294369b05c0dccd40",
         "publicAddress": "96dc9a1b1dcaf1922c297cd90084d520c06cd39fe2fc67ead4d35bcab6c94ab5",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -861,10 +761,6 @@
         "outgoingViewKey": "971713671ff1952716af6b5c314072f42f6b3e2f5907ca5367c98c3d48942058",
         "publicAddress": "1bf1f67f042069b5305e6be05ab2e2c2ece75c530b3e3008e6e17fae87828ed6",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -895,10 +791,6 @@
         "outgoingViewKey": "52a700279cde6a80437115d76b6eae033c239a14d92881eb924765ce85730123",
         "publicAddress": "789b57ff46892bb8e093c07ae14642e5cc31bc302bf6ba3a21b4e2d3e7e358e9",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -929,10 +821,6 @@
         "outgoingViewKey": "eae8484c3ab765cfd2db089634d83a39bcc1eec7677a3121719aba2cd080705f",
         "publicAddress": "6018ff123cebb3843c097df9037b32255f45e81f1955f29b899aa7e5ee08db06",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -963,10 +851,6 @@
         "outgoingViewKey": "aeb7fc6e72dbbd7c194aafc41e764f0146e0ca47872f8bacd65b60f97882051e",
         "publicAddress": "ab3512420affbebc216380a98a24299881ab277263235ee7489ffb7d13c3ecaa",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -997,10 +881,6 @@
         "outgoingViewKey": "efaa7e1c936819168fc96377482f089ca011abd58903e21670cef1c8a23f67bc",
         "publicAddress": "5a24fd0aef51f7aeaa3480c09117332104cdc32e0a54132ddc5b5f0d3ce22cb7",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1031,10 +911,6 @@
         "outgoingViewKey": "a3f1d3ce16f68e9233588d8d8092bd85ce46d759ba1d05f8b15a64123a6e9c5b",
         "publicAddress": "dabaddc5cf439af5908f8319f205fd8d24157e306128f678e360fa7d77051a20",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1065,10 +941,6 @@
         "outgoingViewKey": "42a205a821f3922a48b05e9532ed312f940cd7efe111270eefe3232b9aa15c43",
         "publicAddress": "621c04b28ecb4b2f906489f22338195698da87e08797f03e75f92704331557f1",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1099,10 +971,6 @@
         "outgoingViewKey": "7a303d2d264e0bb40cc8c26c9aef9fdac6531c7cec9d01b293c4a5918ee93431",
         "publicAddress": "5b3df5cb26084fec48c6a96d5a7b9a509e088b436df57a01a2cf29a3d10ce24d",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1133,10 +1001,6 @@
         "outgoingViewKey": "871e6cf86cbdcd672b24968ca181bb55978366819cd38c7893a082809f4bfec8",
         "publicAddress": "aaf3a5b4c02fb32909eb2b6e7d5ef25835e7eca54e58b3cd44c594822bcd66f2",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1167,10 +1031,6 @@
         "outgoingViewKey": "81260fc7bf5b503a72de2ce64f3420f418fc7350840aba9484b8f23fc0948313",
         "publicAddress": "df6022b69b9fd82b723849c759ca4c92a0e34b97f815f010e1d40fbf2824a710",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1201,10 +1061,6 @@
         "outgoingViewKey": "215933aa33ca46669bdb619d858c5a17248eb202db6a927b30b8e86252069910",
         "publicAddress": "048cfda7aeec25a3d3e2ac6095375d2089f12a31b56077519ac36ee2e3d34ed0",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1235,10 +1091,6 @@
         "outgoingViewKey": "65b83e33aee2cce40d0a4be6251f65de68ec92de23f1d4b1476a44327f4f8cc1",
         "publicAddress": "32dc512fdeda898711f5abb46bb8dc9008084da225b14b944bd0b312efd6a211",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1269,10 +1121,6 @@
         "outgoingViewKey": "20702ceceb26301d9d79329173f62a249621520aba2738cda80b9470a4561e29",
         "publicAddress": "b2c741b0e9e25628eca02f6caae6b926ff6728391a61d163ff1fa6b55e809064",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1303,10 +1151,6 @@
         "outgoingViewKey": "25bb4ba9c77cb51babefcf69cf473fc9aec5bbbe7fe81586e73e82097400abb6",
         "publicAddress": "805ffea7883aef584b66ac929b6b6b6eb71f0c82cbb07c93e385def5f511b0a7",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1337,10 +1181,6 @@
         "outgoingViewKey": "d032861b8eac340a735f19eebd08c06f1696d40b3c937da7a8cc4c4a19d63cde",
         "publicAddress": "af0b224e9a92e5794de1946261d548ac1f86e72f1e33b3baab8c7bed9afb7c1c",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1371,10 +1211,6 @@
         "outgoingViewKey": "57608b5b50bbb87858aab594ad32f8d59fc20e14e43752a4a864b04511a81282",
         "publicAddress": "5e9c830e17ea605a7c126578886edb8eba1b3ee7f4f81d6f4e03a9fba90adfe3",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1405,10 +1241,6 @@
         "outgoingViewKey": "3e45c7b75ed3a7af688f456389ef47312c6d51eb1dc526c64d5a295c17d87ac4",
         "publicAddress": "21c12bda4cc8513a8077cae9b36c40e1899479f411232fb8530004ab60b9cdaa",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1439,10 +1271,6 @@
         "outgoingViewKey": "dd0df29c9661fc72d1e6b881eacb58d3df1f8281a503a305f8b864fc866c04df",
         "publicAddress": "4d40d6d6887912fe7202b5f71214294067188e5ab907745982ca920822413cd2",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1473,10 +1301,6 @@
         "outgoingViewKey": "41be532eb688a372a7db7e9b896720ac58e446d6ebbf2aef20582e91d6e9064e",
         "publicAddress": "783116ed913ddc703e3bbe03ec8a28361142507879287438bccc95fba05ed492",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1507,10 +1331,6 @@
         "outgoingViewKey": "d72f7617e3801e64a47d5adc6f6d1811f59201ce860176cf00985870c104219e",
         "publicAddress": "47d999eaea4461ca0814543155867235a03379a7407a6aa4fd93ed89574b3b0a",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1541,10 +1361,6 @@
         "outgoingViewKey": "a2143d5f1125f9c9555080c2a7eaddefc822d017bafda2aaf51e4cc96a3c9538",
         "publicAddress": "b8715e305082d8187af35c20ba25d2ab4b73dd7adccce4afa5c807f33b5dbe18",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1575,10 +1391,6 @@
         "outgoingViewKey": "0c4547105775f656e257dd65fc8dc8326be70c62a81241f6fa5597f33f671d96",
         "publicAddress": "0a7fbc072427dafb07072f8d7bf50200a13667d10c22e3995a6be87b1c3b44e5",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1609,10 +1421,6 @@
         "outgoingViewKey": "5f42fed74e7aced59f3d7a1304d9962456650b37bc1f31a9ee7f712e315f261c",
         "publicAddress": "3c3e2bf8f21abc148a391af40fa50edd59c175049682b6bc8e9285afbc1965b4",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1643,10 +1451,6 @@
         "outgoingViewKey": "4d91c261a6ec570c440902526aac704c739365b0e31d21fa15b5b1ebcc0a1d25",
         "publicAddress": "f8750a287431fe6f43ded7bb94c81823edd79e1d0a2f57e5b851347e10b1e394",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1677,10 +1481,6 @@
         "outgoingViewKey": "a04e01b1e5059781ed214854c85d482535303561334447a044c84fd104c074fb",
         "publicAddress": "671878b88e99e00ba8fdfe1f23b124fb9903ec19ce9b7e2104110567fd43a59b",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1711,10 +1511,6 @@
         "outgoingViewKey": "9ab2b7ded7c7e752869affa8f14c31977fac0760ce81b56b1d4f8a946c59bfb6",
         "publicAddress": "ce62641d3e8d68b8ca1942ecc5fb7ff2183672ab56c9e5980b8176766ad07594",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1745,10 +1541,6 @@
         "outgoingViewKey": "a54b5ee63825fb3637b407d4e12b7e270e59e1cf4e534462e7fae3a09f50c2a8",
         "publicAddress": "b07ae0695139bee2ed184b3974594d42e61db4315f19fb481f7ff24df5436498",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1779,10 +1571,6 @@
         "outgoingViewKey": "9e6f6c4863bc869fe55e62c529a5fe0faeda038126efbff13e8eeb2b0e88dfc4",
         "publicAddress": "780b6c02a062776cbc163f14c8519f5a1e0da73b33ea81e9b34b578bafd61dc6",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1813,10 +1601,6 @@
         "outgoingViewKey": "ab922b559440148f5c96f56a1f0217021a15c0bfc32d757bbe570ffd9674acd1",
         "publicAddress": "34673c676246077cebab12974562f01b62ee38ca4467dbb374e1df1666f4aae4",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1847,10 +1631,6 @@
         "outgoingViewKey": "1432518f908458210add8d2c9669b4bf826264bd498df685ac1452eb49294e17",
         "publicAddress": "2cd11a0a91a051aa68480d3440ad246d3b24b73c1d7aba5552c92cc45a1dc657",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1881,10 +1661,6 @@
         "outgoingViewKey": "a757255871c1c2fe2d6390400864e515704f213851918193517eb59a3c2a1ad8",
         "publicAddress": "f4105dbeae89b4b649e6c674864fa3db11c2fb64ab38ae72b89757b3c95bd695",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1915,10 +1691,6 @@
         "outgoingViewKey": "dde9500f795f3659d252e937045032b0073462d7b6ec8336794e4af30027ce73",
         "publicAddress": "3f5738e2f2f591fbb93651681b5d75e989317835e0940d09d3b85a2f30139a08",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1949,10 +1721,6 @@
         "outgoingViewKey": "d86e5e74e575a127cd3d8d34495845d57dc9230fafa7b3c2da254c2da94a9e95",
         "publicAddress": "b05c262faef56c768cc6c59344e3eae570b12954025e840b001ce60141b1ad82",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1983,10 +1751,6 @@
         "outgoingViewKey": "74647701c4e7d54fec361549460b531e6261d23d5ca907457f24cfdab8030a1b",
         "publicAddress": "259dc82ae14a58aaabddda2673d4a38181cb4a7635d3e9e4686bba2a019a054b",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2017,10 +1781,6 @@
         "outgoingViewKey": "a1d9ca0a0842512961967132b547f4919baed3bd24bf4650d82efa6ffc086ae2",
         "publicAddress": "06f46840413274824b5d639449f14dd33bb4cdb4d5800ea61ff6302c4c619526",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2051,10 +1811,6 @@
         "outgoingViewKey": "2c588bfef0dacd56bc0696327e1d77a10baecfd9e2b4eaec5e854703efdf87a6",
         "publicAddress": "1c60765e46d75908cf7253f984c7aa5eada070707798b3fe8b9054a3247b6dba",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2085,10 +1841,6 @@
         "outgoingViewKey": "746bf9280510af1c8905840ffcf001f653fd69eb3d492bf61ac8d34dce196f44",
         "publicAddress": "32067a35c9c41454d3173d45254379f10f2e10bf967477a97322c0673f91be13",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2119,10 +1871,6 @@
         "outgoingViewKey": "c5e4e574d6f1beb762322d0d888860eb03a9303a08780f5bf667a87796f6491c",
         "publicAddress": "af5eeb0a81d3777e69fdd650b033204d0bc84b0f91ac482a2590c22a007d2083",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2153,10 +1901,6 @@
         "outgoingViewKey": "f170c6c07c690c454d34d5bdd2a5eae7c4156f14a79c2f595b67cd710faef838",
         "publicAddress": "70bbd7b20f0f19cf6133dfc67c8265b7809c2a467d2a4bb7aed53f4f81d10bbd",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2187,10 +1931,6 @@
         "outgoingViewKey": "5aa4c05850ced3ee6a509140949108cb971490a105a2e5401529a5d0e1ac5dfa",
         "publicAddress": "82f585315d97c63d7bdb542d6427423289b0aab39fe230f38610878040cc7fd9",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2221,10 +1961,6 @@
         "outgoingViewKey": "883756280e3af59ded0b066b42d8d5258e4c1258fc7eefe772e230b6dc580945",
         "publicAddress": "e6fc11fc39b00df2dd634446768d547ed45d6bb6dcff1c5e683a308aae6a03ac",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2255,10 +1991,6 @@
         "outgoingViewKey": "e234c0cfa2dcd4e5bec1efea85893471f19d89d63b89d7d257c1cd34df75f031",
         "publicAddress": "331cf749feec60ee195a5065962a38a0b7585dae7d525ad6dadeebf97fb7fd71",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2289,10 +2021,6 @@
         "outgoingViewKey": "b6e405f8aacab86ea5a32a7fa78fed9ab3deae1b06b3b4372a2ba224f0e06a28",
         "publicAddress": "6365ac640b337f148f0f57f4be1fe6bde289962981df68ccaa070a58d0c150c1",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2323,10 +2051,6 @@
         "outgoingViewKey": "068fd8665aa9f27c83d403c4747b6eb5c539927bb2cf087c1e8009810d252f76",
         "publicAddress": "039ede82094e2ba680632ae9deaa573efb39ee0cf83c5296d07d950e3bd0a513",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2357,10 +2081,6 @@
         "outgoingViewKey": "e566bb4949b2893c48faeb031a703345d5fdf9bbdd45e3543d9834acf749acbd",
         "publicAddress": "2755aa07715d9ee5188988cc117368ec1a2e258a836f06f850438bd8094bc132",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2391,10 +2111,6 @@
         "outgoingViewKey": "9a011ce06a0c278c46eff0b5a32f69f395504bbb4c55f7457ae36b3d78b9b5f2",
         "publicAddress": "8854357a01ee4f0d487a04b2cfbc684b21396f6613381ee8f3f56c43151bd127",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2425,10 +2141,6 @@
         "outgoingViewKey": "df887f43ff74d55249ac9c07883d7746ae42639e437afa8de4397d89811c9103",
         "publicAddress": "a5b13405af90c95db0e23d76dbce9574453a95bd34aaa17c229d4483289023aa",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2459,10 +2171,6 @@
         "outgoingViewKey": "a7c43268891991197e9f9dcc29de83663d327a5a6c0d8b3737cefaab15557861",
         "publicAddress": "71047515ace3dcd7b250c544af304e3f154f9820a0c3a8972a392ae3a1967241",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2493,10 +2201,6 @@
         "outgoingViewKey": "11f07b200ddc3d0903e626ff616a37b204c3d0b3619d9e894e30f36ef9d1ab1a",
         "publicAddress": "c93284aaea9da4a4d122b61182b767664fe524f27b2a74a3ec85ed0ba96d0434",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2527,10 +2231,6 @@
         "outgoingViewKey": "34554703bf9f9e00a8025fae3f27f871e44d6cbc5e99a22074f7f1a70cde9f8b",
         "publicAddress": "554a83ea569a9a11c968525e55f30ef8957c41fe559dc283f5096334b0b3d848",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2561,10 +2261,6 @@
         "outgoingViewKey": "0eea2b22ad64c66db65356f5b9065f072e613f189ad7fce79e9780bf71e47e6d",
         "publicAddress": "b78aff0dfd1b6afd908b800afff14b210b5a628007e348aca9c217a833bc483c",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2595,10 +2291,6 @@
         "outgoingViewKey": "a9789b9a2628fbcfa64f995305c7aaf27e04497d5f370d04232bb0d179daed18",
         "publicAddress": "a77d5a29c3f3ad54233ab60fe94dc2838853de55881d937e0fcd0fdc4d3ef240",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2629,10 +2321,6 @@
         "outgoingViewKey": "ae8b99a468cd8c04a27bd14a1fa6d987fc5ed1cc2b7cc2098f432d52f533a4e3",
         "publicAddress": "3e0f2c67411038ecd1d52682acbf93e641fe4d23958844d6a0bbc0b54a853602",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2663,10 +2351,6 @@
         "outgoingViewKey": "5f22d1de31374d3319a2c156387e5ec991a3188f62deba3a6148a158966fd8d4",
         "publicAddress": "5f85351cd4ddbb5a5b12167daab515eac13b08b275e7ac1ddb991239df42698b",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2697,10 +2381,6 @@
         "outgoingViewKey": "182df883bb00695802e9d8e0e5db2805f6f009b9e55cbb7405c0ca05f0bd07de",
         "publicAddress": "b015ac0519f3b1ada969219abb39675c8ca3ae10dece948c0355d4131bca9a9c",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2731,10 +2411,6 @@
         "outgoingViewKey": "83dbc1cd6c64bffae182ac2d3406f13b861b6af1e23c6fbad9be5c43956564e4",
         "publicAddress": "5dde24153772436b2a258fd6f9c2328b29db0eebf56728bbaa085a97b44404b2",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2765,10 +2441,6 @@
         "outgoingViewKey": "936dcc088c5944d1d5fe2b9f2eac2e8c2dfe8f6d755a5c7afd5f9c0e51bfa577",
         "publicAddress": "16753b7e007bfb010d5b543bb3c146de73791438197d2370d1ca0ca650cc1ccd",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2799,10 +2471,6 @@
         "outgoingViewKey": "6f9944a4dc70cf13eac9ea730db0904273ba57a295a97a31296977ec7ce00a38",
         "publicAddress": "56d7f09c3ccedda45345c681f5d92f2a841310847700ba6ecdd9aa8a41f8031b",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2833,10 +2501,6 @@
         "outgoingViewKey": "43b136da7a8311984528a62b95b58dcb6f3ecf7af9b32259c056c9a3d86f5a4b",
         "publicAddress": "87a4baa4ae5de7aecad7da9e04020e9cea371c6486b2089d9f8b2f54c8373d71",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2867,10 +2531,6 @@
         "outgoingViewKey": "dc31bda061361c116907d532085684d6462cd22a924a0280cf0c3b3c39688e09",
         "publicAddress": "54ac8d877e6ce3cebcea2250c6a85dc82da431c200edb021647a0694e1293668",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2901,10 +2561,6 @@
         "outgoingViewKey": "8edfa217fbbdcaae8e500bb2e7bf005a7df9e5348f23d4fe25c31ae70244d6ac",
         "publicAddress": "afafe8ef92504fd79e94c2c5406205cd4c7d8539914aa65fa770f66e872a0c9e",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2935,10 +2591,6 @@
         "outgoingViewKey": "fde8628df154822f37fe7e977745ae16c284b2bbb6b1c253a7eeff5c253e7127",
         "publicAddress": "36fe30a7abea25aa23dde59dada7ee5a44ef01808e71edd1af6e44c12e4541d5",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2969,10 +2621,6 @@
         "outgoingViewKey": "d7ded75d6b250f054798062e4c35b3e15b0bb1fde72935258c55a3eb878bf10f",
         "publicAddress": "cf2d4c5e580758cb6f906d5835be1064f56b93ce29fdd9ff7fb0ab48341b33de",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -3003,10 +2651,6 @@
         "outgoingViewKey": "c17f5fd04f779c4cd0d34984ddc1cd5d86268d0a13354a9b7df08d64e0bb0c7f",
         "publicAddress": "547cfb38facc4fdafec4790486a3167df3a6c54edf71ab015c785e7072ac8204",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -3037,10 +2681,6 @@
         "outgoingViewKey": "db7bffe446f14f978732229740f423b349926d8bf2d0ac4e76bbbb58259f35de",
         "publicAddress": "d9f27b5880cba52700ab263f453f1df24e03c45b850e15cb25d9ce55992ab300",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -3071,10 +2711,6 @@
         "outgoingViewKey": "2d17c71739309cf30c84af8a0d622a5bd088969cd2be3a1d3ac69049bee09406",
         "publicAddress": "22b5e1b0429858309f8bdda4c3fcc25c5f6e9d57380449bc9897d2ceacf469c2",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -3105,10 +2741,6 @@
         "outgoingViewKey": "717ef412cf3d130b97bc1b44abc546b3436e5ad3499dc962ede547d391c7eefb",
         "publicAddress": "aba8f34b269200c3065eec7e0995c13835f978bd4783fc0cddb1dbb7a572a280",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -3139,10 +2771,6 @@
         "outgoingViewKey": "e6a3851cac1f78b3aaca6794e3cc0124585ef3f960c54ea1af41a681ecbf626d",
         "publicAddress": "ae6e39572e8802cbb9d34f09b1764c1973748732e7e7522cdc8c8a917cf90906",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -3173,10 +2801,6 @@
         "outgoingViewKey": "1425b46a33e43464e3ebe201030a57a4e34f8756af3c4584b232711cca1b0460",
         "publicAddress": "36aa7d6e24b66d74a40b25435c0bd613d263047e92006bc5fac8ef29444ccc5f",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -3207,10 +2831,6 @@
         "outgoingViewKey": "a703e01abf09b5704d8b96bb30d71416f5f3ebf5bc44f2ef5c1d1325534ef6c3",
         "publicAddress": "6f3c1d0d22a880e1ba50b9df1ee43de7bddb6f99aff30d278f4d5b15555fe73d",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -3241,10 +2861,6 @@
         "outgoingViewKey": "a4f6a70e112b110cb11791b0535046f705a3150f3515c2f69adabca6b47d9e23",
         "publicAddress": "d91dd2f2286b800c8173826b164b9f230ed870fac7c9d0be94269194a16a3b42",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/primitives/__fixtures__/rawTransaction.test.ts.fixture
+++ b/ironfish/src/primitives/__fixtures__/rawTransaction.test.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "c72293d4552c079aef8ce1a4dd99dec66e90d613d97979268bf1730515d49632",
         "publicAddress": "679388015ceb748ad077e55ad765c19b1f9e774ec08b5faa81c7742556b1a40b",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -67,10 +63,6 @@
         "outgoingViewKey": "a7faa82e8f64b382d89675ef92b521c34c008e70c6bb88bbd18f4aa9594e3861",
         "publicAddress": "d64d1d97d0cc7b74078e854ff58da4ce3a89afaf9d735a7d1477ae76dabcf50c",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -123,10 +115,6 @@
         "outgoingViewKey": "889e84fcd55a3e995bd604d7b963afa25b0e971eac070ad5937df38a02b9545f",
         "publicAddress": "3648870aca0eb021ec8eac4a1cb198c745938494188fd3713ed9b3a62abdc899",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -247,10 +235,6 @@
         "outgoingViewKey": "8a1b3bcf1d76e412fcea0f41d127507b9368edecd5bb3afb92ce40cd20572571",
         "publicAddress": "5d163728e1aab504e0fd6c7c01d0d86e4f36ea73ca975bccf313add54bf72a1e",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -277,10 +261,6 @@
         "outgoingViewKey": "2538c7b0519244f4adc5343a29fda859d0efe96e885411600a1c9c5a04203a76",
         "publicAddress": "e0c7fcb13ec83b6ccddd9d6474f3ca77c958111479dbb5c17c84cef7818dd666",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -307,10 +287,6 @@
         "outgoingViewKey": "9a7fe4b5ac1a434c0160b8b813de9eb19a11a154f6c5c381786f0d7b78651be5",
         "publicAddress": "c58b9dd520fd2b028721602e093c14a703d0912caff686a208364cb7ca3131c8",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -335,10 +311,6 @@
         "outgoingViewKey": "d83c29fbd0c88735af1291da7dc22ce76faa786421dd79c5d26df5aa4d013483",
         "publicAddress": "467f1b1a919834e2f612c32989d15e18a22f7f82cd8a20b5d6c1eb2e26977251",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/primitives/__fixtures__/transaction.test.perf.ts.fixture
+++ b/ironfish/src/primitives/__fixtures__/transaction.test.perf.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "617f831aa3cbc1438de72f7c6aa4be97f11a5270759cca21281dbb6a93d1b45e",
         "publicAddress": "d24a9cfa550217dd522ee0cb687f08d208f5dc83b90aa4345f31759ab130f51f",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/primitives/__fixtures__/transaction.test.slow.ts.fixture
+++ b/ironfish/src/primitives/__fixtures__/transaction.test.slow.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "db89bdb03e5c51db9470213be1079bce087889bb5fb91f54508ad7977ed939cd",
         "publicAddress": "72f16c38ceb3d6bb4e25f5349734d20d616f3b6299be70f4b79ae852bd10e6e2",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -41,10 +37,6 @@
         "outgoingViewKey": "d1085959b9b62ed0399e1210cd42c06fea2401993e4434571ebd50794fbe49d8",
         "publicAddress": "1df36fbb23de7f854cdb0caa57d8aac43135b85918cfb5f42b85f1e267d883e1",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -71,10 +63,6 @@
         "outgoingViewKey": "8918943587a9496a4706fecc77ae0172276605049240da4bdcb39ea1f6374c7e",
         "publicAddress": "53527fc48e19eddcc49f3bb1b50e96c0ec95cd00b0321b9cc5ba62f8d8d4b917",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -99,10 +87,6 @@
         "outgoingViewKey": "202f9d53f5d9af006c7df89a61fd3f59e99efbb8082f8299e684ecbeed272744",
         "publicAddress": "a58aa2dc6af2526932aa1b8e3fc6f788cc85a0173a861863bbfe1d4328a91f87",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -155,10 +139,6 @@
         "outgoingViewKey": "2511557a8ebd83cb41c87088eaf6eca65232f719eaa29c76dd9725129f9a82e3",
         "publicAddress": "710fe174e3f3a8e85f51df19ad9782c01fd57a25e75b5aacbe01f0f0a1752bdc",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/primitives/__fixtures__/transactionVerify.test.perf.ts.fixture
+++ b/ironfish/src/primitives/__fixtures__/transactionVerify.test.perf.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "7445031ded1c51cc6479bc80b0e053fd9b64d70c38915a36352a91b01b31b4af",
         "publicAddress": "d46d7b2c2646a3ef3f51a749ed8bf502f27e3d9acc7db1557494edfd719ceab4",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/primitives/__fixtures__/unsignedTransaction.test.ts.fixture
+++ b/ironfish/src/primitives/__fixtures__/unsignedTransaction.test.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "28d684c737f8473ebd0dd8f5ec431f454d89bf0a525339ef3891c811e32fa625",
         "publicAddress": "7c0fc099c96cbcd7a9982e060339e192293ca432f3acc8e8e42127337b6b7982",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -39,10 +35,6 @@
         "outgoingViewKey": "9793dc32b44f27edb20d778213cd5d925e4c0883aaaa957ba934fb57601d4c7a",
         "publicAddress": "00a671a726f801383409e7b8bf6e4bc5f8b7c9fd4ebb95421073e22ee668dd1a",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/rpc/routes/chain/__fixtures__/broadcastTransaction.test.ts.fixture
+++ b/ironfish/src/rpc/routes/chain/__fixtures__/broadcastTransaction.test.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "03bfb533621e90b2014650388ce233678ab23930c9355faebd41ecfb079eccc4",
         "publicAddress": "306466dafe08e00608c9d018ec4695f921b9fce084cc88b6df489bc9c695cb39",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -71,10 +67,6 @@
         "outgoingViewKey": "fd6c30db7acea51e6a0a9a1a0634263557f0a597356e05c66c4ede4bcbf62a5a",
         "publicAddress": "c45f35d0dca75da3259fc18fd18d5358865dbe242994037e0e698675e7865e93",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -131,10 +123,6 @@
         "outgoingViewKey": "cc651959f2105e23b404cc7c5bd071a2f64407d5cd950874e0a5ed7747173a63",
         "publicAddress": "bb1e73e65d01bf625eccb0c41ddbb1e0ee60ce5c29b330a1dfaee9b4cf442f83",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -225,10 +213,6 @@
         "outgoingViewKey": "75c67e58f22eb1bf710eecad1f8a40512f58b2cf1ad936763696ca1a33d8c908",
         "publicAddress": "3f6ef36188637e5a0156a004d096b0212ddab91f4667c81aea2bc7faa83c712b",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/rpc/routes/chain/__fixtures__/getBlock.test.ts.fixture
+++ b/ironfish/src/rpc/routes/chain/__fixtures__/getBlock.test.ts.fixture
@@ -65,10 +65,6 @@
         "outgoingViewKey": "75a0bf69e568bfd7be2a2fbdfbab23669d8c97f0980dfc58741f68314e6fb254",
         "publicAddress": "223623e00c0ff000e8f1a14e7a01935793d5d4b5db4124a2deb2c9ff5bb6735e",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -151,10 +147,6 @@
         "outgoingViewKey": "d9d24c0a7b9ca24f86d4a9e9801875c573ed65e24cec93a012a51fd4faf0dcd8",
         "publicAddress": "da78544e64187289505423139669f3fadb30acfcf90328be11c94978c7856ad3",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -237,10 +229,6 @@
         "outgoingViewKey": "4b556317c3244d87aa6ba19aa8629e9f2fe90d025671ed12a0ff53cb6470a1d3",
         "publicAddress": "7fea05ec8fa00c8673fd9dec65c8a7b47d8833705c9c026fd963e91b6d261d3d",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/rpc/routes/chain/__fixtures__/getBlocks.test.ts.fixture
+++ b/ironfish/src/rpc/routes/chain/__fixtures__/getBlocks.test.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "384635b7ddbe5fb3d9201605af01749cf21093a02e1de45fe3bfd0203ded73fd",
         "publicAddress": "3ed6732bd6515a7f8898c4fbd1aeed158cf65b7b6c3bf0285ca5921d6f67b237",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/rpc/routes/chain/__fixtures__/getNetworkHashPower.test.ts.fixture
+++ b/ironfish/src/rpc/routes/chain/__fixtures__/getNetworkHashPower.test.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "104e4de1c115cc0a651760cbb4a6768fc33180514214df730f22dbfe85c06683",
         "publicAddress": "016b3419b7ce3c4aa30efef541e745cef562cabce6324efb9a8d9753b8c9438d",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/rpc/routes/chain/__fixtures__/getTransactionStream.test.ts.fixture
+++ b/ironfish/src/rpc/routes/chain/__fixtures__/getTransactionStream.test.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "e595c5fa4f8e3007bf5fdb2f12bc8f93014c4e5fdd0257e414da48c2ae450c33",
         "publicAddress": "dffa34c2c096365153d3b2a2ab332e1cdcc77ff9253fb3ef910a4a154c0ca09d",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -41,10 +37,6 @@
         "outgoingViewKey": "5af0104dbf243fe2f27aad357f00c9069feac604126ddccd6cf1a2c9c1c1f647",
         "publicAddress": "85f9f0c4cd734992f3d24ac73b967e65b90f2aed3b45d459d80b47337b22af0d",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/rpc/routes/event/__fixtures__/onTransactionGossip.test.ts.fixture
+++ b/ironfish/src/rpc/routes/event/__fixtures__/onTransactionGossip.test.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "9fe1e6b833006ed9686245492169344fe5c445f2701ee4bddaa1a57441e346ce",
         "publicAddress": "cd5ecb29276aecc134d02baa70a672fdea6eb4f4531aaf20fabcdabf282c2beb",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/rpc/routes/mempool/__fixtures__/acceptTransaction.test.ts.fixture
+++ b/ironfish/src/rpc/routes/mempool/__fixtures__/acceptTransaction.test.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "86b54867637fd856fa94f05b9d44699ce8c059a46748095af216dbc7e7d4bd96",
         "publicAddress": "f43e280bb3193836f82eabf105bb58b791824020663da31062426d5528881a57",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -71,10 +67,6 @@
         "outgoingViewKey": "3fdb5ea82e1edda8a43b9f8501416128d04842d176e74a563842744d92ba890d",
         "publicAddress": "20c50704a9ae84b9f285ed3ab4c149d27ac74640a043fdf32c1da3f53094e209",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -131,10 +123,6 @@
         "outgoingViewKey": "ea8c09c1cd729f2092ca530376f160f250566c7de433b5ac0a512677c4cbcb94",
         "publicAddress": "1a48caeaa0bd3cefce2b948b9b4744e1b9ad3386aca288f5990bd39fb1ce8081",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/rpc/routes/miner/__fixtures__/blockTemplateStream.test.slow.ts.fixture
+++ b/ironfish/src/rpc/routes/miner/__fixtures__/blockTemplateStream.test.slow.ts.fixture
@@ -39,10 +39,6 @@
         "outgoingViewKey": "42cd8de3af23eda4db16009ea06d4bb2229039cb70995eab04c928a16a513ada",
         "publicAddress": "50d261f111fb62b751824b69099c7fb1385a14eb2e5451ac70d27e1db7641af1",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/rpc/routes/wallet/__fixtures__/addTransaction.test.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/__fixtures__/addTransaction.test.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "f4f4371bfb3a3e27feb85027759759fdd2cb9215b5eca96ef36571c4ea928c67",
         "publicAddress": "8738d2869de49156f979aa6a78e8d1ca49d26f5e2b33b14331ad5ed8a2a2151f",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -71,10 +67,6 @@
         "outgoingViewKey": "b09f37b8d3e46b6d2f2b21cb4e2a10110009c150dd162e6ce926aa2156098819",
         "publicAddress": "49430833b83534a04f6f2aabe9776a1718044871526e8c6cd88504fc572bd095",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/rpc/routes/wallet/__fixtures__/buildTransaction.test.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/__fixtures__/buildTransaction.test.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "81f131c9386cf723baaa43f8a76f640d2fdd5eac75c851b939865b11b6288dff",
         "publicAddress": "1177d57efbb7f96700435b3203ec0329d3e45e63dc48c5cc8b3bded938245814",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -41,10 +37,6 @@
         "outgoingViewKey": "e745b95a7bb3a5bde4c583280f338930cc4c82d0349f265bfb0555f2a6086415",
         "publicAddress": "b75cb540d8226141ca2a5a91bdc97aaa138999b68c89cec2b0ecc1f14a8a2c66",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -97,10 +89,6 @@
         "outgoingViewKey": "c5e8362fd2f9e59ba132d90954f4ae35ac21299925002a4848034864f52aa2f1",
         "publicAddress": "46317c39273f2703ae32946c4c1da6c5014e363aeb3429813da569788bcc7710",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:w0CZimMp/grNx4WBQ130MuO0VZJ/mzDO8F0h3CWo40A="
-          },
           "sequence": 2
         },
         "scanningEnabled": true,

--- a/ironfish/src/rpc/routes/wallet/__fixtures__/burnAsset.test.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/__fixtures__/burnAsset.test.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "03479d64b8caba9aab030f460d5c2f512a74c28b0230ed9e7052270ed521dfd0",
         "publicAddress": "62e773d1c334b2553316eb498fcd1ff738fc336156880bac33dbb5bc6323f6cb",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/rpc/routes/wallet/__fixtures__/createTransaction.test.slow.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/__fixtures__/createTransaction.test.slow.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "12afb3e5ef593e1aa5969af9c16a752b721ae30be51ebd501280ecb43dc14bf9",
         "publicAddress": "9132e1f07c14820e4f8072f685e3f4e7ebe12ad4f3e2959ee67884fcc2c6b9c3",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/rpc/routes/wallet/__fixtures__/createTransaction.test.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/__fixtures__/createTransaction.test.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "983510949d37ab79fa05e4572d22a13a8dceabad002a9bf1cea0c6c2b540a6b1",
         "publicAddress": "b9cbaeef74d8b660f06e9780fbdb438c5235bf57dc42dec3eb50c34e431471c2",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -41,10 +37,6 @@
         "outgoingViewKey": "e503eac79fc36d2adcd9f2622e0036838a17011a24bed18cfba248ced5499a36",
         "publicAddress": "46618b84143dce15e4dac117ee8378f7dab9e5e760f80c01082f0e34835721ce",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -149,10 +141,6 @@
         "outgoingViewKey": "1aa5a6d5a0bd9292bc62a6d6aaf58d7e89c337b16e7b59e13670c736b69a66af",
         "publicAddress": "01baa99b4adf4f7922969aa818e24d185fb24e039a7e395370632ffdf12033a3",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -257,10 +245,6 @@
         "outgoingViewKey": "3074188d8308050673fdfbcd3fc88305c11b55f0237a53c6f026b8770691966a",
         "publicAddress": "24aab339b96e4ac35cd84d41b75c9a4e130f4d528025423f3afe48dbdf7bc795",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -365,10 +349,6 @@
         "outgoingViewKey": "4ed0fab70e549f359dccdd00461440be4b21318ca2909a12c5776937eff6a507",
         "publicAddress": "88f99572c26de97f83dbe566fca39f1140c1f5d8e3d0e2b42ebbc4034b3b472b",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -473,10 +453,6 @@
         "outgoingViewKey": "0e663c8953be8d36c24fbbc2c2f07af0a47b24c54950b703bab6c22312fd6e52",
         "publicAddress": "3548e4ce6ff25fd36fa32631b08572b5a67dd0d3e737b85eb473a743a1458cb5",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -581,10 +557,6 @@
         "outgoingViewKey": "1861f1eb299f1b0f44bc4fa641acaf41dfcafa6a140a606d219ba66b05eaa5e1",
         "publicAddress": "192c35c35749e9c6d9a6fb866106b1abbfd3b5a0feb04b7e61ec7257a0c292f1",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -689,10 +661,6 @@
         "outgoingViewKey": "e41c87be55dce5161c17bbcf8923cd966d37880603e3ac952f5f9e1c03795d9a",
         "publicAddress": "9d6c3d4003691eed83a3ca5c2734143acb9bd6d7dc3a768e29374b183b564909",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -797,10 +765,6 @@
         "outgoingViewKey": "a0e70917d1f0295400ff6077ad2c25f7212fc0a0ca7c1aaec2c1676a6035fae5",
         "publicAddress": "68fb225612c1824945f2a30b017c1d694db2b8e7c01336c3f355ab3f574428e2",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -853,10 +817,6 @@
         "outgoingViewKey": "51b0f8c8a30111229b63e3be0295298dbbcb961692a304f25693c5ffb4135b96",
         "publicAddress": "dee7040f22f8774551b571f474bdf6472b015217bb4ffced86edf13e7db9b74c",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -961,10 +921,6 @@
         "outgoingViewKey": "3105b686e35c271f7b8d73f7a755753955c2895c59406bb2080ca433ab6e43e4",
         "publicAddress": "43de91537f790775d0a82555cd16cc39151b20578d41698e4ca15c7c356f53da",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1017,10 +973,6 @@
         "outgoingViewKey": "fa73270aed4d6311f184f55beb87ad0c41fff16a4dd2047ec2629d8d37cefef5",
         "publicAddress": "af4a2fb8d7247d0b327a96ea81281b72d2bfac0a6510b5b8702425b82b7974ba",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/rpc/routes/wallet/__fixtures__/exportAccount.test.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/__fixtures__/exportAccount.test.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "85e2ebc57a0c56d268bb5e8f0bf99bb5e5956b13e3aca328d0252780bd6e2823",
         "publicAddress": "0bd6b11903fbcc630679c1010f179bd1a1e5a8d0de9c05fdbb9ebe282376a54b",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/rpc/routes/wallet/__fixtures__/getAccountNotesStream.test.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/__fixtures__/getAccountNotesStream.test.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "6ac3f6c051825021f15619e16246398c603c8cfe76987777913e299e6c4f4b1c",
         "publicAddress": "b482623535be678cc3028fa6e404890052a88f6c7125c3e121376477bba728ad",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/rpc/routes/wallet/__fixtures__/getAccountTransaction.test.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/__fixtures__/getAccountTransaction.test.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "32a603667265453b52fa0f09bd78bed1e44f2fcc0261cb8e94fbc0b6ee59fcb7",
         "publicAddress": "951464fc3016ded45a8244c019aba5819aa4773867a660d2d7a6eb2bd235cc9a",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/rpc/routes/wallet/__fixtures__/getAccountTransactions.test.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/__fixtures__/getAccountTransactions.test.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "ecab6a979d93e8890e37b9392c63d136d3b4f06c5820389948e6b78fb45d2acf",
         "publicAddress": "1669ebd494118dd327a537f7313b7f219f36c8a8df1d0367d5fa1862a1282905",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -67,10 +63,6 @@
         "outgoingViewKey": "9972c1973d3cdbf0ca9e3c89d297112e4a633f260a1ae4e8fe803ac8a5b3ae77",
         "publicAddress": "651e9efd2f33806f5932340e5bb25e6c269b57b8418adec2c4ae7e2cdd339284",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:t+mxzH/fp+FaoQn6sCUggzOA+WZM4aBjyWht6rR67II="
-          },
           "sequence": 2
         },
         "scanningEnabled": true,
@@ -97,10 +89,6 @@
         "outgoingViewKey": "890004c4706cc2b6b76e19b1a7f210b1a0a3c764673972920fb84a154136c10a",
         "publicAddress": "aba8bfae6ee0b62242f85d69d3743f6e034691883722b70dc020f6013086dd54",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:t+mxzH/fp+FaoQn6sCUggzOA+WZM4aBjyWht6rR67II="
-          },
           "sequence": 2
         },
         "scanningEnabled": true,
@@ -161,10 +149,6 @@
         "outgoingViewKey": "b19370eb29c9a01b4ff939748cde1ebbf07873a773715af4cad122b35de8a5d5",
         "publicAddress": "33a45213821885bb12acea38620ae55931fd8a70be61699b1a9b1555e4307d6f",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:pNbbBr/Y5tiJAMwxnkbM8z+uZlDeKdOpVJoOLDAAGJI="
-          },
           "sequence": 3
         },
         "scanningEnabled": true,
@@ -243,10 +227,6 @@
         "outgoingViewKey": "ca2e7c8eaf41eb59b6d4c4ab85c0c25cb41acb124d23f87674c31427d5ed5b79",
         "publicAddress": "92eb4c07d4a7ba8a0af23d1c29fb01be57b33037ce907a1957a8cfcfe2054dd8",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:S8LuedCTjYjAqo1cyrzZ0WRCidXLcYDA29KLKWKssjQ="
-          },
           "sequence": 5
         },
         "scanningEnabled": true,
@@ -299,10 +279,6 @@
         "outgoingViewKey": "8c7994e3756b18a2ed09b9368e12a17d0917c9a37cb4ae5544776dd095cc8556",
         "publicAddress": "0a8e5563a69a95a48ee38ed8852a79b53e8a1c5c5a9a2d3d943afe04e975f35a",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:/+AnFuU8fZ8zAMfzr6lbyQkX+J4JcbaE9DEQ2pRnScA="
-          },
           "sequence": 6
         },
         "scanningEnabled": true,
@@ -359,10 +335,6 @@
         "outgoingViewKey": "3b491d19af145fcc0b1b02da8cb5b993f239506980c30f81dadf98d4eaa6aef0",
         "publicAddress": "bcae24c16aa078d03317a071f5e7d9bb910f2477fdde6f1ff1971d9824f0d24e",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:TVjH3I5G+XS9w70BexUxosBJrzfFgQk3xF3zVJ97CNE="
-          },
           "sequence": 7
         },
         "scanningEnabled": true,

--- a/ironfish/src/rpc/routes/wallet/__fixtures__/getAsset.test.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/__fixtures__/getAsset.test.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "bee436bfc038e560c4f68e67cdac7b64844e22ff5bbd3634c083005f12c63067",
         "publicAddress": "f5a270059bd7a23283c0f451b4f1da8991c50e09052066959662e1e696586127",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -41,10 +37,6 @@
         "outgoingViewKey": "7e9de9096a54a05db70238481f80938ae67329b51e3290d90bf71f5c13471da5",
         "publicAddress": "f74fbdfaa5360255fdc5d5aaf126096c0d947a6e73803e0951cbfa6081f0f242",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -71,10 +63,6 @@
         "outgoingViewKey": "6b9640c613ff0dc646ccced7f39ae2aa33be4a988c58364b622bb6dc280bea04",
         "publicAddress": "81c21fc8be107784dd825455451f6556ebab8f31d481a076b89f9748cbe2aba5",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -131,10 +119,6 @@
         "outgoingViewKey": "35f5602ec90a226e83e441c7aea1c6ec3c2a48e5d05f1bee6cb09758eddc222c",
         "publicAddress": "e7b8914fc9ea858f8ec6afcdae7b6a9bbd9d081d074afc4dc4ba80950fd00ff1",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/rpc/routes/wallet/__fixtures__/getAssets.test.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/__fixtures__/getAssets.test.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "93b3c34bccd7d84099457b40f97b26c3a5404b89deca0386eba536d91238c797",
         "publicAddress": "675d8fbbf60d0fb6b043cda596024e69b833859191ae3c83c3252e8e6cfea841",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -105,10 +101,6 @@
         "outgoingViewKey": "91af063493c334a9e638a7ecedb19da986817a8165740c903c03c88018953e8e",
         "publicAddress": "4f0ce8d2c50fd836858a03f2c69dca38444e55cb372e816cbb1d82b82d4a1bab",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/rpc/routes/wallet/__fixtures__/getBalance.test.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/__fixtures__/getBalance.test.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "1a7780e356f6ff92687dd172e417c1d11db1db67e2612f72bbf75d7af9f2a51f",
         "publicAddress": "729b67146151c1ac6498339f39b29854f7338137088d95dc8204fc5c5476094a",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -41,10 +37,6 @@
         "outgoingViewKey": "9e76dbb76ca0eaab4aa1f317f670c200983a658d7173432158b924eaa601dc08",
         "publicAddress": "f0b5e7f518003051809e4fd6c8834d3dd192f08650f3b6cd0333384e5f732336",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -71,10 +63,6 @@
         "outgoingViewKey": "46f90576b523c19844a2f88366effbc0027dfa1ae0a617a0af2394bdd7a789e8",
         "publicAddress": "bac4ec835217387d0781872dff60dd24b21d94096d4029d3ad468a7209650eef",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/rpc/routes/wallet/__fixtures__/getBalances.test.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/__fixtures__/getBalances.test.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "6041f88161055038d01ef544af85980ff343ced5c0f7a33c279cfb29638f6b8c",
         "publicAddress": "be1031271305adff62bfce6445df249c2b64aa436018971a036602eec012e41f",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -41,10 +37,6 @@
         "outgoingViewKey": "f35936d612a39113f8340295fd5d7a5e41f61dc14810e6f3736be2ea821f8ecf",
         "publicAddress": "481bdc39b4258810c23bc9b15f440a4a73e579cab95fb704d50fae8e26994bb4",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/rpc/routes/wallet/__fixtures__/getNotes.test.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/__fixtures__/getNotes.test.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "6b8c52d684367e8e623f47f6b3fb2d8a6e105d758cff0209b9251d7cba882001",
         "publicAddress": "5cb61930c8524305f219a3bd3cd808d1f39195ccf8482fb8c10c198861c5b3ed",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/rpc/routes/wallet/__fixtures__/getTransactionNotes.test.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/__fixtures__/getTransactionNotes.test.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "5ac585dea19a75ffbd48294135c8ade6f121c3c32708ab2729463d7ab3b8fda1",
         "publicAddress": "f5ab8b50af42ac299232a2d36656d1ee9e21d18d96c7469fdbbee06c32b5d5dc",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -39,10 +35,6 @@
         "outgoingViewKey": "4bff5ad5ced8525e8fbf14fdd538e8ab87e80b445c5432e4d85c079a2a99a2b4",
         "publicAddress": "27aafcf1550d220c448a3ef1b9eb92491beac3e0ddb499e2004b0a8af7e01c91",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/rpc/routes/wallet/__fixtures__/getUnsignedTransactionNotes.test.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/__fixtures__/getUnsignedTransactionNotes.test.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "066ace6a5c11451e614718216ea3558b10f0ca4ef08f27838ec4e02ef6aa6db4",
         "publicAddress": "4129f6494c5101f8e7177f82bc11264dcadbb54d97fa6ee9183fabff41e162b8",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -39,10 +35,6 @@
         "outgoingViewKey": "aebf4465bbf6fe59b7c25046f47f891b9b227c06472c4895681a0b6816ed5aca",
         "publicAddress": "c6fc59f105063250464d876bca49d23d03e62073847cdd4f9eddfafe71ed5dc7",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/rpc/routes/wallet/__fixtures__/mintAsset.test.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/__fixtures__/mintAsset.test.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "7a8d801b07a8fd291973ed4f7d40c2ab239a9b0d9c28111e4e0d42ed1e5ec64e",
         "publicAddress": "7021f0c26cc14b99bbf89cca7311fcd2bbb1fc8023798d4fca00fa1b2c9c384d",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -39,10 +35,6 @@
         "outgoingViewKey": "7cd6eff862c8ee13641c28259ce06e3ccbc5bfaa03101d516c65dc1e14b04a6a",
         "publicAddress": "ce985aaca169731d12b8f765c1f0cf82df25afb1a9000a720194c7702bf7c441",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/rpc/routes/wallet/__fixtures__/postTransaction.test.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/__fixtures__/postTransaction.test.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "a1e656b8aece5eb2be32bc2d54bf87d29a0e68c354368a78897025cc346750c6",
         "publicAddress": "90b44771984afa2b97bd70d59ae89c25ca018d2903e95db669cfe585b935f907",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -41,10 +37,6 @@
         "outgoingViewKey": "53bd186e30b1c0438e2f6348fc73197eacb9587fe0f4a26dc7512d59ca520a9f",
         "publicAddress": "004f5a65ce2aed82df88ecf6ba62f7df951a83251cd2f28cdd05f10b3a0035ab",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -71,10 +63,6 @@
         "outgoingViewKey": "bcf9c2370625608975f43186dfa1b5933bfc4bc860c0da1052aae6d5e9bf62b7",
         "publicAddress": "d772dbc9d3faba19e1aaddc5d92d7bd829a7079601bfe3a3de5229ac8238a590",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/rpc/routes/wallet/__fixtures__/rename.test.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/__fixtures__/rename.test.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "a8f37fc1f5173f05ab709f8ed06541198a4964b2e0f87b726d4f14eb4813ca4c",
         "publicAddress": "a88db5652d4d613c3086a6ac198d0f449d5a389b46189780b3b10b021cf6e800",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/rpc/routes/wallet/__fixtures__/renameAccount.test.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/__fixtures__/renameAccount.test.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "7324cb7e93bbec6336492cc55a6818cd1ee3fe797899ca3341f36897e21928cd",
         "publicAddress": "92a34aae04c8d01b3e97a1f43698ec14a88373bd457d9e8eccf0ef2f50ac1d0d",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/rpc/routes/wallet/__fixtures__/resetAccount.test.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/__fixtures__/resetAccount.test.ts.fixture
@@ -37,10 +37,6 @@
         "outgoingViewKey": "b627d9fffe01f46c01084d85a83f3b28af9e63f99ac4d2a11889732b440f566a",
         "publicAddress": "d0487a45725597d62e4b0e49db9185be99424d34c8c400cfa3be2d25624ddf29",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:JCB3ROYUBKhfAUxkvukmQHEn72y+JJ0vsJCS5We8YiY="
-          },
           "sequence": 2
         },
         "scanningEnabled": true,
@@ -119,10 +115,6 @@
         "outgoingViewKey": "da3a87a4ac3fc9eca1f2da4bca164b68eccaf4419811abab0984cb66fc2ad607",
         "publicAddress": "12ca7e3c5ea70a1a07f9fc9e055b84f19c5b48a2865a1c10358bd68df35cab67",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:aqtCIjNR+xIa6laFO0cBpIUGI9zF0i+xehQZJjxj8jQ="
-          },
           "sequence": 2
         },
         "scanningEnabled": true,
@@ -175,10 +167,6 @@
         "outgoingViewKey": "3839711cefccc3e5dd813f21dc681d0419907e29bc3a3f6423727736bdab6bc7",
         "publicAddress": "4777b44c0249ba457de05cfbdcce70fcc18ff31c04ea8d0d4df1e3bbacfd9487",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/rpc/routes/wallet/__fixtures__/sendTransaction.test.slow.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/__fixtures__/sendTransaction.test.slow.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "cdd02c3f54fd634ae0b7abe0d2dce4119e3f18b2fe310e9b0471c1c91f3292d0",
         "publicAddress": "571ca98303db245943b813da0e304b62799eeac13dab4a4d963032b173e812bc",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/rpc/routes/wallet/__fixtures__/sendTransaction.test.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/__fixtures__/sendTransaction.test.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "8c6cadba724f8592dc9507ed9f61eb2741359257a270f72c934b2bf67dc82a98",
         "publicAddress": "70f5854f5b3ade4103359302a767a052df050ea16a5a31356ddaabb78b4409c8",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -41,10 +37,6 @@
         "outgoingViewKey": "27580db2948fdfc7913281bb49079ee5a4fb5b47e58b5f9d2f6be701daa6d027",
         "publicAddress": "49c5001e590c22fec19e7129012070482a7180e08639ea763980f9e54deb4a1c",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -75,10 +67,6 @@
         "outgoingViewKey": "d8cb7863a95db6f5c1f4df76ada81ee2af438e26a9a510204ef521c3f431d57b",
         "publicAddress": "59931555d82a7e0636b9a05a603b7000fd2cfa0773a0dd62a2b14e1ffdfc006f",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -109,10 +97,6 @@
         "outgoingViewKey": "b840aabc7d8b0b46d9a0112b9abee731379d4ba063816cc8d4980ba3a1a1fce8",
         "publicAddress": "36b4e6de88f58da11e4b82d2d91a617f3d8e25e60816045e059ea574b7d74137",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -143,10 +127,6 @@
         "outgoingViewKey": "cc1859327b56f18b337a096fab92314fcf08731a8cdce09f50c703b991fcf5ea",
         "publicAddress": "78b7a7b4e17dcd40fbebdfa45bbcb5cd4a2ce4564ac79a005efe0e881ac49a4d",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/rpc/routes/wallet/__fixtures__/setAccountHead.test.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/__fixtures__/setAccountHead.test.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "40ec5f622de672affca2b8326e3cbf472ac0c98bcfb37d8aea516c8be694d435",
         "publicAddress": "b28a46051bf6ad754ef532c81e3d4387aeb774f6d3e53ff37804313e3323f085",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -67,10 +63,6 @@
         "outgoingViewKey": "0394aea6e1e82f0dc9f8fd97bf4f70a5d57ea53c1790f18a0b843dbeaffcc475",
         "publicAddress": "026ebc87db0dad0cd9f583a764f070799c1f0982e69c902a6e6ebc333987688b",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -149,10 +141,6 @@
         "outgoingViewKey": "bb799b9ac5ab4cd359560cdf1994ce8c2bc71750b08fc06c04ad6f44ef305515",
         "publicAddress": "bf89f8fe948f840b858e2f536382c5190286ee1dd7fad961946bf349546345a0",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -179,10 +167,6 @@
         "outgoingViewKey": "e337328cd763e1d5708682ddb3a6878e4bfab7a9e21ab093fe1c31487a8f3c7e",
         "publicAddress": "81ad71b2e0cb4412ea36d9c9866d01ce1e2c40f6c76a9d7c9d1781fa67d6045f",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -253,10 +237,6 @@
         "outgoingViewKey": "b74b9f27f5b4d5417a38c953f32291e2e8651e04944598a6d6a0fab931056ae0",
         "publicAddress": "0b09729975193c3a4bf9834f5b5a0cba4e73aa21ac9bdfe29585e4988be48ced",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -335,10 +315,6 @@
         "outgoingViewKey": "d014ce8819af236fc0ae23ff07ad3d0f446704a078c8a7f876dbe38f9142c345",
         "publicAddress": "57f06f5b9a9a5f4cab00110c4628f9d5ec56fd4863ecf667a7a9bb663411d905",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -391,10 +367,6 @@
         "outgoingViewKey": "8cb50d16e612d6bddefc06831fef247f56b4ca73fc8f3498d20d054cd71b1f07",
         "publicAddress": "555105a1c62559433156ccf2ba4af5e062743a5395bc38bb5fa72918bcfd1639",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -499,10 +471,6 @@
         "outgoingViewKey": "c8d175450fc753d98133414be93d0416da7149e2b0088dd2a33f80502a344c3a",
         "publicAddress": "3e70527fb955ea2c2d45360a02d77990c562662de4543a817fea04989e95384d",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/rpc/routes/wallet/__fixtures__/utils.test.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/__fixtures__/utils.test.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "e029d4ffd3bd609b431d70b088797f17c4d8114bdb5eaf009b0e7083ba0634f8",
         "publicAddress": "b76e655eb59acb7980d40735625bb2d7fd8f0e97979b3c5fe0d672f62fb14c9c",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -39,10 +35,6 @@
         "outgoingViewKey": "c6346f9eabce5f3e3c0453651dd98c0e3c2bd650ea8bceb99f372fffcd92c91e",
         "publicAddress": "0dac70e13bf50a80b3ad913d171a6e01350d37f7a9df0b72c12746840cd19a96",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -125,10 +117,6 @@
         "outgoingViewKey": "dfb4de4b5f71952c05776ea187ba186d7b73297ad43abfacca25c3396618b773",
         "publicAddress": "e9a1b144a070916ac803c339f3060aba29c3cefff4dcda4c17964c67080094bc",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -153,10 +141,6 @@
         "outgoingViewKey": "34993950723c0ca52f0d39f06e40f74a324ccf6f7e5d210d42bd07aa1ada8868",
         "publicAddress": "0b981ee59b9474d26bea0cdeb4401d02cc2824cfd764f983641bf51cd1bb5e13",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/rpc/routes/wallet/multisig/__fixtures__/createSignatureShare.test.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/multisig/__fixtures__/createSignatureShare.test.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "8cb031c8c8bff795dff350cb2d14615f5f9c165dae8ff8ddb2008d9fbadfcb5f",
         "publicAddress": "cfc1c6c5c2b63bd5e1431a5e6465c3b31430aca4368c8c09e9ef0f88d216d2f0",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/rpc/routes/wallet/multisig/__fixtures__/createSigningCommitment.test.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/multisig/__fixtures__/createSigningCommitment.test.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "c41670518528c64aa72cadd91e195e97beb5349105f75786c82882aea30e9195",
         "publicAddress": "6f711122ec12c51ccfb6890514518a64b96897d2b011bb7025d4f29078e17d98",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -71,10 +67,6 @@
         "outgoingViewKey": "5d6d5dae10eeb5f6b8a0ae46a1234392f2357725f56972921672df5efd0987c4",
         "publicAddress": "003c68aa2a273e8ae917ab4132627826db1c6d60ba2a61c02b37f4a08a0b23a5",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -131,10 +123,6 @@
         "outgoingViewKey": "b63af3eb714e74ccf7832a7385c0179075c16cb574d4e87e12ce8a07aa11949e",
         "publicAddress": "ff0a48b5864a97f775d7c543ff52ffe6140ef7517a9c827e78bd38764b54e847",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/rpc/routes/wallet/multisig/__fixtures__/createSigningPackage.test.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/multisig/__fixtures__/createSigningPackage.test.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "096855fb39ce83d8b51b95ec646999e03fdd569849e09af36d5621eb4f35094c",
         "publicAddress": "1d59e219070af34aa4610d7affb7421b687d9559109a0b9d820a38f0baef344e",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -71,10 +67,6 @@
         "outgoingViewKey": "09913234f7d1807ea95920f95e4ff45839a2531066a94e0679fb47c9e8fafd08",
         "publicAddress": "335b25dda6b38ed7b1bec8205494781d58e2eca3c13411060ae54fbeb15b05f0",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -131,10 +123,6 @@
         "outgoingViewKey": "a841e76c4725ed657fa81ded9639ae74935bf4689ce77a8e7cd6518865a88c2e",
         "publicAddress": "b39091fc75b275b4383aa3ae1b29c54caeab48fadb3c2c57315ca363feb01553",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -191,10 +179,6 @@
         "outgoingViewKey": "5647464b83ebb8b8c0f51e3e370f82be2cf6bdeb9c91a79e03ba7d35b1dce4f2",
         "publicAddress": "78f5c9c779fb74b9797af910044ec9b0f14c478d7cbb8920985924387b4e0d55",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -255,10 +239,6 @@
         "outgoingViewKey": "883cfc9b13e4f6b38f3404a397116d6a1a097261706829aa6ec3896a7af96d64",
         "publicAddress": "a5e8a9158ec5435bf1017328231b5a08b79b7ffdb38ac1e3f79aaf504247e3a9",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -315,10 +295,6 @@
         "outgoingViewKey": "39d9639b3eb6c29ffa1acff3ee847488758e0aa0047af592865f604bd1abb49b",
         "publicAddress": "08b662b49541cd101a55d402b403efbba2a4bc5e6f9544f5b8b32d10d5cab3bc",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/rpc/routes/wallet/multisig/createTrustedDealerKeyPackage.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/createTrustedDealerKeyPackage.ts
@@ -81,7 +81,7 @@ routes.register<
     } = multisig.generateAndSplitKey(request.data.minSigners, identities)
 
     const latestHeader = node.chain.latest
-    const createdAt = { sequence: latestHeader.sequence }
+    const createdAt = { sequence: latestHeader.sequence, networkId: node.network.id }
 
     const participants = keyPackages.map(({ identity, keyPackage }) => {
       const account: AccountImport = {

--- a/ironfish/src/rpc/routes/wallet/multisig/createTrustedDealerKeyPackage.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/createTrustedDealerKeyPackage.ts
@@ -80,10 +80,8 @@ routes.register<
       keyPackages,
     } = multisig.generateAndSplitKey(request.data.minSigners, identities)
 
-    const createdAt = {
-      hash: node.chain.latest.hash,
-      sequence: node.chain.latest.sequence,
-    }
+    const latestHeader = node.chain.latest
+    const createdAt = { sequence: latestHeader.sequence }
 
     const participants = keyPackages.map(({ identity, keyPackage }) => {
       const account: AccountImport = {

--- a/ironfish/src/rpc/routes/wallet/resetAccount.test.ts
+++ b/ironfish/src/rpc/routes/wallet/resetAccount.test.ts
@@ -22,7 +22,7 @@ describe('Route wallet/resetAccount', () => {
 
     const account = await useAccountAndAddFundsFixture(routeTest.wallet, routeTest.chain)
 
-    expect(account.createdAt?.hash).toEqualBuffer(block1.header.hash)
+    expect(account.createdAt?.sequence).toEqual(block1.header.sequence)
     expect((await account.getBalance(Asset.nativeId(), 0))?.confirmed).toBe(2000000000n)
 
     await account.updateScanningEnabled(false)
@@ -37,9 +37,9 @@ describe('Route wallet/resetAccount', () => {
     Assert.isNotNull(newAccount)
 
     expect((await newAccount.getBalance(Asset.nativeId(), 0))?.confirmed).toBe(0n)
-    expect(newAccount.createdAt).toEqual(account.createdAt)
+    expect(newAccount.createdAt?.sequence).toEqual(account.createdAt?.sequence)
     expect(newAccount.scanningEnabled).toBe(false)
-    expect((await newAccount.getHead())?.hash).toEqualBuffer(routeTest.chain.genesis.hash)
+    expect((await newAccount.getHead())?.hash).toEqualBuffer(block1.header.hash)
   })
 
   it('resets createdAt if resetCreatedAt is passed', async () => {
@@ -49,7 +49,7 @@ describe('Route wallet/resetAccount', () => {
 
     const account = await useAccountAndAddFundsFixture(routeTest.wallet, routeTest.chain)
 
-    expect(account.createdAt?.hash).toEqualBuffer(block1.header.hash)
+    expect(account.createdAt?.sequence).toEqual(block1.header.sequence)
 
     await routeTest.client
       .request<ResetAccountResponse>('wallet/resetAccount', {

--- a/ironfish/src/testUtilities/fixtures/account.ts
+++ b/ironfish/src/testUtilities/fixtures/account.ts
@@ -11,7 +11,7 @@ import { FixtureGenerate, useFixture } from './fixture'
 export function useAccountFixture(
   wallet: Wallet,
   generate: FixtureGenerate<SpendingAccount> | string = 'test',
-  options?: { createdAt?: HeadValue | null; setDefault?: boolean },
+  options?: { createdAt?: { sequence: number } | null; setDefault?: boolean },
 ): Promise<SpendingAccount> {
   if (typeof generate === 'string') {
     const name = generate
@@ -58,7 +58,7 @@ export async function useAccountAndAddFundsFixture(
   wallet: Wallet,
   chain: Blockchain,
   generate: FixtureGenerate<SpendingAccount> | string = 'test',
-  options?: { createdAt?: HeadValue | null; setDefault?: boolean },
+  options?: { createdAt?: { sequence: number } | null; setDefault?: boolean },
 ): Promise<SpendingAccount> {
   const account = await useAccountFixture(wallet, generate, options)
   const block = await useMinerBlockFixture(chain, undefined, account)

--- a/ironfish/src/wallet/__fixtures__/wallet.test.slow.ts.fixture
+++ b/ironfish/src/wallet/__fixtures__/wallet.test.slow.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "6377d5152f1939f971ce05bdaa453143ec8fb39ea4a5434c23559e6c046554b6",
         "publicAddress": "77541c0e1b262fa1a4193d9270a2f8d12ea034409e723db7f3d7cc0820d6a071",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -41,10 +37,6 @@
         "outgoingViewKey": "1af1a216bbf52956770b57b0ab5e57cd87dcc31821d25e0da80a6d4e23eecbb9",
         "publicAddress": "73e96fc50663dccfb555066f1bee538f1bb91d4b377f779439da71288a4891db",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -71,10 +63,6 @@
         "outgoingViewKey": "037c362d068141a31720963027d502392db8a671f1aeba1fd9ae745d28dd908e",
         "publicAddress": "2f1f9adbe534fd191234842d9fcb9cd0e85278ec0ab9593b0daafc8ab5436a44",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -101,10 +89,6 @@
         "outgoingViewKey": "f76c8b3b2866bf82e495276464b436ef8e5607a5afe3bab7580b857d215ed2d3",
         "publicAddress": "7c1c0c002b9c327be5462ebec26d7cb6abe9b88cf5a907f02827acb351c91e13",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -131,10 +115,6 @@
         "outgoingViewKey": "5f3f0d4428b60beef032d7c77dce7e40658e2000f22e5a7faa2c48f2be6e3fbb",
         "publicAddress": "ca0adb50725c9a1188d293bdadb79f7c620ad7cdd15451de9aeb329a29fb2200",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -161,10 +141,6 @@
         "outgoingViewKey": "dc1ae928b194faf30475571fc0051a1b88a2f72154da5cead7efcd8af110812d",
         "publicAddress": "887bb49ad3a5908279b23e7adef1d2e9139e66e6dbb556a8a051e9c0b4cfd98b",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -191,10 +167,6 @@
         "outgoingViewKey": "7633a48beda245e7a41432200bccb0c8813b30c55d298a0f084acb997aa81156",
         "publicAddress": "602e31030a5a6e73fa1ffe981c00a167ce6328456f0e80158eb900c4fa7a02d5",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -221,10 +193,6 @@
         "outgoingViewKey": "30a0009b875018fd6600ecc267665288093a9d05ae83647a2b085b0e8f7adbf2",
         "publicAddress": "082e8fbd5b4a20e3fa2da3fde3c60ada5cc98cc3ddd99db5c80a59e721a8ca22",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -249,10 +217,6 @@
         "outgoingViewKey": "9bb1863c1514aea4483033a5f2cac603df247d17e7a04f4c16f402228760121b",
         "publicAddress": "4fa55aa6b74bee48a297861143dc874962e4d60d987f7ab1ac6e055514428823",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -277,10 +241,6 @@
         "outgoingViewKey": "06d0bb3a51e5f7a6e19edc80d51a26c7a0ad7f9413e7f14a719421a7563b13ef",
         "publicAddress": "5cedc32fbc42f0dbf54a2043c3e0a953e93675fc82bb3f9bbc1bd8c0fb14b5c4",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -475,10 +435,6 @@
         "outgoingViewKey": "6bc844d5314ae9cfb7ed51cba881d3ca7c8ff445af54f1f9dbed4f546cc4adc8",
         "publicAddress": "3c68f35cee425b6558a84dc0fa4ea511513bd5874afda504c7f7724b59fe34ec",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -789,10 +745,6 @@
         "outgoingViewKey": "504343491a9c3456353aee3c359ffd706ca2218d0b48333926734ecfc6f1a5fa",
         "publicAddress": "132253857a520a5667b9d620535ed9729ac496004a2b46dc217a3cbdc8582f2b",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -819,10 +771,6 @@
         "outgoingViewKey": "2cd96d74ed149e900c579374879dc6db9bdb6285576bda0a8043158430a04704",
         "publicAddress": "b5a66672b505bea0e8e2983b1c12d2e4df9a8270a105563438fbb976ce76b692",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -913,10 +861,6 @@
         "outgoingViewKey": "4fc5e7296dd5eaa1026ddf7f6441d22dbce7c181ea543162fb1e4c11d15e6afa",
         "publicAddress": "d5d514541a0b44a83743c129e002e3724252d32d0ffd3f0301a2354f9bac5bf1",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -973,10 +917,6 @@
         "outgoingViewKey": "9dae429a6962114f9c53bde513452bf4c6904ba290a18a112255a3397ca1def7",
         "publicAddress": "178e68b62fd1d1e19672b05ddceee673e81185f294dba2fd436e20c3a8e8c58f",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1063,10 +1003,6 @@
         "outgoingViewKey": "3fb40616af231b770687c7c7a41f188d392b91d3ef193ae1cf7e8c1075d060d3",
         "publicAddress": "f7981ab63147a297798a1a48ed9761d63c52baf0e026623848acb47751076d03",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1157,10 +1093,6 @@
         "outgoingViewKey": "6724f4701c92b3be693442ccaca0fc6f042539e97a3afa3d8f56ed3873ffdb76",
         "publicAddress": "2b942391def5544f47beb2512035a77232a7707d61221b07c7d1a80d73d3635f",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1281,10 +1213,6 @@
         "outgoingViewKey": "38fc79fde20c550d6e8b8c856fd05f63163bfc954c68d4951124f796972f56fc",
         "publicAddress": "e74cbbde37b8fa4d8e434de175e1de154987030da6d95e9a95920e577a32a8a3",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1309,10 +1237,6 @@
         "outgoingViewKey": "f17f5a0d9ccadcf3e46fc2557bc22b4a07713b492800642fb77e80b7776f5483",
         "publicAddress": "c84d302bb4451005e05ec815ca85a82dd3486843fe06eb9bd78f4b070674f3b8",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/wallet/__fixtures__/wallet.test.ts.fixture
+++ b/ironfish/src/wallet/__fixtures__/wallet.test.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "9a49fde72f73d899776e875e4fcf0e76893d650a636d7c3e8ebd90d4fcc09252",
         "publicAddress": "97db40051b3ba68f9d32c3d74fb1021ff64789733135f87946b901c9e68e786b",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -39,10 +35,6 @@
         "outgoingViewKey": "9338845301d0247faf65a110c06f0b2c2c1592aefb9095fdb48762e5b9a2bd3a",
         "publicAddress": "3c98da17b0fe89694378b1dd991014531bf79c00eba181996843a10b7a1e0073",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -151,10 +143,6 @@
         "outgoingViewKey": "2034a9f9a0693f58a4fef22548cb4cc3f6be4af451e98c6941cdd531ebb714c0",
         "publicAddress": "07e288b5c34fa2ae88fb941a8c78a71c53047d97fc44a0856407230ef94fd0d8",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -179,10 +167,6 @@
         "outgoingViewKey": "a17792602d1ee8b0bc8984366e06c898e47ebc5e68bed76519440a2c5a9d08ab",
         "publicAddress": "2e78d58ee1838af65b056fd161aa7e6c95418514e3503dd1baf39eeca552d404",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -343,10 +327,6 @@
         "outgoingViewKey": "7cc27038f0ef519d505771b6581eac2c6cd96c5abdc1969b4e7768f63d8848d1",
         "publicAddress": "9f82d0919be7c6dd5b52f85216c121776e8d880cc87e40d00b4cfa03f4ab0564",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -371,10 +351,6 @@
         "outgoingViewKey": "c1bfbc165474f9b377d812e2888fcc2b74579bf4c07e23d0452d31674936b32b",
         "publicAddress": "c5be14da80815cc4751b2908e762b42d2ec219a31bd7e5c9a220c8c3c080a657",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -539,10 +515,6 @@
         "outgoingViewKey": "282c20230932d7fa62714e883f2d65cc17435a43dda64bec7b7b68ff9ef17afd",
         "publicAddress": "566fc5c4abcd1453da088f69d50b330dc9430d20df1eb5e305b700def10ecc9d",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -567,10 +539,6 @@
         "outgoingViewKey": "804a6c7165ea7a86e7a833687d96c13175fc217b7475eb8963e2ee665e4240d4",
         "publicAddress": "9289566fe4045dffa71d3864a5fdf808b0754faa2a1aa5324f546052882973ce",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -735,10 +703,6 @@
         "outgoingViewKey": "ab30913b8ccbe2f17066c0528e70b9e026d69b947593a2b1a97ef82b1eb4393d",
         "publicAddress": "07d400b4204072a1fe1550449c226a00b407be7245762fb0f94d758f5530ff37",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -825,10 +789,6 @@
         "outgoingViewKey": "a3c46b0c39994658b9015d8ba1bd6c152290c9d0da69ec64633c126e74785b9b",
         "publicAddress": "43e93a8c9999e5309cd7e9fdb1d48c8292199f49ceaf68b9947ac895fcd2e7c8",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -879,10 +839,6 @@
         "outgoingViewKey": "4fd093595f3b09465a051d5f3957ffc79bc1e596835d02cd492174f4bbc379a8",
         "publicAddress": "70a9a20bbc1b89294c5ebed55fe8f7d2d47e3239642f22247ba4b6c4b28dda39",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -979,10 +935,6 @@
         "outgoingViewKey": "7620e2ace2aa60dc6c308ea536269e10dcfd0210a27158d76c58e133a4116d96",
         "publicAddress": "9f63309b91ab572cc62da68abca5466cb86cf4cde6f23884171b0f264649cd4b",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1007,10 +959,6 @@
         "outgoingViewKey": "455a5629f056d1ba416a0cff8a8adcc0fa5e44167e4c8fdfae4621e3070f1be8",
         "publicAddress": "4a668a655e54660b48e4187d5891cd3e47a4243104421d1ca1f308a7a998eb59",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1063,10 +1011,6 @@
         "outgoingViewKey": "abf325f312f8dcdf82175341c9b04c68629bab895bd916b4aefd9ac7e071241c",
         "publicAddress": "a6e7a50946974ac2e0851d546c68afc2858dc3617fdb820d41db4b19b75fb23b",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1153,10 +1097,6 @@
         "outgoingViewKey": "634ddd1a0fbf4cc0abe7dc6ec4ce8303c3feb6e92a3f582e4f118ff49205bbcb",
         "publicAddress": "b2f022b352bac0460520ee8dc9ed672270abc7bb9f717112d82d0600aa74e73a",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1181,10 +1121,6 @@
         "outgoingViewKey": "000cb9043646a7452408d72a467bee48520e095a50f5de954c747fb4c4026f02",
         "publicAddress": "6d5f85675ee4b5d6a246c46cb86d7c8784a6021331098eb16bb1ce331c5a9eb3",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1445,10 +1381,6 @@
         "outgoingViewKey": "dd2950393f98feabf755209df37c12b627e4372a16a0a793e5e3f59c3a5c6e42",
         "publicAddress": "2a5fa529543b15ab1d5e3012f1680db6ea372fe030a38257c4de18d046e87eac",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1473,10 +1405,6 @@
         "outgoingViewKey": "195b1dda6696efd627d012ac4707a6fcc769ba4a9a028bc35b32c3ac4f1cc4b3",
         "publicAddress": "dec7c7d5f31d2970a89fe9a26c084d77b4b06e25d11f441b9599d391107250b1",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1501,10 +1429,6 @@
         "outgoingViewKey": "aff0270dc52aa1fe5af378d65f10e5d4a96dc5df980757b8f6a554a75d8e6411",
         "publicAddress": "659d8e27f3c3df437ef4913cda307e0cb0a85896a8089dd10b44a02e33489e94",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1529,10 +1453,6 @@
         "outgoingViewKey": "44c2091eb43bf971b61b992f9f5b3c085297ec5f3a2dad384a58000ba0af4384",
         "publicAddress": "47ba0cbc0b517b5814fa89e10df51204a6ab010dbb7469b1cb770f71b272c74f",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1611,10 +1531,6 @@
         "outgoingViewKey": "428fa313790dd10a1ce04085cb19b077c5310a0645d7effe8cd6bc834e8120e3",
         "publicAddress": "1521437460db8eeffbef208cdc7b5962789678ece99603ea300215e3a7d0c266",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1639,10 +1555,6 @@
         "outgoingViewKey": "59cf12e586d0b9333d26c6ef898b0d07a4896319333a7af0f7928f626425c117",
         "publicAddress": "05b0ccf13f8e8c7f647cc75a23249b50324f632d4f17caa4aa9f9ce5285bb04c",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1721,10 +1633,6 @@
         "outgoingViewKey": "6a8e546555706916004f58489058c9ef0b49f987e6656b6b339db8b88b1c26d7",
         "publicAddress": "2ae67398ef9218a9bb728a6674cf75ddf5e2e3a6671cc33bbc4d021c0da334b3",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1749,10 +1657,6 @@
         "outgoingViewKey": "aecf19091ffeba9ecf8977c3b907b337fcf3ee2e1f1e63bd1282010ebda20bab",
         "publicAddress": "07bfd5e5f4a2fe8a5d0c11f12e04d2c1afa547d49f993c7311808241397fe4d0",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1777,10 +1681,6 @@
         "outgoingViewKey": "e8d6c1d763d690fcbc7a8939f4d91da92c55383ffe9ac27403233b8fc6ce7a08",
         "publicAddress": "784799a0a0abcf80004f5ffc106fbdabdba1042ac0d4d728670ea5d23f35d78b",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1805,10 +1705,6 @@
         "outgoingViewKey": "2151dd2dcc7270b380366c4d94a6b0bbe5c4d6c74277c1723e7826c615919a14",
         "publicAddress": "3eea373b8a34fa8d809a4592e06990ea5d9db3907647114ddc6a225d6384d9ba",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1887,10 +1783,6 @@
         "outgoingViewKey": "72e458c30abf30738dacac7156a6441d69af4cd40d97a526d1cbfdd06591668c",
         "publicAddress": "e19911d0156d27fff52b9cc5b23b6247bb7122e3c759315ddfb8f298fd0a4641",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1915,10 +1807,6 @@
         "outgoingViewKey": "dd91d3adef2f850b3c85de32baca45eabaf192498fc5d8a0f05272d408352f19",
         "publicAddress": "e8196445df0b480d525f644246756c2b839a3b8acb6dd02825599489d4ad4cb9",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1997,10 +1885,6 @@
         "outgoingViewKey": "19cfc410c247722be5bc5f8306e8d584c348dc39597557b9431a2783d7b6403c",
         "publicAddress": "d9933197f4a7f000e843a12d86cbac557b3c127e600e0e2fdfcaa9a49fc5bde1",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2027,10 +1911,6 @@
         "outgoingViewKey": "fe829af5aecf58d0fe3477f0c91db72f4e787db423c7e23c69253be188f00e4c",
         "publicAddress": "2717ffc845f5eb8eb3f966c53e84245db1b915d5cbf13c4be110589b040b233a",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2125,10 +2005,6 @@
         "outgoingViewKey": "fb1060a7d6dbaea1ae6231e266386b778dfeb0acb6b752406b8e04c3a46bc06b",
         "publicAddress": "c7744f1e4575c251acaf6e6d04f1fd461d4c6aca4567d18cb5bb6832c4da36f0",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:Q3agWvJ73i9gmr0xOcMBccxk3mvfD6P6QfXc/xTegr0="
-          },
           "sequence": 3
         },
         "scanningEnabled": true,
@@ -2143,7 +2019,7 @@
       }
     }
   ],
-  "Wallet importAccount should set account head to block before createdAt if networkId matches": [
+  "Wallet importAccount should set account head createdAt block if networkId matches": [
     {
       "value": {
         "version": 4,
@@ -2223,10 +2099,6 @@
         "outgoingViewKey": "d5b9d37a1ac10028a2a17a17a89963f737437a1795eff3682abe4efc1f438e93",
         "publicAddress": "bc80cb6b801f78c27afa0ac4b1982506d4b7ba17c6abcdc758683b4d35956795",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:lvEaYZEraHX9++J0iht4i8X4IJGGicQhjZggsxT+1yA="
-          },
           "sequence": 3
         },
         "scanningEnabled": true,
@@ -2321,10 +2193,6 @@
         "outgoingViewKey": "e150d8bb9da66398a7a182bef6528dbc69560027ce60098693ed0f8d6653cae9",
         "publicAddress": "837f4f7d2eba4ec94cec9a599ff7f09d2da3497da0542c3760a113b4bea6acc2",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:5sGMw6nsoJg0YAZ2wgGgVJWTfkDnSZcLo6Iodu21Qmg="
-          },
           "sequence": 3
         },
         "scanningEnabled": true,
@@ -2351,10 +2219,6 @@
         "outgoingViewKey": "e73c14758a5df387d30365409a00e5857625e10881e0472a532378a9df708da9",
         "publicAddress": "b664709959513a8ad1eaf3ad062ff560dbef3c018a9ba0776e69b63538255f5e",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2379,10 +2243,6 @@
         "outgoingViewKey": "106e6056b605652e636a07dae0f6e1dbb0593e66f8f07cc7cf76bf017be05955",
         "publicAddress": "54f3498af84e33f83a99f45b8786ac7383f224850130c0427b8d2cb5305522d0",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2439,10 +2299,6 @@
         "outgoingViewKey": "93789b8ba70be57f55762519d99f94e09ccc43860cb1a5d7ed660429d294e20c",
         "publicAddress": "e341029ce046d92bf5615a293d3c5d7426d3228e7fb6df3265db8f425abe9d65",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2467,10 +2323,6 @@
         "outgoingViewKey": "6e67297a5641f5f6eeed55123b5d8f01eba0aaf60557e8aaf980d27868415abc",
         "publicAddress": "853d690693981b117fcf6551e4e38989a36d38f1afac4906df08e41e75a789a8",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2527,10 +2379,6 @@
         "outgoingViewKey": "084d3c17a4ed12bddf81b0817869fc58ff543165bdf17728a601ae6dd17644fd",
         "publicAddress": "4fb6b7d948531dafc9e5c744a38a4ff201e78ead23f6ab3236ca3e5aeb7f0307",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2555,10 +2403,6 @@
         "outgoingViewKey": "99c48b12b74dab845debe7f7477e9ac50be8595a286135c7c9cedad76a5042b3",
         "publicAddress": "19e23736b99981eb4836a1f361327735dbff05de994d7d3eaff10d5ff3c5ee82",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2641,10 +2485,6 @@
         "outgoingViewKey": "b75de0dca00b4bcd888fb37fa7e07add8933f82383851d3ae1890ca7b6ba1eb7",
         "publicAddress": "0528f13506da98272e3bf236415f0ef46e8e3a7be7f615cb7e2542feb06d1460",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2669,10 +2509,6 @@
         "outgoingViewKey": "a964fd0345aabae03e50d9c49ef464afe333b94aa285f1b43affd3dc4f398b7e",
         "publicAddress": "3c122e7f28d9a21449efd32adb44f537ffcbcf1b6b7109c6ba9156b30c232f40",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2811,10 +2647,6 @@
         "outgoingViewKey": "aa54c6129fbd3efdd77c012f36bb03911fa8318cc6df9962305e1393f6d315f0",
         "publicAddress": "ca619acda27cc27dc971ce2e91dfa25a8d69e27891a2c03d6054326f847d5e62",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2845,10 +2677,6 @@
         "outgoingViewKey": "0829a6972bdccee8570acc532ca8b86d6ea4d394302fd825d319e347cc3b6c79",
         "publicAddress": "ccebd478ae4d838601492b33a1e9085a627ddce9595d5e3df274340e985904af",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2901,10 +2729,6 @@
         "outgoingViewKey": "a606225016751d516bb041100cd53178371511e20e24f5f26e54a78cf5e85d2c",
         "publicAddress": "7d4e7e56e77621642eb7afe3e95efeb268c1e489e7c3f185518eb75c384127e3",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2931,10 +2755,6 @@
         "outgoingViewKey": "97cfd34efdc837fbae7924fa7fb10ec335fbfd8653c4c499dff765aa81affb49",
         "publicAddress": "549cd2c9aff38d8c8181e663f3ec8d542ef45e2bd75b7d5d76043f1897d153cf",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2987,10 +2807,6 @@
         "outgoingViewKey": "ab9cd785355b3a0436a0edfb4abadd384933a89119fbd5d843bbf344599a47b7",
         "publicAddress": "c68d42d2ba76e02876ddf3d6a4ba2359517fc673ae392dbd4874a91b957f5ae5",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -3095,10 +2911,6 @@
         "outgoingViewKey": "aad4eb453293e8312680a2b3700043965770d62279c299e5a3ed28115e6a3e78",
         "publicAddress": "6cf27da7ff70b6fa6ce68587605e37f9c9c11a225d5892aaa341d87d9e56802f",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -3203,10 +3015,6 @@
         "outgoingViewKey": "59ebbbf2b998bbfbb6343cf0a5c07732bd36328764a01db022c8fef963498db6",
         "publicAddress": "0c141e4fbbc829d161d0040a446dc7b6ced18b00be127a27cc04670dd334b957",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -3311,10 +3119,6 @@
         "outgoingViewKey": "87448c7e42c8ff2595cb9c3d760616aca80acb9fc38b6b18646c201adf73c04f",
         "publicAddress": "3d325ce8f26128c877dff0e7b48717321f5b2e1e823ccba04fdfce8e63779897",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -3339,10 +3143,6 @@
         "outgoingViewKey": "6bbbbf4dd28b6117e88957b301417c41e26f9873dd9879e58034afbb1032b7ee",
         "publicAddress": "9882a6f1ccd595fe0473aafd0acd7e458c81d67fa14284627815c30fe1db4f16",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -3475,10 +3275,6 @@
         "outgoingViewKey": "84f58706af9078ed76c9611124d43fe11d71ce2a7b0c1c51ded0665bf8527771",
         "publicAddress": "255d36c881772766dc97f5fb32753637154255cca5353b161f903a989dedd1bd",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -3531,10 +3327,6 @@
         "outgoingViewKey": "f2792a5d80f0e3a17dfab93ada5453c06a397818661e4315b2d326c3a7ad1be8",
         "publicAddress": "e999d0605cdc725d89aed54254e01e1267234482cf25dd27862067dedb496a6e",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -3621,10 +3413,6 @@
         "outgoingViewKey": "a60dc95c76f36506aa763c4d239ee72ef7afeac7c1d2b25faf63ed344007f01a",
         "publicAddress": "01bbcfb98ea62a15270828ae691b539e5e315e9cf32409d6dabf907d28199345",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -3677,10 +3465,6 @@
         "outgoingViewKey": "f2acdee1c508f63749c1ca6d8858674c981e28984aaa41972878927a53925662",
         "publicAddress": "82246b8a1904814012d9660648fd881c670584086a7202baf1af4837b3362ff1",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -3733,10 +3517,6 @@
         "outgoingViewKey": "bef7ce6c710acc74bdd39354c3363a67bc75912e7190f1bd929f0d9bbe952e67",
         "publicAddress": "341978dd15d5ae09fe61c6e47f0b55f73bba6e9af650fde2f939bf4733793be4",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -3761,10 +3541,6 @@
         "outgoingViewKey": "ae678e64056cef4d466fde470cb03937bef0233962cada091f3472b08df4cf51",
         "publicAddress": "44a8c7a0544dcbebf7d3e79c38fb99bcd30fe04c522e8c0a4040dbedf68c384f",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -3821,10 +3597,6 @@
         "outgoingViewKey": "bb1d7c81ebeecfc4afdb2473196e0a656a3b33c8cfa92b748240491f3bc8a40d",
         "publicAddress": "521113c0e3e5e6456cf5f59ac426b0325aa68951c96de838d6049779e7dbbdbe",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -3849,10 +3621,6 @@
         "outgoingViewKey": "d5222480902addb9baa67cc9e57c1b6093f7de4dff39e2382ef84c9dd125c2c2",
         "publicAddress": "1cabafe87e2cdad8e07e46a1929e9543d1c961979854a84cfcb4f274c15aca49",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -3935,10 +3703,6 @@
         "outgoingViewKey": "c2606b7ee74abc8cdaeef806851ad214b69b808c2bdffc07ed614dafc5072a4c",
         "publicAddress": "998b71f590eb07242bcd9da906d5f8169e6fe896d9647b394e71dc441bbdccc4",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -3963,10 +3727,6 @@
         "outgoingViewKey": "e685cc8ac05ff93bf0799af40cd51a359ce2058af63d7371ce15a8f2efa41735",
         "publicAddress": "8f962daba578a24f702dc4f7ec49cd4e56e63ed37d2809717aef1f632eebcb0e",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -4023,10 +3783,6 @@
         "outgoingViewKey": "87996c645a79a65e08bac9d494a73af7fdc68879681b4a8304710d460adc33cd",
         "publicAddress": "54ba5aa4c8dc570e74f0fc1c48a0ea53b88e31c6bcd9b19a3f0256ca34f221ee",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -4079,10 +3835,6 @@
         "outgoingViewKey": "cfa368d1730329f201788210888b1f6a8683277c5bfa997825968e8713673a0a",
         "publicAddress": "866515cde795c48214cb26173e058ef3d9874659285c98ca1934add93b86eaa1",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -4165,10 +3917,6 @@
         "outgoingViewKey": "50122caf58467fe56f5b3caa7c92730e9cfac35947bcdbecaa85cc40e6fd5e34",
         "publicAddress": "936ede26241c40a59212b251e194e683c0130cd6d4a29a7bf42a7890c94f94ae",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -4193,10 +3941,6 @@
         "outgoingViewKey": "b7c4c2775f1fb999a5cce2ceaa46282022aa81aaf9f44aae39a422702234fd9a",
         "publicAddress": "6cec5bb2c9277b843538df44ce549cee9bbe87796d26f7993f17fdd037b43200",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -4253,10 +3997,6 @@
         "outgoingViewKey": "f8771b7f507974adce966efe9ecb8ce476d5a1fb224b9f8b351f9a2c79d5067e",
         "publicAddress": "73741afc87ffd04a26d3265e5318baa355b175e61c5921f02917bd90fdb590c0",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -4281,10 +4021,6 @@
         "outgoingViewKey": "f54b1a3b861c566c276b947593eb3e81cac158c4e051159bacea1266b36fcec0",
         "publicAddress": "212ea518a951ce594adf965c5e2dd65d622946ca3eaae9fbb77f1e2525e86695",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -4341,10 +4077,6 @@
         "outgoingViewKey": "815fe80a2f67cf8e8228acfe9c3d6bacce5dd4c9f5afb3162f9fc73d58e1f526",
         "publicAddress": "92f7010e34896fd468dff5af5afcf15b2ec2c126cf324bd7d7f58c02994c0a0b",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -4369,10 +4101,6 @@
         "outgoingViewKey": "1000c09122ba07b31e1a053808e1ee52ab4fcf82b1f58677b14bbf6664d90612",
         "publicAddress": "7f6229c26f5ae7ae1d2460f66a49e21a0043738f63ab9919e29ce8af0ee227ce",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -4481,10 +4209,6 @@
         "outgoingViewKey": "c0c68212bfa326b18a81662901f02550f36cdc6f902d5fda40f059a5012ed429",
         "publicAddress": "1d36110d2e6c8dd0f700b747596cf63d62f743d13b8d8924055d96911e9333d8",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -4509,10 +4233,6 @@
         "outgoingViewKey": "c239e74af1eeee7d96916801a4941f2cb7fdd9339281ab9d1921f75523cf6268",
         "publicAddress": "e04def37fc0cab193e44a31390d85c0090a2b89a0610bc16e017f520aecf926e",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -4621,10 +4341,6 @@
         "outgoingViewKey": "2f8bf7b9a052db1c5fcb25b85ad93523fc865c9493a12889dafeec82e1c98ba5",
         "publicAddress": "2db05c91321a5e96af2303c9c9164bfc0a2789ccce25bbeb4213cc986fa755b9",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -4649,10 +4365,6 @@
         "outgoingViewKey": "fd5aefcb77a84360379cb42ca1575af92af0fef6f9d585e00671788f5ab7fb69",
         "publicAddress": "1bc946448310c4b70c9a0ad476741a0b0afeaf02750bdb5ca324ceb3c743dce8",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -4735,10 +4447,6 @@
         "outgoingViewKey": "ead9f6e370a250d3e6f6a8bd26aeec8832f31fb29bbfde24bf29154c3963bfe7",
         "publicAddress": "3c91103dedc461acc29cf0f2c38ea8b68cae02594cd61f007418ba4ea91e0b4b",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -4817,10 +4525,6 @@
         "outgoingViewKey": "eb45a5a3b4a9cbb1cfe22c1efea45c29e55e1c83d925d3ca892d693b28681235",
         "publicAddress": "580336448b2097ac9f598d4aa6e7300219c49bb861bf11c24a9278ae65934f46",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -4899,10 +4603,6 @@
         "outgoingViewKey": "3ce0a0bddfe06268060f00fe2baa4a5ad48cacade1cf0baca6b0df0e1d456f37",
         "publicAddress": "d7a73845f559cfe20c840c3e944a439b3c6d89bfe93aaab4f4f6062d69a033d2",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -5007,10 +4707,6 @@
         "outgoingViewKey": "31eb8cad991687c2132c3fc08be99c62296423e26d4afffcda306ca9fbe658ce",
         "publicAddress": "dd644113f8e1fc1d324f34060696d8352e97a17edf0a3a78dd54e1d246f1a6e0",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -5035,10 +4731,6 @@
         "outgoingViewKey": "3835258a93bbc9f8273c4b67d74f47a3b70a6200b1be82f2ef61d97ab09a492f",
         "publicAddress": "340d2b8c66eaefd69d9ed97d9e047903e9693f6223ac370da7f3ba3c87b7cfa9",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -5117,10 +4809,6 @@
         "outgoingViewKey": "82631567836d529fed8d550459aeb2d0fd89b09a6b197da028b3e730edff61d1",
         "publicAddress": "0c0e73741390118a4965ef6590ff7f76e88355b6c514619e6334733c19ca1bc3",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -5233,10 +4921,6 @@
         "outgoingViewKey": "61893a6f08648028a4bff39a7586a70082bab7dcabe6fb0597068dd1c2089af3",
         "publicAddress": "9d042d3a4438807b1225f6e9883c6af634460304362b1e1d1d11a985b47f0823",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -5261,10 +4945,6 @@
         "outgoingViewKey": "2170357e32352fcc6eafd2fb4b0659dba71d142a6038b157925f1ebf66577582",
         "publicAddress": "ce2bb4c55cbec067fc8ba9d94f780b3def2ba2cef6c0a612c8d88ca3741c4c85",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -5385,10 +5065,6 @@
         "outgoingViewKey": "66408539769523de7eca2418517b62cb02be7c401f0a7501bd13640d080e9c3e",
         "publicAddress": "460d857e7d44100aadb1635d84a2d792131ccf3b111a3142e3551ec4c2f2c239",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -5413,10 +5089,6 @@
         "outgoingViewKey": "4086253445b82ef43620ec4c013f76a684d7f60777b27e308dc9956369a79669",
         "publicAddress": "3e2e7615c181f2afaa6423465e3b3a9ddf8d89020891cd5f1fa77627beac0d4f",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -5673,10 +5345,6 @@
         "outgoingViewKey": "2a16e7d2db5541a55d55bacd69f5a5077d3aca6d64482032a74405042dbe23c4",
         "publicAddress": "002e67c1b367a11cfac003e4c6a22352676c6db67ee482a6cf425614a3903be5",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -5753,10 +5421,6 @@
         "outgoingViewKey": "4a6df989a0340102fef6a71b03df8cba0e0635bee1963791fb900b8dc705e383",
         "publicAddress": "40140a86a5071c4985e1ed66c2b8a0682e9a60ff45cf51e464f8820db66dc701",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:zlABkHbPDQPcYhD7AzaIX5QOulfKN5eNG9QdRHEh3RU="
-          },
           "sequence": 3
         },
         "scanningEnabled": true,
@@ -5783,10 +5447,6 @@
         "outgoingViewKey": "4da65b8bd524c0f9e5b6e98998ab575d8cb912202f42e9ea73e1f4c1e2ff955b",
         "publicAddress": "17eec804ae83239ae38c8849008c0864f2b4bf1ff70b341e71e7a2b126d079b8",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -5811,10 +5471,6 @@
         "outgoingViewKey": "8436e444dc23a2d8d5712f536a14ac56f0cc27e7aa691602d8c2e5fcf4ef4ff4",
         "publicAddress": "a085e2b5c5beed24baf419e0d5d48d1c28acc6ff4aa941e6d75f509450fb888f",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -5893,10 +5549,6 @@
         "outgoingViewKey": "85720d0846bd0c593b496c79637b57e4b6a0f2ec525d157424918d23724d4bfa",
         "publicAddress": "bfcc2c07f689708132f5bc4e04d9457770885b1835152dc8d5a78a11ebe32eae",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -5983,10 +5635,6 @@
         "outgoingViewKey": "fda80687cb6b89197a2f474bc395557aaa78e8ee775375a65fb46fb9c8d4db8a",
         "publicAddress": "77f8f0f146065f36329224ae5b3e3f12cab487ca04d4f589754f97872dd08e2e",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -6011,10 +5659,6 @@
         "outgoingViewKey": "aab99e3522c644aa7a35fd99242b012530f7c92e5f7d09883345a3617711f332",
         "publicAddress": "9b88b5a458a7f981f54b9ffdda6532677519dd0c71f71559207e4df60b5f2e6e",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -6123,10 +5767,6 @@
         "outgoingViewKey": "37dc14d6db97de98a5cb417b4878abee0da710aa9852b78509457db265a7bd9d",
         "publicAddress": "a04b7f87ed8da22822fd6e12d8e4f1ff026e075d81170fa389619687fc09bba3",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -6151,10 +5791,6 @@
         "outgoingViewKey": "0170cde824d36c7b73510632c2eceaead5abdcc3cfe0f3dea276c1fcd2784f4a",
         "publicAddress": "4df7683042db7b5452447fec67f8705fb987eac27dbc7a90b3952631fc9eef14",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -6263,10 +5899,6 @@
         "outgoingViewKey": "e1844f59394714ab1dee5d294c06f4b05884c1cb4cd78e4a68d25ffa121421e0",
         "publicAddress": "e76c858e25070012fcbf5126dfbd4318959d300f4e0bd9e659b0beb1bf771cde",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -6291,10 +5923,6 @@
         "outgoingViewKey": "7ac5c5eb4054140b70697ca4e896c329c5fb55ffd98e1c1b352692b6adc9710c",
         "publicAddress": "7788a27f2d1b3376f6d36b386bacce08a33724fb0565d47c6a24a5d0472f945f",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -6377,10 +6005,6 @@
         "outgoingViewKey": "4ee2db77355e1431706c7cce644bfcb43c102a7d4ebbfe5b5ea70685c17e3a5a",
         "publicAddress": "cf135210deb44de9cff4bf804acbdb5ecb8afdebf15642b16b98c4283068d62b",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -6459,10 +6083,6 @@
         "outgoingViewKey": "6bf7751d5aa48ea23c6ff551afc76814e1ca5da64e6f50506505c115cacd6272",
         "publicAddress": "3ad02fc5efcbb82261f4e1ee206e30125ec84b708ca463f94cd0a8f60422b563",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -6541,10 +6161,6 @@
         "outgoingViewKey": "9ed004a9bd5c88b0cab75aa01c29916a40f67a07d3c0bacfaac041a5e06d7cb5",
         "publicAddress": "9a8787574625ba72f6bb0707dc3d055bf29b9810910f0e75ab20d64a1b0e2610",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -6597,10 +6213,6 @@
         "outgoingViewKey": "e250f39b02cb196bbbe57e381ab199ea21ae82e9dfaabd95f82aa6dcad713e5f",
         "publicAddress": "135e42de661dbade17189fb1b52ebe7b73af3f00b0a22236468c3fcd5a60cc09",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -6625,10 +6237,6 @@
         "outgoingViewKey": "eb4440e0bd5787b009ae6a71d0b2d7b493fdfe0d95d33be05e6e6dcd0da49eb2",
         "publicAddress": "92056c5da34c774e45c9192f4d54cdc7b4e5bfc068897e49cffe47f797f0a543",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -6707,10 +6315,6 @@
         "outgoingViewKey": "26c142151e6a3c3c88f0e6c863722b32b76ae10f2e39d4bb13060e7baacdc5b9",
         "publicAddress": "518cdb40b18edcc515f251ab82e56b1b33850a5a9ec837c81973bb2274f85654",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -6823,10 +6427,6 @@
         "outgoingViewKey": "b788c45b68200423b608cf34888daeb2f56938e76c8d0297a572e43c989655f5",
         "publicAddress": "95205789be04b75526c4c33241dc8a94add1e0ac4455a66786bf53c84952cc3e",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -6851,10 +6451,6 @@
         "outgoingViewKey": "92af0cd3d4f015a0c6bfb0caa6ebf667a2851436b7445fece8766cca68a0bd78",
         "publicAddress": "c703444078753dffeba8416cd0b152f9317bd190474ee6206328d166ba79cc9b",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -6933,10 +6529,6 @@
         "outgoingViewKey": "1f5613cf9e3adca3828dbc5d240fb945f8737681782080eb49a4f7e5a97a144f",
         "publicAddress": "9219c0cded1632973b6f30fe89a1ef5d2ee497a43a9e8b4f327ad5e2c74bdd09",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -6963,10 +6555,6 @@
         "outgoingViewKey": "3dbc7a26ca52b85339ae4dfa94e90394a15e162081d537657b565c1a65554a57",
         "publicAddress": "b4230d53076043fec8aa43688879cfa6a3286f6a5f3ac64719cf9fa33744d206",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -6993,10 +6581,6 @@
         "outgoingViewKey": "ea8bb7fb76575ec9e5c3f5ab3ed106882d99b9b7fcc9afc224e0ce595e3f52f2",
         "publicAddress": "8336fb0657aa4cd82cfb5fb4b6723300af8d8cd64f86b14ece8b0230c6c807a4",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -7023,10 +6607,6 @@
         "outgoingViewKey": "92a38016572d0afc6a1c7bb92632134c761b4ef0dc82e6083b61c8ffd5a7c1cd",
         "publicAddress": "2b617eadeb40c7e6679212318210dd34de44ae591cbb1245a80563bade2e9706",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -7053,10 +6633,6 @@
         "outgoingViewKey": "0f418c817a72226b81e89cd2bc1166bb593d6469aadfb758301a5972a99f849e",
         "publicAddress": "98648a14194cd07bc1fa21d34bdb15fd41d556250dcc10f35888f24191cab41c",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -7107,10 +6683,6 @@
         "outgoingViewKey": "a9186f68b889911d78461e9b5576aae0b2d97547ba4fe809b36b53a53651ad70",
         "publicAddress": "bccc050a0c7444743fb01d59230dde81003021d6cea4d8b239afe021102463e7",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:mZq6o8uyv4LYoSbNLuuK+fF4tYM65yBRkmI4JuPAnok="
-          },
           "sequence": 2
         },
         "scanningEnabled": true,
@@ -7137,10 +6709,6 @@
         "outgoingViewKey": "acd19c3801777aa4fd97cf7819d08d3bece3d14b83245fe29b24acec1bb4fe96",
         "publicAddress": "81ac0d338d2048bac791a3cfb92818638d183465c3fc20d24dccd73e0e442d8d",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -7167,10 +6735,6 @@
         "outgoingViewKey": "702f217dc84ba67dfa4bc09a3c8f6491514c9b5b1b05891ec4b9bc762ff9d4db",
         "publicAddress": "60f29d4d089cbefe816d8892bc7a9e39b14541f4e8ab805819b3381ea3cd3d01",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -7223,10 +6787,6 @@
         "outgoingViewKey": "ee464e9cc173682b92fe04a12db52e03e8951d02d58049776c774c450cebec77",
         "publicAddress": "fc1b87236e98d329028c59dcb55139dece067d9a8092fc02f92bb83d5afd6cbf",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -7251,10 +6811,6 @@
         "outgoingViewKey": "539ea34dcb6523714f018c29b17dc0450fe1735f0acc7980e74038a1ac7f88b7",
         "publicAddress": "5ec695f11f12ae8e29f508edfef57acf4a2f1ec4a157c803c9d6365ce119143b",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -7363,10 +6919,6 @@
         "outgoingViewKey": "c481bc21735be6f39e11cdcafba614db85f4183153b8b539641ea0830fd3c11d",
         "publicAddress": "f0fbe34510ec326ba09245a4d54837dad8b32031a2d9fcad7cc79e66f3effd17",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -7453,10 +7005,6 @@
         "outgoingViewKey": "641d47cd60fb9991e6c62561f53f3b557f04a285ae6924cc5914718e9fbbe138",
         "publicAddress": "cec7be662b6bac78af667994b490f26857d18dca1e728488ffe7de0b01c4404e",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -7577,10 +7125,6 @@
         "outgoingViewKey": "6c88876709c07716f48b19d8056980876a7cd803854f30c6c70091577a6ef8c1",
         "publicAddress": "6ca52578ba0d94daee94af9fe5603043acd6efd1b1a9e8c54647f59b1cf18f99",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -7605,10 +7149,6 @@
         "outgoingViewKey": "1801e8be9cce2b842805bb8d05744ed4b9073d1f2047c2e718c09715892d336c",
         "publicAddress": "3bd5dff2753a8a2b0761c27f468cea32effcca7fa479d66abd38a70a32062a64",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -7717,10 +7257,6 @@
         "outgoingViewKey": "7f7a01e7efdb53e7b4a12ca4664c0277429205c6b21e5532965f6add9967f36d",
         "publicAddress": "74f189128d5f91e129af0bd86d986b948f21ab00561e7b47285000968b8df845",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -7773,10 +7309,6 @@
         "outgoingViewKey": "494d3e951b10776159af788756fc79169babd1c44674fd36abcfade121882735",
         "publicAddress": "71fb7ef377bbe2d80361b858ab2d8cd2dc526bd5e1591f794e7d213f890d1644",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -7829,10 +7361,6 @@
         "outgoingViewKey": "851ee2cb193f56a66e242c5d2ba4ace7a653fb1d6b11476cc78d98e1e0d3525b",
         "publicAddress": "132e02ec40e55f3f0b5e53721f41539e2559c3da3435a4128e2de74cc6ec9bad",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -7885,10 +7413,6 @@
         "outgoingViewKey": "2f1b93b172f76c3cd8db1e33fbdb4d09ad2f56e53b8756496201f8e69f94cc20",
         "publicAddress": "3c0e7e7752ece79518668342353f58c0e2ded73c5f8ff59bab2dc934a650dc5d",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -7941,10 +7465,6 @@
         "outgoingViewKey": "cc5eaab7ea9948a69faf90cde50994cf5229b3d1a4ed346009895e4089b3deeb",
         "publicAddress": "58ad1cffd3236ef303e9543a48ea92784f46233e97de4f739abb432860bc7244",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -8023,10 +7543,6 @@
         "outgoingViewKey": "6ae21c18dd5b081ecec4fe73fc417ea7c83213e218403b3b80a92d8f0420ab20",
         "publicAddress": "b6a489a014a64d0113c110531b99e19927088f301bedd11034121c28ff977848",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -8077,10 +7593,6 @@
         "outgoingViewKey": "8e6945c8a702223641536e38de45e76cd64ef9e8ce64f2f901ce7ae8ca6e8288",
         "publicAddress": "b85eb15dcc56677ff073dea9ebf79d284f6f34a83466dab734cb3f5e3afb53b6",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -8119,6 +7631,100 @@
           "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAeRsNEYt3ZwfhpUmTnlAoxMI6+BpLof6oRfHanFWaLQqWZCetZjOwdBadG2PWNRfhOYCj5kCz/FYXyqKDMKkTU/gS5tSiLixEqeVWt+LwUneKKoyXAeZ1OKNH/obHr4wFzvBwbPZ1/NhhgsGvbcBmENXpKynPgC4At7PCqBjLn6MS+xh8L8JI2YI25c2Jzac7boKEO4SUJWqQjnhT/PVNx2NJkd+ET9pPxDPxVJ9qaEGN5lmieKU0h91OfnpxUPWoHvbHt0fyfrEXLJOH2IMF1P6q8YPzmBNIPE9uWSh1Khrcv2cKbkul0cpw3Nt32rShV5kTakqHe/LipBTzKGmRSyfMk3R1qvkdot4OrlSGrgB9MMJKLf9yjvMe2Mq3p0tRzViHcNTZm4LWDwbaG6MdKaHz94M4iDqzrLa4lxGQaNoV6qLzRvvUtvliIlUh6ZRyXS37gNlD7Q7BNWuGEMsDmjy4xt0/fNsbO14ZaTKnn+EPbGECCOoDKX1yDFBlhzCAOEd41+Mi1AT641saSnvO5sMHoLy2r4x+lrDE7qyCL/3SClcmj0PFbi+CjPhSJn40hErDnV3//Q+X5tw+NcSBzwydSpdZgwwRm38Y+h3u+IsG281wffNTR0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw2eSVCgULZgJi31KzK3GdX62J/O4YGGwndBTL55y1Qd0m4Jq3ikdnPKJCLa67MczlYI9hwYzENBQbt3O3NOeRBw=="
         }
       ]
+    }
+  ],
+  "Wallet importAccount should set account head to createdAt block if networkId matches": [
+    {
+      "value": {
+        "version": 4,
+        "id": "40cd7bee-9703-4894-af8c-f6a9e84af545",
+        "name": "accountA",
+        "spendingKey": "94a2e29d9ae937bd7a00cc9d8d245df355a21c986285802b102688445b5fdec4",
+        "viewKey": "eb4fbda47ab5823a90793777f448ef1dbc6cc450a51046f59c528211cd1c0f6a64fe9213b300d579786c1c9e5f85fb58fbbc923dbfd3f1bfd1a3481aefa514b2",
+        "incomingViewKey": "f8da007a022b6e4b3d2b8e84baa1bd3da5a79301b128d24365393e1416e4f306",
+        "outgoingViewKey": "12fab1f90ec76593c16efabbcd3f3383a19b1d050715e376d91a5eb6e49859c4",
+        "publicAddress": "6f5fa7fe0f0bf11d5a7d8e4a97c9d1e817399cd28a2bff3694fd774bfabce0a9",
+        "createdAt": null,
+        "scanningEnabled": true,
+        "proofAuthorizingKey": "fcacca5cddc5d0a808f0aaa43b50f2175124c7d8061a9445fe0890b23be6430e"
+      },
+      "head": null
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "4791D7AE9F97DF100EF1558E84772D6A09B43762388283F75C6F20A32A88AA86",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:Z5Oubqr1XxuGPaWL4bTesBwOScNIdsWzldF5tZtxWTQ="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:6DQNsugOl0CfC/U4FEfNmgtYDJduutd7ngjb74TRRus="
+        },
+        "target": "9282972777491357380673661573939192202192629606981189395159182914949423",
+        "randomness": "0",
+        "timestamp": 1718333259953,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA12QzQjvn4eukBJlONDX2cf88xNVf5YQI6d5KIuG/VKGpKx7BPdPoSErPERS1sSJFk3MW45hoBFzLJoa6+jVUzBnkOeydMSzU7Fq9yEMocIuAt0r+4IYG8vCSo7D5KMgJl1QqY8YSEnjwjMgK3F7WOiQkk8H69IZUWiglDlYWbXgA8bTpFxhdARYF7maigwmbPUVi34gdAo20/prJDE8wjsl5EDZ5P0ndFhVKuUB+1OGARPYiwdoOiraJRi+VltLqRQkLM/5UJJi2YrMj+nNYfI+b6gWYQ3bzx3T49FXM8a+GJFHvI/5lYMGGLmlP28UYdJb4IrEtEEqUmOfQKJxypPnRKKWrZOw3kfltrWix1gTIayWb2aDCoMY3dbwVxuVlvKeH6TCbA2FRa6V/qwx8wCR+J/DidIA+Rqq5VM3gEQ1BbBTdJhnniunAFFw4zbirliu1yZylDmVtJw3VinLF5exG+TiEZ22G+ffojUaCkzrSUKYbcjvqEGiudgrsK/vPFzxYRA+EqShHeRqwphgDc+88g+4VMrRnZ47QMV6AxvU+zeQQu6lomVhzrHkt/lZGE0S3vfWwGvZEcVb7oVR272xndXSc8NQ9G2RqzODoeM75UXUs1LKitUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwNyDgjtPw9mbY8RCH63I/88NmH/cLLAnB/oGcDlERtJpdpxiNmGaIkott8YPJi+nmsCvVGt+xF7xGngbJCH1wCQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "19FEF61BB854D3BFC2AC9F6F44DC0CAFDC95136B4D860AACDACE6D8F1D69019D",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:GomwUVdUPWoEUWBw9/8YG2eDn4rWOSwiEwBXl0IsW3E="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:vbTq1Ose2zr/2azEUoOWVVpyOZX01srWNWLuxh97O5o="
+        },
+        "target": "9255858786337818395603165512831024101510453493377417362192396248796027",
+        "randomness": "0",
+        "timestamp": 1718333260555,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA1yMHRmkSX2bbtsmKEZ7wjgB3LXOxC9tac0PM/VNhxl2AInYFlivUTO/llVD/q0H4xwMe8bzBQj+Vj9bVSV8H8ZNPKFgXrdixXEB85t2yBP+lgiRbL5BkKmAOoJTbSzBLNDGHFBhZzXncFcK+CiHod6oIstN+ewMniTaOWVvsDOIUqtkV0F/PNrotYH87mBOyEVQs92QnkITgn6ZEjDvziqnqZSlqWkVgQI1As2fT2bmXmgGsVS429eKhd0HW+kO4OSUetovpF1ptScY6GarqwLG9SlWDWHRUOCTaWqwvtK161WFlJ+HKtgwy1TDVRrcqc1WP7RxID0octDWCsHzIgsUlnR2Q8jT1b0sxgWmN3FJH409qBLq0cvzb+DMCC8dVhV4IICQWbfdtSHhh7HNK4X9fuoxCg/CteLw8fSQbeB9JiNnLOaFMyuLG6xc50PMMasYlrnrj96STWPrbyC7rq5SNXtzrmgRvniDoup+NmYUesstJ15sGf4qVYw83tlHM57unVYLLESXhOXhmdBh+nkl6HtmfAluRDoQkBxvWc9oRselehkUuMrdM7YwFfXHNxy7Gw/gk2jncUcNKUYUYXkUOZ5h14v6KLhDKAQP1WOypm1QLRak5Iklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwtYA1P+Wu6tS06wFDicrzBNzkElcDokxpHWZf66Xa6UDSR6+3A2q3GXWpQnLfywRxD444bMDAjDnXr7yrr+MRCQ=="
+        }
+      ]
+    },
+    {
+      "value": {
+        "version": 4,
+        "id": "595450ad-9b90-4c4c-ba3b-cde77dede2e1",
+        "name": "accountB",
+        "spendingKey": "d8f05456ff22da901df36d4d8b8dc847e7b46ba4dec479e2fc435a54e4e9cdca",
+        "viewKey": "29951f8649fdc53edda6f6b046be046c551a226259458df9843350be86c5c44add592fb47b6fc8012a8df358f6a6434f53472f39ed5a8fea8049b3aa55870249",
+        "incomingViewKey": "2824ec7b8f979678911b31d862a0518f492b27c2a1d9edb57f03c81dc1b62c06",
+        "outgoingViewKey": "9aaf0a151baf26bff6e428f93dc180a043a7ee42a9822026ebf85ff5f075a3e9",
+        "publicAddress": "e80421bd8e673aba9af9938dbf8849ad3e7604304d8b1f5666ed565a93ea5373",
+        "createdAt": {
+          "sequence": 3
+        },
+        "scanningEnabled": true,
+        "proofAuthorizingKey": "eb204700e3bfdb05bb4c01cb397beabf691990f835e09a530f125b4ece53450d"
+      },
+      "head": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:scj8dCauxaBoyOGqK3AyfAoAHEfUQ3QjtQXulvg4jCE="
+        },
+        "sequence": 3
+      }
     }
   ]
 }

--- a/ironfish/src/wallet/account/__fixtures__/account.test.ts.fixture
+++ b/ironfish/src/wallet/account/__fixtures__/account.test.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "b18c908916adab5f7c32e2ef098e1fafbaa5fe9bb2eb9bfa388fbca0e3b740f6",
         "publicAddress": "3f49624ecbc2d05cfc0abb3a1efb9e904c910e9a2e1723cbf2d1f73691386a42",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -93,10 +89,6 @@
         "outgoingViewKey": "33070566a268006e71a6c93f3a4d53d844562b4c54b9a68644e1248497e20789",
         "publicAddress": "e520c0f003b151f6e3de21e721d24abe9a34115e6ae2ceea2e41dafea1fa6030",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -149,10 +141,6 @@
         "outgoingViewKey": "375550b61fb01688883fb63609b8a85b9f7dd8eafda1c893e94517218bbfb264",
         "publicAddress": "4d4d54d33d9821fc6ab6d5ba64753d431d69f737a5a64fcb990434fcc6a8fea4",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -209,10 +197,6 @@
         "outgoingViewKey": "966d8c89da8e6ef5d72d68a447948193bd4f97363dafd2563f154bef33b04cf2",
         "publicAddress": "341891a33d3766afe947db236db4ba033e36413f0562d02406d2a640e7ce8bcd",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -269,10 +253,6 @@
         "outgoingViewKey": "95020805131dba23c01825ab7e574396e1654616a71caa23ea69286bb149181a",
         "publicAddress": "129c97b922b8379f367d27d00d3e506ddc79a89af0b767eba8203f5e532588d3",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -329,10 +309,6 @@
         "outgoingViewKey": "94f72b4704a06c69e02f72871cca2029f8d6a0adb852588db4e5b25a6587b0d4",
         "publicAddress": "42efc95b2c8f7fae8e74538a4c1b1ce3839c2ba0bbd5e39a4460e1c9713b4501",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -415,10 +391,6 @@
         "outgoingViewKey": "f76e6253c3672780c381b1347e212cfda484b0535354febfb2ac7c8f77f5f465",
         "publicAddress": "eed7a318e89cfbb1b6f8dddc84095a991d5e7e870ae6baf7db0c160924cc6743",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -445,10 +417,6 @@
         "outgoingViewKey": "6892fdef3ad6095beb72ab3a194ad99aa259620416704d9a1faa812c1cb91181",
         "publicAddress": "731b7002a42644a751f217ab2a8421a41f15febc9a227f398c6e7ba3f206798a",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -505,10 +473,6 @@
         "outgoingViewKey": "eaa91d76eccb3902438194afc5ad79f0a4274677b2d4aba618826d8e7b89074d",
         "publicAddress": "767a4b0219dea215211390930abde11526f2695b3aca3576dc2c9e1e4b93dbad",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -565,10 +529,6 @@
         "outgoingViewKey": "b39a594b7669a6dd116b0db245ac6f8b65f67b079233ef1a4699ba55a9b77eaa",
         "publicAddress": "9472e986132e8ede887f640d2dbce65437ca661bed6144a9e4c8bc6a2bf725d9",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -625,10 +585,6 @@
         "outgoingViewKey": "6caf703b0e5e72ac7b2a5a86e6f458840d97fcb6e7bca1a98d61b097e64c0725",
         "publicAddress": "a04382ec95c41b019d3aec27de9e6f5f2740787690e7512b9df54c211c276b46",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -685,10 +641,6 @@
         "outgoingViewKey": "0f2ab686374f065809a195852d44b6166f8765db7b865b39d19b9c531b82a7e1",
         "publicAddress": "95d56befeea15827bb2a2387855b26ba77491e34284377836e7b2f6f1ee49b67",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -749,10 +701,6 @@
         "outgoingViewKey": "2484c6a5610d532d6d4ff95483c99d3bf6cfc85c86956acf234154132627afa1",
         "publicAddress": "bc25597cd139fb58357720ba0076170a86e22014a16700681ba27ccc236e1726",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -777,10 +725,6 @@
         "outgoingViewKey": "12c72c52a0c91dea2fad1ab8ae4d33a0b8b83d6b581d3234dca283d02d5cdf43",
         "publicAddress": "887b5bfa5bc03dd02c3323280b6aea4f7834b5cec5e527808ce5952e722b5cf3",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -837,10 +781,6 @@
         "outgoingViewKey": "b7b5f67e20861a944d930a50b4eb1196e384786806e500c2f23f429a5c27fd37",
         "publicAddress": "213da4fd030d02f65fb9319bc6dd2dd223c0f4a8d42fcecf7baa001c8571e480",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -865,10 +805,6 @@
         "outgoingViewKey": "1cd8608b0ad5c9035d8645c189aa839b3a08e815766d482b73448663f11e90db",
         "publicAddress": "d249a351a4a49aef6bbcf7bb49cb7f7eff89bc23d95f86b6a506da6fa44b6f3d",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -925,10 +861,6 @@
         "outgoingViewKey": "92a5f4809bae9b364e5facaec2c753de9d5284aedc1e9bbad715b757744283d7",
         "publicAddress": "5e623592e63417a09e98879744fc203bb857cacef4f2cc3079cae4ad51586702",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -953,10 +885,6 @@
         "outgoingViewKey": "f73e1b9dad4722670aff54562e955746350b9cb26d9e64ab5ea062405a0234fb",
         "publicAddress": "a44b26d9e9b3b16bbe833204907a341daa45ac9ab32f579a804b6625a048b39f",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1013,10 +941,6 @@
         "outgoingViewKey": "443e0e2fd88b61e77d0589eaa21968931ce68ec38a8d288a8ef66201e0303094",
         "publicAddress": "2c1b2798fd04fdd7a4e1364e673050dadd646dff8c4c06945eac230ec7db4191",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1103,10 +1027,6 @@
         "outgoingViewKey": "329ae99721991dfcd1ecc149c6cbf500f57dd5c7de3c8008b115702cb40a2729",
         "publicAddress": "1c8f76d5a887c23314d95a49921e442f48c2cd943440f47c4dc2d14f234114de",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1193,10 +1113,6 @@
         "outgoingViewKey": "83781599c4c64a50564a3a63e00a7783f3d9760e1d2accec9f8f5444f78e49ce",
         "publicAddress": "f29a3062b368550b32db41fa30339fceaf43d5aa6ea2ccb3bdfdfb7dd4c094a1",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1283,10 +1199,6 @@
         "outgoingViewKey": "cdabc02da8947b85f640753695e61de06c3af89db6ac7bb9263035da3d9fa32f",
         "publicAddress": "bd05c7a763f6f03abe31fee861f9986635429364dbed4aaef45f8919e7e675b9",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1373,10 +1285,6 @@
         "outgoingViewKey": "1a077e174d146dade031b5a4b2b8cbb5b9e83baccb8c7f1368909c53611c7a13",
         "publicAddress": "cc4083c164429cc9f7bbc57f639dc71071c471b118d656cb88bf46cfc255fde9",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1485,10 +1393,6 @@
         "outgoingViewKey": "ba41b94f3d18c7d0d3a8722a709c75d85d083ac1f395eac08015ea43afa053ae",
         "publicAddress": "2dfdb4ea610437c5ab0d495219da54d8c9748eab65cd2cc3cba836449f541980",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1575,10 +1479,6 @@
         "outgoingViewKey": "8c596e327a762700cbfdc66109f684b2b6b78efbc6cf58b9ed492276cd2c014c",
         "publicAddress": "081414c6cfd5027f700334269459b21684981b1b258e17d723f9303e909666d7",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1603,10 +1503,6 @@
         "outgoingViewKey": "27fd1bf45b314db7dc0d2817da5735ca2d0ee252340c215a0cf1c3b6358fc450",
         "publicAddress": "47c23087cf276488239759a0bad6cd0a4e1c61ddcdd084449f5da5133c35b885",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1693,10 +1589,6 @@
         "outgoingViewKey": "ecaefd2715dbfd671f9e56a344a1b2e5e9052c8ef4e7e4902f04d863b8156271",
         "publicAddress": "def9acc76e8657f224e7f9de4de9b9189f3ce33e92e5115aab5f26fa3e0122bf",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1817,10 +1709,6 @@
         "outgoingViewKey": "932a0ee2cebf96126e034b4f42febbabe4182634afcf91e5670518e7d7ca24b3",
         "publicAddress": "47add4da83cde3f837e3c83f923a62be67c46024ebaab75ca628ab63d5117bc2",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1845,10 +1733,6 @@
         "outgoingViewKey": "aeb3f44de3d183f4beda06da4b189ff05bcc9134d36d98edc34084382c53185e",
         "publicAddress": "2ce168a41537392e6b0504721e056f4d08c803ae70886526a1c04c41aa85793d",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1909,10 +1793,6 @@
         "outgoingViewKey": "3243869c6514827b9014e6fc0de1e5aae6e43ba05b16fad4d97c0c4647cbfdb3",
         "publicAddress": "4a73bb07dcc20ccdca41b97c380340b41c1806e365e9c6e509c4d7230b35940a",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -1937,10 +1817,6 @@
         "outgoingViewKey": "a3b486d1a21815d426948ce415b1bcb981537a68800d72ae2bde96044a3f9450",
         "publicAddress": "9aea7f79faa96852124a70410b3aff9903844f68ff87411072138d7f4f7e2124",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2129,10 +2005,6 @@
         "outgoingViewKey": "cbfa51a70ee2389fb84f1258f95ce3202cb369f80fc413310279dea7d8142980",
         "publicAddress": "53ffdd6e6ecf898c4c4a31ee3d0f21e0157fed422c9b346afcf6bc2aaf69a5b2",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2223,10 +2095,6 @@
         "outgoingViewKey": "df0486867cd25a2541b59f49e00cb1e61d4bbe30fdf7673e28f1e03127d47534",
         "publicAddress": "6e4649fedf65bcb1047fe8bf632e05cecad19d670afaa9b806fa845100dcd282",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2279,10 +2147,6 @@
         "outgoingViewKey": "cd4f6a6b9a89c5da5926618ee145c109cdfc6a84732cbdc23ac326a823e660a3",
         "publicAddress": "4e13f8947e082724b6456610fa73589402c0cf44a889340ae1cf05ad28b64582",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2369,10 +2233,6 @@
         "outgoingViewKey": "5ef8f7ca0ed6983ccd38541244240aa9cd50635899711c7f410b2b00811e7066",
         "publicAddress": "0933f0aedd039d5b798394cd1b645d6ded893a0d449f066d4d57fed11c9c7c0c",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2459,10 +2319,6 @@
         "outgoingViewKey": "12b51e7eb8c9294a7de10021ac5f7a2619cbe13fac4affd38dc205f8c71f92db",
         "publicAddress": "cd8934eaaa0f8256a645c37b06dfb35f0eca99bb553520434f0fa44cc391a051",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2549,10 +2405,6 @@
         "outgoingViewKey": "13fd2bad9807c39e782daec40c978f2418d75825d340ce99bdf26118908524dd",
         "publicAddress": "f032507ca858e16b5328366ddae183be953e94ebc4424b90a674539745630302",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2639,10 +2491,6 @@
         "outgoingViewKey": "f03bf4592df6b0faa05481bce128f15fbe743efb398f63fa09debb42299bd2b2",
         "publicAddress": "558a5c9c93b33a1a74211e50f62af3d2d2435f96feac906dd11a8811cddd54a2",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2729,10 +2577,6 @@
         "outgoingViewKey": "e088397eb2ae4309084934a067ffe32055471933883ce1eea4de38c5a742309e",
         "publicAddress": "900f057354aea66db6da4843ae0542cff43a8a39c4f54a2dad66a8e86c660d8d",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2757,10 +2601,6 @@
         "outgoingViewKey": "40ecb267ff5f57e50977ed2bc4b2aaa62db15e8b5daaea9378e6c2d351089286",
         "publicAddress": "ab6d3b8e8100f7c80096b619c528096e090b32706118aeb78c5affda0f77b529",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2881,10 +2721,6 @@
         "outgoingViewKey": "64afb70ed31eb05a0b8d7057b545747b86210681a3e2acff71d7baeee68cd6a8",
         "publicAddress": "53a4b53ecb59c47715840d1f4df65beef82679f742baeb9f29fe7cf4b1687966",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -2909,10 +2745,6 @@
         "outgoingViewKey": "4a07003df338a0410949be1ad21ccd1f9ae5e58652bba088a520da1fa627e86e",
         "publicAddress": "7eb97f282aaa0c267681fe8b42ebfbdb9031b70c6d1e7bf1fbf7ea5b6a1529ee",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -3033,10 +2865,6 @@
         "outgoingViewKey": "44ee41ec9ccf6d7628dc5f2c6fd0fe036ea9bfa9fb967f8c0beadf82eaf790d8",
         "publicAddress": "763b6eb7292662385461734398559a9eec21a04fd62aec2a2c3246fb5c6bab1f",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -3061,10 +2889,6 @@
         "outgoingViewKey": "299ab11109129ad8dd41ff35e3fec0ef654fa70c87595f8f6905dd25626cabfd",
         "publicAddress": "ee2080f7e5ce526199e171e944d5fd8ee0acf43462150075b05d6b666d01af3b",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -3253,10 +3077,6 @@
         "outgoingViewKey": "6c1ed124dbb7a76ebee7d1b34cef1f518ee50fec27e7655afcada4ac0aa4495e",
         "publicAddress": "8903639a8f6a83fc68aa6b2132368863c1d1a4b5639f894e5f071531af1ff212",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -3281,10 +3101,6 @@
         "outgoingViewKey": "8833aea97a7eb9dcf3b004b059cbe085b2e47b85d6940b685ec8177d55266a3d",
         "publicAddress": "6615387cc2f76766439bd205bc8b0be0a6acaab2d8a71318456e44e564d5fc21",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -3371,10 +3187,6 @@
         "outgoingViewKey": "f299ad24f06f398206cfdba970c389a08cfc585b24f1f48815bd422117426bcb",
         "publicAddress": "2b507f5be19ed8c1936e37a01859b4d444e704a66cc655168d51afbfb0c1609b",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -3427,10 +3239,6 @@
         "outgoingViewKey": "b7a3b6083e6e9dec8b612bfd3f19222226821bc2fd786f15273c313dc9d2b9a9",
         "publicAddress": "c2ecc73670eb0cc9315f12f0130cb2a0724d719530e653e42d2809791ecb3b1f",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -3483,10 +3291,6 @@
         "outgoingViewKey": "48d704eb34763ee3f0199403b7f9d74745fe2a91f211f8186f87b98887885757",
         "publicAddress": "3e05ba92905ef8ecfc830ddc9226fe641b3af2f593c61f8f3bfde409cb38be91",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -3543,10 +3347,6 @@
         "outgoingViewKey": "8f6ddd5f3803ff35251c71b6f530d6e0fa9757000a0d1f49a891f2c4c542a9ae",
         "publicAddress": "b27491dccac9fedeee504a4c074bc4e9e38a05d6f2e4db67793803e8a5b13e88",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -3571,10 +3371,6 @@
         "outgoingViewKey": "6bf1d7a5ece33504f023554749186f508cfb0e247f3ebc78f60ee126ee485a2a",
         "publicAddress": "5395635a189710d8b800867df03d4bd116cf7171d1b074003fc83fcee6c24f71",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -3657,10 +3453,6 @@
         "outgoingViewKey": "ca32e39c6a62182e76349fe91872c942148c41dd1326424de8c419ac5b815529",
         "publicAddress": "7b5f1b0e343d3b1bf4cc7ba58413f4d545c3247a6a9533be7405fb6d752eaf86",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -3685,10 +3477,6 @@
         "outgoingViewKey": "550f1c5977777e18058626f1ffbd2bdd7986db808a4dd7db1ad8b627c01297b8",
         "publicAddress": "f5a49089524a6b11473ec5710ccf52bb69ce5906054b41a2b3eb72cbba80c416",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -3801,10 +3589,6 @@
         "outgoingViewKey": "b00950790b15c742c29430fec4f3c62d8d733d3bb903602358fb34a8c933bf0f",
         "publicAddress": "1a4c61f6834acf1324f9090cdf270e325984f09641a111f77169b1342bba34e9",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -3891,10 +3675,6 @@
         "outgoingViewKey": "9ec1076107b67e49f6ab935a812a57a82c70640b9b2c440c105a1d9bb7843f21",
         "publicAddress": "986296ac20dae0a4b22e49fc2563f22881422a15176518194054f482d855b867",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -3919,10 +3699,6 @@
         "outgoingViewKey": "c584804c92166e2fc1d0e82a2586002f3a7607fc1771d082c6dd5b460dfb51a2",
         "publicAddress": "69647ec8942334a069823e284da48f002ae5abf0cdc6d1e64aa5ad20a182aa21",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -3979,10 +3755,6 @@
         "outgoingViewKey": "ef2195dc8ae2a34734dd12a9c27522223dd6aec3444f89328b256c4f3132ae40",
         "publicAddress": "2200a09d4b6208ffa74a71203063ebc42879bcf6214f24ecd18307b7a79baa17",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -4007,10 +3779,6 @@
         "outgoingViewKey": "486fd1346a96eb36061183302bdb8708e4446d6a466a43b74099e3b3b1975b91",
         "publicAddress": "7121c16ce957dc99bd2761795a48c632799335637d02019126a70dff6639ab0d",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -4093,10 +3861,6 @@
         "outgoingViewKey": "660589070fac6beee4b4222954e90780cad2ad362163754725302d667688f2ae",
         "publicAddress": "afb1a5a17b61aca1d843bf6db72b12b9b44bd2127442d94d0d8f89d3fd28fc1f",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -4121,10 +3885,6 @@
         "outgoingViewKey": "fc65e83023f7df1e1b9bf5158682757dfacdb1740f7f05b2a1915551286b3768",
         "publicAddress": "d361a969842fcc9786ac13bc8b17941f971251156d41fb40907fae47c317fb1b",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -4237,10 +3997,6 @@
         "outgoingViewKey": "bf26681ed89a20ef84db0fab5a0de6b8d21dc78b2409d692d4bed268d7f9d2e9",
         "publicAddress": "27b36c92bd91061ebc8aaf21f08ba03b1feb80900fcb27ce8eb8a592ff7b114f",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -4293,10 +4049,6 @@
         "outgoingViewKey": "98ba87a18d9f8ba51a5d0ffd7a283e9059d43c182a372e5b54ac9f76d5d51cea",
         "publicAddress": "626019ddd48af3941e8e2508a4fceb06d741458f09326e0b009b33a1c9f53091",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -4321,10 +4073,6 @@
         "outgoingViewKey": "d0de2eba473509211af1c0179b1951f79b300cd5e80c31675d5fe9f58216c54c",
         "publicAddress": "0ec5c3bb13ec333b075eaf14c42592a26c0d4c88fb5f9ebb72b01a82b1cd7e96",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -4381,10 +4129,6 @@
         "outgoingViewKey": "64bc64bf4050b085b5f681376d3edcfbdbc009ae44e98da62c215ad4a075f43b",
         "publicAddress": "92777755667cf8aec04e2daf3284ad8ac2b943d284bfb98fc0d1b0f6bcc10623",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -4409,10 +4153,6 @@
         "outgoingViewKey": "1a9c9ebb222cea79b38fbdec85bde99bf16e5a342503a5146ccf9d6556a9f524",
         "publicAddress": "d02e528eccd6dc2915ebc1060af8bd9acc2ecb5b21d9580e7ff6e4045510e88c",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -4529,10 +4269,6 @@
         "outgoingViewKey": "0c52e5c23550c403e65506f8c9e44072166374e932542f9244c3414beaad27d8",
         "publicAddress": "9ce0b1f26bcf060b623a9a363877f3fcff728f2fbee361f1026192bef48b88cc",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -4619,10 +4355,6 @@
         "outgoingViewKey": "1754fe76af30537060fb79bdf77f80fd18a056780fbf43bb4653c1bc6c81f740",
         "publicAddress": "dfddde5e152615683837887cd32e76279c0efb7f5a14c5889305aa8abeabe6d3",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -4679,10 +4411,6 @@
         "outgoingViewKey": "6a1e6b40e31108ca0dd0ac7a6a9a81ecdb06f636a52dad794c2eae5c90db7bbe",
         "publicAddress": "854ac0db4f915a001d86a278fd533f4a9aa2e4747e583d719d4dd494f7b984a2",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -4743,10 +4471,6 @@
         "outgoingViewKey": "8abf62370da721c1f0f3c8022f9e290dcf0d9402e22204977a22f5cfe215b81d",
         "publicAddress": "7b2a978f9d3e4a101802d3ef6953140f53482c279c92a7e6957bd4633f667181",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -4803,10 +4527,6 @@
         "outgoingViewKey": "1e610e1b727cd8308769254c94e795d1aab32dab939da68065176aa416728323",
         "publicAddress": "ec961e80a92abdf29fe86f656e8564b0c4600533dcf5486ca8e856dc9a3cb3bf",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -4927,10 +4647,6 @@
         "outgoingViewKey": "133ba38cfc6fed34b6004a56778cff418fa2007d4aec70077f57d7366160891e",
         "publicAddress": "7c3e58b99491e82c9777f1b375b5682204ea00e429844efead5325d0b1d66fc4",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -5009,10 +4725,6 @@
         "outgoingViewKey": "7a1030c39a890fa87ff0ae1b4fe6fc1a911768531f17b039eae56eb6212ad893",
         "publicAddress": "6c0e7cee97a7f12bf40de4467ec0b9e1f7464d363eb54a8140dc880c9ca9b79c",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -5037,10 +4749,6 @@
         "outgoingViewKey": "0fba7bbef0ef966fea0b51bf326da66e05546483b70ecac5ebff4a4e86a3ec3f",
         "publicAddress": "526f8688c1a3a69f7eee74d359c9e1ea68d033e6b8076ffd78cd811160efd5f2",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -5263,10 +4971,6 @@
         "outgoingViewKey": "48e44490b92d9b185148caf83766ec0342d0d070487e5f7847025c9ef34a8801",
         "publicAddress": "c62e39de9246dbcf0865195b4eafc5e66213a95f9879259bb68964654e1cb080",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -5345,10 +5049,6 @@
         "outgoingViewKey": "0a0a47932e395a7aa8918ad0e2eee3b59c95e007481fd78f02c083d17c333584",
         "publicAddress": "7cc6046cd7d11717c96e376fe8c024fc39c2e73e664df05ea5f6b9dff25e2411",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -5401,10 +5101,6 @@
         "outgoingViewKey": "57cf1828472f3cb501555910fd2721207d9aca0e946bb3090bd267200b46af6c",
         "publicAddress": "f825b7e01ba3bbe383b11882bab2b890132e9c44a0fe5b539bffc7417f35dc71",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -5491,10 +5187,6 @@
         "outgoingViewKey": "4e763e2d4a17725b9708ae8b4abf9b35890ed665e848608b34d7b7017aacadda",
         "publicAddress": "a4e71fcd90fe3154bae11504368a4503175f577ff5918ffa5ece7fa2fd4755ef",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -5547,10 +5239,6 @@
         "outgoingViewKey": "2be239f107aacb7904ed74da32dab8a19e31ac5ed64d19a7ea417a717adae007",
         "publicAddress": "f82d8c9b141f0d58bb3fc3275e06a69bc36ca598492b2b3619986bdcea680a60",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -5575,10 +5263,6 @@
         "outgoingViewKey": "8d696d3e23f63ceb0d5343718b0493ac7d9fe4829c10981f6c1067e39d51861f",
         "publicAddress": "a40de31d12aa99c6c3d89e3d6dafec11c7f115b7b97b3f09c36442a5255f345e",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -5699,10 +5383,6 @@
         "outgoingViewKey": "038a665c0eb728e70621f00bdd03cf19bf24983a4f4894e27bacb5d8fefe4431",
         "publicAddress": "a3cfa297e7b56c9064dbcfeada016da0f94e168b9856f8d9dbbd67b3a141c790",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/wallet/account/account.ts
+++ b/ironfish/src/wallet/account/account.ts
@@ -69,7 +69,7 @@ export class Account {
   readonly outgoingViewKey: string
   readonly version: number
   publicAddress: string
-  createdAt: HeadValue | null
+  createdAt: { sequence: number } | null
   scanningEnabled: boolean
   readonly prefix: Buffer
   readonly prefixRange: DatabaseKeyRange
@@ -1243,7 +1243,10 @@ export class Account {
     await this.walletDb.saveHead(this, head, tx)
   }
 
-  async updateCreatedAt(createdAt: HeadValue | null, tx?: IDatabaseTransaction): Promise<void> {
+  async updateCreatedAt(
+    createdAt: { sequence: number } | null,
+    tx?: IDatabaseTransaction,
+  ): Promise<void> {
     this.createdAt = createdAt
 
     await this.walletDb.setAccount(this, tx)

--- a/ironfish/src/wallet/exporter/accountImport.ts
+++ b/ironfish/src/wallet/exporter/accountImport.ts
@@ -22,7 +22,6 @@ export type AccountImport = {
   outgoingViewKey: string
   publicAddress: string
   createdAt: {
-    hash: Buffer
     sequence: number
     networkId?: number
   } | null

--- a/ironfish/src/wallet/exporter/encoders/base64json.test.ts
+++ b/ironfish/src/wallet/exporter/encoders/base64json.test.ts
@@ -76,13 +76,7 @@ describe('Base64JsonEncoder', () => {
       incomingViewKey: key.incomingViewKey,
       outgoingViewKey: key.outgoingViewKey,
       publicAddress: key.publicAddress,
-      createdAt: {
-        hash: Buffer.from(
-          '0000000000000000000000000000000000000000000000000000000000000000',
-          'hex',
-        ),
-        sequence: 1,
-      },
+      createdAt: { sequence: 1 },
       proofAuthorizingKey: key.proofAuthorizingKey,
     }
 

--- a/ironfish/src/wallet/exporter/encoders/bech32.test.ts
+++ b/ironfish/src/wallet/exporter/encoders/bech32.test.ts
@@ -57,13 +57,7 @@ describe('Bech32AccountEncoder', () => {
       incomingViewKey: key.incomingViewKey,
       outgoingViewKey: key.outgoingViewKey,
       publicAddress: key.publicAddress,
-      createdAt: {
-        hash: Buffer.from(
-          '0000000000000000000000000000000000000000000000000000000000000000',
-          'hex',
-        ),
-        sequence: 1,
-      },
+      createdAt: { sequence: 1 },
       proofAuthorizingKey: key.proofAuthorizingKey,
     }
 

--- a/ironfish/src/wallet/exporter/encoders/bech32.ts
+++ b/ironfish/src/wallet/exporter/encoders/bech32.ts
@@ -46,7 +46,6 @@ export class Bech32Encoder implements AccountEncoder {
 
     bw.writeU8(Number(!!value.createdAt))
     if (value.createdAt) {
-      bw.writeBytes(value.createdAt.hash)
       bw.writeU32(value.createdAt.sequence)
     }
 
@@ -114,7 +113,6 @@ export class Bech32Encoder implements AccountEncoder {
     }
     size += 1 // createdAt byte
     if (value.createdAt) {
-      size += 32 // block hash
       size += 4 // block sequence
     }
     size += 1 // multisigKeys byte
@@ -147,11 +145,10 @@ function decoderV1(
 
   const hasCreatedAt = reader.readU8() === 1
 
+  // TODO handle old versions
   let createdAt = null
   if (hasCreatedAt) {
-    const hash = reader.readBytes(32)
-    const sequence = reader.readU32()
-    createdAt = { hash, sequence }
+    createdAt = { sequence: reader.readU32() }
   }
 
   return {

--- a/ironfish/src/wallet/exporter/encoders/json.test.ts
+++ b/ironfish/src/wallet/exporter/encoders/json.test.ts
@@ -12,7 +12,7 @@ describe('JsonEncoder', () => {
   describe('encoding/decoding', () => {
     it('decodes the value into a AccountImport and deserializes to the original value', () => {
       const jsonString =
-        '{"version":2,"name":"ffff","spendingKey":"9e02be4c932ebc09c1eba0273a0ea41344615097222a5fb8a8787fba0db1a8fa","viewKey":"8d027bae046d73cf0be07e6024dd5719fb3bbdcac21cbb54b9850f6e4f89cd28fdb49856e5272870e497d65b177682f280938e379696dbdc689868eee5e52c1f","incomingViewKey":"348bd554fa8f1dc9686146ced3d483c48321880fc1a6cf323981bb2a41f99700","outgoingViewKey":"68543a20edaa435fb49155d1defb5141426c84d56728a8c5ae7692bc07875e3b","publicAddress":"471325ab136b883fe3dacff0f288153a9669dd4bae3d73b6578b33722a3bd22c","createdAt":{"hash":"000000000000007e3b8229e5fa28ecf70d7a34c973dd67b87160d4e55275a907","sequence":97654}}'
+        '{"version":2,"name":"ffff","spendingKey":"9e02be4c932ebc09c1eba0273a0ea41344615097222a5fb8a8787fba0db1a8fa","viewKey":"8d027bae046d73cf0be07e6024dd5719fb3bbdcac21cbb54b9850f6e4f89cd28fdb49856e5272870e497d65b177682f280938e379696dbdc689868eee5e52c1f","incomingViewKey":"348bd554fa8f1dc9686146ced3d483c48321880fc1a6cf323981bb2a41f99700","outgoingViewKey":"68543a20edaa435fb49155d1defb5141426c84d56728a8c5ae7692bc07875e3b","publicAddress":"471325ab136b883fe3dacff0f288153a9669dd4bae3d73b6578b33722a3bd22c","createdAt":{"sequence":97654}}'
       const encoder = new JsonEncoder()
       const decoded = encoder.decode(jsonString)
 
@@ -30,10 +30,6 @@ describe('JsonEncoder', () => {
           multisigKeys: undefined,
           createdAt: {
             sequence: 97654,
-            hash: Buffer.from(
-              '000000000000007e3b8229e5fa28ecf70d7a34c973dd67b87160d4e55275a907',
-              'hex',
-            ),
           },
         }),
       )
@@ -41,7 +37,7 @@ describe('JsonEncoder', () => {
 
     it('renames account when name is passed', () => {
       const encoded =
-        '{"version":2,"name":"ffff","spendingKey":"9e02be4c932ebc09c1eba0273a0ea41344615097222a5fb8a8787fba0db1a8fa","viewKey":"8d027bae046d73cf0be07e6024dd5719fb3bbdcac21cbb54b9850f6e4f89cd28fdb49856e5272870e497d65b177682f280938e379696dbdc689868eee5e52c1f","incomingViewKey":"348bd554fa8f1dc9686146ced3d483c48321880fc1a6cf323981bb2a41f99700","outgoingViewKey":"68543a20edaa435fb49155d1defb5141426c84d56728a8c5ae7692bc07875e3b","publicAddress":"471325ab136b883fe3dacff0f288153a9669dd4bae3d73b6578b33722a3bd22c","createdAt":{"hash":"000000000000007e3b8229e5fa28ecf70d7a34c973dd67b87160d4e55275a907","sequence":97654}}'
+        '{"version":2,"name":"ffff","spendingKey":"9e02be4c932ebc09c1eba0273a0ea41344615097222a5fb8a8787fba0db1a8fa","viewKey":"8d027bae046d73cf0be07e6024dd5719fb3bbdcac21cbb54b9850f6e4f89cd28fdb49856e5272870e497d65b177682f280938e379696dbdc689868eee5e52c1f","incomingViewKey":"348bd554fa8f1dc9686146ced3d483c48321880fc1a6cf323981bb2a41f99700","outgoingViewKey":"68543a20edaa435fb49155d1defb5141426c84d56728a8c5ae7692bc07875e3b","publicAddress":"471325ab136b883fe3dacff0f288153a9669dd4bae3d73b6578b33722a3bd22c","createdAt":{"sequence":97654}}'
 
       const encoder = new JsonEncoder()
       const decoded = encoder.decode(encoded, { name: 'foo' })

--- a/ironfish/src/wallet/exporter/encoders/json.ts
+++ b/ironfish/src/wallet/exporter/encoders/json.ts
@@ -12,8 +12,7 @@ import { AccountDecodingOptions, AccountEncoder, DecodeFailed } from '../encoder
 
 export class JsonEncoder implements AccountEncoder {
   encode(value: AccountImport): string {
-    const encoded = serializeAccountEncodedJSON(value)
-    return JSON.stringify(encoded)
+    return JSON.stringify(value)
   }
 
   decode(value: string, options?: AccountDecodingOptions): AccountImport {
@@ -58,7 +57,7 @@ type AccountEncodedJSON = {
   outgoingViewKey: string
   publicAddress: string
   spendingKey: string | null
-  createdAt?: { hash: string; sequence: number; networkId?: number } | string | null
+  createdAt?: { hash?: string; sequence: number; networkId?: number } | string | null
   multisigKeys?: {
     identity?: string
     secret?: string
@@ -79,7 +78,7 @@ const AccountEncodedJSONSchema: yup.ObjectSchema<AccountEncodedJSON> = yup
     version: yup.number().optional(),
     createdAt: yup
       .object({
-        hash: yup.string().defined(),
+        hash: yup.string().optional(),
         sequence: yup.number().defined(),
         networkId: yup.number().optional(),
       })
@@ -99,29 +98,6 @@ const AccountEncodedJSONSchema: yup.ObjectSchema<AccountEncodedJSON> = yup
     networkId: yup.number().optional(),
   })
   .defined()
-
-const serializeAccountEncodedJSON = (accountImport: AccountImport): AccountEncodedJSON => {
-  const createdAt = accountImport.createdAt
-    ? {
-        hash: accountImport.createdAt.hash.toString('hex'),
-        sequence: accountImport.createdAt.sequence,
-        networkId: accountImport.createdAt.networkId,
-      }
-    : null
-
-  return {
-    version: accountImport.version,
-    name: accountImport.name,
-    viewKey: accountImport.viewKey,
-    incomingViewKey: accountImport.incomingViewKey,
-    outgoingViewKey: accountImport.outgoingViewKey,
-    publicAddress: accountImport.publicAddress,
-    spendingKey: accountImport.spendingKey,
-    multisigKeys: accountImport.multisigKeys,
-    proofAuthorizingKey: accountImport.proofAuthorizingKey,
-    createdAt: createdAt,
-  }
-}
 
 /**
  * Converts a AccountEncodedJSON to AccountImport
@@ -143,7 +119,6 @@ function deserializeAccountEncodedJSON(raw: AccountEncodedJSON): AccountImport {
     createdAt:
       raw.createdAt && typeof raw.createdAt === 'object'
         ? {
-            hash: Buffer.from(raw.createdAt.hash, 'hex'),
             sequence: raw.createdAt.sequence,
             networkId: raw.createdAt.networkId,
           }

--- a/ironfish/src/wallet/wallet.test.ts
+++ b/ironfish/src/wallet/wallet.test.ts
@@ -730,18 +730,16 @@ describe('Wallet', () => {
       // create an account so that createdAt will be non-null
       const accountB = await useAccountFixture(nodeA.wallet, 'accountB')
 
-      expect(accountB.createdAt?.hash).toEqualHash(block3.header.hash)
       expect(accountB.createdAt?.sequence).toEqual(3)
 
       const accountBImport = await nodeB.wallet.importAccount(
         toAccountImport(accountB, false, nodeB.wallet.networkId),
       )
 
-      expect(accountBImport.createdAt?.hash).toEqualHash(block3.header.hash)
       expect(accountBImport.createdAt?.sequence).toEqual(3)
     })
 
-    it('should set account head to block before createdAt if networkId matches', async () => {
+    it('should set account head to createdAt block if networkId matches', async () => {
       const { node: nodeA } = await nodeTest.createSetup()
       const { node: nodeB } = await nodeTest.createSetup()
 
@@ -765,13 +763,11 @@ describe('Wallet', () => {
         toAccountImport(accountB, false, nodeB.wallet.networkId),
       )
 
-      expect(accountBImport.createdAt?.hash).toEqualHash(block3.header.hash)
       expect(accountBImport.createdAt?.sequence).toEqual(3)
 
       const accountBImportHead = await accountBImport.getHead()
 
-      expect(accountBImportHead?.hash).toEqualHash(block2.header.hash)
-      expect(accountBImportHead?.sequence).toEqual(2)
+      expect(accountBImportHead?.sequence).toEqual(3)
     })
 
     it('should set createdAt to null if networkId does not match', async () => {
@@ -792,7 +788,6 @@ describe('Wallet', () => {
       // create an account on nodeA so that createdAt will be non-null
       const accountB = await useAccountFixture(nodeA.wallet, 'accountB')
 
-      expect(accountB.createdAt?.hash).toEqualHash(block3.header.hash)
       expect(accountB.createdAt?.sequence).toEqual(3)
 
       const accountBImport = await nodeB.wallet.importAccount(
@@ -943,7 +938,6 @@ describe('Wallet', () => {
 
       const account = await node.wallet.createAccount('test')
 
-      expect(account.createdAt?.hash).toEqualHash(block2.header.hash)
       expect(account.createdAt?.sequence).toEqual(block2.header.sequence)
     })
 
@@ -2011,7 +2005,6 @@ describe('Wallet', () => {
       await node.chain.addBlock(block2)
       await node.wallet.scan()
 
-      expect(accountA.createdAt?.hash).toEqualHash(block2.header.hash)
       expect(accountA.createdAt?.sequence).toEqual(block2.header.sequence)
     })
 
@@ -2042,7 +2035,6 @@ describe('Wallet', () => {
       await node.chain.addBlock(block2)
       await node.wallet.scan()
 
-      expect(accountA.createdAt?.hash).toEqualHash(block2.header.hash)
       expect(accountA.createdAt?.sequence).toEqual(block2.header.sequence)
 
       const block3 = await useMinerBlockFixture(node.chain, 3, accountA)
@@ -2050,7 +2042,6 @@ describe('Wallet', () => {
       await node.wallet.scan()
 
       // see that createdAt is unchanged
-      expect(accountA.createdAt?.hash).toEqualHash(block2.header.hash)
       expect(accountA.createdAt?.sequence).toEqual(block2.header.sequence)
     })
 
@@ -2069,8 +2060,6 @@ describe('Wallet', () => {
       // create second account with createdAt at block 3
       const accountB = await useAccountFixture(nodeA.wallet, 'b')
 
-      expect(accountB.createdAt).not.toBeNull()
-      expect(accountB.createdAt?.hash).toEqualHash(block3.header.hash)
       expect(accountB.createdAt?.sequence).toEqual(block3.header.sequence)
 
       // reset wallet
@@ -2547,7 +2536,7 @@ describe('Wallet', () => {
 
       const accountA = await useAccountFixture(node.wallet, 'a')
 
-      await node.wallet.resetAccount(accountA)
+      await node.wallet.resetAccount(accountA, { resetCreatedAt: true })
 
       const newAccountA = node.wallet.getAccountByName('a')
 
@@ -2583,7 +2572,6 @@ describe('Wallet', () => {
       // create second account so that createdAt will be non-null
       let accountB: Account | null = await useAccountFixture(node.wallet, 'b')
 
-      expect(accountB.createdAt?.hash).toEqualHash(block2.header.hash)
       expect(accountB.createdAt?.sequence).toEqual(block2.header.sequence)
 
       await node.wallet.resetAccount(accountB, { resetCreatedAt: false })
@@ -2593,7 +2581,6 @@ describe('Wallet', () => {
       Assert.isNotNull(accountB)
 
       // createdAt should still refer to block2
-      expect(accountB.createdAt?.hash).toEqualHash(block2.header.hash)
       expect(accountB.createdAt?.sequence).toEqual(block2.header.sequence)
 
       // reset createdAt
@@ -2787,7 +2774,7 @@ describe('Wallet', () => {
 
       const account = await useAccountFixture(node.wallet)
 
-      await account.updateCreatedAt({ hash: Buffer.alloc(32), sequence: 1 })
+      await account.updateCreatedAt({ sequence: 1 })
 
       const block = await useMinerBlockFixture(node.chain, 2)
 
@@ -2799,7 +2786,7 @@ describe('Wallet', () => {
 
       const account = await useAccountFixture(node.wallet)
 
-      await account.updateCreatedAt({ hash: Buffer.alloc(32), sequence: 3 })
+      await account.updateCreatedAt({ sequence: 3 })
 
       const block = await useMinerBlockFixture(node.chain, 2)
 

--- a/ironfish/src/wallet/wallet.test.ts
+++ b/ironfish/src/wallet/wallet.test.ts
@@ -306,7 +306,10 @@ describe('Wallet', () => {
         hash: block1.header.hash,
         sequence: block1.header.sequence,
       })
-      await expect(accountB.getHead()).resolves.toEqual(null)
+      Assert.isNotNull(accountB.createdAt)
+      await expect(accountB.getHead()).resolves.toMatchObject({
+        sequence: accountB.createdAt.sequence,
+      })
 
       // Add second block
       const block2 = await useMinerBlockFixture(node.chain, 3, accountA)
@@ -414,7 +417,10 @@ describe('Wallet', () => {
         hash: block1.header.hash,
         sequence: block1.header.sequence,
       })
-      await expect(accountB.getHead()).resolves.toEqual(null)
+      Assert.isNotNull(accountB.createdAt)
+      await expect(accountB.getHead()).resolves.toMatchObject({
+        sequence: accountB.createdAt.sequence,
+      })
 
       // Add second block
       const block2 = await useMinerBlockFixture(node.chain, 3, accountA)

--- a/ironfish/src/wallet/walletdb/__fixtures__/assetValue.test.ts.fixture
+++ b/ironfish/src/wallet/walletdb/__fixtures__/assetValue.test.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "83dddfcb9c47a43f6a463a6ddd558ef9bc971cd139295a00c3183528db778456",
         "publicAddress": "137ba12fb2999890c0096c9f6f975f7034eb29bc83f994b913c9d54106e41c62",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/wallet/walletdb/__fixtures__/decryptedNoteValue.test.ts.fixture
+++ b/ironfish/src/wallet/walletdb/__fixtures__/decryptedNoteValue.test.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "b69d6eeedf237d2f376b588dfc097ee02cda113eda1246e9f5d8dd088837255c",
         "publicAddress": "5b75f5f1730af9967eb714d1964184d171f5ae6fe4ba178a05d3aa8a28465cb4",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -45,10 +41,6 @@
         "outgoingViewKey": "6df1a8829d02621b6b2e3a1afd132585a8665456d44c111ed88d20e7c5e14fea",
         "publicAddress": "7810e37574e8958de2c4d072a2aad403d97b6395e444766404d862993cd2f3af",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/wallet/walletdb/__fixtures__/transactionValue.test.ts.fixture
+++ b/ironfish/src/wallet/walletdb/__fixtures__/transactionValue.test.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "1df1d675d8dcc3c603cbf1261f344ad30673e4feade7bb7e2b5b2316d3442a40",
         "publicAddress": "f727de41be04c2cf6e343c8e81eca1209d8af4c265ca5284cc1f3b7b7bed2303",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -45,10 +41,6 @@
         "outgoingViewKey": "d10e03d482de739d3dc1b97daabf9f5a49ab6c901d588096f43ff31983926e30",
         "publicAddress": "49c9ed48e24cda10abb40bc7005424a29962f3bd820918bb41f7df089af1e832",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -79,10 +71,6 @@
         "outgoingViewKey": "9af5cd3fbadc1e4781ff1af05594034956b5d7961476e3988c701cc1398cd66d",
         "publicAddress": "c6b0a3f850b3099e293e0d5b16cc79344ac2b7fef8e6ba0d7741b9efed89aacc",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -113,10 +101,6 @@
         "outgoingViewKey": "7414c9f0641a50688700b095667a258ed808a2f6bcbfb76e9f9d1ade465bccef",
         "publicAddress": "e525b78bd88c85c89c89b1c4c15ba125d05c2d9acee0fe5dea960e62120d4e94",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -147,10 +131,6 @@
         "outgoingViewKey": "2f6e794e6a52f0850043f1bedeb63868826548318f028613debbc1bf23135632",
         "publicAddress": "6e729466f45069943bc55fdbb9f35be733e888ffbff06e0e364ad98f578c222c",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -179,10 +159,6 @@
         "outgoingViewKey": "c5163fdab7ea32326ec8ac5e51330bddf78f5b0c302acbac891257df661f207f",
         "publicAddress": "e977dbbc97f942df21e729572e8030e639fea0436167f876f5f853bfa4263538",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -209,10 +185,6 @@
         "outgoingViewKey": "30a3e3182bfbc5603354335cb408ba44b94aa97309261fbc97bb04e1bc815985",
         "publicAddress": "5385e34f39e1e3f0c0193eee68e8da5676a8ce7f6bca46e29a0dfdd89041785d",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -243,10 +215,6 @@
         "outgoingViewKey": "6193eec71a1b67769cfdd76aa562a6666d254beac4a585abd5b245b15b7f1350",
         "publicAddress": "625b29181821b9991a4f6ae34198c4b9d57eff99d47d3b8927b1ce9f37c5f70c",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/wallet/walletdb/__fixtures__/walletdb.test.ts.fixture
+++ b/ironfish/src/wallet/walletdb/__fixtures__/walletdb.test.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "38d0b71890263f7ae873c834a86cfd8c7debb856d5558eaa17b048dfea52c1dc",
         "publicAddress": "df5dd91c46403560964dcc1c4d9462932775bb61dbc469285e2abad6e299f858",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -41,10 +37,6 @@
         "outgoingViewKey": "1423d36d9daaa4598a4cdb76fefd6d37822ab0f62a8b58115c37a1aef55d9e3b",
         "publicAddress": "457db891b144364f68100eed5936b4f24cb28ca9f2baadf625f0232551ce639e",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -165,10 +157,6 @@
         "outgoingViewKey": "574db11c63e2a88637257b08be27e5b6c33db6d2c029d289bb4d893a0d34d5ea",
         "publicAddress": "da34efa7725c6a6ed32648ed14ab77640e8acebcf521a6908c5f0bd59cc3a3c5",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -195,10 +183,6 @@
         "outgoingViewKey": "57cd20ca9df88429f5533e5ad0e450c8c9b72e2be960977ce8bbe9e671ebc149",
         "publicAddress": "b782216d4ae965d886f30f8f6c54b76424ad5e4c86f26e87b0f02dce6c5b9fd5",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -251,10 +235,6 @@
         "outgoingViewKey": "6ad0420aec2b010fe2b51e81066b8d1f2a000f05473078bd5a15a049957e6515",
         "publicAddress": "2350bbe227a6e95ad0c3278a904edffb4ddd19d55de726f2ce7d006919c7119b",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -281,10 +261,6 @@
         "outgoingViewKey": "80db0061643c7a8e1f656a6f157f48bcb12f1dc2cd3c29cc358302d302e2d410",
         "publicAddress": "865862686f68cf5a4babc8b53f548d37a9d5eb1946cae93e44f0f3fb9c6ca927",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -311,10 +287,6 @@
         "outgoingViewKey": "0fc5f6ede6992cf840243ed44fa7366ed96bbb65812ec3d71598fadacecbffb6",
         "publicAddress": "03f1411728bdb4635921158c3ef2d1044faf03d3e4febc649f6aca2af027b42a",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -341,10 +313,6 @@
         "outgoingViewKey": "b7bea33267e82c89d78d0e8385cea9ab57f849a5489c15c1c97ce49d91abf1b3",
         "publicAddress": "733e08a1817fcb6c13054c7e4aa21cefbe4e5548c3562dfd07b9dce196fdfc6f",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -475,10 +443,6 @@
         "outgoingViewKey": "6cc6b324db922e5e7feeb2de7b785a1e883a6282f232101578da354b74ccc32d",
         "publicAddress": "a9a915c9c3969b6da27f23ba75b8e60a79ac8265c75b39784d6c8120fd3411e8",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -609,10 +573,6 @@
         "outgoingViewKey": "3ca324b9bcffcbb6be6ce16bd658075828d17ebd04af239beaf7abd3e9e38f09",
         "publicAddress": "5f8b3902b7d4fb1e3673fbc7263a391bea92b8967924075ce36b08a57c461b4b",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/wallet/walletdb/accountValue.test.ts
+++ b/ironfish/src/wallet/walletdb/accountValue.test.ts
@@ -18,10 +18,7 @@ describe('AccountValueEncoding', () => {
       spendingKey: key.spendingKey,
       viewKey: key.viewKey,
       version: 1,
-      createdAt: {
-        hash: Buffer.alloc(32, 0),
-        sequence: 1,
-      },
+      createdAt: { sequence: 1 },
       scanningEnabled: true,
       proofAuthorizingKey: key.proofAuthorizingKey,
     }

--- a/ironfish/src/wallet/walletdb/walletdb.ts
+++ b/ironfish/src/wallet/walletdb/walletdb.ts
@@ -41,7 +41,7 @@ import { MultisigSecretValue, MultisigSecretValueEncoding } from './multisigSecr
 import { ParticipantIdentity, ParticipantIdentityEncoding } from './participantIdentity'
 import { TransactionValue, TransactionValueEncoding } from './transactionValue'
 
-const VERSION_DATABASE_ACCOUNTS = 32
+const VERSION_DATABASE_ACCOUNTS = 33
 
 const getAccountsDBMetaDefaults = (): AccountsDBMeta => ({
   defaultAccountId: null,

--- a/ironfish/src/workerPool/tasks/__fixtures__/buildTransaction.test.ts.fixture
+++ b/ironfish/src/workerPool/tasks/__fixtures__/buildTransaction.test.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "bbc9ae7cb0b423b055975e0a743a79e9925878fdc2c90ac2e928d8f24b7ae44e",
         "publicAddress": "822cea0c8ba6d7befe2cdca17b169af77af1020c39c5a2ba7b69a502321fbc3c",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -67,10 +63,6 @@
         "outgoingViewKey": "d6bfeb2fb714f46ee3f36f652639898364fde0925c455343c30a63240cee8d9d",
         "publicAddress": "3da09cfd855c88268f6b5d5d52c7739bc95f36cffca5f6aab380569579bc8d4f",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -127,10 +119,6 @@
         "outgoingViewKey": "0bcf6a7de21357a0e66f2f811a8f45066c1e86c6ad3e5f4db6c69ba8dc42cd6a",
         "publicAddress": "d6008ac673c004db0dcf514bd2e0160b9da3c75193856833235f0190c4daf4eb",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/workerPool/tasks/__fixtures__/createMinersFee.test.ts.fixture
+++ b/ironfish/src/workerPool/tasks/__fixtures__/createMinersFee.test.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "454bbb0bb377f5b47789bdf67dbe02dd82638837d09f6f94e189e44a217f2298",
         "publicAddress": "8e682b65721c34bff195424374c376dfa23ec736a118b2d1b9febdf89dd9b9dc",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -41,10 +37,6 @@
         "outgoingViewKey": "912a3af11e929016fbdfa097b9d9f43adc51fa9338797fc07864d57ba582e9cb",
         "publicAddress": "eae823d3859e9ac3eb5f5cab0511045925200a0f6912e4d39d863639ab831b62",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/workerPool/tasks/__fixtures__/decryptNotes.test.ts.fixture
+++ b/ironfish/src/workerPool/tasks/__fixtures__/decryptNotes.test.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "773588f4197f32ed2fe39e8d9bf36ea006a7dd9f05721f734c60f382902c75a0",
         "publicAddress": "02adb43d8419bc9876af1be710dc538ac61fd599c07630f356efb8a5a303cb43",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -45,10 +41,6 @@
         "outgoingViewKey": "b48765aa521c39337e06ade3c200d6adbc31e98b29a9d223a5a441ec9fb65191",
         "publicAddress": "d7fc67312e8aac8d5e726f7ca5a05fbed2014aa596302e280d5a9d73bea7edb7",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -73,10 +65,6 @@
         "outgoingViewKey": "41b4bb83e6deb03cdb44a98275e62c37ef38f3f4cb5d5ed0f7e96aaca0846674",
         "publicAddress": "9b8e652eceb3881051eb96d7e4d97d41294a69a1faa5a6c76dacfb95bc3d6e6c",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/workerPool/tasks/__fixtures__/postTransaction.test.ts.fixture
+++ b/ironfish/src/workerPool/tasks/__fixtures__/postTransaction.test.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "bd6e20fc98627d71299d78ed4f9fe9addca20ba81a4a328767264ac537094c51",
         "publicAddress": "c21b1004faea7f6ea9796c720cdfd54a5bacd6c656de9c21da5a31ce0393bdc6",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -67,10 +63,6 @@
         "outgoingViewKey": "9e99baf683fefb0a798ab30d51d1cc666db7ee65670156b100573056fdf15004",
         "publicAddress": "e08f4bb6a8ee008a871b20226f7732c7220772a01ed38a3a5f25825e1edd92e7",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,
@@ -101,10 +93,6 @@
         "outgoingViewKey": "81cac10c2d64fe95c6cedd0243d5dd0d6c215502c60a0c9fbd277ad1e82925a3",
         "publicAddress": "3b2b189820ab4570c123b6719dac5ed1937a590365001c27d591eead211cfba8",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/workerPool/tasks/__fixtures__/verifyTransactions.test.ts.fixture
+++ b/ironfish/src/workerPool/tasks/__fixtures__/verifyTransactions.test.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "37dc78ba1d45f12e36cd34568ee7dfe2d733bd3a1606fb8651fed83101a3500e",
         "publicAddress": "a4e186a4d17525ecfd77cfb0ac5f4647c23b9124e7c1a2073e083ff95d832cb3",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,

--- a/ironfish/src/workerPool/tasks/__fixtures__/workerMessages.test.perf.ts.fixture
+++ b/ironfish/src/workerPool/tasks/__fixtures__/workerMessages.test.perf.ts.fixture
@@ -11,10 +11,6 @@
         "outgoingViewKey": "8213c8a9c4ac12b5b47da90ac6bf0a6a3b52a0078e44fe6b391092241b8d16e0",
         "publicAddress": "3fb65c3bafac91b10ce54e6847576b4d8a0376ff14369295ebba039038d246e7",
         "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
           "sequence": 1
         },
         "scanningEnabled": true,


### PR DESCRIPTION
## Summary

sets createdAt sequence to 'head.sequence - confirmations' to mitigate issues with setting account createdAt around the time of a chain reorg.

adds migrations 33 to migrate existing account.createdAt values to use the existing createdAt.sequence - confirmations

updates account fixtures

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
