### PR TITLE
removes hash from  account createdAt

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/dealer/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dealer/create.ts
@@ -72,25 +72,21 @@ export class MultisigCreateDealer extends IronfishCommand {
       participants: identities.map((identity) => ({ identity })),
     })
 
-    const chainResponse = await client.chain.getChainInfo()
-    const hash = Buffer.from(chainResponse.content.currentBlockIdentifier.hash, 'hex')
-    const sequence = Number(chainResponse.content.currentBlockIdentifier.index)
-    const createdAt = {
-      hash,
-      sequence,
-    }
-
     if (flags.importCoordinator) {
+      const chainResponse = await client.chain.getChainInfo()
+      const networkResponse = await client.chain.getNetworkInfo()
+      const createdAt = {
+        sequence: Number(chainResponse.content.currentBlockIdentifier.index),
+        networkId: networkResponse.content.networkId,
+      }
+
       this.log()
       ux.action.start('Importing the coordinator as a view-only account')
 
       const account: AccountImport = {
         name,
         version: ACCOUNT_SCHEMA_VERSION,
-        createdAt: {
-          hash: createdAt.hash,
-          sequence: createdAt.sequence,
-        },
+        createdAt,
         spendingKey: null,
         viewKey: response.content.viewKey,
         incomingViewKey: response.content.incomingViewKey,

--- a/ironfish/src/blockchain/__fixtures__/blockchain.test.perf.ts.fixture
+++ b/ironfish/src/blockchain/__fixtures__/blockchain.test.perf.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "06997d130a77169a3166b574cfb2cfbd1da790b467806980f3b8219c587a8105",
         "outgoingViewKey": "28b0f8b4679473d9c9adad455494caeabf0ead48caea86db99bcc2425e82740f",
         "publicAddress": "c99fce0caf37289e0b5d9ff1b896cd6381688ff97e2a4c1a74be726dcbbcaaeb",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "a9e3276ce11d0940e231dac817f5b07579a29283393645dec8c1427157863809"
       },
@@ -38,13 +32,7 @@
         "incomingViewKey": "69001c519812fe3684167a365ecc96143e29ea569cd9bb273a77926c99abd905",
         "outgoingViewKey": "261b0e6b4252bdd3c27677e1f7fdf1d2bd2db39e19290e6fd0e1d65f2965ad27",
         "publicAddress": "85a057d38b8e0272a3bb97f5da2e526f2c997e8a708cf051982993e33f1fc9bb",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "1b77b502f4e5dd4273d542850496824da73a89fd7b4b835ffc21171f8b30f805"
       },

--- a/ironfish/src/blockchain/__fixtures__/blockchain.test.ts.fixture
+++ b/ironfish/src/blockchain/__fixtures__/blockchain.test.ts.fixture
@@ -1142,13 +1142,7 @@
         "incomingViewKey": "f951470cc4b32523d8509d0755187a7104ee0f1b827f05e369e937fadea63c05",
         "outgoingViewKey": "0406f204ff132ae168783c8af1a4dcd82f45e7c271dc4e04e168a26fb936aa1d",
         "publicAddress": "ddebcac61504e6d2f39effc355270bb0aab239277293361e794e6ef6ab777051",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "628bbd05b228c55941516eec3ffc6af6c9365d8f6bf5b8aaea7f4c919d9cdb04"
       },
@@ -1170,13 +1164,7 @@
         "incomingViewKey": "1aa40190fefc22a73e4cd47cc7fc687f15dda7858e502293c3982f07e64c1b01",
         "outgoingViewKey": "1cd881299d0f9b63f8eda5ac55235b4687d95dca4aca55228f0300de867f79fe",
         "publicAddress": "6f45ef61b28a39668ad24dc9b5e5b94a4f98c7173ef6af473d07e00ccc57ca00",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "d48d58b990dff0d3964feeb8be829ea86c8f0d39fae9bb22479be47748c33e05"
       },
@@ -1338,13 +1326,7 @@
         "incomingViewKey": "0fdbe642ef8a214ece9b79c668bc4012da47913093f19c36c448748abb3a1904",
         "outgoingViewKey": "6bb9bab5d445aa4632018b15507411a369dcf2c265b27cce3300a285818e9a3a",
         "publicAddress": "77292e480846943968dffc2318a891f98bc2c0e3b976bf5dace782dcdbbcc0a7",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "86379e503fe418bbf414f0601b46dc8479da0d2cfbf66850ef6cf3dc54449a00"
       },
@@ -1398,13 +1380,7 @@
         "incomingViewKey": "5ca35db937738fea351b43525139c9b92203372b27c6b3257dd6c14051be6a07",
         "outgoingViewKey": "3930eef29048ee6b82c71ad473de272fac4a66c5252c90c07b1c53a06cc221c0",
         "publicAddress": "155bf6feb8c76630cd3d9b925c8ee6516acc612ad3c1333bf03fd4cae8803fd2",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "910cc6748965b443716643bb6ac811ff50c80d28c90572baa701454843a9f405"
       },
@@ -1432,13 +1408,7 @@
         "incomingViewKey": "e0827a4ea42cfb5324f62c9f942c31571ea55fc8746ba297dd5f638486967002",
         "outgoingViewKey": "758d5d4f9f7f76150b0602878adf8474692753908d26facfd32bc45c3dc93867",
         "publicAddress": "d0b3c7671b495a8c6ff89f7c82fb3bf98c9850bbf667d7a1ee2318778f147ed5",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "f7ff16341cd1944564ae55f72e133bb2b7eb00d4b39534bd84a7919fc763fa03"
       },
@@ -1646,13 +1616,7 @@
         "incomingViewKey": "3271992f6332276ea54e0132554b39fcb2b6fa86fbfbb2172b93b4fa61580407",
         "outgoingViewKey": "fe2776db23240c1d27393f1fb83e0b83d176a7078e8f248f679fedc043315723",
         "publicAddress": "2ec32245f13b501b11e83ba0ef9a8b541a2619235299e5f2ca91ebcf2907a424",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:kticrtSfaYHaDuXgxReIYTT3i/0dSNeRtLS24Y3FTRA="
-          },
-          "sequence": 3
-        },
+        "createdAt": 3,
         "scanningEnabled": true,
         "proofAuthorizingKey": "e13e234b096dde0bb00bfe7fe269629ff48814e3ed3532964d854358d0af8601"
       },
@@ -1810,13 +1774,7 @@
         "incomingViewKey": "d8ad4a084a4bad8b157647dad77befc361c6e5051224ded6b2eba04d52e29a02",
         "outgoingViewKey": "67981a5887f9d75ea342a56425e7f985b7a305037c96051b70663bf2f6d80d25",
         "publicAddress": "cb5f0e2d214e2f08143200850d8bb4f8f6239a26a7ae15e1ffdb4bb71750eb5f",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "518cd1effbc3993f198f335af2fee48d1eb71aea2e7762e022db0a584140ea04"
       },
@@ -1924,13 +1882,7 @@
         "incomingViewKey": "a396ad6fd3fa2877d2370f04d77a22adfdde6a4e556bda88072664fd7d7a1705",
         "outgoingViewKey": "ecb1fc7bc28e2edd443e8b85e95f898fa20f04881df9c04e0400d8adeba38d3d",
         "publicAddress": "5b6139ccda5772ea9f51b20a436fbcb81c51d5ae4e44ee5c0192f61a1fe47beb",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "549078964704c3bfc83e298e92e3429098c1aa6526cdad3eb1a512bc9bc42203"
       },
@@ -1988,13 +1940,7 @@
         "incomingViewKey": "34d830807aef3f3cf3d101922e1708ac19cac6cce07b6722727239db4a158306",
         "outgoingViewKey": "cbd178f77d6a3517119ffedc29815b755f7bdcf94a9e10d9affddff40eda29ac",
         "publicAddress": "10fda5ded70e0befe7471324f91334d0527e0ccf0e96a3fdbecfa152979fa61c",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "cfef1154a5291cbe3cb160e620f17d318a6d420ebcf4eace1fac13d922a20500"
       },
@@ -2052,13 +1998,7 @@
         "incomingViewKey": "dfd5a7d94cc78921fc649d2e1b8c073c184f37b91494219669e0157d5a06f700",
         "outgoingViewKey": "d952c3c3df01f15fa0b2d9297fae0581a0f6365983f9985610b7a8afb94a4699",
         "publicAddress": "2496bb01bd1b2fe33f39b0d866e6203b86d32154d3082ec7b82ff91addc39aaa",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "4261607611d01965922ac00f06ad9cf6ae06aac34ad91a3551b1bd25d419a80b"
       },
@@ -2172,13 +2112,7 @@
         "incomingViewKey": "1054e9d0b32b3ad0e527397d05bbdcb7b5b7f8be42fa355c26f5e83998f6eb01",
         "outgoingViewKey": "3800a2f30ad6a6ded383ecd4afd2e3f951a6cdea13c2f39a605e5ad90e64dce2",
         "publicAddress": "246ff23fe4ad29a4fa0611ffbe33fec63b0dbe1c6be319ac0fa5d25ab80f4321",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "2c174a29a107dc3f876876d5952f07e3e1833750feb1a4966eadb16f99983309"
       },
@@ -2200,13 +2134,7 @@
         "incomingViewKey": "8eb25ae7835c046bbb4615117b7f09fe86949739b811678ff08c2fdd80843306",
         "outgoingViewKey": "1134745b2631e17988272cdb21d14beb8b7d1aaf456f03007364c7cf9865e069",
         "publicAddress": "44288a1c8aaec069ea59742149a148ba1a3aacf19eb910431105e2881b246212",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "861aedfb9451974e533e3dd0ac7c1e76209d3173024f7f9de44fcb8de6f80909"
       },
@@ -2320,13 +2248,7 @@
         "incomingViewKey": "79782f89beca13a9c6c2a851c4c462d7749201a6efc169c170c211e8920e8606",
         "outgoingViewKey": "6f0e8a67f2b4dd6a86e0364459bf1593a3c469a32b70c60caafcace0b4facfa0",
         "publicAddress": "c836c91cb3670772e9d008bd2cd6a956d8757013f0599920e58e048141a0606a",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "bbe2d0a06475533f62945a47c55c6778c8935e864f95338284af57102b3f0c06"
       },
@@ -2440,13 +2362,7 @@
         "incomingViewKey": "4cfc75aac98a80a707a5475d3d1cb305caa191884d856aaad968c74017ccc902",
         "outgoingViewKey": "d3489f54cb693d8f576801e37608f20012e95ba07f82644db223b0d53c76f12f",
         "publicAddress": "46a254523ff1188292eec63dde55b63c5c7d8fc1a55125366abd629e9304f720",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "495fe381cdd57a0fd76a0e17d25384a193fcb0abe944c6d6481b38ffa3b59903"
       },
@@ -2504,13 +2420,7 @@
         "incomingViewKey": "00a0b83811a4810926717f208b01c1ad3607dfb060fcbd2ea5636f8c17133302",
         "outgoingViewKey": "f5d4e9944c90d10bf54129d19e11da8fe37808bbe6e96f8653e3102d87f0388f",
         "publicAddress": "ae83e265d6f62f93026e22c77b8ba297e57a32734278dd0abae4e4ef55c872df",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "42ba4683b043c3ac8cf892add4afce94ae0c5658f3789d8d805773c5eced7d06"
       },
@@ -2598,13 +2508,7 @@
         "incomingViewKey": "2740cf00d776c88c600daebf72b679800e81ddbf1ba29c437325f4a7e3ce5c05",
         "outgoingViewKey": "5b77aade0039c3c2a5cc0f555346b61834cdd28e95306c89eaf71e37be149898",
         "publicAddress": "c7c479c0f57e61d20973f200f3e4eddfd7c277d874e74c486413c76499e5b286",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "fc0bf4468ee33a5d7ad06ef154004384a2b34f834e7012b5b94da3e971c29a07"
       },
@@ -2848,13 +2752,7 @@
         "incomingViewKey": "a7bb7f564a42a08e25b7724ea165bd94716b19f4c07617ef8cbe837db465ad02",
         "outgoingViewKey": "0216cad9e92dacd253ba540bf7ac80ac41be0cdcb731d4afd12abced48ff506d",
         "publicAddress": "32e83a3893a10fb54039beff28054ff2b85a7ae5d3e92367e0b79eba29523ab5",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "99136a7276a3698731d72082a54f20c656749d3ceff61b128171e2ed76719b0d"
       },
@@ -2876,13 +2774,7 @@
         "incomingViewKey": "5e34dbe3031d4378fce819b77bfd68a0f8bc5ce0af8bee5f166ad092b6928407",
         "outgoingViewKey": "b57e43e1d424a1bc6658e0736ea827bad3e52c33942c5c9d5bc5f543242147de",
         "publicAddress": "819a2f570116dbf53f98bb3658932a439eec9dded6e136bfeb81927cbdb3e113",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "5ff5dde4df90fb64b017a34f912680e088e2c3bf7008858b584d7c9302023600"
       },
@@ -3048,13 +2940,7 @@
         "incomingViewKey": "ccffeacf9a30dbb2b36e54755b0bd176dd03f3db0a5ea111f380852b9a41d906",
         "outgoingViewKey": "013ded83f42a33245ea4d6e3ec2ba1311a7c9f553c47822fac809ff9e824566f",
         "publicAddress": "0a2d4727d753bc9d223873ecbddf8768eff52b301c7a6598ee509ad45c3d9f35",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "2cc167cd3a531d3c2a7e46a8f4d94a060f75c12e42f223c3eb0b40e2397d9e05"
       },
@@ -3112,13 +2998,7 @@
         "incomingViewKey": "3dc904a7b13210d82a38127e180ff489111d0241fea267d5082828c2376f4507",
         "outgoingViewKey": "62d82b21577a8a8ca4ecac65096f2590b936cb167111d8f20049e1d4010f0f67",
         "publicAddress": "d2a69e3ec5414ef142d65a62b7d5efb438a17baf10ce2a51856691dbd5dd0862",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "fd272f99f56fe8dee9993e2070800e2e08bdf741d4bfbdec0b53d11ce9a9ab08"
       },
@@ -3140,13 +3020,7 @@
         "incomingViewKey": "7dd8fa122feaa91775afc486ddeff5eac3bab963ea5de999a7784d6d060abf00",
         "outgoingViewKey": "46ad4c45ea0decc4e18fee0b52fe1c731175e8025b67aff7440bbcb0b9f6a5fa",
         "publicAddress": "b37f7ce956725aa2706e8a34922427a160af35bbc84f60ce958da8ccbddb5ca9",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "71e0a0f53ff2887cf576d79bd1f2bd9e8e5d135c61dace4cd81a42cddca31306"
       },
@@ -3238,13 +3112,7 @@
         "incomingViewKey": "e89fe7e6ca496fb342472395dc882d50f1c30e1258f2ea7979421dbd1f226b05",
         "outgoingViewKey": "9a79d2dd34c9890205e268f7ad073b2bc23d7e7d66bb61671c7af7d6d6e311d8",
         "publicAddress": "8c25c7893a851c5eb2d4d6fa288a99f390becc20d8a04f5e69279d44a82f531b",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "43aced26882eabc3efc10b14e4bb4c518948bbd9d6271f873798dea9af046208"
       },
@@ -3332,13 +3200,7 @@
         "incomingViewKey": "a6159f50a390dc2be885289b49a08bb41108fc3aa63075af3c67fb21fd905b07",
         "outgoingViewKey": "ee447f81042b8fc38ea46521099d26dfdf458159893931e98afb65a9252b8edf",
         "publicAddress": "e15e6e9d7666f68e50be1fc087d880a2d0caa6e378de19c67e3f65bbfb61b60e",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "99e1d41e990715ca718f1c2690e6fca9dee35c30b84d35fa9d7bc9ca2a40d509"
       },
@@ -3430,13 +3292,7 @@
         "incomingViewKey": "3a5a88253f2842e09f49b419a71b7587befe30990b408dd7f534af0fa2d4b007",
         "outgoingViewKey": "45f83a764d77b1f761840a2cb3412c5a7ad4fa3cb98b2d88520973cae87405a1",
         "publicAddress": "9acf0d928a4cdc334d01c2de26fdc824824287a21338b00507cccc5f783633ab",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "16f65360afef652456a141b08128a01bdb4d6eb9f8daaf5e331f8bfe67408b0d"
       },
@@ -3494,13 +3350,7 @@
         "incomingViewKey": "ff299c746e209455544a74da056067ee32e415af9a14160e533528957d9d8f05",
         "outgoingViewKey": "e7d4ff4e20699155e3829cfc073ddac74aea8e1550c56e6c818758c262354e4a",
         "publicAddress": "fd99dbb1b010f76f583c9ff06054c489d22394dd5f7dd635234f1a67df46b3cd",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "cf48dc1c46564bacbdd76bc2a90663fe687a8c26e95624fab658bcae06a06200"
       },
@@ -3592,13 +3442,7 @@
         "incomingViewKey": "bc273f274f33a5dc1bb2ce59e60a6b3d4991af3ea1bc253faa2659a2c4439802",
         "outgoingViewKey": "2de94163df57d42c44abc57907456832266ec5ee23e5b654fe1360bc3a0b8a07",
         "publicAddress": "51cc1d523d1554480bcad269de9c9d0eab068e9fa2e902c68f9b38c28a5b385b",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "a345f98b4e6cc8e9d1bc8974213c7c96be313af86a49a46052f8ab8a6b24fb0d"
       },
@@ -3620,13 +3464,7 @@
         "incomingViewKey": "13ab2935c0e57c5b204debc400ed94278d5378409fbb0c787359902010f5c307",
         "outgoingViewKey": "77474eccfb163f56742eb2420d04b3cf22053fc22dcf79176987b0a93e697256",
         "publicAddress": "01cc134518b1016fa0215c1993238b8854df51b46540f1bf10d48ef222592299",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "e9c6d061348ff25de370991df31c6d1fe1f57a23a989cba2ddc572b1c78c1100"
       },
@@ -3718,13 +3556,7 @@
         "incomingViewKey": "d75785abc8ebabc4d1662e1429c78eed7254b568b385594a4ac66d86f309cb04",
         "outgoingViewKey": "d0eee74a254f7c1ae83930a46bc7d566c694c32e0c17186d79a7da7a501d3cf3",
         "publicAddress": "5748c722c5752dfef22b821f040d858e64138f6602ec396ba317f22d23f999ce",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "e38bf61089bad8f5b34dfa90ab27ff3eae28504bfcc68fdcfedfe05ee9f6c30a"
       },
@@ -3812,13 +3644,7 @@
         "incomingViewKey": "4d8a04196f8660b9f4fbbcb42c614ed3ef79acc071323fb503c5116893d9be05",
         "outgoingViewKey": "464e0cdcd91bebbf29a7a8648e8933cb197833fd6949a8be6c35b7d5076c7bf1",
         "publicAddress": "9d199f4c23b779aa11ee7ad9e7123230263f93bf89032a83eeecae5cb6c192b3",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "08fc02576ec631b2e3c4dd57f33fb6cb78ace71aae0575ee30c961109882730b"
       },
@@ -3906,13 +3732,7 @@
         "incomingViewKey": "74d4f567bb7b2fa94539c2b38b2c2a30a8dc723c07e8ed49e1ab1cbb443adf04",
         "outgoingViewKey": "740a2581c7677ef86753e3abd977607f692d0d95fe11e69f922ebca7d8df6264",
         "publicAddress": "5e7e4bc375a05259b5ad097fac428a243d90ab5b13db87bdf85fe8e50be2b6c2",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "0cd53e262e99feeba48d4ccfc1b91b97fb957616eec2ac3daf2a580959718d0d"
       },
@@ -4000,13 +3820,7 @@
         "incomingViewKey": "39cef27abea7dabb629887a220a6d2304fe829a5a18586121daad50b1cf8d701",
         "outgoingViewKey": "26918cc68c2948a21431e7e991df7f02c5b59c2d8e5ebc2e4b94a8b139cdda94",
         "publicAddress": "e393c3d8d772199a47b3542ca35b1ecc8788cda2f77ceb1e9395818ac4b0ebdb",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "05450fff5964625dfcd1e72493208daa0a268cd0a3f0053b40f8860fdebb5700"
       },
@@ -4192,13 +4006,7 @@
         "incomingViewKey": "cd86fc413bb29fc3046e319e23677b8ad186dc2e7309bb393234a52b57c00101",
         "outgoingViewKey": "36ee95982dcf313c71e436e329a26a407f66bd482c3cd124562701e69d676fd5",
         "publicAddress": "aad8f18c9653bf56712cd7c6bed8b2f779599cf5db11ca111035fcb84cca87e7",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "5868bf67d9e577e4c64f6c9d6a7c2ca7ad0d0757470ec5e7528dd9a7981eb106"
       },
@@ -4220,13 +4028,7 @@
         "incomingViewKey": "6b22b8e94ed0feeab9a9bc688116e211dd81cc7c35fad8ea60fb4681491a8c00",
         "outgoingViewKey": "e2c49209cda2d1656fe0c21dec6bf13d86df28cbbe546c3303cc1aa44bd23ede",
         "publicAddress": "2bd265d684d2861de86a7d9d7fda26039c33ae31a275ba61952645a242262d4a",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "224d6b32309438342aa81614f6ac8a124c695c87bc0830e9532480a3d0e3f30d"
       },
@@ -4336,13 +4138,7 @@
         "incomingViewKey": "552793faa8b4366050cfd8a0fe9508c67ccd0acd660e720427c7908256cc3004",
         "outgoingViewKey": "588b74d56e7f2981effc0bd7ee93e0c3a43df72226b44fd6f60bd83ffa8f7f8c",
         "publicAddress": "204575129e8f222d722b9ccc281d872fd0d9ce11ae03466ac62aa5fde6c01247",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "c95efe07c4665af58997f834538e4773160a2abdfb3e4134d90aa32084cfb002"
       },
@@ -4434,13 +4230,7 @@
         "incomingViewKey": "db2892d8839df94bebce4f7dec4c46f15edf6ff445ea826c657f49cffa27f303",
         "outgoingViewKey": "71506fca3186274adf5e156db4c86eaeaab8e1d6488938e14f7528c81ef7d5d9",
         "publicAddress": "d1609d40d8a86e88b54fcc5eb794d24e1557d8b31ae8ccddb6415bf81d203fde",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "161976761f463c929d400bb8ea55fe96545a9344a157520582fbdf4c01bbea03"
       },
@@ -4462,13 +4252,7 @@
         "incomingViewKey": "2e0d6869c14425e1693e12f286a7b483baa0f47408b9e01ad14d862e0b402906",
         "outgoingViewKey": "7a2e3d0c095077c66e746923138d6ce94669f638d8eeeefdbf8c1ed3611ac4b2",
         "publicAddress": "9728a8201f9eeae43ee332377b964eafaa99975eec2a6e8670c40abebc0f28e6",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "dfbed0c3f279d95336ad38be4f24bee6819c280355049173caa09f97b42b9902"
       },
@@ -4576,13 +4360,7 @@
         "incomingViewKey": "83f8a78b5521c57f2af824fe889351d6b50a3c38d3f1e0b9fe74b428f65c0e02",
         "outgoingViewKey": "dbf66108ed861f923be539fdb8f26e0e267fafacdda8cdde966f30f4c7d6ee65",
         "publicAddress": "32c7547ffe1dd0d7e38bcd3fe00f0792a8c665ac89960d5cd09f9038343bfedd",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "20b6dfa74937993b94f3a804332603a00683021e1455efc9e705c0ce05be4c02"
       },

--- a/ironfish/src/blockchain/database/__fixtures__/assetValue.test.ts.fixture
+++ b/ironfish/src/blockchain/database/__fixtures__/assetValue.test.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "b075942e9c29e7ef20bffb9216da127476d0befc246c968587686c40e3ae0600",
         "outgoingViewKey": "de67a5e14b8911282873502631d9f7449c37ace371e6bc757847251544f7f225",
         "publicAddress": "107ad9374229cbb43a822f9b617658e06432dec804a4ddee38835a014e6d1865",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "3cd46bb64213e76a9fbc6d94b735b115ecca1df9ea4045a4a20fdd4655bb2603"
       },

--- a/ironfish/src/blockchain/nullifierSet/__fixtures__/nullifierSet.test.ts.fixture
+++ b/ironfish/src/blockchain/nullifierSet/__fixtures__/nullifierSet.test.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "e536066fbc7ec90e86dcb8042276059c265807275e21ff244a640c626b148305",
         "outgoingViewKey": "faa66599ee577712eac1a8f41d287ac15b117bcd15ab57e47268f145e06bf2dc",
         "publicAddress": "afdbe0aa15787f2ae6c74a217190470ed623199f16d79aa83afa3af467f8415c",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "2493d2bf08d9c6a218355a7d5c45d09dbdbca1597328719bfd48371cf8beb104"
       },

--- a/ironfish/src/consensus/__fixtures__/verifier.test.perf.ts.fixture
+++ b/ironfish/src/consensus/__fixtures__/verifier.test.perf.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "dd5a50d8e028a9726b0dc60c97264ef24fe1ad978181e951dbfdd838f6ca8707",
         "outgoingViewKey": "c5b5d8116e04c506ec577bea28eb190e7896259c3e11c7787b5af0da2a8cd159",
         "publicAddress": "ba1ded13a19a4baa5f5f8dd8ea39956b5d3c91b68092d2226e308765df4c1023",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "b82eed8ff1c48d3ceb716edff673082c1e5da5c741e2143fa04889d1db5a4e0d"
       },

--- a/ironfish/src/consensus/__fixtures__/verifier.test.ts.fixture
+++ b/ironfish/src/consensus/__fixtures__/verifier.test.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "b015dafcf89e380aea2e46c909690013f24c27bab9ff3f0383befa278fa5f601",
         "outgoingViewKey": "ecde93dc29e9a17e90961784bda44e8aed456968d26d63422cecc33da6ec9239",
         "publicAddress": "7f29e9c467f443e3ca7ea1395f8e1ffad524081ec14409d5f38702311c2f2491",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "ad9dbfb1c15ffe5ed313daa87aa8ffb4692038e66ed5afa58d3ccd3b52f21503"
       },
@@ -70,13 +64,7 @@
         "incomingViewKey": "f0d3666df7a7929e6cd9c800f8096bcec564d7ce71a101aedc8adb03638cae03",
         "outgoingViewKey": "b4b237e29a99971eefdbef25047ab4ef48aef714d1c7d972ee5e2fae6f20dd24",
         "publicAddress": "7124fdcc974220f7fc2772b58c2b5c15d674a1d7205054e7c3c0c7d5146b7f4f",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "31a3c65e56505f62729a94e3f637021a068268f577f21aacb1f697c9ef060006"
       },
@@ -104,13 +92,7 @@
         "incomingViewKey": "d1e49eeed263e3c91645fbce03292c3ca7040f8e667ee4cfed2c372c02f06f05",
         "outgoingViewKey": "b7f82711e405a6c6a8ad76c74142417d7d0f4cff39cddbe732c31defd9c25a2b",
         "publicAddress": "f1cb1874a36ce65cfc2db424e98c72d601baa54ffa0d87f256d743c1660ea25a",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "4761ba917a5565e9c3941f9ef339f026484fe0cac6671d19220e3dfa9d3a1607"
       },
@@ -168,13 +150,7 @@
         "incomingViewKey": "26b7c09c9f0abf1880cbaedf9efbaf0af73a836c04c071d712b04633a4922c02",
         "outgoingViewKey": "0eba0a0a9568c45bb4721f9d68c36d8c6f1b53c830ee7b5c34b5dd3c670f6fa0",
         "publicAddress": "70ede7ea540538c4e16e843c706f2f825869267fd59b4bacf223d38cf820d070",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "ba624e85103d7139d07e366db6a967c1271ca475f3f2693cd22de956600ea405"
       },
@@ -228,13 +204,7 @@
         "incomingViewKey": "951b94f1ac41e2e798970a2ff00badfe79cbb88d85383665e93da58ed1b98006",
         "outgoingViewKey": "0a909b83d368efb395f7f761e1b0c1ef825c2377dc2512a5e66b81ab0d39fefe",
         "publicAddress": "8c76d32ba57fdcbccf511958c41db71aaca7a27e5e846b7295baf05e0ddd8fda",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "efe829018a425fbf06e5f6fab54a093598c12710321b94bde8457142c1182906"
       },
@@ -262,13 +232,7 @@
         "incomingViewKey": "390b3d9f72a1749b8c6ea69367a29e2c08ac36eca48707549227b51205fdf402",
         "outgoingViewKey": "54c6bcb374fb2975f5e2942e0a91eb9eb550e312709581e99b6ca3e312b4723e",
         "publicAddress": "4bdad1bb20555a78ce0e9555b25ff747b4d65198812091cf3059db450d2bfa4f",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "0ca109ca05d6e93f57548ed522f96ef9c901fc8171068ac1910245577a44f400"
       },
@@ -322,13 +286,7 @@
         "incomingViewKey": "40e99d9fd08b6a61ebd082eae03251e903fa1cb8dd293a6bc8e8e7614ad5db00",
         "outgoingViewKey": "7cae38872ad370f6dd25a4fe04bc2001c9f0fe74fcd597d8d0664e4a3caa2e20",
         "publicAddress": "aed34e1c94c9eae5deac9436e9f0ef320f2e3111903aa491bf00d7b36dc599dc",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "bdc8fafcf2b3bbd6dea7c51bc30e298636aa83c3af9afa1535abb9603e794402"
       },
@@ -412,13 +370,7 @@
         "incomingViewKey": "1755bbeae189df1faea7bb8100642044727288fd65db455de9f771cd33654a05",
         "outgoingViewKey": "7a9ca683f55187e4634f78eded9a0656d8631359be216f907d447e9d13267391",
         "publicAddress": "66c7c26ed5a646293f9dafbc187401b51733f5d18170507169764e9f2d9a1ca3",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "fe60196125ea61b834aa1a0aea4f634019b1bf6eccb48406687c3736bc725001"
       },
@@ -498,13 +450,7 @@
         "incomingViewKey": "8e6a30f0f781cff6917f5d889b6a8df0db208d4816e0d63ecb8c8859055ca405",
         "outgoingViewKey": "a9854cad1f275e7158c06bf5e92747bed7ef1e24917d26ddec158122d2696122",
         "publicAddress": "1d19330ea917ec33be82f2a764ee05018a9006def2ee45d304348a07200c2a3c",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "c10316f59d200dc2ea0e20fc50e08611fbef73ea3c3a0352f932103d45dec004"
       },
@@ -526,13 +472,7 @@
         "incomingViewKey": "420b82d719a04f6c195ade3df63c3dc76075f413d560d3ced339eb1362dd6101",
         "outgoingViewKey": "8ffb3442445891812d57a11b1063ea22b84479799ac03cd465cddb85e64146d4",
         "publicAddress": "7c71323eec3e68841305002f45eba2aab6e1a94f9c17ab936bf34bbb70c968d6",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "3f985aad7524af389c520209e72cfade126d784c14910c544b9e435b646eb401"
       },
@@ -676,13 +616,7 @@
         "incomingViewKey": "a74ad97bf98fb75e53633e1647a6a61cac1ee619f9a87c73371bdf5e0cfc3e04",
         "outgoingViewKey": "7abb14f5e6b25d121338a479168a38e2dc669d33159dc115af6e0a5f2a8dfe0b",
         "publicAddress": "d5f9171338b1a5ece3d76d7a5bb654257fecd43a76b912f0940d82b8bfb9731c",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "bfdf24170f7b2e3705c584087dc93808e8930d87fa9cfff8bc3309b8056a0800"
       },
@@ -794,13 +728,7 @@
         "incomingViewKey": "978850d5cce809ce4f9fe304fadb68d178d8a7286932dd9e5f98e84aff56cf01",
         "outgoingViewKey": "bcb883306988931bec27a6acafd688557bbbe8f6973db5e5788f35c715173b5b",
         "publicAddress": "71e8ccd429955cae33a7e15cc475d0d9eff743a2359642cce31784eafdb4b856",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "9bf6af779faffea33cef0140889dda147603e73e95388b2379b36c81b950ea00"
       },
@@ -880,13 +808,7 @@
         "incomingViewKey": "660a63e961144d6c7c882c10cf446f54d5ae56bd13d157596d5bbf56f1f0a104",
         "outgoingViewKey": "e4bed26ec0899d93eababaf73599317292f2050ddfb7f71652dca998c61491d7",
         "publicAddress": "cd94f660430ad1edce7d3a60cddb9ac7c6e3b09da3787d820763e9990615e6b6",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "e458a3ac9916644f886b3063319cdf78a74750097d05ba70a58178bbe52e5601"
       },
@@ -944,13 +866,7 @@
         "incomingViewKey": "81a3bc5855b4f9bc78adb38f44dcf0d5ee28e3f669b5e0754dc67a718404e202",
         "outgoingViewKey": "b83441141f939a4cfe8b6c7d2812b247b8069a7ba0b99d83ea99c6da343e752c",
         "publicAddress": "7f5fee4c7c073e6ff3cd63f4556acb6a10225e192381b9ecfe999030890180bc",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "34bc70a07230e4971615a47f45f1074229dfe7fea9ed12aed0837a6d00a8a00b"
       },
@@ -1068,13 +984,7 @@
         "incomingViewKey": "b41d195038807b68a09f5aee78298a12451d256678d08af7a81f60239bbc1702",
         "outgoingViewKey": "b8df0986bc5ed0def61abbb32f47e025344a2e1d54de661cc064e5d8e0d7a56a",
         "publicAddress": "ab6eb06a17dea02eae6862157a044473bf8fe0ce564b73e0334036f5e093da98",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "6278bd6561a77119548bca9da82cacb954f3915202d6ec091db071dba8160e03"
       },
@@ -1096,13 +1006,7 @@
         "incomingViewKey": "441bf4fc23737020a149a1a0f3d3e315d1e1119820958f35b339edfeea68ee04",
         "outgoingViewKey": "a021f6eec58b386beaf9840c42902ff7499d9d720debd76e845b746bd91d680b",
         "publicAddress": "711f5ba34f987e8c4b0e248a3b89d0055c959b3b4654ba3c67248847ce6b45ee",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "d90540f966397a740d3f2e4f202b6f621c9ddc4dc9d82b940a27215a3f140b0e"
       },
@@ -1412,13 +1316,7 @@
         "incomingViewKey": "daecc3ebaca0043e470ed005e725fcfb6a2fc35e302bd64c26d9b40693d84207",
         "outgoingViewKey": "c8dd3c4b169ebac8948edd779b715c27916d71ccc7e3fb20dae1a6adbde89add",
         "publicAddress": "a7f6c66015f082e9ee9de917c189e55c9583b42e6ee29b390fe50c1973966d15",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "1c01d9ff712ecc783adff18f48728e07784422fedcae730a191314a71ec3f201"
       },
@@ -1498,13 +1396,7 @@
         "incomingViewKey": "7c1c9b88dccb76a8391eeb6a4f7337a05f16fe99a0233cd1e8a1dbaa3967e402",
         "outgoingViewKey": "47283a69c3bc0880a99c775bd32e3a630498e8b0bc39168927abe53bba53f1ba",
         "publicAddress": "8fe526922e2e677deaafedcafbc2b786771c26634462affb1c0016f34ede6f06",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "655c5b1fd80ba771be8054c8b6f83bfe1cac2177bf772b314bc37d69c34d7103"
       },
@@ -1584,13 +1476,7 @@
         "incomingViewKey": "2fed0dd910a1d849181acbf27507f470fbd7959e342341ec447e2e405e766e06",
         "outgoingViewKey": "fc75a8e79a7530542881ce59a1009b39624b7a11c567d0da854ae6d8880ee5d7",
         "publicAddress": "51fdfd1efb467981e723832e5fbf1de39e8d2b4bfeb34cec5fd50535a86202bf",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "54f8bdbdbe51032446f7ac3389616a638fe70958f193cd8d3dae3122215d2d05"
       },
@@ -1670,13 +1556,7 @@
         "incomingViewKey": "9d73971fe49b6574ce9731d48a049afde50d8dfff4c17093056ac95ec8264106",
         "outgoingViewKey": "770106e259d4fe448b1920fcd63f16fe8bbd83a55bc414d5e237b8831dd537db",
         "publicAddress": "20c7acc5e0412f515491c3e9c4a2c6dcb5580d03b1bdbc39c4075ea66fab9be0",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "c3a71a1259074a12e421ecf72236e46a56d0f28b110b2f4867b4550105bfde08"
       },
@@ -1948,13 +1828,7 @@
         "incomingViewKey": "58808ced6af22301efd6db16f082d7af610c94e2a7e45962ba9734fd6fd95600",
         "outgoingViewKey": "84cf5eb773da4bd017f1e2eea9972481f525fcd847731c50392ef70191591eaa",
         "publicAddress": "37c8773f95df6967ac8c5e123e12553036cd0961b5380154e0a0015a6b8c136f",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "cbbfd01e3664279b5f52c7ebf2ddce51f17b7c07eea9bbb438f2c68e558b280a"
       },
@@ -1976,13 +1850,7 @@
         "incomingViewKey": "f5c664db20053bc9ef3deecfd7a6a0c1f16d79d4d1bea43a5510982776279d02",
         "outgoingViewKey": "2e26c08f65dd416695bdd9f95f9cd3bfa8a2f1854ca7177853412b2d4ae77dbf",
         "publicAddress": "f89bcaf5fd2bfa4ceed864d279c3ff70732aeae44d35755a9fca84106d0b8293",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "a42f0ce790db68e949c71194fdbd57b959c3bd04c6083970399842ccf867d805"
       },
@@ -2006,13 +1874,7 @@
         "incomingViewKey": "94b08a08f50f62364ca60e9c4b77c4553b180523eecf0e268478e164101b4504",
         "outgoingViewKey": "0a6acb3680b47dd8e69496c6fcb286feaf0485652e9aca25a1bbcdcbb148ffd5",
         "publicAddress": "4b0e91aeb323136f341acfe193cbd43557f6295864f5e670e088745d3bb92cd1",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "f7cf0970c6e99b3597b92df450b79b00b2e33c5bbd77c63c60dce1d0e9b1a308"
       },
@@ -2034,13 +1896,7 @@
         "incomingViewKey": "6a77637de04195bf00bd14913187d488bc28b9989869cf0d9cf1f9c108aee904",
         "outgoingViewKey": "6f0b0614303951de1fa7fefb160d710b1c2a2f8984075b0f6b5b94aeb94722c1",
         "publicAddress": "d1ff7d7868191a6dd89355cd9f930a5ab5b2280a73e0b9f6eaa9ba32a70a114f",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "6186eafc3607bd95d8b135d6a9e896fc13692eb3b6de2324589baf3077e7c502"
       },
@@ -2064,13 +1920,7 @@
         "incomingViewKey": "db2f01934fea60512488c341ae818411f33a530303b6c1aef8cc470112692201",
         "outgoingViewKey": "d3a00cecdcbad383ba8b8b8aab5f51f006a69c22d22b8479ac706dab80573b06",
         "publicAddress": "7e88808b1ca170bb3926f534efd70677717df27e9d729c53369b6420345d8b8b",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "22398bff2988013504cb4628cd08b9456ca69d51158eac8894e89284f7bec701"
       },
@@ -2092,13 +1942,7 @@
         "incomingViewKey": "aaba363299d2aff5c29ae44a292e353eb8519236fdf7f760b81e1f4ad7a37e06",
         "outgoingViewKey": "42a399587b610fdcd02140cfd4944cabd5b71b0ef5c020444980f2c4456a214f",
         "publicAddress": "ff463649184ff49b39a7a195731d8f606b9e2b8a949cb4a3d882d14307fb0f64",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "28bcb8b84daa5d6d7fb1f85af5c6c72cf1b3c02fdb225d2fb92faddca049f308"
       },
@@ -2122,13 +1966,7 @@
         "incomingViewKey": "2e238558d464bbadb32c334c9ca826723eacd654a825dcc91c6f72444234f101",
         "outgoingViewKey": "79ebbf16c18e5b86436c7482649274f4869265a7255171dca89bdfbfa5ad9670",
         "publicAddress": "f789aadc287507187246f9731c3122e7af3e7b697109fe4443e3a09864070cae",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "89232e7f7d20e85f9d364315b4762809f0e55efb37c2ee03fb1c061bee80fa01"
       },
@@ -2150,13 +1988,7 @@
         "incomingViewKey": "a7dd305bbf14dde22555eeec69cd1bd9a328742e36004f5596f3099bbe8e5107",
         "outgoingViewKey": "c93149335d41ae231a99a30d15769541fc2708c8207747d9a4d6f457b0cb87e8",
         "publicAddress": "28202a50127334119acc98209a5a08328abd7e399b4406c47d34ef03268a5896",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "41b86ecb0f98a869182e1081efeb2d42616855856196f1d03c1ca584e1e1a10a"
       },
@@ -2180,13 +2012,7 @@
         "incomingViewKey": "e46ed4f03ab1aa82ea1ce98d984516a8472e352eb57a92bb99935ab53e810407",
         "outgoingViewKey": "aaf6f6ad8eeb1b77800a3c946b6c65a492603bbd7da1d5f9e2619a14e2d65692",
         "publicAddress": "ba1cba2e35cdadcfdd3affa15cc0f5fafaf9f8e6a37c9d82e693e68a5963c398",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "7bc75f47c82fed63293d4c825b985cf7683816985d01719981d46eb716c7030d"
       },
@@ -2208,13 +2034,7 @@
         "incomingViewKey": "4014db7ddef991e6fc2a7c5a91e5a6ebade8a638f34a141a122bb3b258cbd006",
         "outgoingViewKey": "0b0d3c6b1597114c8077817401533baa7b1b47b9aa51006ee04cc102efe16a87",
         "publicAddress": "8df2f5a580da1ff8d41c7688b8e39e5028b08ca447f6ed50e727b317dfc3f42d",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "dfc1a4285dd48b9fd0ce1fba4f0728d8ed1cf15a6d336584598cbc4a130f2909"
       },
@@ -2238,13 +2058,7 @@
         "incomingViewKey": "23f6ee50c80c770a13348b7b6003120e508e154b4b3ba2896c0f8786b143ef03",
         "outgoingViewKey": "20bdfaaa561602a2db98c7c2f21155a8ba092712ef3a54cf077a3f98a374b406",
         "publicAddress": "f75074765e2fb180b8c799b2be7398928aa508a2267ee5ca60aacdf2c96af463",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "b34bbeba449bf2ffff277c87bbbc8fb1fef69190f98efc974b25faba397d4c07"
       },
@@ -2266,13 +2080,7 @@
         "incomingViewKey": "77c57b9a902edeec18fb902ab5440f3b4f23cdb02af7f3cf81a1b31e6690ef06",
         "outgoingViewKey": "dda91c1f7063e561dbb64d4163ffc0e8350d751048f630ed27be721819002871",
         "publicAddress": "a64e2c0ac1d2835e2f6e3e01b4ffbd404c5cf8017e41d5c2ab16be451c31d1ed",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "34af67e0aedeed2682d4da7f3f29b85d6bf44fb33740b36f07208e90c9ecfe06"
       },
@@ -2296,13 +2104,7 @@
         "incomingViewKey": "79d822c632d6b53274c8d3adc4f50af60c9b5a172c34714286a2997ed62fae06",
         "outgoingViewKey": "c92ad7dc39266eb6ea98b5907d091db749e6ca98c0f4073d81b45011f7ad86c1",
         "publicAddress": "e42242f29d95e598b3a5cb12a8dc61cdd534e61ba679db9b13c15a9345d5b113",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "10eea4d283eaedf03a29d6ab7bd2e0dd1a1f892176df363917d3da1ca47a290c"
       },
@@ -2324,13 +2126,7 @@
         "incomingViewKey": "9f17345f9db417fe5b8bee57b88f0905d5e67a6b1d32b51b912274295f18c403",
         "outgoingViewKey": "a9eba4f5ab1eb7cec4802ad2abd018aaf49c51e885f244327a7c02e414b20d5a",
         "publicAddress": "ddf65ec4caabfc49385311309c8afa7fe39ab8d9a49a6e433c6d2fab28ce9892",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "eeee2e2734892c8d31ec3ce856e180d80b1976bf1ef367c7f6325c75cd55a004"
       },
@@ -2354,13 +2150,7 @@
         "incomingViewKey": "1c55affe55488bceefd02207bd6ba70ff0759291c84a6e56dcda82fabf3d1b04",
         "outgoingViewKey": "01c2545ec2a99a96395b1faaf1be094e2dba1bf7185d34c4617458a5c80a7c84",
         "publicAddress": "a4d74e0e0adb703bdfef767de0690724542e893501324fd9762cd4a30f583dd1",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "5b004f1bf094853c6a2b308ffdd32e098b75941f59fd05b59f72fa65f578f408"
       },
@@ -2382,13 +2172,7 @@
         "incomingViewKey": "21188b8f02760f8fb556c2fff42db195eac68cfb28f6bd48abb8a5d9ab09be03",
         "outgoingViewKey": "8b95e6c693c0baa8cbb2a0dd7afb0efcaa1790bcb1d0356a3fe3dd50996f63e1",
         "publicAddress": "6348ce922027226e7ccfced229d705c14609e0e390f81299419f253e988a7be2",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "bc824705936b4d2ceea9759d14820b7c1b02aff370a1908ed80f1b53ee93b007"
       },
@@ -2412,13 +2196,7 @@
         "incomingViewKey": "628caa667d3aa3c12c9cab44271375de5f5f07d7f42bc5d23af099376b49d402",
         "outgoingViewKey": "41426e6ea1df42791c0b07f37eff83aa5706e96bab2746538a0bdb5245134c57",
         "publicAddress": "7b386f3eee9eb5155510ffede2781ed290c8b87e1d8df88d9d4aa9a300a24d73",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "8216ac1a368a8ae32088aa8f5fc9b719b5fc87151aeadd2ca2c01a8b3d67020c"
       },
@@ -2440,13 +2218,7 @@
         "incomingViewKey": "6a76beb15e60666c80e059316e8a2c465a3684edace6e5b9e67cd314c8c3ba06",
         "outgoingViewKey": "da11b38c1ab00df81953a372eb3da7ad29cecb20eda8aaf2c76702fa990e0f4b",
         "publicAddress": "0456ebefb54269cd4f547236cd05e39fec9c88dfcc900f911ec2b3be52e9cb60",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "057223eaf3663a88ef975868a4d0656d9b5f2dd0a76fd02d49796b0284d56101"
       },
@@ -2470,13 +2242,7 @@
         "incomingViewKey": "cb2ac9fae2ec0a4f86dbf97456279807e5ac5736c245d382d7dc179e7ad35d01",
         "outgoingViewKey": "fd1c610f476df0d7a1b72d0b092404b64c039d71ba4cef4b2029ffffc3d6d640",
         "publicAddress": "905e6fd5c79387def3f5f7fe5f6891b7d24bd36c56343380c736514b4df41428",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "205aacf0d47c1dd9929e5b52a8fbeefbb7bc53e84de9b0e1d46798d72714a30c"
       },
@@ -2498,13 +2264,7 @@
         "incomingViewKey": "2b14a7e1a15de9a10b9703c51041b3e6d13ace9dc0a99062e3ae6bf76c977b07",
         "outgoingViewKey": "636f43db6c93acce26c4a6ef9c316e68f0ab5dc72c4d9a3fe756e9d26802df4e",
         "publicAddress": "b37c83e546ece1a245863a605b995632e0369fc9e46840ce8f0812a7b9613142",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "c01df4492314895ee686fc4bcd68b11c0956731c767cb5638c536406bac1e103"
       },
@@ -2528,13 +2288,7 @@
         "incomingViewKey": "18ce44df85c3c6ed7a96a084910583de56e0eccc26b352ec546f15b5a267ea06",
         "outgoingViewKey": "60efabb0facf30a1378bb43494153e37caca0442725aac757ce75b6f49183190",
         "publicAddress": "46a7c021aaa49997795caca0775df8eca8e44e42b355a0b44009299d837b974a",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "cd731e5747fe170ff2a0d74fecc1e211bf981d94d4e27e0d42925fffef9acc02"
       },
@@ -2556,13 +2310,7 @@
         "incomingViewKey": "4446e7e70d21375cbcecb7af3c5ef70c93a319f7b5b53962aabf8c5bf8744702",
         "outgoingViewKey": "cce166aeaa25b4ff185565b8377873e4d9f1bba1cf206eeeeeee907d1cab7ff1",
         "publicAddress": "c25fd22518a8bc4e11d2eed44ee10f72c49d4769621a72a4189f66eceba56110",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "8c68612b02685311c4756d4f2fe86dcc2de873b8bed5ea0cf287e83141c6890d"
       },

--- a/ironfish/src/genesis/genesis.test.slow.ts
+++ b/ironfish/src/genesis/genesis.test.slow.ts
@@ -7,6 +7,7 @@ import { Target } from '../primitives/target'
 import { IJSON } from '../serde'
 import { createNodeTest, useAccountFixture } from '../testUtilities'
 import { acceptsAllTarget } from '../testUtilities/helpers/blockchain'
+import { toAccountImport } from '../wallet/exporter'
 import { addGenesisTransaction } from './addGenesisTransaction'
 import { GenesisBlockInfo, makeGenesisBlock } from './makeGenesisBlock'
 
@@ -128,7 +129,7 @@ describe('Create genesis block', () => {
     expect(deserializedBlock.header.timestamp.valueOf()).toEqual(info.timestamp)
     expect(deserializedBlock.header.target.asBigInt()).toEqual(Target.maxTarget().asBigInt())
 
-    const accountNewNode = await newNode.wallet.importAccount(account)
+    const accountNewNode = await newNode.wallet.importAccount(toAccountImport(account))
     await newNode.wallet.scan()
 
     await expect(
@@ -262,9 +263,9 @@ describe('addGenesisTransaction', () => {
     const { chain, node } = await nodeTest.createSetup()
 
     // Import accounts
-    const account1 = await node.wallet.importAccount(account1Original)
-    const account2 = await node.wallet.importAccount(account2Original)
-    const account3 = await node.wallet.importAccount(account3Original)
+    const account1 = await node.wallet.importAccount(toAccountImport(account1Original))
+    const account2 = await node.wallet.importAccount(toAccountImport(account2Original))
+    const account3 = await node.wallet.importAccount(toAccountImport(account3Original))
 
     // Next, serialize it in the same way that the genesis command serializes it
     const serialized = BlockSerde.serialize(block)

--- a/ironfish/src/memPool/__fixtures__/feeEstimator.test.ts.fixture
+++ b/ironfish/src/memPool/__fixtures__/feeEstimator.test.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "92ba93212ac0e955eea6017e5b5f7a93401a66b8fca39e2fc4f731f3f31cf304",
         "outgoingViewKey": "82218bdf824381b43c0bb1352c1409b0975b87da61c443a3548da26a89ca6115",
         "publicAddress": "2f1814f0578635fa8e605c6ca54e9ecc5a0a7dfb4a9a34dd926a5f206f61de42",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "d0364549e07782cceff1e4e45f8e23532e52a48d6fda0b1c6fadac1b28db3200"
       },
@@ -96,13 +90,7 @@
         "incomingViewKey": "7ec19194d45dda67b1311215980b5f6b2a50733d8cd64d2e10aeb884780d7405",
         "outgoingViewKey": "77d9692805dd28e274a58db0f9830085906c067a96e2f2f1abe3644cde10cf1a",
         "publicAddress": "736cac369c1e219734eafbb4500fd04fefa678bf6d3a90775b39495fe9a991b7",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "e98de35fb4e8aa73d8c230fddab84743fd5e33de8f65de90fa184f1845fd7808"
       },
@@ -238,13 +226,7 @@
         "incomingViewKey": "3b37c0414d064dcaebddfbf9d1629cd52095e8fd9bbaf9c2ed9712dc088f6804",
         "outgoingViewKey": "4df413af5e4a983c087e4237a68ba282c301699a660916feda7d5266332515fb",
         "publicAddress": "83b9dc3a6d1d19ad4c5b8d3696fa75bd496f4bc7516a273f2d0c857988592b9a",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "966969c58ee4816662be5d48d3ffd564c1afbcc5b078f05ee1a86d26a6ad5000"
       },
@@ -354,13 +336,7 @@
         "incomingViewKey": "2ff9c23447f928835434827ac656952facd98b8d903527fc74f4aebf3e2bdd05",
         "outgoingViewKey": "03233166b2d682ad442151bd28abd6100be387455939a4b6016f39669e6114df",
         "publicAddress": "f250a45968cb7da493d62d00d01b982dda31a626eb86d0c4291da577a623710e",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "01961886cab608eab3df193b577ed7ae86fa130d8e45442da3644f6710fca308"
       },
@@ -440,13 +416,7 @@
         "incomingViewKey": "879311429dca674ae73bb8091b7f438f9d492b1dc64ad46d1663f776bab11200",
         "outgoingViewKey": "13420c8038195cff809733cf626d8c2c97343dd80f7ae37eb4d736087b8fa81c",
         "publicAddress": "6046dc21627f05e32c55a702e9a16813832de37f342884aa740c6ad3ed714a6b",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "b4a56ef6900ac9d40b6c785788d2f3f66efc64cce0569c0dbf5af837ccf67009"
       },
@@ -526,13 +496,7 @@
         "incomingViewKey": "57fa41d91003b3eaeff5e7a17d7a0c019a73e286be64be538c3024cfdd5c3505",
         "outgoingViewKey": "4179903a187bac37bffd51e6af5c852613a1f90436066502aecf594e8799f6f6",
         "publicAddress": "ef6287403eb37f87f1e5121c5cc0a16e6047defc8ea1dcce850d2bab2e27ba1b",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "fd35983881d545cf8f3e91bc0f6f9dc3da98b1feba94ba8fa8e9a8b7feaacd0b"
       },
@@ -554,13 +518,7 @@
         "incomingViewKey": "1895f0510c9ad358396c524877bb923bfe6530cc21b8316844564e0089625206",
         "outgoingViewKey": "851820d48c509e1ae6d6fdb3e23ea222a98d763601d627c4fac11db86a838378",
         "publicAddress": "1c82e02713d3e036ac76e3f3071f58c002800e8ae4cc5fc3a44b45e84853435b",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "0b650828e2c044a8e11fe09ba6259688fb284d9bfadba62dec14bfc179dd2304"
       },
@@ -696,13 +654,7 @@
         "incomingViewKey": "25345a762f894b3fdeb068dcf06701d7ad7db30ae6d63c3f45946db040e5cc06",
         "outgoingViewKey": "d4377a747984cf25b2c58c64e058a94a58c72c300f69b11025628529eaec183a",
         "publicAddress": "088e264b5f8da6892bee00468520820cd50cb0d99750de0ba8a5b96362a8e08f",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "7537e251221c21c5e409703c6b5583314ebfdabfdbca59c2f864a5762c214501"
       },
@@ -724,13 +676,7 @@
         "incomingViewKey": "634bdc9ea531c695da8bccd6c7738fee55fb40b8235a812ae494f0d9369b3906",
         "outgoingViewKey": "ac01df2759956114959c7ed77f128d69f0ea2ff12f3939e2f05979a7f4ecdd87",
         "publicAddress": "3331b4cdeb6c0fef9fe6b3ff270896b8611fed9989e84263eedd08f24491cc98",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "cd268893ceaac9e35bcc05a4e1a489ceffad35ba5194220092a250104d764600"
       },
@@ -866,13 +812,7 @@
         "incomingViewKey": "63797b585597172ec45828f6fc2babc68c2a924a2012d8516336ca4e2d562803",
         "outgoingViewKey": "4622cea6bd701dd409bf927c94b862cec1c86b91f23b0406a437e1f3a4487711",
         "publicAddress": "3a72bf39ccaf5aba947a9faf81394e4da234fb9575226580a4f069de29cb6eb6",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "a12cf6e43b020bbd3ee62a72f10c4edbc3873931407aec90e87bdf1901da660b"
       },
@@ -894,13 +834,7 @@
         "incomingViewKey": "055ee5112a949bebd70814f75c1d0f5cd7d750c2c4c23be6a43a684cb3226c00",
         "outgoingViewKey": "a9bd7b167e788f1bc39733800bea04adac971e2158fea0ae82e65640b9fa0837",
         "publicAddress": "15221c9c95d09d878d41d9714511101c915d9e50c1f379442b30c1cc93c55b52",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "220ad3b22b67202222a73869839b658904091a6d430808d2648e9f87d6652f09"
       },
@@ -1096,13 +1030,7 @@
         "incomingViewKey": "0d76aea2f86f34c75f19089b2d6a9feec77373871d5ccd0d3c511e964a6b8606",
         "outgoingViewKey": "4d46bae1833e1696fcadac245701b398dba6be66ed698bdb828479ac80dd1ef4",
         "publicAddress": "e39903d026ffeb33540ed7db02f9b07aea2afee1247cb4084be99a3f3459a955",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "fef00c3dc2d02da98d92f4330b2e9cb16d59ce0f769b0cf45495c62a973a0802"
       },
@@ -1182,13 +1110,7 @@
         "incomingViewKey": "b1e7a64933cd755321cc67f5915985017ff5980e76f1c0c6c7ee8b0e7a911506",
         "outgoingViewKey": "425adae5816587b57583885a86e95f1f0105b9c3c13b5271ed68a0c36252624f",
         "publicAddress": "0dc9db820b8cb02ee878beaa5be61cb666fc0a0d4d877738780ee5cd304474e9",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "c0e84d61ea5a6d8c77e23766e11bcd0aec9e7f9a594324987eac83f0fd3be206"
       },
@@ -1210,13 +1132,7 @@
         "incomingViewKey": "2c92837dd023b48e4f5d0068ef2f504108adc3568af482dca9cb26d78edeea01",
         "outgoingViewKey": "3f8c53841e345422f6d05ad3962d90c23b28ac141d8f3a145398529a8c0daa4c",
         "publicAddress": "505fd6c795345cd2a04d308f822c7639288843b2ca4e706dd74d37116377a345",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "39182e99fd19aa0a5174ca39ca68e4e7dccb56be67a09d944e0545b086aa2001"
       },

--- a/ironfish/src/memPool/__fixtures__/memPool.test.ts.fixture
+++ b/ironfish/src/memPool/__fixtures__/memPool.test.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "ecf99ac983c3275c65cea3f09cc4ff93a0db78007947ea4abf4c916a306ce702",
         "outgoingViewKey": "daf301cceb5ec5658fa53e7244fc869caa7fdb74ea3054d58b2f5f2a0c6f9be5",
         "publicAddress": "7192694fb7ccc63ff5699771d78e889072ad6041c712bb71d7f5c7529df15984",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "303ae2cf43782aaabb477d7a96d30c182e079ddaa3ca0f71d1850477f0bf2e04"
       },
@@ -38,13 +32,7 @@
         "incomingViewKey": "58ebd1b3a7fe9d3e08cb29b731f796411428e89166922390d8ef6d3f1a7f4a07",
         "outgoingViewKey": "01ce04649e0f0d629e6453823b12d9b41845656dfc6d6845f1424244d1094827",
         "publicAddress": "721586be843a666358f8cac7e22a99b84c655c8c084e044e3eb3521e9ccb769b",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "196eab9c9a61a5a101a8aa286b61b264baff5816af9d6df9b8b6cf0be337e108"
       },
@@ -124,13 +112,7 @@
         "incomingViewKey": "9654ac3f30d18905f70291b7250b7810096f6af5fe5d72a16e1a6aa4d3ebfd07",
         "outgoingViewKey": "a0cf6e62c8943e0d57f6a7b2cfe827147c008a9764072332e06c243548d8186b",
         "publicAddress": "d83159a913219b8007d766f50b79665deb91b21836d69c7363aa6110fff99c31",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "8266e39b74cd6cff3305dff928474279b7ebd5572e40b0439fbe1ba9f0677b08"
       },
@@ -152,13 +134,7 @@
         "incomingViewKey": "9b1afcca3cde2396d38c9ee61cde90004d00cbf7e13382f7eee8c3195958cc00",
         "outgoingViewKey": "67f4582e2760ad5e40ff1544bbc7b099c40c23f404cae502b4a05cadaed845f6",
         "publicAddress": "2d07a874dbafb7a02f9ebd700717238b5a6a4fac4234d104ef679be0d5437edb",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "fc52bc9bde696a5fc1095ce98f2686d00d192a7a802a6bd422b72745dc82410a"
       },
@@ -180,13 +156,7 @@
         "incomingViewKey": "50337d9b7abdedcdef912cda45b55dbd0c8638f59958fa12c5a3eda623d63002",
         "outgoingViewKey": "7620bb440371d14e1a4156247db75a142b0d3d63177ea0ab8c11d911075cd1af",
         "publicAddress": "4a04f7d127b00d2e4dd828daf441b5d37c7a70d1633eab42236f7dc2eb1bcae3",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "16447026afe68add3cdf17a7ce3a55ccfe5efacb2b24091a8871a6fc146e4509"
       },
@@ -208,13 +178,7 @@
         "incomingViewKey": "8f08de27b3fc2b2e84e5c57071f12f47f233ae90d735303352fd766a7f55b200",
         "outgoingViewKey": "5bd04f6ab19e894739ef441e0b2fd7e0e7c4356be078d9af435d2ee951851f2d",
         "publicAddress": "7e9941fd061f20083a12c4aa65810c384324a35ce75bd46ad22e812e6203ebcb",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "c8dc15a9ddb0b28ba4c8677e6eefa9012624c477f21e438e2318b4a7decda104"
       },
@@ -350,13 +314,7 @@
         "incomingViewKey": "8e1e7e40719a763b61a3d7af72985cd32efd1ed3fdc925c0388cf6d5492daa03",
         "outgoingViewKey": "95a209ea3951a031622e0e72e0b776c5c64b53a60d4c57ca1a44899ab923ec86",
         "publicAddress": "d82442e947345cc9c38a7652683eeb613917cf58044942fcc6055c20a560d283",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "05fad53bed20de7e96a31dac41fad24f29d461e286dea29d1e4d3ba25bad3709"
       },
@@ -378,13 +336,7 @@
         "incomingViewKey": "f6035dd51de6a4896d153b9d2253c9832b53813e0bb1361bd61660c87fd10a01",
         "outgoingViewKey": "829fabaebf89e4e2f7dc758b26d61aa057a746d8f3f015f7c714d494d3bca4fa",
         "publicAddress": "53670de254b300e195a889836ada74abeb41eff7f59a6de5fede88d539653267",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "1b157fd4e1a4c6fb22d3173b6016b1a0922120cb2bb5f1e1a57038757a987405"
       },
@@ -464,13 +416,7 @@
         "incomingViewKey": "751d22de99d65205722b70331e17f341c6bd4abf1268aa2e0742a4cf07b57a06",
         "outgoingViewKey": "2b8ef0388019488fdeb4d00eabddbc690d09c301e0e90be8e6c701577554cf37",
         "publicAddress": "da176c1e458faab66ba6d6b7ff39f497b4637ccd03ee39aeed90cc88ace9e3af",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "e837a5265726a512145d8356d4a770cadd92a24abb42469d3e639eb406913900"
       },
@@ -492,13 +438,7 @@
         "incomingViewKey": "078a92bdb5729a58aed4edf32a1a1d049819a1377c164e1f113e56ac205cf601",
         "outgoingViewKey": "068578bd5b4f27c496b8d6a791dfe0480ff6a28de798db1434e5c41df4b6590b",
         "publicAddress": "c136564cb097edf4625906e6686d503b123d3ec3d19b71fe79f03c90bb121651",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "703f6163c45e5444275eeed4943812929a792203894ae55252a29451e7444403"
       },
@@ -578,13 +518,7 @@
         "incomingViewKey": "6c001fcb54a01449076369a6c27976417c4908dd7becec8bffca5c035a654905",
         "outgoingViewKey": "720ef147eb7faa4e508eea66fd248fc0533c9e59db634bdf1db40333b344fc01",
         "publicAddress": "e15568163b1c191943ef89ddbe9561e93e1730d1de5f1096375890b4587189af",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "68a52890f0516bcd2b051c7e9749c27e8e977838aeafb94376e2fafba05f630c"
       },
@@ -754,13 +688,7 @@
         "incomingViewKey": "367d175757b5cebcfbf8b058d6210402be522f7984e53f5a6dac52672ff74805",
         "outgoingViewKey": "f57f314b9e022eb37024e8dbd42fb1dfccc558cb522166a1afb10d133af55160",
         "publicAddress": "473cea5671c29f2ac391f16a1c16b1a0cbf51a98c1dde852f51c49e20f56dda3",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "18bab1bc3664ae8cd254d5abeae7c99dbbce1094616bd40e05a96a1a8ec82708"
       },
@@ -782,13 +710,7 @@
         "incomingViewKey": "3bdeeb0a5ea4acdcfd178fde1e4b25b5514da36bb207fa19dbc8c6ac52b20306",
         "outgoingViewKey": "265e67d1878418298d8fa81492d1d1873173d7c964abed6a96087fada9f8f9e8",
         "publicAddress": "47ff8b79a88aa105c968d3bccb3686be3f8960856c1e1d98c07307eefe63689c",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "daebd57a9b07aac907b4530cc96837bed5ef19df7798eb9a50753ddb27ddf906"
       },
@@ -980,13 +902,7 @@
         "incomingViewKey": "e22a2eede15cf55337e870bb0049e6ee82d0c0a4137157b800c0b2b564ed6a01",
         "outgoingViewKey": "e745673b69941fe4b9cd1d86b6a1de78f2f5ee0f62e49392f9fbdd84013df5c9",
         "publicAddress": "2e9a8a5e423854c35b3ac5f40b6c851d3014b05a8b80adeff2659d1e58301dc3",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "94dea7f14d66f9059a762fc199568de6d104d87232bd3b35b021c6f6bb96e306"
       },
@@ -1008,13 +924,7 @@
         "incomingViewKey": "7591b692c8a5e7ef957441e28c69ab59201bf9a72e8c5e612872a6f70f791002",
         "outgoingViewKey": "950b03c9528d2075b3f93197a0ac8201c64c462028ae12fc703ba2111b66ab63",
         "publicAddress": "22d0eedaa722d7f8123d09d5f904a6e59ed33b1509e3592c8bddb5def4148649",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "cef7e2db7d541c9cf60ceeaa039f43fe3d1754c8ffbd1607a5d165c2c2ac930d"
       },
@@ -1150,13 +1060,7 @@
         "incomingViewKey": "f3a4a141e702d9d4f032a4cf19b633a4fd348d6f9c18e0c4e24b15a238111107",
         "outgoingViewKey": "d0fd9c8672cfda8feebdd523cc84b0138c95c96663fd3beba142583e2744dc79",
         "publicAddress": "c5cc07f1f87f31ecb74ecf0cd3b9f01b52ddc3287b5d9a8447d2003500071939",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "ac8b13d503674df925d230e1e354fd7aea5a29925489ce47a0121cd6ada73404"
       },
@@ -1178,13 +1082,7 @@
         "incomingViewKey": "a054940ce1543a88bb705cbdeafa2a92fab9748b9edd1e8d7362c1f18d636b00",
         "outgoingViewKey": "504edc04aafb532170295f21160cb16933fb5d4930c5c88f8d043dabdb64d2dc",
         "publicAddress": "0a24c6ce4247f1e4070f3ae5de4d3c81b568878c0a46e45037c0d27d957ef241",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "1d6662fce684bf607b704f8b0bebb18865a63ec12e877fdff7e29682e61c8706"
       },
@@ -1264,13 +1162,7 @@
         "incomingViewKey": "dbcf53b28fa602a54242055e4d1092e9aefd4c2f195d9deab18f99b65234d705",
         "outgoingViewKey": "7e532b745be8557f01dc7c8533b2cfbd2f135d07c26a7bd6757b345b90122d3b",
         "publicAddress": "8fd1a2499485f89f74121f8e7b2a0913fc317186d8075beda1bbe32b1421b1bf",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "5f8b70269949858bc4fb4db860f9c57d6168e6b3b54f87b52df9d23e68626f0c"
       },
@@ -1292,13 +1184,7 @@
         "incomingViewKey": "041dc399a8e9597d72cf5381af402737a412d9561cb430d6e21d0894fd23d905",
         "outgoingViewKey": "5e88e0d3591059cf37da564801b1fa658ae7d505fa0fc4b91ef27e98ee854b07",
         "publicAddress": "7b9e1691ea5d8ba0d0c5f04429b969c675c6634554feaa38d9caf52724cf180d",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "9cad9aa1b855dbbafb1a7d7e173008cdbdaa2b47004144862e7f02a207f46105"
       },
@@ -1378,13 +1264,7 @@
         "incomingViewKey": "7376d2b372e1910ea56db2c5dc43c8b59c97a67d7cdbb0b1dc85190de16ab307",
         "outgoingViewKey": "bdbb0e5cc4f2f02ed9e51876f04a6d011074eb02461f2b2a91b5b55ced75889f",
         "publicAddress": "a58bbb300a29e9d78168e95c88cf1bf7e377f0e9938a9ce5d1535d8bae8ac589",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "b6493f796bc4031d219b67c767c4af89d575ed13702a54d523d079f30848dc08"
       },
@@ -1464,13 +1344,7 @@
         "incomingViewKey": "dcd08de8e40bba45b03fdbe53cb2cac4ed46c50210e4db3ba6831c8cbb96f607",
         "outgoingViewKey": "11dbcbb85f76c21696f77f0c813911bc35a482b4fadcb4cda6996ba7ba23ae79",
         "publicAddress": "4c1bc554bc1d517512f0b6c26c8bf0d09ce1efb6ea20824f85cab4d0bf97b8d9",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "8a1bb41fb6111643983a4eac1f85647f6f88a8a1f07891295e1aa37119458106"
       },
@@ -1492,13 +1366,7 @@
         "incomingViewKey": "29c34b41f4b09ee039f5d02d10b2fe37dec73adbb920d07c33f72682534f6102",
         "outgoingViewKey": "960438a3f741640293a832fb275126fb557b3132761417f9cacddf9f7667af5a",
         "publicAddress": "b641285bfce03f4d6fa0d6956400d55f6e96db233e924a953d416e5016a1c13f",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "a4f177dcc1c8884375d7ddb9be4aff6ad8d0cdc4ed07674a9a715715ea445900"
       },
@@ -1608,13 +1476,7 @@
         "incomingViewKey": "5d773239ed2f00de2af76d0ebbb650d28171e96cadbaa17629fa121bab95b706",
         "outgoingViewKey": "358d1049003a1490c5ba95e4011ea4dd6fdf8a8c9e84c049a83b7bd59bc7681a",
         "publicAddress": "aa210f7cdd8aa4a1781a853211df0e37cbec63cc4ac65891f342da8527d0c54b",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "704f27bf49d820ce90c3f0d2bf7f3460d3a51ae9fe3468eb6dd12b40bbb5e002"
       },
@@ -1636,13 +1498,7 @@
         "incomingViewKey": "27259981764575306da9a84f6cc90bb883f8a567155da0bb92d10df2f0ad2107",
         "outgoingViewKey": "9abcd66810df732896e0c55d58606b3918936b019ee33f6b1f7b75dbf5d495f1",
         "publicAddress": "ce3bc1e3670260e4087b77e61902215b6fdbe608526fab3e48f3e33696e935d9",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "baec0f1606b16ceed1e57ad3f2c3f69611e9a2c4bc9eb5ff2b0663be88adb507"
       },
@@ -1752,13 +1608,7 @@
         "incomingViewKey": "641c367f4a19794b684e50337a3991c6eedf26ba334cb09c77d93bd6d530bf00",
         "outgoingViewKey": "447b2593c4d3659cb400e5a00ecb41bb84cb615509fb27fc669175f750c669e0",
         "publicAddress": "f4a6daa32d460b6f72530b6e6ab8c3d8a80c63e1b37dded04856d36ede83609a",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "914c5e449dd7c38bea9eb3b4e6104120d2947bf5861c5d92f66c591e0444360e"
       },
@@ -1842,13 +1692,7 @@
         "incomingViewKey": "55951723737c645983c1ba1b10dbdeb3bf70d3d20ff3fdd72d92a0ce2e5c1307",
         "outgoingViewKey": "4cbfd6ff9d2df9bf48ca80e15cf886ef0d6a64d2ac85931194aba636b7f3d281",
         "publicAddress": "512d108e5dd3c25a308e023a889784f5418583bbc51afe46e055c2abec87dd53",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "61731cd223547dbaa234b479fefcb40b40296a008cdd782d3758b40e207e4e09"
       },
@@ -1870,13 +1714,7 @@
         "incomingViewKey": "6184df7fb0a6bd94da8a3de0ba06863c8fd01c1aee138daf544a9dc0df020e01",
         "outgoingViewKey": "ba27ab9108f05c16d23b6efda8c93acf2357fe9639d76a8c32afaaae516043d5",
         "publicAddress": "2a0b03a2ccd104a9a7c5a0cc94a0f1da16ae32c78d11b79604efa3850e7a69ca",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "99e30cade7f2040bd549bcf90bbbcf7f798094c810c0f24867a08dc76c95f500"
       },
@@ -1956,13 +1794,7 @@
         "incomingViewKey": "ac260cc238d18eee78a25238b741f6b7b457acf8a51e0a158e7244c6ea087c00",
         "outgoingViewKey": "9a93a9bbfac0f46c956405edd73d5765567b0b48c10a802371adc93d92b4234d",
         "publicAddress": "9c97781e8658f5f07739e75c0c10c3ba17dd54e4ae982021ec59cbfad1ea2713",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "0a7471247e793ffb4acc971d687ca8eb3a5b27db7c02286fc48d7ef65715cb0a"
       },
@@ -1984,13 +1816,7 @@
         "incomingViewKey": "73a2852bf286c7e9adde72510cd37dea09ba5a9c27d130a9160df00c26939403",
         "outgoingViewKey": "b3a2601b8f3fac989d56bbcf384222f89d22c2564322dcce07386f7fd072c132",
         "publicAddress": "19bedc7ffa953add8d056cb5cef4cc5f084c7ca031135ea2b2ee8e0caead6502",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "0fe75fff15b8a6110403145ba696f065ea91c3d528537abad192ed92eb5e3400"
       },
@@ -2070,13 +1896,7 @@
         "incomingViewKey": "6f6a41eb8e7cbbaa940e40dbca4e7fc288901002122288c8187bc4e9c88bb407",
         "outgoingViewKey": "3494d8bd135989e36ca313189fdf79f8e1570608388f6512ded229125cc3fdd5",
         "publicAddress": "0951dd7e4cb1d2db8da5d49ca0c6da4669e525d66c99f3e1915d23e02fc89a36",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "2fbf858e971c2ad74401d214e5b1d16ac47e78e077c897556e4257dcdd30550a"
       },
@@ -2156,13 +1976,7 @@
         "incomingViewKey": "a086c88dedcecb30f5fe3b856f49655690a9d85601d8b45a8443ddb99a184b00",
         "outgoingViewKey": "9041dea07bfc8828676f31100eda630be08a94592025994d06c425d8ee5bb74e",
         "publicAddress": "71cf65e974256158585bd31067cbde1031ec7f71490d2e1333d6665d850d9e81",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "c45c3430e10fc7b03a68d8055c227e2778f73a5586cc831bd5771765ca63eb07"
       },
@@ -2184,13 +1998,7 @@
         "incomingViewKey": "306eebc7664800dca392aadbb21750ac7c77c6e693241c155747b64c42f33807",
         "outgoingViewKey": "3ab3efcd24074ede53ebe3228de58023c5276393ea855089ff4f8561fc10a76a",
         "publicAddress": "6a28bb9390dc017a462ee796158fa4e04cc96fbd6c0712bbdffd4ddf614991a2",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "fb215628206128dfe6fe759fafeb382858f65fce9d87264d3a17540ba80c7907"
       },
@@ -2326,13 +2134,7 @@
         "incomingViewKey": "ded9b055f45c10ee45a6a0876df52ae6c8fe9495f24be9a68fa1e63f787ff404",
         "outgoingViewKey": "9668f954988f2e47eb5d3bdd1aaba61274ce2510f24fde13217fa7815e7321f8",
         "publicAddress": "690c60e41efa3fc768e70160fb48bbd66888903e4c9712c7da9911e756dd7271",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "1fa784d25101acf82d42830b18ab7d3b808c13584100eb656d041f5d9639e70b"
       },
@@ -2354,13 +2156,7 @@
         "incomingViewKey": "f527a07bf733e22236fcf0eb9d6723ac0a7cc43352c67541c8be9f67a16ef706",
         "outgoingViewKey": "3e0a3958147123cb50e28d266e6680161873d70f8851932ef2fa7d63a2db1470",
         "publicAddress": "64b1a7eeda653cb27670fabe81b6a3281933af9bce8b872ae89b021d7ddf5e13",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "e7f4adbf61df611e5488c6b5c72bbf2369423dc7bb4f7ba564b0158330ef2c03"
       },
@@ -2522,13 +2318,7 @@
         "incomingViewKey": "2f7e8724cabb58d83bfdaa76f1cdbe1e382c6b9ca39a00a1bea6612f0aaa1605",
         "outgoingViewKey": "6c4cc4a6c03572c45cca0c6e78c193e0bb4c8644ce0a48d0d7a41646c83fc452",
         "publicAddress": "95ffd9e349e6f187942dbcf0412b893ff37bba6e865d79d64ed61a035d9aa867",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "f2152f25218502ef87c7e10b767944c8bd0b30c7268595c8f1518d8484db870d"
       },
@@ -2638,13 +2428,7 @@
         "incomingViewKey": "6b0e3646c4c0d1b25f41e5a915b341f95e7a62052b38c9be43159388e106c704",
         "outgoingViewKey": "e0155800089a1023de15045897a728c94d016a072fd624f8c4ca60ff948bc389",
         "publicAddress": "7e590291a050dfa4bb00d5a59dc734292abae44aa6562c873c078a2789b51b16",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "e97a77ff9c6e09ebd4a15d2de0901bb10cd6572342d33c274a8890fff471f904"
       },
@@ -2666,13 +2450,7 @@
         "incomingViewKey": "4b6eb71375ce8cc617859449dce9ba48326021f2f65a3d23be9b58d7c0ff8307",
         "outgoingViewKey": "6df008ca674b739f399170a996c01ce7239308da5debf73c66fec34374e86987",
         "publicAddress": "c89a82dfd4454a2e98db0a227f8e9f98cc88c826746b0e20a6c7fe784fd66682",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "596c2084a8b47f6c36e9475798275d9f0f02a86b6b133bfbc4424a0742911e00"
       },
@@ -2752,13 +2530,7 @@
         "incomingViewKey": "d7752bb2ff4688dbcb3be41aa018ae47b6111ef6a96cb781496fd91a6f42b601",
         "outgoingViewKey": "d8e10b89b51c0f5afb8a267c460d3d48ab98f483d64414b3c00cb4a725f192f9",
         "publicAddress": "912e957ddd5dcd94ec0aad4f923d81a012a6715200f799138974044393a1f08a",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "e03db46d1398e03564a6f901baa14266c4abe906874e43ca2b80b196a176b301"
       },
@@ -2780,13 +2552,7 @@
         "incomingViewKey": "1f7fa33034ebe1c0031a846ee91ba24710bb01ad260a5b15eecb93c8ad897403",
         "outgoingViewKey": "b8547abe29aee4817946ddb6e0c092e853d64d7975185a56749cd26922b0cfc2",
         "publicAddress": "10b777e1f04c64019b8e20097a20fa9cce9b172c781d1b00bf2443a428011acb",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "5a4caa42171364a4051c2c9f8e6ffd1ce85eca03e08a17ab0167413f71223c04"
       },
@@ -2874,13 +2640,7 @@
         "incomingViewKey": "0f43be442609c6ca1f1e59957e908fbb9299cee90132082fb928efd575bd7f07",
         "outgoingViewKey": "63069e2d6d54aed1771398a90c780eae1e6bf99ff49d3b8f61d7c34992c15b7c",
         "publicAddress": "a6b7103e4a5873b9499e54bed34553918fc76bdb922d213dfa62ad25d13426ec",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "ab41645b8cc863bcb96fd56416ac45a43dd01fb7674015eb5139e2d554f4d409"
       },
@@ -2902,13 +2662,7 @@
         "incomingViewKey": "5b22ad9f2dbe844875604f6177958fe93c384b8ac471d8e0577942e766671400",
         "outgoingViewKey": "76f90cae362f8d1fff903cc6bdf0e7be4b4f3a48d724773640aac4250238688e",
         "publicAddress": "acf86aa92aade18b5f3bf259805c369bc8d83f1df26ab412ba4bb33c9f9bf468",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "3101a62f585c962d6ef70068f165d52092703919eb4cc02709cb42c714df0504"
       },
@@ -2996,13 +2750,7 @@
         "incomingViewKey": "88b4d801e5b2dedd6c21642509d469565c619fada643c108237fa7ba71d8de03",
         "outgoingViewKey": "cc468ab5a269706c3f1bf901f7f481f37ca0d2a4869d96ba180723befe9f0a61",
         "publicAddress": "7e5c4234ff179a5651233e5d28dfa8e317914507b1e13d25449cd2bb5d06a6e1",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "421d8822312e09491dc82a5bd55bbc125c6abf85c05a577577128bd92c2cb300"
       },
@@ -3024,13 +2772,7 @@
         "incomingViewKey": "77d46c4efa3504a838595c310b6775819ee7250f621ade5cc5d4381d87b77905",
         "outgoingViewKey": "3af84f09abe4c8d05be010a399c0c1ceba7836e11be39dcf96f0c29e35137287",
         "publicAddress": "651edb139cc2b2d3f2af1c021fb7d07568f11872123f18a5c5f876009e169d54",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "1031e002fdb1b4af66c53e2e249cf9ea6b70db86a25ecdb68dfa99a88cd65102"
       },

--- a/ironfish/src/migrations/data/033-account-created-at-sequence.ts
+++ b/ironfish/src/migrations/data/033-account-created-at-sequence.ts
@@ -1,0 +1,56 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Logger } from '../../logger'
+import { IDatabase, IDatabaseTransaction } from '../../storage'
+import { createDB } from '../../storage/utils'
+import { Database, Migration, MigrationContext } from '../migration'
+import { GetStores } from './033-account-created-at-sequence/stores'
+
+export class Migration033 extends Migration {
+  path = __filename
+  database = Database.WALLET
+
+  prepare(context: MigrationContext): IDatabase {
+    return createDB({ location: context.config.walletDatabasePath })
+  }
+
+  async forward(
+    context: MigrationContext,
+    db: IDatabase,
+    tx: IDatabaseTransaction | undefined,
+    logger: Logger,
+  ): Promise<void> {
+    const stores = GetStores(db)
+
+    const confirmations = context.config.get('confirmations')
+
+    for await (const accountValue of stores.old.accounts.getAllValuesIter(tx)) {
+      logger.debug(` Migrating account ${accountValue.name}`)
+
+      const createdAt = accountValue.createdAt
+        ? { sequence: Math.max(1, accountValue.createdAt.sequence - confirmations) }
+        : null
+
+      const migrated = {
+        ...accountValue,
+        createdAt,
+        scanningEnabled: true,
+      }
+
+      await stores.new.accounts.put(accountValue.id, migrated, tx)
+    }
+  }
+
+  async backward(
+    _context: MigrationContext,
+    db: IDatabase,
+    tx: IDatabaseTransaction | undefined,
+  ): Promise<void> {
+    const stores = GetStores(db)
+
+    for await (const accountValue of stores.new.accounts.getAllValuesIter(tx)) {
+      await stores.old.accounts.put(accountValue.id, { ...accountValue, createdAt: null }, tx)
+    }
+  }
+}

--- a/ironfish/src/migrations/data/033-account-created-at-sequence.ts
+++ b/ironfish/src/migrations/data/033-account-created-at-sequence.ts
@@ -29,7 +29,7 @@ export class Migration033 extends Migration {
       logger.debug(` Migrating account ${accountValue.name}`)
 
       const createdAt = accountValue.createdAt
-        ? { sequence: Math.max(1, accountValue.createdAt.sequence - confirmations) }
+        ? Math.max(1, accountValue.createdAt.sequence - confirmations)
         : null
 
       const migrated = {

--- a/ironfish/src/migrations/data/033-account-created-at-sequence/new/AccountValue.ts
+++ b/ironfish/src/migrations/data/033-account-created-at-sequence/new/AccountValue.ts
@@ -3,12 +3,10 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { PUBLIC_ADDRESS_LENGTH } from '@ironfish/rust-nodejs'
 import bufio from 'bufio'
-import { IDatabaseEncoding } from '../../storage'
-import { ACCOUNT_KEY_LENGTH } from '../account/account'
-import { MultisigKeys } from '../interfaces/multisigKeys'
-import { MultisigKeysEncoding } from './multisigKeys'
+import { IDatabaseEncoding } from '../../../../storage'
+import { MultisigKeys, MultisigKeysEncoding } from './MultisigKeys'
 
-export const KEY_LENGTH = ACCOUNT_KEY_LENGTH
+export const KEY_LENGTH = 32
 export const VIEW_KEY_LENGTH = 64
 const VERSION_LENGTH = 2
 

--- a/ironfish/src/migrations/data/033-account-created-at-sequence/new/AccountValue.ts
+++ b/ironfish/src/migrations/data/033-account-created-at-sequence/new/AccountValue.ts
@@ -19,7 +19,7 @@ export interface AccountValue {
   incomingViewKey: string
   outgoingViewKey: string
   publicAddress: string
-  createdAt: { sequence: number } | null
+  createdAt: number | null
   scanningEnabled: boolean
   multisigKeys?: MultisigKeys
   proofAuthorizingKey: string | null
@@ -49,7 +49,7 @@ export class AccountValueEncoding implements IDatabaseEncoding<AccountValue> {
     bw.writeBytes(Buffer.from(value.publicAddress, 'hex'))
 
     if (value.createdAt) {
-      bw.writeU32(value.createdAt.sequence)
+      bw.writeU32(value.createdAt)
     }
 
     if (value.multisigKeys) {
@@ -84,7 +84,7 @@ export class AccountValueEncoding implements IDatabaseEncoding<AccountValue> {
 
     let createdAt = null
     if (hasCreatedAt) {
-      createdAt = { sequence: reader.readU32() }
+      createdAt = reader.readU32()
     }
 
     let multisigKeys = undefined

--- a/ironfish/src/migrations/data/033-account-created-at-sequence/new/MultisigKeys.ts
+++ b/ironfish/src/migrations/data/033-account-created-at-sequence/new/MultisigKeys.ts
@@ -1,0 +1,74 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import bufio from 'bufio'
+import { IDatabaseEncoding } from '../../../../storage'
+
+export class MultisigKeysEncoding implements IDatabaseEncoding<MultisigKeys> {
+  serialize(value: MultisigKeys): Buffer {
+    const bw = bufio.write(this.getSize(value))
+
+    let flags = 0
+    flags |= Number(!!isSignerMultisig(value)) << 0
+    bw.writeU8(flags)
+
+    bw.writeVarBytes(Buffer.from(value.publicKeyPackage, 'hex'))
+    if (isSignerMultisig(value)) {
+      bw.writeVarBytes(Buffer.from(value.secret, 'hex'))
+      bw.writeVarBytes(Buffer.from(value.keyPackage, 'hex'))
+    }
+
+    return bw.render()
+  }
+
+  deserialize(buffer: Buffer): MultisigKeys {
+    const reader = bufio.read(buffer, true)
+
+    const flags = reader.readU8()
+    const isSigner = flags & (1 << 0)
+
+    const publicKeyPackage = reader.readVarBytes().toString('hex')
+    if (isSigner) {
+      const secret = reader.readVarBytes().toString('hex')
+      const keyPackage = reader.readVarBytes().toString('hex')
+      return {
+        publicKeyPackage,
+        secret,
+        keyPackage,
+      }
+    }
+
+    return {
+      publicKeyPackage,
+    }
+  }
+
+  getSize(value: MultisigKeys): number {
+    let size = 0
+    size += 1 // flags
+
+    size += bufio.sizeVarString(value.publicKeyPackage, 'hex')
+    if (isSignerMultisig(value)) {
+      size += bufio.sizeVarString(value.secret, 'hex')
+      size += bufio.sizeVarString(value.keyPackage, 'hex')
+    }
+
+    return size
+  }
+}
+
+export interface MultisigSigner {
+  secret: string
+  keyPackage: string
+  publicKeyPackage: string
+}
+
+export interface MultisigCoordinator {
+  publicKeyPackage: string
+}
+
+export type MultisigKeys = MultisigSigner | MultisigCoordinator
+
+export function isSignerMultisig(multisigKeys: MultisigKeys): multisigKeys is MultisigSigner {
+  return 'keyPackage' in multisigKeys && 'secret' in multisigKeys
+}

--- a/ironfish/src/migrations/data/033-account-created-at-sequence/new/index.ts
+++ b/ironfish/src/migrations/data/033-account-created-at-sequence/new/index.ts
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { IDatabase, IDatabaseStore, StringEncoding } from '../../../../storage'
+import { AccountValue, AccountValueEncoding } from './AccountValue'
+
+export function GetNewStores(db: IDatabase): {
+  accounts: IDatabaseStore<{ key: string; value: AccountValue }>
+} {
+  const accounts: IDatabaseStore<{ key: string; value: AccountValue }> = db.addStore(
+    {
+      name: 'a',
+      keyEncoding: new StringEncoding(),
+      valueEncoding: new AccountValueEncoding(),
+    },
+    false,
+  )
+
+  return { accounts }
+}

--- a/ironfish/src/migrations/data/033-account-created-at-sequence/old/HeadValue.ts
+++ b/ironfish/src/migrations/data/033-account-created-at-sequence/old/HeadValue.ts
@@ -1,0 +1,41 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import bufio from 'bufio'
+import { IDatabaseEncoding } from '../../../../storage'
+
+export type HeadValue = {
+  hash: Buffer
+  sequence: number
+}
+
+export class NullableHeadValueEncoding implements IDatabaseEncoding<HeadValue | null> {
+  readonly nonNullSize = 32 + 4 // 256-bit block hash + 32-bit integer
+
+  serialize(value: HeadValue | null): Buffer {
+    const bw = bufio.write(this.getSize(value))
+
+    if (value) {
+      bw.writeHash(value.hash)
+      bw.writeU32(value.sequence)
+    }
+
+    return bw.render()
+  }
+
+  deserialize(buffer: Buffer): HeadValue | null {
+    const reader = bufio.read(buffer, true)
+
+    if (reader.left()) {
+      const hash = reader.readHash()
+      const sequence = reader.readU32()
+      return { hash, sequence }
+    }
+
+    return null
+  }
+
+  getSize(value: HeadValue | null): number {
+    return value ? this.nonNullSize : 0
+  }
+}

--- a/ironfish/src/migrations/data/033-account-created-at-sequence/old/MultisigKeys.ts
+++ b/ironfish/src/migrations/data/033-account-created-at-sequence/old/MultisigKeys.ts
@@ -1,0 +1,74 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import bufio from 'bufio'
+import { IDatabaseEncoding } from '../../../../storage'
+
+export class MultisigKeysEncoding implements IDatabaseEncoding<MultisigKeys> {
+  serialize(value: MultisigKeys): Buffer {
+    const bw = bufio.write(this.getSize(value))
+
+    let flags = 0
+    flags |= Number(!!isSignerMultisig(value)) << 0
+    bw.writeU8(flags)
+
+    bw.writeVarBytes(Buffer.from(value.publicKeyPackage, 'hex'))
+    if (isSignerMultisig(value)) {
+      bw.writeVarBytes(Buffer.from(value.secret, 'hex'))
+      bw.writeVarBytes(Buffer.from(value.keyPackage, 'hex'))
+    }
+
+    return bw.render()
+  }
+
+  deserialize(buffer: Buffer): MultisigKeys {
+    const reader = bufio.read(buffer, true)
+
+    const flags = reader.readU8()
+    const isSigner = flags & (1 << 0)
+
+    const publicKeyPackage = reader.readVarBytes().toString('hex')
+    if (isSigner) {
+      const secret = reader.readVarBytes().toString('hex')
+      const keyPackage = reader.readVarBytes().toString('hex')
+      return {
+        publicKeyPackage,
+        secret,
+        keyPackage,
+      }
+    }
+
+    return {
+      publicKeyPackage,
+    }
+  }
+
+  getSize(value: MultisigKeys): number {
+    let size = 0
+    size += 1 // flags
+
+    size += bufio.sizeVarString(value.publicKeyPackage, 'hex')
+    if (isSignerMultisig(value)) {
+      size += bufio.sizeVarString(value.secret, 'hex')
+      size += bufio.sizeVarString(value.keyPackage, 'hex')
+    }
+
+    return size
+  }
+}
+
+export interface MultisigSigner {
+  secret: string
+  keyPackage: string
+  publicKeyPackage: string
+}
+
+export interface MultisigCoordinator {
+  publicKeyPackage: string
+}
+
+export type MultisigKeys = MultisigSigner | MultisigCoordinator
+
+export function isSignerMultisig(multisigKeys: MultisigKeys): multisigKeys is MultisigSigner {
+  return 'keyPackage' in multisigKeys && 'secret' in multisigKeys
+}

--- a/ironfish/src/migrations/data/033-account-created-at-sequence/old/index.ts
+++ b/ironfish/src/migrations/data/033-account-created-at-sequence/old/index.ts
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { IDatabase, IDatabaseStore, StringEncoding } from '../../../../storage'
+import { AccountValue, AccountValueEncoding } from './AccountValue'
+
+export function GetOldStores(db: IDatabase): {
+  accounts: IDatabaseStore<{ key: string; value: AccountValue }>
+} {
+  const accounts: IDatabaseStore<{ key: string; value: AccountValue }> = db.addStore(
+    {
+      name: 'a',
+      keyEncoding: new StringEncoding(),
+      valueEncoding: new AccountValueEncoding(),
+    },
+    false,
+  )
+
+  return { accounts }
+}

--- a/ironfish/src/migrations/data/033-account-created-at-sequence/stores.ts
+++ b/ironfish/src/migrations/data/033-account-created-at-sequence/stores.ts
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { IDatabase } from '../../../storage'
+import { GetNewStores } from './new'
+import { GetOldStores } from './old'
+
+export function GetStores(db: IDatabase): {
+  old: ReturnType<typeof GetOldStores>
+  new: ReturnType<typeof GetNewStores>
+} {
+  const oldStores = GetOldStores(db)
+  const newStores = GetNewStores(db)
+
+  return { old: oldStores, new: newStores }
+}

--- a/ironfish/src/migrations/data/index.ts
+++ b/ironfish/src/migrations/data/index.ts
@@ -21,6 +21,7 @@ import { Migration029 } from './029-backfill-assets-owner-wallet'
 import { Migration030 } from './030-value-to-unspent-note'
 import { Migration031 } from './031-add-pak-to-account'
 import { Migration032 } from './032-add-account-scanning'
+import { Migration033 } from './033-account-created-at-sequence'
 
 export const MIGRATIONS = [
   Migration014,
@@ -42,4 +43,5 @@ export const MIGRATIONS = [
   Migration030,
   Migration031,
   Migration032,
+  Migration033,
 ]

--- a/ironfish/src/mining/__fixtures__/manager.test.perf.ts.fixture
+++ b/ironfish/src/mining/__fixtures__/manager.test.perf.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "16aeebace566b6ea0b8b80cc8ec566954107fd74e29d03ea9b8fe1d530393801",
         "outgoingViewKey": "6f5862f6ed322d5bafd757a792a13442e5dd666492b6ea0dcf89732d78256e70",
         "publicAddress": "a805c8549eb4942bdcbcdc56c8c83881ed924b1341c44d0456dc27152e3e3a89",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "d8267ebb82942375847f6461bde52c5e2ec43140d60212258ec5c8f25414e805"
       },

--- a/ironfish/src/mining/__fixtures__/manager.test.slow.ts.fixture
+++ b/ironfish/src/mining/__fixtures__/manager.test.slow.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "71bf5067fb9f71c003508417db2bf7526e7fc8c4ffd6bcccfde25b3e26528501",
         "outgoingViewKey": "9b2a1a4c088b8b62eaa1e7f4bd49ddb1e190cf99e802e0195aca0b16f7370e00",
         "publicAddress": "cbb56c58e51a1591bcb08942c579e6e9c8f9e94e45f53aa9a9eccf8676f6f2f0",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "1bf1a42f4b9d65c06b4769f485285511b7e3b74afae1d0f62e7784267873e909"
       },
@@ -66,13 +60,7 @@
         "incomingViewKey": "ddcfd76bcccec321d72a10d344c012497bbe290570ba82c44af519b9ed223402",
         "outgoingViewKey": "7b9d6518f475b94399d835c63b6e11f10626d7168168a09237a9445e3a0a90df",
         "publicAddress": "695c8e40505b64b4f15fc6b787c9a186bc8b70bfa95fce6cf1b389a96d52056f",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "01db1ccf29440a84abc91fdbcd6e6e50026245bc66f0adba380065f57223b604"
       },
@@ -152,13 +140,7 @@
         "incomingViewKey": "3b7f236f54da49e99057cd32e58d870d4c2d124a996e56e146629117400fed01",
         "outgoingViewKey": "f986b6064dc98d6b835365cdf1f1966b7f4823af2edabebf5ea0eb72f8b93c9b",
         "publicAddress": "2bd459634e51037ebe4db46272bfbfc86c14b4d4ca195ee805a4bf5762d8e318",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "09d806d056550225dc7101c5ad4b1d0118b0af9596365e838abaf654fbab5107"
       },
@@ -180,13 +162,7 @@
         "incomingViewKey": "d235b93a7f5de883021277a7e6c6b7d5292592bb23081585d3b8701a969a6805",
         "outgoingViewKey": "ea891d1a0338cce986cbed80ab69ee848497b34952ca17834ae260f4be8c5791",
         "publicAddress": "238b6f085a5a773a07d1df2c1302a52969c9e6bd219269a62a5ba8baa0cfb2c3",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "c54ffb1e7b4b618c832d5ff0555a9df088129506c90c6a1d32245cdfd81f8106"
       },
@@ -292,13 +268,7 @@
         "incomingViewKey": "cedec06fe5c85c415c9478163af8a244e08b45b2782c53a943b37c985c5d6604",
         "outgoingViewKey": "5c0430ed1990827380f72e7217d0b2263d3c243762cf20236e621d30e12786c5",
         "publicAddress": "d784b46c3836343c6e904d010ef2b0ac5f8600b0892a7df075b5e639cbeac3f1",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "95dbee4a7507b26d528e64be8352e9ba04b811f7a19f91aaad9bfd17cb92ca04"
       },
@@ -378,13 +348,7 @@
         "incomingViewKey": "28a095a81cb832dab6145280d45ed2ade428980afb3e2294efee0a88de664802",
         "outgoingViewKey": "d02b576cc5b6681de96a1a8484411890155e85ace5cf0b40677684f8d63f27fa",
         "publicAddress": "d996d974b9d8c4fc05b69f64665b0fc198efc61de791904cce8ae31639fb5cbc",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "a3e06e58f79092c18a47c532efaec3fade3b742a90fce7a054ea401eaf0b5604"
       },
@@ -406,13 +370,7 @@
         "incomingViewKey": "761addb60b4089c1f363199467e7ed535314bf796d84d127ed7045d4b2c97501",
         "outgoingViewKey": "373a4fc3c1be7acf23aca5ab1df77e55e20330b8cf7b5ff05552b08bc5d7eb43",
         "publicAddress": "6c0486933c3fad366c5156d2c18e02da687b04c8de0d5aa54d04fb9434538f17",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "ecc84f79e58a05e078739c9bfbeb533c9fa7e1b96b57f4f12ce82ccfb479c901"
       },
@@ -556,13 +514,7 @@
         "incomingViewKey": "a5f1dec97698f23b51354ba6ca719b2fc1cb32643d1358da9b42984d406ebf06",
         "outgoingViewKey": "3ba811363532f0a28ab5244b221b02b420e13f9c079d7255ccfab0421bfafa69",
         "publicAddress": "797d6d0c12c85fe780c9c7fcf50290c3f1c8cdc5a308826d01071d96ebcb6ea8",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "d8caf60e1c2e99afddf79f2ccc51e41ff019eb5c3a8611e277cf9c025ceee604"
       },
@@ -646,13 +598,7 @@
         "incomingViewKey": "1ea52660b90ede3f3852b72a233b2ade57173d09648bd6b780bc60d58080a801",
         "outgoingViewKey": "684c980dbaae846dabbaeb7fb8d7ae8774c4c6d88184425f9b182860babdeebd",
         "publicAddress": "33c3f078a9a3346d0c4a935c6d8a88071cf2ab6ee0a89e962e6aa24e86161785",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "d0e3fc9b31c308809ff51ad820cd11355738188221b5f526b15548f0d7995300"
       },
@@ -706,13 +652,7 @@
         "incomingViewKey": "d1abca7897a0ae33ac04f1ca75b92944339027a454ea575a101fe2a12d8bca03",
         "outgoingViewKey": "f70f52e58cad6ec93207a5348ea2d430d8b36d60585b9df9d7328a27f6a040e6",
         "publicAddress": "6a4eb1097f36a2327e18f4181b069f927c8d9d888d29fbd18aff30c5aba3f76d",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "db5934e9d62d8b960571fdd102f828e89070afb2d99f77216e80015831369709"
       },
@@ -762,13 +702,7 @@
         "incomingViewKey": "9101ca1aa58220ac1692f060d28223eb5394dc643c6ae173f52d90f6a8c43605",
         "outgoingViewKey": "3f43351ac0d7d88e0a1c27b3f9fb536ef88a17f9779bea008967279a31cd2cfe",
         "publicAddress": "ee3175d7bab913d324c80845a9ff59c9da837b99c83e05662fbbb80020afa411",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "59894b4cc6f5fb4ce5395c9475aa576d8d734ee8d96ec6b9f051880daee27c02"
       },
@@ -844,13 +778,7 @@
         "incomingViewKey": "979801be52ede28e0df51e9c27331a2f8881ec07e77470ce0dd16941cf902405",
         "outgoingViewKey": "b80e978779e60f325a8ddc11f9ad92d3758e69579f9f8510b13ed8f4582ecb9b",
         "publicAddress": "dda970d64a5c91b473ddf82e18a00c73cca788e22d8a13d586e0809558c872aa",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "aa707f1c70fa9819a51fa1ea48ca3eaf2900a9e93b79cf0f869423b1ae1b9a00"
       },
@@ -900,13 +828,7 @@
         "incomingViewKey": "4a9f3d5e5aa6630c737daa5d1575845ead144f86a7312b1e1e82b26dc9214205",
         "outgoingViewKey": "7bea1974bf9d0fe8b1a98d2b8f281ef5e9f4d1cf58491f679265ec433c677a5f",
         "publicAddress": "6c430d95525b74ad7487b627940648bb28fc255888532f4639af0b2c349f9a87",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "52c9c5926c8ec66970b5776264c99b494bda1cb63e7b9855d5f24d29f484e407"
       },
@@ -960,13 +882,7 @@
         "incomingViewKey": "2f158849eb26585957134f13c1e7ac74afeb87fae7aa68b186dfc9ce42088906",
         "outgoingViewKey": "610fb80345e49120544db4436aef8312f1f2507b6f1f1cea5d110b22c9ed38cc",
         "publicAddress": "55f7cc929b6884788023c361e76637295919340a86bdc08f0c88071deb0aa493",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "f7dd5235b040d2f03cc65114bba84ebf0ec2fd0b2683c6c666e0b0ec672ad406"
       },
@@ -1046,13 +962,7 @@
         "incomingViewKey": "83e9c631d2c11f58d4ee69d2f1acd4ece9fe3c3625307d74db59a35b6670ee05",
         "outgoingViewKey": "781c6ed5b802ad44c684101316280c804a87f2d6c2e847e137c122665388b72d",
         "publicAddress": "b112e3c21782a754d6b8538f7801cea3b48abff7c0a4e10dcd4e782b2274efac",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "b7b652a403a0476902fe0f4aecd64df045102c9c9ba818fa2fe4dffa36d6e509"
       },
@@ -1128,13 +1038,7 @@
         "incomingViewKey": "c355501536417289d3bff9eec5209d9ae46c1e1de7ac2bc27be931fb59687b01",
         "outgoingViewKey": "cc5f82d9ebc69620fbb04bbd632c7787a0e98dd1f811d11a064bc3c33231684a",
         "publicAddress": "97a1311968bf528bf86c5fe358fa3f2beee08b2cf77702378ea67772deb5220d",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "0153897187ae36327917977591ea14d2abf745d30432da0bd384e28feaaa7101"
       },
@@ -1158,13 +1062,7 @@
         "incomingViewKey": "4da0ddcd61abfebf4d925328c0c337e84419bc72151f5a6b7fad87e60e0e4d06",
         "outgoingViewKey": "4334f7dd081b19c82f2c90f80aa54df19325a51bbd15cded22affb889dfc43bd",
         "publicAddress": "de96c980112bfa57aa9dfff2db522823bf5fa0acf139b6ea4daa38ce2838ae64",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "1ca16add44fe7d8b34dae62fc30fbc6802c675f0e774624904331186e688fa09"
       },
@@ -1188,13 +1086,7 @@
         "incomingViewKey": "0d38163e6412a59b999abad27555edfd3775288ce771fde90e63571e29654207",
         "outgoingViewKey": "986bd0df24967e1070df691754c28889bc9a50422f27c4b335574d77f28281f3",
         "publicAddress": "a360a2128cbf850d03940b5d4f0477f58ce28738cb9dafebe68b84f468530c88",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "8a1cc39438829515e56ac83158236eaf4c265fcc1f760189ec4a11d9d9787808"
       },
@@ -1218,13 +1110,7 @@
         "incomingViewKey": "a872b2a88554ebff19b21cf3874b9189c37dc1b50cb3d801d7c68e86a24e6706",
         "outgoingViewKey": "1cae03e46ab1bf87aa5b4ebfc033636709ea99f701bb9d9abad7579afbcafacf",
         "publicAddress": "10e22b4cad2ad004d904d3aa8ca29b16b40e154a470902ffcdb8500b53487fea",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "4f9162aa9a0b8f2b624373996b761ccabd69536be44f9dd226a453f936631306"
       },
@@ -1300,13 +1186,7 @@
         "incomingViewKey": "7d9c823bee8340949815cce88f1a7cd7dd4dd310ebe1a1cc69f5bd71f5290403",
         "outgoingViewKey": "daa113143e69223aa5a11afb1c73f67cc477cff8946e021c940f189b79faa674",
         "publicAddress": "391ed9950b53b4a6fa26a4cae4f4a7ab4bc891f3ccc3f3366f10b840dd6d8639",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "559d47a404b5b7cf188d9ca5c4b81c27f4e5c8980f0f5c7878c85ba8c9ea4a00"
       },

--- a/ironfish/src/mining/__fixtures__/poolShares.test.ts.fixture
+++ b/ironfish/src/mining/__fixtures__/poolShares.test.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "87a3ecf1ca4dd036258b3f890bc9801fe83cd6b3fa68f348a3ecfe3c578dd400",
         "outgoingViewKey": "d3f1c7d7c9a6e3955b8d7ec4450fd702f92bafff6c21bda57e9718507c25730b",
         "publicAddress": "5027b5e54378805079d897b7e91c4a6e2a675336f051d3ad5c8d2ce6c123602e",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "5ef5551b68c929c3db7fa60475baf1928055ac16e13c655353bdf4616b25e303"
       },
@@ -40,13 +34,7 @@
         "incomingViewKey": "0af64e07af2ddeb44152f1e62cfd2e4863b1fecbbc736b81d905a457f058c905",
         "outgoingViewKey": "a6c9ecfccb11d543bdce4479fe5d29547c36bbc882e17f1066982d7aca9ffc98",
         "publicAddress": "59b6001e83fd3a6b80daedf3ab1ad67f496806bad088ceb43248fb45481e0c6d",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "7196ee451cc1f7b95e3e53bfb44f3b45c05a6e8ae1a1df58812ab8f9ef871600"
       },
@@ -70,13 +58,7 @@
         "incomingViewKey": "8872fbb3e00fc3958350f1e7d0d66885273fb549a525a8be04ea5765cc99f800",
         "outgoingViewKey": "ea4e8f4d3cb8d7194434449d6ef1efd34f1151bc1a234ebfc97fbd8d9fac57fb",
         "publicAddress": "c31f7d5cddf9f7b6f128994bb177df7337909a02abc80eea9a2c44c0b0894fe8",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "079c06e6a6e3f4b2028746645e573ffd4a1276bcd05d35d63fa7c3d8d2f18802"
       },
@@ -100,13 +82,7 @@
         "incomingViewKey": "4cfcbe06a42ac4f3cb1db0c753da6ff2d1cb25e3f46024371891ce3f6a3ddf00",
         "outgoingViewKey": "47676f95061e5e707ecd16782f8645fb36ef16a794bf0f24950b0fc01d80aaaa",
         "publicAddress": "4d45c3aea5a48a6894e6308c5d589609a8aff83aab6904ad7d292870db743ecd",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "0242b47067514d1b3b96fe24e45fa8b73bf7a4b21c1207244cacd6e82e508105"
       },
@@ -130,13 +106,7 @@
         "incomingViewKey": "b74980171ab8da217ec9c25fdb3dd77d6a626abacad0c731be6f8c786dfa5001",
         "outgoingViewKey": "5d3c66ea054912516a3550e37274f30508ddc4e19d23642e37a8d96a9d050675",
         "publicAddress": "8c7579199c84c07df79808b7ea99d7a6a7ea22d75e250be8882ed63e5ca9c280",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "cf0457e9962e621b71dbc95e81f8000fd9a294b9d5dd2b3eded85435d3ed8908"
       },
@@ -160,13 +130,7 @@
         "incomingViewKey": "39f13ace0cf8ffb3fc8d75b969ff684033dff87863fc4105591cadbcafd43501",
         "outgoingViewKey": "cf431b5ad0fc17afacba829cdab91aa9ba7edd2b4f9185f5c0e0a8dc322b34d7",
         "publicAddress": "b96df9d9a26a555ae9885b6654a08844dd2eb4f4243bd1d3e2be8b569feaa604",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "353fe3e92360a04a3cf902212728ff5ec7bcafe55317de20542decc0ce343404"
       },
@@ -190,13 +154,7 @@
         "incomingViewKey": "20ff23ebfb5597528c3ca9d8f8a041ea9bb68131bb732f47cd4ab95b857ae207",
         "outgoingViewKey": "1d0bd639631318ddc6c0eea6eb706a61ca7b39cb38adca32ba6fbfba2fba76c7",
         "publicAddress": "0a0fce51eb25432cd813ef2ba136fcdb3faab1cf0fa5533ff50b40e942777fbe",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "e373347425a709c8c8c79deceeb67a30dfc4d2d1359a73727f6f4a3bf67f6d02"
       },
@@ -220,13 +178,7 @@
         "incomingViewKey": "130c83bad9142ca196f0aa26c780f9fffc50662101c7f1813669fad6a95fd302",
         "outgoingViewKey": "fac7695f687c20bf5f30097822871d0e105d6923354c80e01c53702843998f28",
         "publicAddress": "0c0765adce3b83ce0d5079bf1ca4a6f55e0e808cf45da5ffca38c397da571035",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "abd7b92057b8941ef9ed367ae3782f0fd6a6239207998000334ba247f4dc850c"
       },
@@ -250,13 +202,7 @@
         "incomingViewKey": "52e1d50fcb297adc74efac12ad9243ae273f7d1b1d1fe4f1acd8cc4454f80103",
         "outgoingViewKey": "e88079cd703323c773801344df8a0d1033f51d0453158da397469f1fa146c3d9",
         "publicAddress": "a50e88a71199085a5e4cc22da74e2b8920bed8b2a0176c2287f9193dad78b11e",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "660f68b64cb4cd709dfa5c3bcd50ead4625917d24129804a7b56c31e09d74700"
       },
@@ -280,13 +226,7 @@
         "incomingViewKey": "1ca2b9c3f0938d589882d5b0833c730a6f43760253df3f1c119f1a97098a6b05",
         "outgoingViewKey": "0352e1e8550063c44db4650d1b6c41bbac14006b7bf70e2cb1a0345faad610b0",
         "publicAddress": "ab9581ef2e7da183ffc59800f1f4a46b53f76453af231fd2a387e8986f8be433",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "9b5f2327935d5d7c437a12e09b75aa7d78b249565f6f762a5daa083c229a9c01"
       },
@@ -310,13 +250,7 @@
         "incomingViewKey": "49b8d4b2c719ca5698895b50b4aa32aacd6e064614a23ae90ff50fd3be4e5204",
         "outgoingViewKey": "a9eb8ca8bfc8800c1f6f17ba3dec7cd5f2339e50bd3437793cfb111c98006ba8",
         "publicAddress": "87a83a757a57f39b7ea8068f719424841683f54979e1f8d67e931e6f1d34ad29",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "10061c16222a3db20989a9eaa9e23f214877e88bd026481ec1824cb7fa651600"
       },

--- a/ironfish/src/mining/manager.test.perf.ts
+++ b/ironfish/src/mining/manager.test.perf.ts
@@ -14,6 +14,7 @@ import {
 } from '../testUtilities'
 import { BenchUtils } from '../utils'
 import { Account, SpendingAccount } from '../wallet'
+import { toAccountImport } from '../wallet/exporter'
 
 type Results = { mempoolSize: number; numTransactions: number; elapsed: number }
 
@@ -99,7 +100,7 @@ describe('MiningManager', () => {
     // Initialize a fresh node to get a fresh mempool and re-import the
     // necessary stuff
     const { chain, node, wallet } = await nodeTest.createSetup()
-    await wallet.importAccount(account)
+    await wallet.importAccount(toAccountImport(account))
     await wallet.setDefaultAccount(account.name)
     for (const block of blocks) {
       await expect(chain).toAddBlock(block)

--- a/ironfish/src/network/__fixtures__/blockFetcher.test.ts.fixture
+++ b/ironfish/src/network/__fixtures__/blockFetcher.test.ts.fixture
@@ -94,13 +94,7 @@
         "incomingViewKey": "4dadbf337463bd878ebb90931959fb18721fb3ac31da8d879f667a56cccea503",
         "outgoingViewKey": "e69ddffb85a833ec79cd5f4d2615375c50de94fed57d011372f164c9371aacd2",
         "publicAddress": "4f7dc6759c617fe1b59f864616b3d938732ac50ce62ba46da55caaba6108c319",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "6108de6c7f60f5de11c37f7afd4a46fefe8daedee31afe81e56864e825e8cc01"
       },
@@ -300,13 +294,7 @@
         "incomingViewKey": "436d6a91c6abba76b3059be99529f05a3a81025258ec0cf2399de5a60d2cad03",
         "outgoingViewKey": "5ee34b7f0b8be796a120f7765788973fe6165da3b94c930f23b32fa35c623a67",
         "publicAddress": "28471a17d96dd72d0b43525f6fa29d1c17a403dd494825d0717d1ff15d6740ef",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "36b97fc770f920fa4e89f7f89855db8cbded4959edf73560ec24d274a806af0c"
       },
@@ -506,13 +494,7 @@
         "incomingViewKey": "3dbe7538546154830590dbbe3860a3c213b7d49c2ac01505745cfcc7140e4803",
         "outgoingViewKey": "ade7f214edf2ad5513975301f7bb3b1a2bf43dd34abd203aa78c30b5db5f0536",
         "publicAddress": "c9a1de564f8a313eba285f349bba8dcc3ab71195c32ebef7773b5e22cffcb48d",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "d7edd751413c2fbe8c761923cf24e9f1aa54e1d55dabf0faa3ea07061b27e60c"
       },

--- a/ironfish/src/network/__fixtures__/peerNetwork.test.ts.fixture
+++ b/ironfish/src/network/__fixtures__/peerNetwork.test.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "0ff15bd853ef54c7e7a5354c07ea4391fc0977257e9b0d74406d40647da61a07",
         "outgoingViewKey": "d9977fb0bc5c2d6fb5b346abe12c41cabc7c5ff5fa19ffd36b8992a9e76be168",
         "publicAddress": "b071dcdaf075f82e732732f63aba0165ffa2773142d83a67db52d44055da565a",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "770ca209e13925ecc56f4ef3dc9d0d5e24df89cca4a5218232b6a65fcd844d00"
       },
@@ -74,13 +68,7 @@
         "incomingViewKey": "c6f5db098878c6e01d877d40f07efd9ff1c17d0c017ddc809b8a332f0ce34b04",
         "outgoingViewKey": "b8e4479493a7557b92b5d1dff598a084a27de4eb5aa8bc173c982a93dbc8f4c6",
         "publicAddress": "8c0f1d88d1fdc18bd937670c42fa531ad6414838d0a38e9146ab54eafc137044",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "2e3370c060217f38203134cd98b87aca4c6f09bc463c4da519cdcc9d1b111408"
       },
@@ -260,13 +248,7 @@
         "incomingViewKey": "b16a6a5c28b30b853bfbd595fd7cf582d1e3194f12e51eb5cd38167ada7be204",
         "outgoingViewKey": "5d602e7ba6aa86560819d39631d12a4748340c459b33a19fe8f1775c20dd2507",
         "publicAddress": "75a7b9c0af881a7d23caef89bc8f5c95fd27b736a9a070ccde463b8896bfc336",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "fbe38f330f1e1fd8ae4c83e66c6d70550337506ea136662cc3c8a3823c5e770a"
       },
@@ -324,13 +306,7 @@
         "incomingViewKey": "be44fcb6a2a86154e573c4492affada701296ec876629f40002ee604ffaa8005",
         "outgoingViewKey": "e8ae2564c73dee0c18c57099bea5382a293342c8d4e90e61dd52466cff685592",
         "publicAddress": "eb20966c088d3836693de19f0d536ab469a9185cd8a0b7f8d0bcdf33e42fd7bd",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "8124b2e82262f922dc99250c852cc79d37bcf9541112464855a6ae855e7ab207"
       },
@@ -2018,13 +1994,7 @@
         "incomingViewKey": "e008986839d2a31d5c53e0356ec47f966743ddac78922adcf5261570c94aa207",
         "outgoingViewKey": "086ab5643922cb88f52f3b8d0b57ad73f233d82a52390ea178b4176c20f29ebd",
         "publicAddress": "1d125fc892d45354b912cc02d0041ff5c7ec0fca1f635e3a9baead2a9cb55457",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "6ac977692d2b009e5f6fc24ab7478503973d36da5d120b31af2929e8b1929705"
       },
@@ -2046,13 +2016,7 @@
         "incomingViewKey": "9dd8576ecacdb97b5b165c0b784db91bd20087b310545aa49073fb7d6297e300",
         "outgoingViewKey": "a88f2fd557404bdf89a318e44156f8f2c4c9470559638d24c349fb311bcf0959",
         "publicAddress": "2b2a69d27cb5204605025a40633c4f25cf94b5444b390cb0885fa57a1143398e",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "12b44dc04a5477e04815e4ce9fe321e84fc9a9089f2118ce475e0f9febb3170c"
       },
@@ -2132,13 +2096,7 @@
         "incomingViewKey": "35d37e9a3f2f6c312c2d96a6c1f7adb760e56a882933072a99a408591d78e307",
         "outgoingViewKey": "fa65ba5e47b43d7edb43e1a7d1d31bf36b9cc98c633a38734b8d9b261aee4b89",
         "publicAddress": "eb4cc0fdd088df117392bc43792f9ffd0d6bee45752c27d56f20a3f1d557d1a6",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "0c86df1641553f8ab8371a87679a63f75b29361fac63613aa62a9e46d48dfc09"
       },
@@ -2160,13 +2118,7 @@
         "incomingViewKey": "5934df10af7ae6f65561561b8334c4f2bb39bd122d9467ca2f7e63543b9cfc03",
         "outgoingViewKey": "3fa8d0b1fa350115bbf2c4c02f6cc851cd8cab137a0777d6dc81b9c14eb9de5f",
         "publicAddress": "ceed0308fee361d0d97bbf9b748ce923a6ceecdfeaffab38ee414f53f0c050c2",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "07aaae15b3af2f2c068367a3b3f2a57eedbcc6bddba42784a70bfeeae92f6d00"
       },
@@ -2246,13 +2198,7 @@
         "incomingViewKey": "16de44fadcd1d944d530427fa5c96b574ef1a4881374169e2d0e1d5165bc9d02",
         "outgoingViewKey": "fd0ae817ac451ef961928795f50955cd12d4844e5f5582f7dbd763c4dc4b609a",
         "publicAddress": "9ace7ba7c5b7f855179dc24b6fd0d21ec75901c41c2194c29ca47ec8391c9038",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "85013de535e49050ae6d8accb460865e7ad33054067b32edc0f93ab29a0bde07"
       },
@@ -2274,13 +2220,7 @@
         "incomingViewKey": "282d1a13e6d6a51e3933d2646fb3be5474140faea1325b2c93a9b4cf302d0b06",
         "outgoingViewKey": "3aa8f61ec1d62237410a2f2c60221e817df74ab6bae89ca141f9137ab8b0c23b",
         "publicAddress": "905b72876b75c49450b4d4af514709338ae0bb981aadf16d4c2a2bf1e3bf2ec6",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "485c5a50c09dcab010363afc530c98c592cb517942e3fd7fcc08cc14651a7508"
       },
@@ -2360,13 +2300,7 @@
         "incomingViewKey": "fafb71c7d55b0e9ebdc62cb45e7f45a1591bb5d94c06dcc4c05ecaf0cc465104",
         "outgoingViewKey": "a31869184b83845840a172c72d3cf7f2b27b4e9bcf4432ceea044a1ee693f2bc",
         "publicAddress": "d6cb525c8d2f48d0a6f33bfabb75d9b74725eb078344e8e180c8a1aa21490d5d",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "8048e94fd99144c8ff5b81312f904496eee6ee18aa547d9ddc75265967a4760c"
       },
@@ -2388,13 +2322,7 @@
         "incomingViewKey": "5bf0da475c0e9889036b86858c49e2f13baa197b83f34f995e9a22f8aa4e4d02",
         "outgoingViewKey": "3a5cee62e67fcd4f71978633b1335120361580dfacd6939b3074c426cf1a4d80",
         "publicAddress": "adcc88dcd41afc5694085432e6831ff7dad1a48168c173a0409aa06b7fc0eba7",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "54caa3ac6b8bd5a13e32b8939e3ebe9858e9d41effea0403562f3fbd8a01ce05"
       },
@@ -2474,13 +2402,7 @@
         "incomingViewKey": "003cd141a40b586a2671c7abd7c4ec964141821c045b1050d381cdb389d72c06",
         "outgoingViewKey": "131e8ff48484453f07f14e0bbffdc9510effe3d2eb5364a1235000b4ae53d662",
         "publicAddress": "8dc1c9fbb82f357a75f1a5698ba856c99db955e1772a37f14f304a81c8062c15",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "af3aae7eb5a2d6302f49834f4127f9853e3dc36a72f659c0a9ec6d2a72e6dc02"
       },
@@ -2502,13 +2424,7 @@
         "incomingViewKey": "5be09fe7c407b5b4bd0baed22c91c19ded47327daffb07e28b41117440907a01",
         "outgoingViewKey": "a84c67e5475289b8146d375aac69796712d9be275048db6401b09c492b7e3fb6",
         "publicAddress": "256b3ad7ecb3c852426bc41391a8b223caf9e8e1ae1d0cd3009b5ba2d5593d82",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "0a5398155c90c7b55dd7b38b9df741f265a683383ce4a543a992df039b684808"
       },
@@ -2588,13 +2504,7 @@
         "incomingViewKey": "b71f9db7e4fd9b768531d8766a9fed5aa6c57f50c8d4e4511c46b7fcc7ac6e06",
         "outgoingViewKey": "e328042580ffb69cab0c538c93fc465350165889ac703b0fd126f6c99d5f0bf8",
         "publicAddress": "fbb13149a0580d4106624154bae645dc257f84da38fff69c38c91d9909125762",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "18da85a93c5f25450fc58815833ebbf1b660188c04ab2f16be9d4433f6bd5700"
       },
@@ -2678,13 +2588,7 @@
         "incomingViewKey": "e9ff7e6d6f84681ef9569384df60b167e2b73432bf297d4522e64f66df138305",
         "outgoingViewKey": "d3e1f69e4b8ac467d030573b52f576d8e224b4f75c070386c5458a5e8ec3df27",
         "publicAddress": "580a88393d5526f01e8bcb2d942c3ade396667b19c4b3d3f9d6988eae117c0ce",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "5775abb7babca0a45c8390b0fa91d5d3c07b7c090e2780a80f8a0c3e47bbaa0d"
       },
@@ -2706,13 +2610,7 @@
         "incomingViewKey": "04549a43c9d519dc82d2797fe6d8c476dc6b5775da246fdcb38a2c0057ae0b05",
         "outgoingViewKey": "b84230a63de95d5d8a956a6e851335189fcbf29b5ab8a86ed5a71281113576ed",
         "publicAddress": "e43f433f9a4618d0749f8a8b6af6b3d697539b6c623d54c1a645a281b58d886a",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "dbbfccd8b12ea68f353fa395d2fc91b4c20848e4200320fa8113dfd1064be206"
       },
@@ -2792,13 +2690,7 @@
         "incomingViewKey": "d87732bf1df105ac77e3da668a6160ed71a1155d80b5d192b5001389353c9702",
         "outgoingViewKey": "edbcbbd08e3311f03a8388774d450b95947338b786189cef2ab5e2b8b7f9fa0d",
         "publicAddress": "eee443c63a6c2be7f8f4632f4d1323fa4f424e4188a8036b5569ec51b1b0f3c8",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "63405cadc17e43455be4e04003bf690eccde520ff3ab65ecf8c284bdc4fc4c0d"
       },
@@ -2820,13 +2712,7 @@
         "incomingViewKey": "dbe7bdd086d2cb61c13cb8ca9b7317d0833567a5f67f40e22be33ad3668dcd03",
         "outgoingViewKey": "9d7775a3f8b62ea31b8cc7f7b465f2136aabbed734a1d47715dc848bf07f6b6e",
         "publicAddress": "c10e9b0e0b43f9b9124c9cb68e95152ab16d2274182cb101101099f22648631c",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "bc752e5102ce07e58f0dbd4793192d39db16f5542aba0e84130dedb9f4073301"
       },
@@ -2932,13 +2818,7 @@
         "incomingViewKey": "b5a40d34395b471ef62d436e3985ecbfe9bbd396a6600c10f77a5f19a50a8d00",
         "outgoingViewKey": "c4405147fb3fcf863134e5f539f6f66679746220532c366fe7d700c03fe06eaa",
         "publicAddress": "d23368835d4bf19be83ea2f35f331b7fe42ce3f4abadd0dba8549fedaa72c955",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "b28036262f2f93bde2d136b92d1b038d492495060c9cd45b786a57ad13fd1304"
       },
@@ -2960,13 +2840,7 @@
         "incomingViewKey": "1db6cd8c9ccbb12c77d4d4af29d4383c71191038ed3958230f0c2e5b2b5bb007",
         "outgoingViewKey": "1931a64a7e728f4613d89b21cb12a6f463d51742694e763a3d29687e426044b6",
         "publicAddress": "3ec1f268a725e4bb18ef4600343dbd2f12b4a8beb6d0cd2527b46eacb0a22adb",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "7a5ba1963afc291412e51a4a022f6bf35c607175c98afc74fe06f1801b27b206"
       },
@@ -3046,13 +2920,7 @@
         "incomingViewKey": "a6ea6d96525a8af4ec440a2986769ddca36f7ce8fd1d9bea43ee330ea78d7b06",
         "outgoingViewKey": "3294c70f28ca96a54dd250ac8828a76eebccf6b042eedceccb4c222a9cad99d9",
         "publicAddress": "f4a0909de6f424ed8f421842fb53f7dc7e36e78529ebf2e8228e7c11b3a3b2b1",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "5a4e99b58e12f17b0abd631cc42f0829ab74eb625926f558d3af24921ef2c70c"
       },
@@ -3074,13 +2942,7 @@
         "incomingViewKey": "b97c53e42bdc0c931f75e47c6441a5ca3162e4c9bbf320c8ba0b9a2691363107",
         "outgoingViewKey": "3db32f45180abae8d4ed1def454c014731a75be3d428a435b8135affaa617092",
         "publicAddress": "7c82563017fd87ef92007216bac6822414755f37091a727740501a362bf20d11",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "7763391173c42d663bdec19f6062ad6eb2643a91f9c8f5d3169fd822bf6bc402"
       },
@@ -3188,13 +3050,7 @@
         "incomingViewKey": "32eca8079331176d53730db3928e802fe68132dea5b810e031326eea3e097404",
         "outgoingViewKey": "f5d47b6fc4021e82c9a64bfaeb3fc107ef9b34227b7c9d012ae42827b8b9de5c",
         "publicAddress": "97ba6f73e2f4c8916db3bd06c234a4cf640b4fce0de05d69f846ff9ec0934bc2",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "e011131a1506549b642d895467fcd14d8eb5c3a3fca13e62b727459f8b6cea0a"
       },
@@ -3216,13 +3072,7 @@
         "incomingViewKey": "00f09893dd909e7630aa8b448c988804377d417bdb963cf827e35748c995c500",
         "outgoingViewKey": "0229dee182057254ea827e0f5e8a80e4b1b3596325fd699f23debc5df8703ded",
         "publicAddress": "ca1a07da7ba050c080fde8adc8d20462372f7d9d2a479c99c722f2dbce665b0f",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "a91af23cc4178c6acf83524e8b90d29a1c1a720b3ecd1488f0da7f843d5ba40a"
       },

--- a/ironfish/src/network/__fixtures__/transactionFetcher.test.ts.fixture
+++ b/ironfish/src/network/__fixtures__/transactionFetcher.test.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "781be34d888818f58824331932e1e37b59358f0b11d42a8183ca5564e0e3d206",
         "outgoingViewKey": "4fe4e24ace26ce0ef198a206c9f76e510b836a8705769fc4ac7b9293e3b380cc",
         "publicAddress": "d48aae40b11f6a36345090e8acb99e477165d95cd847e6e61c18e25bbdbbeb5a",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "9d50c7500c67ea546becece39480314eabe8d3b88c2fad83e62a5cdd0fc4420d"
       },
@@ -38,13 +32,7 @@
         "incomingViewKey": "16fb80cf0523ba5de5843cebc0c87d29b9d7a93d19ab7e774205e99cf7254400",
         "outgoingViewKey": "486b92d8bec1cb0361fa534a8f8d62e2b7b14a53fdb5fe1b7054e01b328b289b",
         "publicAddress": "998d3f3840e6998931e41531ecc61811160f7256b2bf488d3e94c48764b01117",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "4aff11aa279d535dae4085c95a437a2fb02f23728ed91365ae4b0c9e3b5c080c"
       },
@@ -124,13 +112,7 @@
         "incomingViewKey": "9042e05b674f2142ac633f7bc30cfefddbdc542422f7e3037d530c34c6631302",
         "outgoingViewKey": "709fb4a434097bc617325e58dbc962e4b16e58541947d472424efe29d1799382",
         "publicAddress": "7e8eaa6d90e0ef3281d03bdaa0eff16bf76841d98446fc7238f787bafa8c572e",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "22b80b404eb82fbf7d88b0da85247f7239cb5efc9ef2d7446fb393d7976a7701"
       },
@@ -152,13 +134,7 @@
         "incomingViewKey": "294fb1a7beecd0f99e1b754675dbbe603b0a4c24fc23521ee725388120220a02",
         "outgoingViewKey": "d0895aab83bd2dd86069804f369b19ff40ef6c16c7a9c883414b8c2475d010d5",
         "publicAddress": "f71a47c668e06f559cb689ec177672ddfa07a43bdfaf137a3729f459efe57a1a",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "22cb83afd79aa6a3cb90b951a97d52530edff1abff4de579f4ee3a9eb8d8020c"
       },
@@ -238,13 +214,7 @@
         "incomingViewKey": "96e116729b3cf33a20d6e98489bd69dd5364b3552cbf81d64c93712931d1cd00",
         "outgoingViewKey": "8258c135399f31049d561ee5d90dd21f8d020ae64ea436407f0629a9a2eb31c6",
         "publicAddress": "b1fd3e52b001724b5ffd7fad71a92213f212f1aca48df81a729dfac3483fcc0f",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "644f0982533e2680cac80775bece8e2cd1f829c43813b7aacaa1a4803a51b607"
       },
@@ -266,13 +236,7 @@
         "incomingViewKey": "d7b319189f2005433ad68d8891ba4698329e35a4faffbc7785f29e3f2676c100",
         "outgoingViewKey": "1a7388c2aaefb3dc41dad8802a150c24faae1bb18ea207ea043074a8f8439b51",
         "publicAddress": "59d754a28bc85d0682f9b58074ba58e60db6f816229a8edc22ac71ad48546e73",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "175f0820827aa5b1281cebfc23730a518a213d9a839d098c2ca92d2ba91aed00"
       },
@@ -352,13 +316,7 @@
         "incomingViewKey": "bc0c770e31ac3c35aef5748d50ba710f653c0797cb8a95bef286cb87c4b84a01",
         "outgoingViewKey": "b85cb3a8372b94f93424e24f2ecfd0c4a99fdb30f5a13abcf513dd61edf64941",
         "publicAddress": "33e194acacbbba6a8352e7a8302ca05175e4e6ef496eec5826a05abf61eddbe4",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "9506da910f641164ccaea36b5dd1bc80a226a1e41d33bcdf1d720c96d82b9004"
       },
@@ -380,13 +338,7 @@
         "incomingViewKey": "8d620ee4387d02b1a966be56f902d6a5c2b2d89f565cfb53cc0eb0660a4bf604",
         "outgoingViewKey": "5717e95165731eacc45224783b0940507a6e0a45101766c6dfcef3674aa861eb",
         "publicAddress": "ce93e8ec32f81174cae3b5172089f0ec4be948b827072c26a3ad82641a69aeaa",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "e8d8a640c1e2519d66595626793da83e9174d77b07bf254d7f21b856fa077500"
       },
@@ -466,13 +418,7 @@
         "incomingViewKey": "d32cd4e27a9de6b42b229edc0948dab2b3c947c3e0b840a019d5f592f7d89505",
         "outgoingViewKey": "cd68f41469e10fe3da512c38cca0ed61c2e06050fee925406e861fcd5d893014",
         "publicAddress": "88080af53d7db6d73a6edeedb50e4b7812b7aa222997e7c448a931ac8da57a3c",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "63ad90a0c6e44416af95e4a907926f78f0e6d5821b0f63548159c459aaef4700"
       },
@@ -494,13 +440,7 @@
         "incomingViewKey": "3a740c73c9717b5bc2e46f5af6225e539e37dd1ca4007a8813f84356b11e5902",
         "outgoingViewKey": "7eb00d68f2b137e325cccef011f5b3ccc3e87fbf54f384752a161f0266e8fd90",
         "publicAddress": "106bd9ca646878acd64006ab9f6a672680455df8d1890c64cbf8bd8abf80e1dd",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "765cac0d01586e4f9435a5fa638b9aaf6a760bda10e08183607415844e1ca00c"
       },
@@ -580,13 +520,7 @@
         "incomingViewKey": "548f6eae46ddcde88f3b221dfeacaa096196f0527147ba5ce44d0d060d2f4c07",
         "outgoingViewKey": "cd0ef3feac1f0971823c6545541447e339e0511a15b75339ba7569025be77b1b",
         "publicAddress": "e15d5a1f07e7760c0de873fcf45181b6dcf923be9879851d4546ccc6993d250c",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "a335b56bd376c271621ea7e8a549a2edfac079adde7b2b0cb76f384b97d4310c"
       },
@@ -608,13 +542,7 @@
         "incomingViewKey": "2e8d8558e29341cb4a4f63873e7c4f4c341f17f521c8a6b496a57c5610a95b06",
         "outgoingViewKey": "9f60af88258f6d413b1a0f5aa681f51ffb7835d3f8d0ff5fe94a6294b783c48a",
         "publicAddress": "96e4691cba4791c0ad48d6e433049916bd7541633b0751509b301ad9e6e4e311",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "d4cfa6cc644c8690094250c0b41ae308c16983f046d7a7ac9a38a507a8fb0b0b"
       },
@@ -694,13 +622,7 @@
         "incomingViewKey": "1fd540218fef00f9acd6fb30d2f4b8a749777bec451b2e6eb2bd2ab81a0e4705",
         "outgoingViewKey": "5066933d19ab16d4143a428c930d1a9d8589ef8d64e9848fda4a02f66c128359",
         "publicAddress": "9187e5cd3dabfebbbee0031407683c5691f129a134e825a888193c58a58b0d03",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "11e410de3eeafc1eafd6f97d994099d18f66c91e92515c0acb65584cb58c2106"
       },
@@ -722,13 +644,7 @@
         "incomingViewKey": "bbd53db87c92db69ab70008601e01ffca1c3c8f1f67cf6a9efb521a844cb4c05",
         "outgoingViewKey": "c17441172bdc407d211a66dc2f28c4fc7f1a3818b7ff4da14567309b09fde482",
         "publicAddress": "e58c63d4528d14c9b03dfc50af696c9e5d21af82f13d245e724a1e2d0bdb3521",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "585292a6d7a33441e4e55d40ec15880cce347353875b7cf993a455e8ecb6e904"
       },

--- a/ironfish/src/network/messages/__fixtures__/getBlockTransactions.test.ts.fixture
+++ b/ironfish/src/network/messages/__fixtures__/getBlockTransactions.test.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "6461c45a3d01daf3b5142e0fd4f5902cc6426e364afb9aff3e22cce844a12f00",
         "outgoingViewKey": "81ae666494f863ffea0fcdffbd0f33ef7b5615f71c4ec3a6ef69dceb3918f0c1",
         "publicAddress": "79b81bfd6088f276291d595dbc20368d3f590ea090e0b8374d4e3e0639624266",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "5334e0a957a4b619c065a0109e0c406339ddef5a3705995bcd37cde7e2f3980c"
       },

--- a/ironfish/src/network/messages/__fixtures__/getBlocks.test.ts.fixture
+++ b/ironfish/src/network/messages/__fixtures__/getBlocks.test.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "7036f248233413f60aa8d776ffa329f36dcd9d5262ccbc46a00f5a2e23627607",
         "outgoingViewKey": "b75446854bab30c717f322b4feabc9296522d9a134686db7d5da1983df964db5",
         "publicAddress": "25e53d32c286a95ac67d4efbcd35ca0841757d7c1be5be333c59ec5d2c1a4f47",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "9f2d38e9ecd754170a6243a75fad5906c18bb2fb621c1bc250aea92e5e2f8d05"
       },

--- a/ironfish/src/network/messages/__fixtures__/getCompactBlock.test.ts.fixture
+++ b/ironfish/src/network/messages/__fixtures__/getCompactBlock.test.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "138c75f9f3a5abff9487f8c091f82cf284c516eb3c6124eba61c62800961d301",
         "outgoingViewKey": "4f51f09d539d6ba2b91c42bae6466b81bdb564e07cc2242fbbf5abe7e95d2748",
         "publicAddress": "ae560a6703321aff5697ee2c47be33f340738ace5755cf09d678caffbf0fa105",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "d27ad3cc8a013d0aba56e9a7140562334f050778945ec0266631428e3c67b109"
       },

--- a/ironfish/src/network/messages/__fixtures__/newCompactBlock.test.ts.fixture
+++ b/ironfish/src/network/messages/__fixtures__/newCompactBlock.test.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "c1d9a24a375551147c787690ec2550393828af65f8372c75b1b0c4f355fc8402",
         "outgoingViewKey": "5cdccbdb899c1e30d0260153f1f827f6607bd4839cee9204d996c0aabce61b71",
         "publicAddress": "4cdcca459b02c986234b95b946c1126e6411b356af0ead539604a6a18230d42f",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "fc2a7c5db13bcb78191135b128456bbf73bf2bebb7a7045ab7ecd763bd3f4603"
       },

--- a/ironfish/src/network/messages/__fixtures__/newTransactions.test.ts.fixture
+++ b/ironfish/src/network/messages/__fixtures__/newTransactions.test.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "0cfb2878c93568d9d146b42fcbbd3c1a1b15281da0ea8f3bb9708b084092fd01",
         "outgoingViewKey": "a2fe285ad3467f77656bdeab488d33c24255ff0b00724eca76c1a0078402a38e",
         "publicAddress": "9d7fe5704bd95292092514cfe05139ac0eabbab59c6523bfb79e2c1e49cd6744",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "352328510845c5e0cd4dbe4d4bd484d076eb06d74871619b5bd1a421749a1500"
       },

--- a/ironfish/src/network/messages/__fixtures__/pooledTransactions.test.ts.fixture
+++ b/ironfish/src/network/messages/__fixtures__/pooledTransactions.test.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "8308d55c8032414f80b971578c1e7e933dedc791c44e64538447aa57cc176207",
         "outgoingViewKey": "f94d2a4183be7a144decc1e19e4b4a2007f4a985c56e5b6e9962cfcc159f35ca",
         "publicAddress": "e651cd078d5bdebd637738a63b39e87b7f2f56c8f90631ef91f29e0277306671",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "c418f93c70fe950c9453aaa87504877476d7394c390dfa9935bde6dc7a24830c"
       },

--- a/ironfish/src/primitives/__fixtures__/block.test.ts.fixture
+++ b/ironfish/src/primitives/__fixtures__/block.test.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "844afee785d2e03e7bd23dc7690360c2737a8efd8f3622b08f86f7dafe80cc02",
         "outgoingViewKey": "8e145fbf7cff75d28029cd6d64ae8593be6d2a0c84ffe9c6af5e7d670b13476c",
         "publicAddress": "b2c930b390f58849daac00853aeb483661eea0a7c08f9e651ad5f49395c007c1",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "db332f6d102dc8663f7865baba4140e519da0a9f2a7028614afd3f2d90b1a600"
       },
@@ -38,13 +32,7 @@
         "incomingViewKey": "89287d60709a3fe8008a80ae3fd3ea6203375cfe1b4a3db2c4912e7a3b6e3902",
         "outgoingViewKey": "0f9917d0d7f02c7903b1b0baefa0f365c3abbf134beb33298786d75d063b2271",
         "publicAddress": "923ba3629a36f3b36d0de2784a5d3929c32032ae28fe98d9e787e6cbf2e2c566",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "4568de98f714676cbfa7f3ec755e9f3944ab29396c989e054a477ab408243608"
       },
@@ -152,13 +140,7 @@
         "incomingViewKey": "ac8b3a96cb6cb016f90a4477736aa883e9a7f97d52d88f0be560d6d00ed5f202",
         "outgoingViewKey": "a391670c08a40a52c8d182336ae1911928412ffaf109c6a48dd2600f0e06ed62",
         "publicAddress": "a0671795b5771637ac17d07d92b7f3f57659186168b4374dd394f07dcb48372d",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "d8594fe840528b8fcedfe105dc69fd568a8bcffbef84541c578e11551829440b"
       },
@@ -242,13 +224,7 @@
         "incomingViewKey": "98418ed78d23b3e4fb27438826d8690b2db2d127890b87a65b06e4750326a906",
         "outgoingViewKey": "793d58d941683407aa13f034bcec86387985ad4ffeb5860969e1aaa319cc7105",
         "publicAddress": "9093d4c52c741d2e9a90de2a639be1d6b239aefdfa43176959189471ae042531",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "884edd3407652fc1443cf89c191f517ffeb2dfc6e630b4c2abdc25b9a041d30a"
       },
@@ -356,13 +332,7 @@
         "incomingViewKey": "fecbbf47bb917f14e8e208dbddfec54b66fa6a0bc6bb4e351bbc32a89dc1ff04",
         "outgoingViewKey": "d0f9b35210d145b36bdfedca31b0db0f934f475bf49db0c6bb1a88798e5a1d2a",
         "publicAddress": "1356f7e0b6fc6dec3a5d57a8cb86fd8b529811a6ba1e2a1ed5d1299c239dfed7",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "d8e304af458933dc5e40cfb4c95d9e06035aa9c07adbde4f6185e65b4953320a"
       },

--- a/ironfish/src/primitives/__fixtures__/note.test.ts.fixture
+++ b/ironfish/src/primitives/__fixtures__/note.test.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "07f39176c60c0a8a601e4c07edd8d051bd1ff494309ea6c67e0afd2d4972f106",
         "outgoingViewKey": "b21a3c72aae7b27c3617103365378f48eff2c0bb1d0a3449f3240b15e0af93a0",
         "publicAddress": "a007411ad315ddaabd22545187241b37b46e1176d7fd6bdc4f33182b839f0907",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "0b14002f0091e15016419f636d6562cf69e07ef0ba25a0330b4209e423e8ad01"
       },
@@ -66,13 +60,7 @@
         "incomingViewKey": "297b8020fc5deaa192de642ce5b2810969f143355cc7e7a89b0f30964b35e705",
         "outgoingViewKey": "4795c829d68e5dc83eeee8fafb7ce3a79dae1f3bdb97404a43565a2f6ddf187e",
         "publicAddress": "57e217fb045825ef5b7008cded044e6848f15b83d9f34c35e9c7252f6c4325d3",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "8de91233bb6c461e97442b4681aa88f78922d1f7a940cc32a4a39af7f9962e05"
       },

--- a/ironfish/src/primitives/__fixtures__/rawTransaction.test.slow.ts.fixture
+++ b/ironfish/src/primitives/__fixtures__/rawTransaction.test.slow.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "df0de3fedf22853e8ad0977e56aa0b5cd04787c4a7cbb40d02e915da52247706",
         "outgoingViewKey": "4e79b4081ef66e6d0de284c14529294bc8ed69ea737a19ec54d22f26c9e8dc52",
         "publicAddress": "ca6e5a2ae955a027a2d75bb38962f68b06f6985d8a362d5f4a393090b1a73653",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "621c5f6c63c9e0688aade0a398b24e15687bd4c0c3b72112ab223538053c920c"
       },
@@ -44,13 +38,7 @@
         "incomingViewKey": "f3d9a01236d1111cd4e22f87eed93272eb0a03ac55db7f3d5f937ec6953f5004",
         "outgoingViewKey": "b007fed4cba0e5ae21800d64f358ab434097a19dc2fcb1dbf4a15bb39ed4d013",
         "publicAddress": "0a3440a7c169322f4682ada244b24e763c0fc0a5737708436fcf8e6a4608baaf",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "f75958e5e1bbac7d5ce35701ebcfbffbdd06d0fae9e24d1c7615ba6e3fc74906"
       },
@@ -78,13 +66,7 @@
         "incomingViewKey": "117e7520573e16fb5393720fad510a51e0c2c34f5a35f8c63eb7112a6ee8aa01",
         "outgoingViewKey": "cc15d7e8764cfc37d78e9878c7742758ac5e48f36ed71c3a939db9e0f2a39208",
         "publicAddress": "4fd817b6404e2b3e93f58d9d7da03a92beadcf6e5ecc18310c9d3bd1d7f4866c",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "328c13ce5669d22d3526caf1f2dcbfea1189fb27d22b0632876d8e14e055910d"
       },
@@ -112,13 +94,7 @@
         "incomingViewKey": "7b14f58604c5a1a36d0c2e6a325416c119813b04a826b54d83836c8813d48106",
         "outgoingViewKey": "a5e92be651be199aa528d5cb31fccfcc6ecfeb5d6da97b04982f33e3a1ee619b",
         "publicAddress": "d1b8044eea25cd37bc39d1fe17b4fde08b15d43d0c0ab3ed01efc79b55505ca2",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "d21264a0bf058abce89b2fe1f017d2faf2c1e3e8d48114242dff58f971cce602"
       },
@@ -146,13 +122,7 @@
         "incomingViewKey": "230a155ca4f25451b16d30a82eaae64273012c7c4676ed6c479ddc2905dd3c04",
         "outgoingViewKey": "a18f6a40d2f78af1c56aab5c08e65c8f7112369584d4058aa084722bdf6f88e0",
         "publicAddress": "6c7ff7c6e7d1a7ef888e8421d9cf90491c96f3c2f19af07a6ced3bad76c0956d",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "6c98e2f8c0a773c3fcb3a7bae19e0b720a673dbfff5b0aaec0b86e34dfd8210d"
       },
@@ -180,13 +150,7 @@
         "incomingViewKey": "ece3d97a7b31b12b4f874d5b16da1868627b56b68f2445da2695111a333c9f04",
         "outgoingViewKey": "5b131060e3658049c7f7d39b58cb918d24f03830258ed5e5a5fdfa9ad814d869",
         "publicAddress": "cc17d9b164c5e2033697fe183e1b1a99e5bdadca2082e26d43c1d9ee160a1e18",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "e6548261b72441232f87b3ed53447c1c5152c5674ffde391c1263c9444bb350c"
       },
@@ -214,13 +178,7 @@
         "incomingViewKey": "10bfc84c531f921b6bce77935f5182c71b955cba84eb9a4aed714e94a16b0a03",
         "outgoingViewKey": "ef6856043de1e273dca61b355cafc173e93cdbd9fa10b4bf7684b2e3599b3952",
         "publicAddress": "70e012e4d5e777e8ac5a527774853bce642aa7f99d3b14bf521975ab062a9e21",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "bd26d9b035f7164a45638cfcf2a830687611df08d9d181cdaba4d0d48fba1603"
       },
@@ -248,13 +206,7 @@
         "incomingViewKey": "2731eeeca629aed44ab9f58479662ca9d0ef5761af5778af2ca41fe6c3410104",
         "outgoingViewKey": "0fb9ee5f055ee7809130e28a625f6aa39699c7f877100e5b3171a02ee988ff89",
         "publicAddress": "e013322320fe32337166f6aada1fb4ee5e95b2d71bac2f065dfeac59a152643a",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "01d51ae59dfb5151d7987843101dc86a40015f5636999dd102fcaabc62e2e508"
       },
@@ -282,13 +234,7 @@
         "incomingViewKey": "c25e52bf123eafb98a26e5acf84c33a5cee0db179f6725025d93816eb3592205",
         "outgoingViewKey": "f30d86cc97a4454aa5ab7b3a4339e54967c2da291b047f9bf069d9a7a1e366e6",
         "publicAddress": "6816b1e2c09126d8b9f32ba9b606c78f9ad7534256f72733df079eb6c682bb3e",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "84bfafcba4db4a972dfe7a991b4ba41cd4ae40300c2ab00cd9a1bf4413509a08"
       },
@@ -316,13 +262,7 @@
         "incomingViewKey": "9bf3c0215b62a45c8fd80da137e42e57539a994ca6b47c33f5dfec43495b0e02",
         "outgoingViewKey": "1d952a75f9c63972b1e4370ec4b995bbec090a09f7904d72e633d1aac3683013",
         "publicAddress": "6b48ef5542540f0a0681babf80b39131ea8a7982ba2d69e950763cd976edc64c",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "f6840561c30342325d1b1ab6c3ab49f1d0572b33051ced325b11a55fe3006b08"
       },
@@ -350,13 +290,7 @@
         "incomingViewKey": "21d3ed322afe6f5867c5c21e70ffdb697af14e8569f3a142f5a0ea55beaf5706",
         "outgoingViewKey": "f3d56fb4838671f31aff88c12ddf06f96663c46322f7c61f517192db815b366f",
         "publicAddress": "30fc42ed6a433c3e0a885175f549cedc1b2dcbe03698615f92534c877e31a1d1",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "cc68fe49f1b9de86d9c7a593acb56ff61b621bcdad45d28ed5a72e258a3e730c"
       },
@@ -384,13 +318,7 @@
         "incomingViewKey": "95c284c97cd5dd8931df9e5c6d244074d44b6e017e930a29e6ca1f55da5ad800",
         "outgoingViewKey": "7002087cd2a6fb128d0f35fe1ffd60d86372ebb4d8bfd7a078081988b7f11744",
         "publicAddress": "1666f1e9ec2f42e4ca445195384d8d35228024d00e855bc3f5763f12c50747ee",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "66f06a8747ced1deaff85ce6ea9117f03544f123f5152e9d5e51c90cd38b0e02"
       },
@@ -418,13 +346,7 @@
         "incomingViewKey": "3317bd1a79be33f9046de21cb107aa5aa76e80b2e3a2422d0b2ee816236f7500",
         "outgoingViewKey": "0cfeef3959fed1d155711dba2e5797050cb95c1d9103f778f51c13272aed6b73",
         "publicAddress": "bebdacdc831f4506de8b290de10cacd10e8833d975148583865871cea5d1dc81",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "2e8571f213f7d17bb6f020b684e0b81edc85347c1f0d4c86a3fd280d25cdf108"
       },
@@ -452,13 +374,7 @@
         "incomingViewKey": "b92eae49052a66417d23d85f7f9bc1ce0f502a83c646f8afe2bf58cdcdc5f201",
         "outgoingViewKey": "af900ddefba91a5fe6389b45305f8b6c3fd74ba05c25b519aec6978a859b8337",
         "publicAddress": "bcb78f55eae6a038c966b541f98fa493c57c730f414f51a84a935303acfb63e1",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "2c7973bf66ae8f390d7bf686e93bb5a15332a629aa7850ce211284c5b3614802"
       },
@@ -486,13 +402,7 @@
         "incomingViewKey": "6393dc12180593c6fb354090ef2ac48010a7723d035d462387ebeec9d2b2e307",
         "outgoingViewKey": "1d50d55d63a4b007f85320ba587a051ecf0e5a5de174fa69d4a13f4d8eadc20a",
         "publicAddress": "ac43ef3843cf1c122ae6a18170e0a4e9ef90ab51fb8d859e4be7cee6b040b009",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "e9fd5ce552d0cd61b3c988a0e782017ac736b033a51f54a4e60fc6a831f74f03"
       },
@@ -520,13 +430,7 @@
         "incomingViewKey": "d38a689cbbb5aad135a1dc62b9dafe7431f61d63d259edef97bfc759fee68b02",
         "outgoingViewKey": "d05cc682a102b20d7c57f916998a94399afa8c4dd2615a2a1d7e84f51c46e237",
         "publicAddress": "6fb8049625fe64d89ddd6981ae12460b094387f8dae77bf32ab4c54752e90221",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "81da73ec326fc26247543c58fcab48f2066eacb88c614922197ebf3ab33c1d00"
       },
@@ -554,13 +458,7 @@
         "incomingViewKey": "04f518e9673e606df21615f89f90434b2933b7aa282b2c332cb5230909318200",
         "outgoingViewKey": "3be4d4cf1f59e83b461bff561c3a7bd4aaaf29925b0142e6a5127b985975daa2",
         "publicAddress": "d6aac67b54c9cc543493b83eb5ae6e841ca12188d8c6e213be353bd6e93bcd6a",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "c9605ca6c9d27347ab33e52e939f09c1365224206b0af80eb463eb06fa2fb300"
       },
@@ -588,13 +486,7 @@
         "incomingViewKey": "1319d3da4946a0fced7e8065e33da458846c3d1744d23d2d0327914231668a07",
         "outgoingViewKey": "3d5d0cc06fbc7c59caac83b64e9b3caa744954843fb9100855f6ea856bf81b60",
         "publicAddress": "a86c714cbe4c1377e3e6754703d06d338cc347cf753fe7ee9d8e33d3b8da1696",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "d4c81b0e61bc2f6a75e365d428bd8eee412997d46ad9a5f3adeec9862e7e2406"
       },
@@ -622,13 +514,7 @@
         "incomingViewKey": "a7869106b148fccc32d65801a51b8f2cc450e349b54432f1f023524caae8c806",
         "outgoingViewKey": "b07aa7ffe7e1bbf41bc46f61d758883a6b90bd5eca6ad7524357074d8a84e20e",
         "publicAddress": "04259b1f6440a16e5e8a1b6d7399799a1460006b76fff6c5d4179beabf6df095",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "bb1b839bb701a91462edaddfa330f77e5a227472256b1ba9786ef42bf9aedb00"
       },
@@ -656,13 +542,7 @@
         "incomingViewKey": "1728081b45fe5505b136f557626e803cdb710f74d4b2bd88ac0f03eaa90a6506",
         "outgoingViewKey": "ba8479a03f6a4c5fce0fbbe6585df3d25904b61f13a280d6d14a8e0704e70e8d",
         "publicAddress": "a29dacf3e67ff866e0d3f372b1932d71a979285382ee2ce89b4d27e2f7cf06cb",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "a18b8ae0eba3b177d0eebf1623988c455c06aff447fc249c9bf8bfdab3540f09"
       },
@@ -690,13 +570,7 @@
         "incomingViewKey": "d1c715a8aa089267ec497a22c5fe843e9829752916e6884d949c49c585f69206",
         "outgoingViewKey": "fc11999036e0f6ef20d9edeb9cbb30e026402444c1db70458fdec0912c6d1df3",
         "publicAddress": "e0280e43942ff26cc1dbbafae5e82de07daaec6695769fbf0e3a54dd7da15554",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "347c3cf2e96197101b06818e13030fffb6cb4a523d5d04e3cb45d574d5b67f05"
       },
@@ -724,13 +598,7 @@
         "incomingViewKey": "f21e0fbff9a70755fab960fc6983f3bc7c6adf7a271106ebd82db9afef863407",
         "outgoingViewKey": "4579246868c7e0dd16ed65e5b01f87c15485e3c33d171903c4ad53d2b454ad8e",
         "publicAddress": "d93b2a777b4769c67383299e6628f77e2a4f38d8d6240fb51d01d08249aa172d",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "48365b5fcf7ffaa0afc3f04164f455a6bb023d7d896beea71e436d68597da90d"
       },
@@ -758,13 +626,7 @@
         "incomingViewKey": "04b07f927309e71373cc91728ce961762462c5ef6f1d565f78baaf619f80ee02",
         "outgoingViewKey": "e124df489ce109c0e38a86d1282e9032c483c06e11fc8645e1aae2deac5ad08b",
         "publicAddress": "996b2ac3cf84b5c7568a995b758c3021819e27cf3d73d582092cc4712e9bcf6e",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "c582335104edf5ceced128df4046faba32db980ca66dc442d77071ea3d45e608"
       },
@@ -792,13 +654,7 @@
         "incomingViewKey": "94071dc3097c218bfc552dd8c8e123edb0c2d81c9af7c568c709b54ff861e104",
         "outgoingViewKey": "60a121ac254b1955d7d402f914e211727bc5f08d8be57326e52472ae4671aa29",
         "publicAddress": "a9f5650f69edda9ec8c40867a4aab3d5d428ddb864e161d52bdfe902aa7cb3b2",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "082b3216470477db89f7de3681c56d73b5b8031133622ebd12b81cd01b9baf0a"
       },
@@ -826,13 +682,7 @@
         "incomingViewKey": "d812389209abcc11bb67fe13e0a11540ac065cdb6356805524d7d23a5975a304",
         "outgoingViewKey": "2d5ac34d8bdb136677596800d32b49810d539dc250276e5294369b05c0dccd40",
         "publicAddress": "96dc9a1b1dcaf1922c297cd90084d520c06cd39fe2fc67ead4d35bcab6c94ab5",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "44611d9aeda8acd2f8c327a98ad4b3e2c8881b5de8af30b4f2fd87e494ca6005"
       },
@@ -860,13 +710,7 @@
         "incomingViewKey": "063c55a1fcc3040363e535641efd7ebbc43fa0d50db967e5346a6362ac6f3407",
         "outgoingViewKey": "971713671ff1952716af6b5c314072f42f6b3e2f5907ca5367c98c3d48942058",
         "publicAddress": "1bf1f67f042069b5305e6be05ab2e2c2ece75c530b3e3008e6e17fae87828ed6",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "033dfb419ad2419400827e4eb6b63e0434c0a73e55a0909e2439ceaad23ebe08"
       },
@@ -894,13 +738,7 @@
         "incomingViewKey": "e4f6ceed7f622489b58c972eb34778a51aeaea085ea981dd36ec3f1904cf1107",
         "outgoingViewKey": "52a700279cde6a80437115d76b6eae033c239a14d92881eb924765ce85730123",
         "publicAddress": "789b57ff46892bb8e093c07ae14642e5cc31bc302bf6ba3a21b4e2d3e7e358e9",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "061bdce0421ad63b747060151b0be3641f758246e1c801ebc80b0b52bd0b330d"
       },
@@ -928,13 +766,7 @@
         "incomingViewKey": "80dda8caae0315789b26f403742cee0345f85898c0a2f999b7ded055212d7900",
         "outgoingViewKey": "eae8484c3ab765cfd2db089634d83a39bcc1eec7677a3121719aba2cd080705f",
         "publicAddress": "6018ff123cebb3843c097df9037b32255f45e81f1955f29b899aa7e5ee08db06",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "153b044c98b46451cda06a0903144228b0709fc360a2d34717c9277fb6debc02"
       },
@@ -962,13 +794,7 @@
         "incomingViewKey": "e5710a0e58bfcc8ac22c406e0e189565386049c5d6c2acd35cc695b2d039ec05",
         "outgoingViewKey": "aeb7fc6e72dbbd7c194aafc41e764f0146e0ca47872f8bacd65b60f97882051e",
         "publicAddress": "ab3512420affbebc216380a98a24299881ab277263235ee7489ffb7d13c3ecaa",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "30e941bf173931fb22c667447a6790a4e1d7570c7885dc2de01427f73f10de08"
       },
@@ -996,13 +822,7 @@
         "incomingViewKey": "7cacfe51a1473c7b3a8a8a950d40f7886968217103879292ff8204a4269ea401",
         "outgoingViewKey": "efaa7e1c936819168fc96377482f089ca011abd58903e21670cef1c8a23f67bc",
         "publicAddress": "5a24fd0aef51f7aeaa3480c09117332104cdc32e0a54132ddc5b5f0d3ce22cb7",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "15a80e949c585a675ddf060c5afd1823857112f5a2b2d5ab7590f4f32fc0af01"
       },
@@ -1030,13 +850,7 @@
         "incomingViewKey": "a5abf72c1a101f6fba241e7baf078f8fb336da14ee7d98d41c92750ea329db06",
         "outgoingViewKey": "a3f1d3ce16f68e9233588d8d8092bd85ce46d759ba1d05f8b15a64123a6e9c5b",
         "publicAddress": "dabaddc5cf439af5908f8319f205fd8d24157e306128f678e360fa7d77051a20",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "9dfe0529ff5ace4a4dd53b8dd574348c2e7e3c6dbb52e8697b891555ec7d7100"
       },
@@ -1064,13 +878,7 @@
         "incomingViewKey": "2d7e6b1b00e639a5ac799e772616fb802f07152b802119939fd7394aa00c9c06",
         "outgoingViewKey": "42a205a821f3922a48b05e9532ed312f940cd7efe111270eefe3232b9aa15c43",
         "publicAddress": "621c04b28ecb4b2f906489f22338195698da87e08797f03e75f92704331557f1",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "c9a3ad9f68bc04b8c146f123d1e6ef12484baa3303f09cc82d22b7f96b695a0b"
       },
@@ -1098,13 +906,7 @@
         "incomingViewKey": "61d903c7092de887050808c13ebc16b8c6f7b4519a198b4ba6f612bbf2b77b03",
         "outgoingViewKey": "7a303d2d264e0bb40cc8c26c9aef9fdac6531c7cec9d01b293c4a5918ee93431",
         "publicAddress": "5b3df5cb26084fec48c6a96d5a7b9a509e088b436df57a01a2cf29a3d10ce24d",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "f4ad1164a76336ddc3c62ce86988026e8e69537cb1d360ca692c3e89b133680c"
       },
@@ -1132,13 +934,7 @@
         "incomingViewKey": "42d62d391eba5b8307d626aaa43fc6148092c6451e2e4e579e178cea3b8a6506",
         "outgoingViewKey": "871e6cf86cbdcd672b24968ca181bb55978366819cd38c7893a082809f4bfec8",
         "publicAddress": "aaf3a5b4c02fb32909eb2b6e7d5ef25835e7eca54e58b3cd44c594822bcd66f2",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "d795209fc3a77416e36c1dc41009095b0330e2337f2030219d4e51c2c05dc009"
       },
@@ -1166,13 +962,7 @@
         "incomingViewKey": "4858c71df87d3d08584a0929d7ed791cf4f74dc3ddfbfdbc26a6261318f74902",
         "outgoingViewKey": "81260fc7bf5b503a72de2ce64f3420f418fc7350840aba9484b8f23fc0948313",
         "publicAddress": "df6022b69b9fd82b723849c759ca4c92a0e34b97f815f010e1d40fbf2824a710",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "d1ac8b04c380b511472c6a60e5ff8ffd80b63dc5fe54adb53920d438d77cf30d"
       },
@@ -1200,13 +990,7 @@
         "incomingViewKey": "6f74e8b310037299027e7abe1192f00e2ac2c82130ed6609991fa58e7407f501",
         "outgoingViewKey": "215933aa33ca46669bdb619d858c5a17248eb202db6a927b30b8e86252069910",
         "publicAddress": "048cfda7aeec25a3d3e2ac6095375d2089f12a31b56077519ac36ee2e3d34ed0",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "53f2dcf5168b21d1f6f05b1cdd71917984e126ca3325a6973fcb11d17da02000"
       },
@@ -1234,13 +1018,7 @@
         "incomingViewKey": "b6135e920304d353bd972992a2af67daeeee2da8bca5be2fc789c908259bc607",
         "outgoingViewKey": "65b83e33aee2cce40d0a4be6251f65de68ec92de23f1d4b1476a44327f4f8cc1",
         "publicAddress": "32dc512fdeda898711f5abb46bb8dc9008084da225b14b944bd0b312efd6a211",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "f74bf1252c03d75e14acf7c392ee9bd3b3fed8dbc13b1f50fe7979078cfc710e"
       },
@@ -1268,13 +1046,7 @@
         "incomingViewKey": "a1a2fd708a8e748dde66f3398692abf129e741dd0d6f5f5bedb6724aacbb8703",
         "outgoingViewKey": "20702ceceb26301d9d79329173f62a249621520aba2738cda80b9470a4561e29",
         "publicAddress": "b2c741b0e9e25628eca02f6caae6b926ff6728391a61d163ff1fa6b55e809064",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "5f11843a2e4631d01c5ca55c47bb72717cde49f2c5995a95848596ae96e51f06"
       },
@@ -1302,13 +1074,7 @@
         "incomingViewKey": "44b552b9f5f5e884b42d223af2e40dd2514973330bf8b6cc11288952f4097c02",
         "outgoingViewKey": "25bb4ba9c77cb51babefcf69cf473fc9aec5bbbe7fe81586e73e82097400abb6",
         "publicAddress": "805ffea7883aef584b66ac929b6b6b6eb71f0c82cbb07c93e385def5f511b0a7",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "8b1cce11605460435d1ba596d5a4c609f8c3ea6a9aac1a838576bdee5a88c808"
       },
@@ -1336,13 +1102,7 @@
         "incomingViewKey": "8a64742514da610feec18e0dda3fb3cfe8a96fa5719b40b19d05d5a629299700",
         "outgoingViewKey": "d032861b8eac340a735f19eebd08c06f1696d40b3c937da7a8cc4c4a19d63cde",
         "publicAddress": "af0b224e9a92e5794de1946261d548ac1f86e72f1e33b3baab8c7bed9afb7c1c",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "1f9e87c21dfcc5b721a81dd23f88755758d607506fd97bd3ba47c0909f3f380c"
       },
@@ -1370,13 +1130,7 @@
         "incomingViewKey": "aa58505a9508218b4afb3cd87bd32a1ec64a08a1f536c85b0371e352bd545f02",
         "outgoingViewKey": "57608b5b50bbb87858aab594ad32f8d59fc20e14e43752a4a864b04511a81282",
         "publicAddress": "5e9c830e17ea605a7c126578886edb8eba1b3ee7f4f81d6f4e03a9fba90adfe3",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "f852bbcb00fc1b4524641e9c42c5b894c8cf3b37680420d823ef6fb526f4650a"
       },
@@ -1404,13 +1158,7 @@
         "incomingViewKey": "fac071adc7192abe45a9f7d3a4730ea9cab3f0acd4ad292303cb6688f8e2ed01",
         "outgoingViewKey": "3e45c7b75ed3a7af688f456389ef47312c6d51eb1dc526c64d5a295c17d87ac4",
         "publicAddress": "21c12bda4cc8513a8077cae9b36c40e1899479f411232fb8530004ab60b9cdaa",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "21e1313206421197b2d99799a70aca6e30be66ae53703a228c66867bf3a61f05"
       },
@@ -1438,13 +1186,7 @@
         "incomingViewKey": "1e71828932727c921219e3d408956f1d26a5389fbb2ccc9a1794c1946c361d07",
         "outgoingViewKey": "dd0df29c9661fc72d1e6b881eacb58d3df1f8281a503a305f8b864fc866c04df",
         "publicAddress": "4d40d6d6887912fe7202b5f71214294067188e5ab907745982ca920822413cd2",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "826a776f8229c089aaf0b27366e6c4bbbd5cffa2bc20e70aedebf93ec9c28b0d"
       },
@@ -1472,13 +1214,7 @@
         "incomingViewKey": "0c4d871f3b4d261a1004e71e2946f7431a935843140d55e5c79682f6b97bbb05",
         "outgoingViewKey": "41be532eb688a372a7db7e9b896720ac58e446d6ebbf2aef20582e91d6e9064e",
         "publicAddress": "783116ed913ddc703e3bbe03ec8a28361142507879287438bccc95fba05ed492",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "60525ace2a2d19771441dafce0f1b7d3835ec0539181f60fe109a104b0b6fa06"
       },
@@ -1506,13 +1242,7 @@
         "incomingViewKey": "d4623742589784b2081fe99cc69bb8ab723af2030e1b39f891b89974ec4b2304",
         "outgoingViewKey": "d72f7617e3801e64a47d5adc6f6d1811f59201ce860176cf00985870c104219e",
         "publicAddress": "47d999eaea4461ca0814543155867235a03379a7407a6aa4fd93ed89574b3b0a",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "4098e2426268bfbf2ecda844634c9f0a6155c0c15058367c8bc991dd892cc802"
       },
@@ -1540,13 +1270,7 @@
         "incomingViewKey": "6a4d58147c5e0acdecd6e24cedfc6590c980c98835e81709ae31a4f389137507",
         "outgoingViewKey": "a2143d5f1125f9c9555080c2a7eaddefc822d017bafda2aaf51e4cc96a3c9538",
         "publicAddress": "b8715e305082d8187af35c20ba25d2ab4b73dd7adccce4afa5c807f33b5dbe18",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "5bc1b2838b9db4b9b1f18d204979a194f28e72e76adcf61c68e7fc00a37d6606"
       },
@@ -1574,13 +1298,7 @@
         "incomingViewKey": "9ef1475d8df76013cf747874d1df24b61b5802b69985993fc777b4607e164300",
         "outgoingViewKey": "0c4547105775f656e257dd65fc8dc8326be70c62a81241f6fa5597f33f671d96",
         "publicAddress": "0a7fbc072427dafb07072f8d7bf50200a13667d10c22e3995a6be87b1c3b44e5",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "ca40c3689677ab9679d7307cf9ffb4f7146908c45058060e46656693f68e3b00"
       },
@@ -1608,13 +1326,7 @@
         "incomingViewKey": "6171f8a20615975a075555c76c00bf0da508182d63304814b53a7bea9c23c205",
         "outgoingViewKey": "5f42fed74e7aced59f3d7a1304d9962456650b37bc1f31a9ee7f712e315f261c",
         "publicAddress": "3c3e2bf8f21abc148a391af40fa50edd59c175049682b6bc8e9285afbc1965b4",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "c59d7b3d4d6c409b6ad990e2d9e980321ceac4c514b671cd4ad188df595f650a"
       },
@@ -1642,13 +1354,7 @@
         "incomingViewKey": "a1ad8b7c09111b5567aeec8ae469f58cb0e18b20d36d71ebaef642d79c0ee505",
         "outgoingViewKey": "4d91c261a6ec570c440902526aac704c739365b0e31d21fa15b5b1ebcc0a1d25",
         "publicAddress": "f8750a287431fe6f43ded7bb94c81823edd79e1d0a2f57e5b851347e10b1e394",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "38fe85be2e04572b6fb4d3e56ec3f47f537457fb6a1c5a79324c484298ee8105"
       },
@@ -1676,13 +1382,7 @@
         "incomingViewKey": "7110091944dbddd2a09def39c3c26496e4c2fe7232b76a3074125acde503c003",
         "outgoingViewKey": "a04e01b1e5059781ed214854c85d482535303561334447a044c84fd104c074fb",
         "publicAddress": "671878b88e99e00ba8fdfe1f23b124fb9903ec19ce9b7e2104110567fd43a59b",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "b0a6001823d0503d8a9c91d14acf0d8f3cd3a6c617e7a4c2b4a57033971ec304"
       },
@@ -1710,13 +1410,7 @@
         "incomingViewKey": "a8d2fd01538ad2340507c5fe2480db343b68ea31e0d5ccd8441cee1a12877c03",
         "outgoingViewKey": "9ab2b7ded7c7e752869affa8f14c31977fac0760ce81b56b1d4f8a946c59bfb6",
         "publicAddress": "ce62641d3e8d68b8ca1942ecc5fb7ff2183672ab56c9e5980b8176766ad07594",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "54bda58c51ebeb734641b5c77c1767f4337963fc87331f2b1da23f9374d88c06"
       },
@@ -1744,13 +1438,7 @@
         "incomingViewKey": "777cf56a7759e20766333034f52187b32bf5a961ab5112348405783523599604",
         "outgoingViewKey": "a54b5ee63825fb3637b407d4e12b7e270e59e1cf4e534462e7fae3a09f50c2a8",
         "publicAddress": "b07ae0695139bee2ed184b3974594d42e61db4315f19fb481f7ff24df5436498",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "f45676144f6da6a3487ac8d11c6bf03001a97e6b7ff65cf5a028eb26516a5c08"
       },
@@ -1778,13 +1466,7 @@
         "incomingViewKey": "e98bb227f34170b4a6736f4b1f5e4556721cca4a417cef8f9e0555cb110d2601",
         "outgoingViewKey": "9e6f6c4863bc869fe55e62c529a5fe0faeda038126efbff13e8eeb2b0e88dfc4",
         "publicAddress": "780b6c02a062776cbc163f14c8519f5a1e0da73b33ea81e9b34b578bafd61dc6",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "438228735461d240bf77aa43b3bcf1e93e85836fc72f1d87ea41496542ecf50b"
       },
@@ -1812,13 +1494,7 @@
         "incomingViewKey": "3a947e90e6b21418fef8b61472d29f7e4135a9f1f928d8bf26c403adb2491505",
         "outgoingViewKey": "ab922b559440148f5c96f56a1f0217021a15c0bfc32d757bbe570ffd9674acd1",
         "publicAddress": "34673c676246077cebab12974562f01b62ee38ca4467dbb374e1df1666f4aae4",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "891f77759ec81e2c889d919dcb42a2c23af74bb34048fea16acf1dedeca7cf02"
       },
@@ -1846,13 +1522,7 @@
         "incomingViewKey": "7cf456dae89bfa08c9e4932eb3d8baed4457253a84eea766d7ef15fbf7099a06",
         "outgoingViewKey": "1432518f908458210add8d2c9669b4bf826264bd498df685ac1452eb49294e17",
         "publicAddress": "2cd11a0a91a051aa68480d3440ad246d3b24b73c1d7aba5552c92cc45a1dc657",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "371fa2ce7ed79569b7bf486a8d9fcc833517c5cb9f710098b1693c6e604a6405"
       },
@@ -1880,13 +1550,7 @@
         "incomingViewKey": "e3639cdc252a48b07e45abc13154ddd07632afe73950604f0f9f88b240a87a01",
         "outgoingViewKey": "a757255871c1c2fe2d6390400864e515704f213851918193517eb59a3c2a1ad8",
         "publicAddress": "f4105dbeae89b4b649e6c674864fa3db11c2fb64ab38ae72b89757b3c95bd695",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "185a4144463523d4f0c87627e886a37e58ee1f8b934be690ada07e561ff2dc0d"
       },
@@ -1914,13 +1578,7 @@
         "incomingViewKey": "065ca89aff2bbe72374ff5f782014ade55d788ed79d3bd13d34b01d8b5364903",
         "outgoingViewKey": "dde9500f795f3659d252e937045032b0073462d7b6ec8336794e4af30027ce73",
         "publicAddress": "3f5738e2f2f591fbb93651681b5d75e989317835e0940d09d3b85a2f30139a08",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "8ce2ee5740d53272a8fe0c402abd2de82af583d5dcd0b13e81a447047d6ef10c"
       },
@@ -1948,13 +1606,7 @@
         "incomingViewKey": "bb59ae6ee00d9169dec2aafadaea3483434c803bbe80c2331aabb14c29d2d607",
         "outgoingViewKey": "d86e5e74e575a127cd3d8d34495845d57dc9230fafa7b3c2da254c2da94a9e95",
         "publicAddress": "b05c262faef56c768cc6c59344e3eae570b12954025e840b001ce60141b1ad82",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "8347d5b55d7a5dd98595a3e610e155fbc5248ee9a711062d74ab942bfc3e9d09"
       },
@@ -1982,13 +1634,7 @@
         "incomingViewKey": "0ceaf8b2dea92d77111f1fcf9a84ea54321fdf47623d52cfac8e8cb45b758d03",
         "outgoingViewKey": "74647701c4e7d54fec361549460b531e6261d23d5ca907457f24cfdab8030a1b",
         "publicAddress": "259dc82ae14a58aaabddda2673d4a38181cb4a7635d3e9e4686bba2a019a054b",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "a06d64bec3e600f5c0e7f9bb024ada36a5ada5818aea6cc8201a6c81b6085107"
       },
@@ -2016,13 +1662,7 @@
         "incomingViewKey": "be5756e992fe65e24f1fff53a4ba9e2bd40bc511cf72527c4e52200554b8c502",
         "outgoingViewKey": "a1d9ca0a0842512961967132b547f4919baed3bd24bf4650d82efa6ffc086ae2",
         "publicAddress": "06f46840413274824b5d639449f14dd33bb4cdb4d5800ea61ff6302c4c619526",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "dd174c738d46d334a4a40cd0cef29513bb7ed8193b4f472195962282f932d902"
       },
@@ -2050,13 +1690,7 @@
         "incomingViewKey": "dbc31bb455485b5e956debb9f9c7636913a1da8dba3215f7f421d6ae4e4cfd04",
         "outgoingViewKey": "2c588bfef0dacd56bc0696327e1d77a10baecfd9e2b4eaec5e854703efdf87a6",
         "publicAddress": "1c60765e46d75908cf7253f984c7aa5eada070707798b3fe8b9054a3247b6dba",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "ad194c383295b37a704e1f456c0db5fe8089772e81141045c55c81015b58e504"
       },
@@ -2084,13 +1718,7 @@
         "incomingViewKey": "14a94d3fd5210db60cb2164c4dc280d04d8404d41e3e1b470cab5ae833fd7302",
         "outgoingViewKey": "746bf9280510af1c8905840ffcf001f653fd69eb3d492bf61ac8d34dce196f44",
         "publicAddress": "32067a35c9c41454d3173d45254379f10f2e10bf967477a97322c0673f91be13",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "2f46540c0fbb6a36a2afd41aa2bdf400fd49aa4c2c4e022f1ab0afe0f309f702"
       },
@@ -2118,13 +1746,7 @@
         "incomingViewKey": "3224a88759ae571bf50564f57478d2c693b59175c0214c46ae34cdb79a283600",
         "outgoingViewKey": "c5e4e574d6f1beb762322d0d888860eb03a9303a08780f5bf667a87796f6491c",
         "publicAddress": "af5eeb0a81d3777e69fdd650b033204d0bc84b0f91ac482a2590c22a007d2083",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "cbb7e0482fe2095fc9fdd5533bb67eb365de043a85b08cd25b66f9d8a57f7c09"
       },
@@ -2152,13 +1774,7 @@
         "incomingViewKey": "96b3f26b2b90a6578c0c6d6f707e9d2b4b9d417f57e4b34d2d290ab450113105",
         "outgoingViewKey": "f170c6c07c690c454d34d5bdd2a5eae7c4156f14a79c2f595b67cd710faef838",
         "publicAddress": "70bbd7b20f0f19cf6133dfc67c8265b7809c2a467d2a4bb7aed53f4f81d10bbd",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "ed9baf354acddbfe5804b6cd174f811320c0d48b66e743a27b24d315c1b36a0c"
       },
@@ -2186,13 +1802,7 @@
         "incomingViewKey": "1cb85ca2a8b6309f58789ea2bd0c6e7de7c9c5bb33db17f421e08a6d51486b07",
         "outgoingViewKey": "5aa4c05850ced3ee6a509140949108cb971490a105a2e5401529a5d0e1ac5dfa",
         "publicAddress": "82f585315d97c63d7bdb542d6427423289b0aab39fe230f38610878040cc7fd9",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "92e8b84396ee05e9657e0f9a8b3db5f23d11b753698b30c6c8e4b87c6b6baa01"
       },
@@ -2220,13 +1830,7 @@
         "incomingViewKey": "931158e840a6f69c84092b45830b5a038303c045efc42061585113161d766106",
         "outgoingViewKey": "883756280e3af59ded0b066b42d8d5258e4c1258fc7eefe772e230b6dc580945",
         "publicAddress": "e6fc11fc39b00df2dd634446768d547ed45d6bb6dcff1c5e683a308aae6a03ac",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "cf942debaef88a2521930bfefe76456b1a2ef45759ab917153a1322b5695170d"
       },
@@ -2254,13 +1858,7 @@
         "incomingViewKey": "0f7487fb90e3242b87db216f700b88f6afb2870d2bd1cea7b975e58a8992ed07",
         "outgoingViewKey": "e234c0cfa2dcd4e5bec1efea85893471f19d89d63b89d7d257c1cd34df75f031",
         "publicAddress": "331cf749feec60ee195a5065962a38a0b7585dae7d525ad6dadeebf97fb7fd71",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "68c94cfb6bfc5e466702874bc1a2260452aa05039522080eb00440a22b37c901"
       },
@@ -2288,13 +1886,7 @@
         "incomingViewKey": "92ed61b6a406989c1279331529cf9ada157f5304a1c061087e2403ebabe87202",
         "outgoingViewKey": "b6e405f8aacab86ea5a32a7fa78fed9ab3deae1b06b3b4372a2ba224f0e06a28",
         "publicAddress": "6365ac640b337f148f0f57f4be1fe6bde289962981df68ccaa070a58d0c150c1",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "70cd5310b6615e850e1cee1167b5a0017c83d40a093ef2ea93a1f4b04df31b07"
       },
@@ -2322,13 +1914,7 @@
         "incomingViewKey": "1edd103820d1a147e6ae0ad4e29c18155effea47c37627e712fe521901371d07",
         "outgoingViewKey": "068fd8665aa9f27c83d403c4747b6eb5c539927bb2cf087c1e8009810d252f76",
         "publicAddress": "039ede82094e2ba680632ae9deaa573efb39ee0cf83c5296d07d950e3bd0a513",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "63f160c4212589953483892f29ad6f40086af1412a599b0ead5aabc5f172730b"
       },
@@ -2356,13 +1942,7 @@
         "incomingViewKey": "7b5c4f127d99094acad5a003b58862c8dc779d17aaeae9d66ad98e85f3e48e07",
         "outgoingViewKey": "e566bb4949b2893c48faeb031a703345d5fdf9bbdd45e3543d9834acf749acbd",
         "publicAddress": "2755aa07715d9ee5188988cc117368ec1a2e258a836f06f850438bd8094bc132",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "84df15fc9ee1cee8eeb0c4a4ced61547d2913e76cce0fcb4e82da33fe8d73107"
       },
@@ -2390,13 +1970,7 @@
         "incomingViewKey": "01ac2d58e9d547cfae1816840ac042bace381412143124a8194379ac5cb91704",
         "outgoingViewKey": "9a011ce06a0c278c46eff0b5a32f69f395504bbb4c55f7457ae36b3d78b9b5f2",
         "publicAddress": "8854357a01ee4f0d487a04b2cfbc684b21396f6613381ee8f3f56c43151bd127",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "ce69bf7141b57781b5c0ac376390217b7df99e1ecd528029cd73bec4affd7202"
       },
@@ -2424,13 +1998,7 @@
         "incomingViewKey": "8b6938f5cb22fc55281ba82baa36ee70f361ed9828dbde14cd1b4c811abc5305",
         "outgoingViewKey": "df887f43ff74d55249ac9c07883d7746ae42639e437afa8de4397d89811c9103",
         "publicAddress": "a5b13405af90c95db0e23d76dbce9574453a95bd34aaa17c229d4483289023aa",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "c321742e46f24e6762f6b0be9eae21ff989d6d14666bc65baf63409f58fe7209"
       },
@@ -2458,13 +2026,7 @@
         "incomingViewKey": "e4d38c7517cf0c9a8bdc75b8b10e33e053058e41ae456162cccf45d2b0a30606",
         "outgoingViewKey": "a7c43268891991197e9f9dcc29de83663d327a5a6c0d8b3737cefaab15557861",
         "publicAddress": "71047515ace3dcd7b250c544af304e3f154f9820a0c3a8972a392ae3a1967241",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "bc804f03495f595663b4bea0d9a7261eed6fe6f58493b30fa859f14a519a0800"
       },
@@ -2492,13 +2054,7 @@
         "incomingViewKey": "5ca196e697bb84a7758d842ab0e867f2beee3dfe32f095d1ada18868ccaedb00",
         "outgoingViewKey": "11f07b200ddc3d0903e626ff616a37b204c3d0b3619d9e894e30f36ef9d1ab1a",
         "publicAddress": "c93284aaea9da4a4d122b61182b767664fe524f27b2a74a3ec85ed0ba96d0434",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "f85667fa9a38eb8760e47673256b479bd17dd9027430cf09269e32977e6ddb04"
       },
@@ -2526,13 +2082,7 @@
         "incomingViewKey": "c8c97c70b08d79f6cb841214c25d55a0cfe6b9f800e367cff081e1c8008e1e01",
         "outgoingViewKey": "34554703bf9f9e00a8025fae3f27f871e44d6cbc5e99a22074f7f1a70cde9f8b",
         "publicAddress": "554a83ea569a9a11c968525e55f30ef8957c41fe559dc283f5096334b0b3d848",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "3815058756a96af284c862c1833d7f336442e15a96a04d2e3f17d5d936fa320d"
       },
@@ -2560,13 +2110,7 @@
         "incomingViewKey": "4be81874e4803bd4cc13c9ac47672cb2c60327bad045a952a53401a595ed5b06",
         "outgoingViewKey": "0eea2b22ad64c66db65356f5b9065f072e613f189ad7fce79e9780bf71e47e6d",
         "publicAddress": "b78aff0dfd1b6afd908b800afff14b210b5a628007e348aca9c217a833bc483c",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "b5d1a96376913a410bf2788d20a2dddf4d44593e6b46f4ad62f883706e1b0f0d"
       },
@@ -2594,13 +2138,7 @@
         "incomingViewKey": "d5f68964ba104611e8f7864f5d79508e0a05b1ef4d1531d295f303fce25d4506",
         "outgoingViewKey": "a9789b9a2628fbcfa64f995305c7aaf27e04497d5f370d04232bb0d179daed18",
         "publicAddress": "a77d5a29c3f3ad54233ab60fe94dc2838853de55881d937e0fcd0fdc4d3ef240",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "8a5b60384d8aea36dd9768cf2fcfab61385b2ffdddf24e38550922483168b70a"
       },
@@ -2628,13 +2166,7 @@
         "incomingViewKey": "d0f5dfed247eec26ef5b8de9bd1a8d629290c31941d1cd81bc54313caf520002",
         "outgoingViewKey": "ae8b99a468cd8c04a27bd14a1fa6d987fc5ed1cc2b7cc2098f432d52f533a4e3",
         "publicAddress": "3e0f2c67411038ecd1d52682acbf93e641fe4d23958844d6a0bbc0b54a853602",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "ede2d396559c1f8b9cc06df0edf70edd030a11e0753fd1a59d3d553a3a91fd08"
       },
@@ -2662,13 +2194,7 @@
         "incomingViewKey": "58572e0ab8cfc936c40ca011a041b9ced8d7b8bc310929d4792f4dcfecd4fe01",
         "outgoingViewKey": "5f22d1de31374d3319a2c156387e5ec991a3188f62deba3a6148a158966fd8d4",
         "publicAddress": "5f85351cd4ddbb5a5b12167daab515eac13b08b275e7ac1ddb991239df42698b",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "906f5bec45963660060ad21ba310fa8059a8da44221093d1f854be8bac5f4f01"
       },
@@ -2696,13 +2222,7 @@
         "incomingViewKey": "cd3e5b13521de23edaa35bcc0465b6d19af39577d84d199198347a0218cdbe00",
         "outgoingViewKey": "182df883bb00695802e9d8e0e5db2805f6f009b9e55cbb7405c0ca05f0bd07de",
         "publicAddress": "b015ac0519f3b1ada969219abb39675c8ca3ae10dece948c0355d4131bca9a9c",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "81a175fd1fe8c062aa26e512328199c72d8f8d20859105075a38e8a6dedfc502"
       },
@@ -2730,13 +2250,7 @@
         "incomingViewKey": "eb2792c9b895ca6987f142f9e3f2e178bd03455a079868450c6bb473a25c6002",
         "outgoingViewKey": "83dbc1cd6c64bffae182ac2d3406f13b861b6af1e23c6fbad9be5c43956564e4",
         "publicAddress": "5dde24153772436b2a258fd6f9c2328b29db0eebf56728bbaa085a97b44404b2",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "1080955c9bb19462421b60f89f603c78b204a578bce9f2a50e3efb7430cb1603"
       },
@@ -2764,13 +2278,7 @@
         "incomingViewKey": "320440100467a8990ff11da666f43830d6330e83f8ed6e4a7af4efc975746403",
         "outgoingViewKey": "936dcc088c5944d1d5fe2b9f2eac2e8c2dfe8f6d755a5c7afd5f9c0e51bfa577",
         "publicAddress": "16753b7e007bfb010d5b543bb3c146de73791438197d2370d1ca0ca650cc1ccd",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "09cbbf6c55110de869a0b50331745acbdb9e4870f0ce25e35d6a4130a006a60d"
       },
@@ -2798,13 +2306,7 @@
         "incomingViewKey": "5ea566484626b7a1a894397671a60a1efc79583d38cc4b6b11d7bffde96b2c04",
         "outgoingViewKey": "6f9944a4dc70cf13eac9ea730db0904273ba57a295a97a31296977ec7ce00a38",
         "publicAddress": "56d7f09c3ccedda45345c681f5d92f2a841310847700ba6ecdd9aa8a41f8031b",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "0d4d9b304e6c5118400948d1902190cf15502d703da84cb39a8f1d8f4135510d"
       },
@@ -2832,13 +2334,7 @@
         "incomingViewKey": "bb8d2ddbcb02fd7d0c871b95eff8296c31091415f988985e4226a7dc74aeff05",
         "outgoingViewKey": "43b136da7a8311984528a62b95b58dcb6f3ecf7af9b32259c056c9a3d86f5a4b",
         "publicAddress": "87a4baa4ae5de7aecad7da9e04020e9cea371c6486b2089d9f8b2f54c8373d71",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "e09e5154f67f9bd1401f92b12b6df1cf8092fa5b7764790bb100191728b8f505"
       },
@@ -2866,13 +2362,7 @@
         "incomingViewKey": "84dee3a199931d4801fca1bf87a6b70f9f5436f6dc6a62d38d79c2a95a4dc301",
         "outgoingViewKey": "dc31bda061361c116907d532085684d6462cd22a924a0280cf0c3b3c39688e09",
         "publicAddress": "54ac8d877e6ce3cebcea2250c6a85dc82da431c200edb021647a0694e1293668",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "c75996859b1e64214500184baa1856a2f8cf62741417edf2c9df994662ac1709"
       },
@@ -2900,13 +2390,7 @@
         "incomingViewKey": "ff2c4b6c78d275b46b20dd94ed184bdfdd00fa91cef0753dd6f5b072141a6d01",
         "outgoingViewKey": "8edfa217fbbdcaae8e500bb2e7bf005a7df9e5348f23d4fe25c31ae70244d6ac",
         "publicAddress": "afafe8ef92504fd79e94c2c5406205cd4c7d8539914aa65fa770f66e872a0c9e",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "90903657a17f25f07cd73645bfb81d204ce9957c97edf03900af9a6b55996405"
       },
@@ -2934,13 +2418,7 @@
         "incomingViewKey": "8de2f93e61824e5ec47cc03a4c51451079d097999531c7157108ed093e5cb406",
         "outgoingViewKey": "fde8628df154822f37fe7e977745ae16c284b2bbb6b1c253a7eeff5c253e7127",
         "publicAddress": "36fe30a7abea25aa23dde59dada7ee5a44ef01808e71edd1af6e44c12e4541d5",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "22c1f436b855ef20c06d022f84baa2cacebf69ed6d5a7fde431009e30ba2a20b"
       },
@@ -2968,13 +2446,7 @@
         "incomingViewKey": "53dbdeebbfc4d7231c0169d450731e5ddc728ce38edb0c7c70c69ca226472803",
         "outgoingViewKey": "d7ded75d6b250f054798062e4c35b3e15b0bb1fde72935258c55a3eb878bf10f",
         "publicAddress": "cf2d4c5e580758cb6f906d5835be1064f56b93ce29fdd9ff7fb0ab48341b33de",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "4d715e3d610504b801958ba94d8abc004361905eebb7335c818b199189923300"
       },
@@ -3002,13 +2474,7 @@
         "incomingViewKey": "7604eedd2bb381400c52ff675286806035970cf583b4b240c4634517300fb503",
         "outgoingViewKey": "c17f5fd04f779c4cd0d34984ddc1cd5d86268d0a13354a9b7df08d64e0bb0c7f",
         "publicAddress": "547cfb38facc4fdafec4790486a3167df3a6c54edf71ab015c785e7072ac8204",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "eb5094ee1ef047ac65d9089b6b6e210c1f4f6b46ddf31a4453b74f630f6d4405"
       },
@@ -3036,13 +2502,7 @@
         "incomingViewKey": "e87f0058ee49ee05ffb3657686992db99aa7995d8626badf5614491e6d63a207",
         "outgoingViewKey": "db7bffe446f14f978732229740f423b349926d8bf2d0ac4e76bbbb58259f35de",
         "publicAddress": "d9f27b5880cba52700ab263f453f1df24e03c45b850e15cb25d9ce55992ab300",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "03b843207332d7104f6f8c191bbdea846aea3aee02dd179527648264433fe506"
       },
@@ -3070,13 +2530,7 @@
         "incomingViewKey": "602f642a0dd2654be6e97c67cfe59308f8026ff68e1b5c1817bbee97f7464807",
         "outgoingViewKey": "2d17c71739309cf30c84af8a0d622a5bd088969cd2be3a1d3ac69049bee09406",
         "publicAddress": "22b5e1b0429858309f8bdda4c3fcc25c5f6e9d57380449bc9897d2ceacf469c2",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "10e296f2f6aa6bd2c27454c08c4a8a73d627b99df65e7f8557cac582a42df905"
       },
@@ -3104,13 +2558,7 @@
         "incomingViewKey": "5ea5bbe4b9ac843fc69d22a017dff6a65770a48da6453b28f40e797d38634105",
         "outgoingViewKey": "717ef412cf3d130b97bc1b44abc546b3436e5ad3499dc962ede547d391c7eefb",
         "publicAddress": "aba8f34b269200c3065eec7e0995c13835f978bd4783fc0cddb1dbb7a572a280",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "ccf0123afcb9afb8c81b14773c754e6b763287509809740a43baf0ef9dc12f0d"
       },
@@ -3138,13 +2586,7 @@
         "incomingViewKey": "5643a2dd2e5ac0390d77caf4e32d0171cd127e48c2ad576e6705db947e26e500",
         "outgoingViewKey": "e6a3851cac1f78b3aaca6794e3cc0124585ef3f960c54ea1af41a681ecbf626d",
         "publicAddress": "ae6e39572e8802cbb9d34f09b1764c1973748732e7e7522cdc8c8a917cf90906",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "5d8cbc62a5dd7903a666f3efb893ac3282d0becd3dc66dfa7b5b9f0ce8aae30b"
       },
@@ -3172,13 +2614,7 @@
         "incomingViewKey": "798bf41d5bc3676ddf05c4cace84148643f8b6fbf035278789e91041fa8cec04",
         "outgoingViewKey": "1425b46a33e43464e3ebe201030a57a4e34f8756af3c4584b232711cca1b0460",
         "publicAddress": "36aa7d6e24b66d74a40b25435c0bd613d263047e92006bc5fac8ef29444ccc5f",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "fffacb62cf700d81ff37219dac79eadd35c7534c23da3e509b76cdbb60104004"
       },
@@ -3206,13 +2642,7 @@
         "incomingViewKey": "edd6b20a9edb848554ee4d20bb685582166ccdf77447643f8fd5f15f9be32d00",
         "outgoingViewKey": "a703e01abf09b5704d8b96bb30d71416f5f3ebf5bc44f2ef5c1d1325534ef6c3",
         "publicAddress": "6f3c1d0d22a880e1ba50b9df1ee43de7bddb6f99aff30d278f4d5b15555fe73d",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "e9756f4f1cc46c253f7a531572bec5d3f042c9e518f4133ee47821b4562fc30d"
       },
@@ -3240,13 +2670,7 @@
         "incomingViewKey": "6eb829cf01b36a5872661d69947081b1282f9e543d8fcd3b2e492dea14f83600",
         "outgoingViewKey": "a4f6a70e112b110cb11791b0535046f705a3150f3515c2f69adabca6b47d9e23",
         "publicAddress": "d91dd2f2286b800c8173826b164b9f230ed870fac7c9d0be94269194a16a3b42",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "9d2e111b71fd3b890f9d9602bca955e43e0a0d61528f53c7abcd6c12562a7503"
       },

--- a/ironfish/src/primitives/__fixtures__/rawTransaction.test.ts.fixture
+++ b/ironfish/src/primitives/__fixtures__/rawTransaction.test.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "7c7b4b5d0e246d1fd8d3b61257725eee1f7b6658c45ea6dda943953124823705",
         "outgoingViewKey": "c72293d4552c079aef8ce1a4dd99dec66e90d613d97979268bf1730515d49632",
         "publicAddress": "679388015ceb748ad077e55ad765c19b1f9e774ec08b5faa81c7742556b1a40b",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "43af87ebde93a2055839808d63d301d7954513fc7a29ae345174794e8677690a"
       },
@@ -66,13 +60,7 @@
         "incomingViewKey": "fa0e89ca718c85f281ab1aa1e5319f66f48ac1a272e5630e2522e85c30d42201",
         "outgoingViewKey": "a7faa82e8f64b382d89675ef92b521c34c008e70c6bb88bbd18f4aa9594e3861",
         "publicAddress": "d64d1d97d0cc7b74078e854ff58da4ce3a89afaf9d735a7d1477ae76dabcf50c",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "6016ce9b48881b7f0d9c8377bd9cf05acc5c7dc7439fb2d30aa4a7c53d420505"
       },
@@ -122,13 +110,7 @@
         "incomingViewKey": "1268607211e4fffe701ff28e84f26b40b4bca5aa44a55e483e17e08e4a464a02",
         "outgoingViewKey": "889e84fcd55a3e995bd604d7b963afa25b0e971eac070ad5937df38a02b9545f",
         "publicAddress": "3648870aca0eb021ec8eac4a1cb198c745938494188fd3713ed9b3a62abdc899",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "7a454175727367a2f6301affa3f22fc215b5b7bdf379de7a25b88fea31b20f02"
       },
@@ -246,13 +228,7 @@
         "incomingViewKey": "88c6530330b43b03e70d0a2ea4b053089a36af79dd8abce28bfe7c4846ae1005",
         "outgoingViewKey": "8a1b3bcf1d76e412fcea0f41d127507b9368edecd5bb3afb92ce40cd20572571",
         "publicAddress": "5d163728e1aab504e0fd6c7c01d0d86e4f36ea73ca975bccf313add54bf72a1e",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "4a3c98e9c966ea51677e237215b3488442499c82103a8fca20efb95e5d27dc0d"
       },
@@ -276,13 +252,7 @@
         "incomingViewKey": "d4c4e5fb2f4f12fd5dbf42ef5778a4d0b0009d3d31eac1f56d411b1125dbe805",
         "outgoingViewKey": "2538c7b0519244f4adc5343a29fda859d0efe96e885411600a1c9c5a04203a76",
         "publicAddress": "e0c7fcb13ec83b6ccddd9d6474f3ca77c958111479dbb5c17c84cef7818dd666",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "69ad5c7704ce349b04fb14fddca0c1c9b3e4618cd7d58e18a990d384b2fccc06"
       },
@@ -306,13 +276,7 @@
         "incomingViewKey": "7331f671e36413277394bd8d628fb3fe46495110d81b125a6694f506d0fb2502",
         "outgoingViewKey": "9a7fe4b5ac1a434c0160b8b813de9eb19a11a154f6c5c381786f0d7b78651be5",
         "publicAddress": "c58b9dd520fd2b028721602e093c14a703d0912caff686a208364cb7ca3131c8",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "571f66a91970b8342c984a1012ade027e2a0e0f5e7e72bfff8c8b879247fae02"
       },
@@ -334,13 +298,7 @@
         "incomingViewKey": "0e9c9b3d08882fe24947d7522d0b9d1fdc68ab0f896d4db17ab88dc7af25e104",
         "outgoingViewKey": "d83c29fbd0c88735af1291da7dc22ce76faa786421dd79c5d26df5aa4d013483",
         "publicAddress": "467f1b1a919834e2f612c32989d15e18a22f7f82cd8a20b5d6c1eb2e26977251",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "1f086c37bc457f2f5902816b8bb338f3bf1bbbd840017989a58645f2541e2402"
       },

--- a/ironfish/src/primitives/__fixtures__/transaction.test.perf.ts.fixture
+++ b/ironfish/src/primitives/__fixtures__/transaction.test.perf.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "6a872cfd53e0e6ad00552dfecdfdbec3ecb0632544590ef49a9470c1b9219805",
         "outgoingViewKey": "617f831aa3cbc1438de72f7c6aa4be97f11a5270759cca21281dbb6a93d1b45e",
         "publicAddress": "d24a9cfa550217dd522ee0cb687f08d208f5dc83b90aa4345f31759ab130f51f",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "a9e42c9378469fe0a80cf991fead99d9cf40ac67f62de0af91e9ad84b9422f05"
       },

--- a/ironfish/src/primitives/__fixtures__/transaction.test.slow.ts.fixture
+++ b/ironfish/src/primitives/__fixtures__/transaction.test.slow.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "f32c0d7a4c5d4865416d05af430971e363357cbaf3e47468d48079b65d13df04",
         "outgoingViewKey": "db89bdb03e5c51db9470213be1079bce087889bb5fb91f54508ad7977ed939cd",
         "publicAddress": "72f16c38ceb3d6bb4e25f5349734d20d616f3b6299be70f4b79ae852bd10e6e2",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "1a73d7f0558e9b8a48fb94dc49e90f7d0520e8c1ec7c09928c3015a4bc81f004"
       },
@@ -40,13 +34,7 @@
         "incomingViewKey": "d3117dd8e979243a7d5b5b9c911e31fa6b071141491112f028eacd230ec77506",
         "outgoingViewKey": "d1085959b9b62ed0399e1210cd42c06fea2401993e4434571ebd50794fbe49d8",
         "publicAddress": "1df36fbb23de7f854cdb0caa57d8aac43135b85918cfb5f42b85f1e267d883e1",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "8f32475d9e740e7615dc44a83a58544ac28472504547515ba821309c4e4f1a02"
       },
@@ -70,13 +58,7 @@
         "incomingViewKey": "77f9652632b5102b443235101686ff18508b87c8438f12956f7a3f9d7afcf200",
         "outgoingViewKey": "8918943587a9496a4706fecc77ae0172276605049240da4bdcb39ea1f6374c7e",
         "publicAddress": "53527fc48e19eddcc49f3bb1b50e96c0ec95cd00b0321b9cc5ba62f8d8d4b917",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "f0b5628e257418ffd31a3e2fbec233114cd8289408d037f12e4c013fd3cea806"
       },
@@ -98,13 +80,7 @@
         "incomingViewKey": "3a851a9b29fc1a982b1dfbc5a83eb4d540bb1bfc9d8a3d818725227089ea9f03",
         "outgoingViewKey": "202f9d53f5d9af006c7df89a61fd3f59e99efbb8082f8299e684ecbeed272744",
         "publicAddress": "a58aa2dc6af2526932aa1b8e3fc6f788cc85a0173a861863bbfe1d4328a91f87",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "e19bdf8f442cdbaa87eab790380c6422eae643d8c9eb0427075e838e463cdf06"
       },
@@ -154,13 +130,7 @@
         "incomingViewKey": "7e5e51e2131529aec4b2646a2eafe65011df0c0789fd4b3d3cd2520f88861000",
         "outgoingViewKey": "2511557a8ebd83cb41c87088eaf6eca65232f719eaa29c76dd9725129f9a82e3",
         "publicAddress": "710fe174e3f3a8e85f51df19ad9782c01fd57a25e75b5aacbe01f0f0a1752bdc",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "e9357fbdb1d94969d8b064323cf04c3f7e983b244df35cc59cefb2b08c23af09"
       },

--- a/ironfish/src/primitives/__fixtures__/transactionVerify.test.perf.ts.fixture
+++ b/ironfish/src/primitives/__fixtures__/transactionVerify.test.perf.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "53e1fdbc9ba175413fe897e4a867424bd1ed9afec74573153905c1d4800cb603",
         "outgoingViewKey": "7445031ded1c51cc6479bc80b0e053fd9b64d70c38915a36352a91b01b31b4af",
         "publicAddress": "d46d7b2c2646a3ef3f51a749ed8bf502f27e3d9acc7db1557494edfd719ceab4",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "3f4a78c948efc4a08c80d19f3c7b5fa6e0103976ef0bc3d3917f9ed95d3a5d09"
       },

--- a/ironfish/src/primitives/__fixtures__/unsignedTransaction.test.ts.fixture
+++ b/ironfish/src/primitives/__fixtures__/unsignedTransaction.test.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "a459d205aca9c39e376545855fb680d6ee5d11f5f404888049ccfef725166e05",
         "outgoingViewKey": "28d684c737f8473ebd0dd8f5ec431f454d89bf0a525339ef3891c811e32fa625",
         "publicAddress": "7c0fc099c96cbcd7a9982e060339e192293ca432f3acc8e8e42127337b6b7982",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "4060ff40a0edad8a3633f869f7a5e59fb22eb02b553711e13ee88428f9c6d106"
       },
@@ -38,13 +32,7 @@
         "incomingViewKey": "945261a0e8f327e017aee2acdddeb42b454ca83356152c265d9669790e2e8d01",
         "outgoingViewKey": "9793dc32b44f27edb20d778213cd5d925e4c0883aaaa957ba934fb57601d4c7a",
         "publicAddress": "00a671a726f801383409e7b8bf6e4bc5f8b7c9fd4ebb95421073e22ee668dd1a",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "c6911e69eea103239579cb4a50676ab9ac0c0cab513539d759685cc6c1bb340b"
       },

--- a/ironfish/src/rpc/routes/chain/__fixtures__/broadcastTransaction.test.ts.fixture
+++ b/ironfish/src/rpc/routes/chain/__fixtures__/broadcastTransaction.test.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "9ad1c295421474e3c97b7fc915e9e2439654503051cb70e583fc2613f3f1f601",
         "outgoingViewKey": "03bfb533621e90b2014650388ce233678ab23930c9355faebd41ecfb079eccc4",
         "publicAddress": "306466dafe08e00608c9d018ec4695f921b9fce084cc88b6df489bc9c695cb39",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "8f1cb163572acf5311d6cec4e5ccf76fe231385bfdeab53e1a0bcda976c62d0c"
       },
@@ -70,13 +64,7 @@
         "incomingViewKey": "db79418e2f992c88d7b75bf11500009b6ee9656c940ed0e14eb10a37784a3b00",
         "outgoingViewKey": "fd6c30db7acea51e6a0a9a1a0634263557f0a597356e05c66c4ede4bcbf62a5a",
         "publicAddress": "c45f35d0dca75da3259fc18fd18d5358865dbe242994037e0e698675e7865e93",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "6e33592e536f5c11c8113d72ba9a9a928e352e1cea2b196f8695c23adffbe00a"
       },
@@ -130,13 +118,7 @@
         "incomingViewKey": "fd9f66acbe8f8bea85b87c0e4592f73f7779209ebfba03f5610a552ddbf5ff07",
         "outgoingViewKey": "cc651959f2105e23b404cc7c5bd071a2f64407d5cd950874e0a5ed7747173a63",
         "publicAddress": "bb1e73e65d01bf625eccb0c41ddbb1e0ee60ce5c29b330a1dfaee9b4cf442f83",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "eeffd3f4f3861ceaee35b42c000ef6e05c9d87036242b37de4911cd5bf6f8202"
       },
@@ -224,13 +206,7 @@
         "incomingViewKey": "655ae6b4126073f708a0f99cf5cc5ee6155425a5772325d11045300407d56d02",
         "outgoingViewKey": "75c67e58f22eb1bf710eecad1f8a40512f58b2cf1ad936763696ca1a33d8c908",
         "publicAddress": "3f6ef36188637e5a0156a004d096b0212ddab91f4667c81aea2bc7faa83c712b",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "e230db7c15b70e9a77bce29f92044bab6c6d7d91be80d914b9c025223201f901"
       },

--- a/ironfish/src/rpc/routes/chain/__fixtures__/getBlock.test.ts.fixture
+++ b/ironfish/src/rpc/routes/chain/__fixtures__/getBlock.test.ts.fixture
@@ -64,13 +64,7 @@
         "incomingViewKey": "62b44f2341a407501ccf3a3e965f033258c8720e826f5aea1e17b458bffd3706",
         "outgoingViewKey": "75a0bf69e568bfd7be2a2fbdfbab23669d8c97f0980dfc58741f68314e6fb254",
         "publicAddress": "223623e00c0ff000e8f1a14e7a01935793d5d4b5db4124a2deb2c9ff5bb6735e",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "87014db264cebe61473b3c3e747d8b3592d69c861e27bf190c958c5a14a17701"
       },
@@ -150,13 +144,7 @@
         "incomingViewKey": "a4cd13c6076573c84212a6b1f4ccb0e10fe973cc92717f3dc92a1df9d1fabe02",
         "outgoingViewKey": "d9d24c0a7b9ca24f86d4a9e9801875c573ed65e24cec93a012a51fd4faf0dcd8",
         "publicAddress": "da78544e64187289505423139669f3fadb30acfcf90328be11c94978c7856ad3",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "4e7d3301a730ed67b70f91e2caa577dd6c93c11706958b07d82439c68663600a"
       },
@@ -236,13 +224,7 @@
         "incomingViewKey": "c882e74aa3375469207769dd7f168de3883e394a25e0b7ba5d0c16bd67b69006",
         "outgoingViewKey": "4b556317c3244d87aa6ba19aa8629e9f2fe90d025671ed12a0ff53cb6470a1d3",
         "publicAddress": "7fea05ec8fa00c8673fd9dec65c8a7b47d8833705c9c026fd963e91b6d261d3d",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "3f7c4cb2c1c253c9a99e2ef25c4015fd0fb671b06c43e0907600fe68f816a105"
       },

--- a/ironfish/src/rpc/routes/chain/__fixtures__/getBlocks.test.ts.fixture
+++ b/ironfish/src/rpc/routes/chain/__fixtures__/getBlocks.test.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "66e9bfad14998fdc39f033a8fb2a6486b75d5dbf402b3000ea651863512f5e06",
         "outgoingViewKey": "384635b7ddbe5fb3d9201605af01749cf21093a02e1de45fe3bfd0203ded73fd",
         "publicAddress": "3ed6732bd6515a7f8898c4fbd1aeed158cf65b7b6c3bf0285ca5921d6f67b237",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "3a35e3c6e34d572bcb3ea1d9a9e97ff33aa5ee1e4f83a9b18f0ff11498344001"
       },

--- a/ironfish/src/rpc/routes/chain/__fixtures__/getNetworkHashPower.test.ts.fixture
+++ b/ironfish/src/rpc/routes/chain/__fixtures__/getNetworkHashPower.test.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "e80ba5eb81b6f9fb15cedc70d7a04cbe24ea919fc9e3497b5a55085bc87ab307",
         "outgoingViewKey": "104e4de1c115cc0a651760cbb4a6768fc33180514214df730f22dbfe85c06683",
         "publicAddress": "016b3419b7ce3c4aa30efef541e745cef562cabce6324efb9a8d9753b8c9438d",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "44082ac62b8d969b6cc43a4b129e1a9b794361a6191e24dbc505a70efcc71503"
       },

--- a/ironfish/src/rpc/routes/chain/__fixtures__/getTransactionStream.test.ts.fixture
+++ b/ironfish/src/rpc/routes/chain/__fixtures__/getTransactionStream.test.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "1b9463a88bd8c92de3dcba75f275583486b1116563f9f7c581b31f9f67e3af04",
         "outgoingViewKey": "e595c5fa4f8e3007bf5fdb2f12bc8f93014c4e5fdd0257e414da48c2ae450c33",
         "publicAddress": "dffa34c2c096365153d3b2a2ab332e1cdcc77ff9253fb3ef910a4a154c0ca09d",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "9e9459769ad0b02be4ed37d39b3a00659ad185f33b3b95df79b8cad228158700"
       },
@@ -40,13 +34,7 @@
         "incomingViewKey": "b1932165800ba9a374fece8a284737cbb78c0d76a587b22d097a60ac43048902",
         "outgoingViewKey": "5af0104dbf243fe2f27aad357f00c9069feac604126ddccd6cf1a2c9c1c1f647",
         "publicAddress": "85f9f0c4cd734992f3d24ac73b967e65b90f2aed3b45d459d80b47337b22af0d",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "7ce1754c2063a3c198e5a1c421bb417298f82a729f177cd71ef9a8545819f10b"
       },

--- a/ironfish/src/rpc/routes/event/__fixtures__/onTransactionGossip.test.ts.fixture
+++ b/ironfish/src/rpc/routes/event/__fixtures__/onTransactionGossip.test.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "e49952a1e1ada7f0a3a12018560f0b4c7d8be8d6860fb6b2d69ccdd69e66c606",
         "outgoingViewKey": "9fe1e6b833006ed9686245492169344fe5c445f2701ee4bddaa1a57441e346ce",
         "publicAddress": "cd5ecb29276aecc134d02baa70a672fdea6eb4f4531aaf20fabcdabf282c2beb",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "bddf44503ded45a0ffd15762652d313dcb8f39d8cb7947cb058b927290669b0a"
       },

--- a/ironfish/src/rpc/routes/mempool/__fixtures__/acceptTransaction.test.ts.fixture
+++ b/ironfish/src/rpc/routes/mempool/__fixtures__/acceptTransaction.test.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "912c63c37c7606a1fe2ef0054f1b3807686683df343b19fb799457d61df58300",
         "outgoingViewKey": "86b54867637fd856fa94f05b9d44699ce8c059a46748095af216dbc7e7d4bd96",
         "publicAddress": "f43e280bb3193836f82eabf105bb58b791824020663da31062426d5528881a57",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "7075c0cf91bb09e85ededf8b27a942eae6a0f74e2a51e73fef0e9a4422a24b04"
       },
@@ -70,13 +64,7 @@
         "incomingViewKey": "b90bd7d5548fad4c66c152f6eaa09955546d822132f58a9312e9928f14d20505",
         "outgoingViewKey": "3fdb5ea82e1edda8a43b9f8501416128d04842d176e74a563842744d92ba890d",
         "publicAddress": "20c50704a9ae84b9f285ed3ab4c149d27ac74640a043fdf32c1da3f53094e209",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "3b0b4820b7cfc6abad3ab839a998ec0ff6f753c62f4a3d7de4fa4e38a336750b"
       },
@@ -130,13 +118,7 @@
         "incomingViewKey": "b0cd43063065da94ca7a88129b228abe9e49b3f290d3d2950219598024fc7501",
         "outgoingViewKey": "ea8c09c1cd729f2092ca530376f160f250566c7de433b5ac0a512677c4cbcb94",
         "publicAddress": "1a48caeaa0bd3cefce2b948b9b4744e1b9ad3386aca288f5990bd39fb1ce8081",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "fc5e413a9ab130e0cc5de3bc3c2c2c33830657d6339e441dfded32732c1b670e"
       },

--- a/ironfish/src/rpc/routes/miner/__fixtures__/blockTemplateStream.test.slow.ts.fixture
+++ b/ironfish/src/rpc/routes/miner/__fixtures__/blockTemplateStream.test.slow.ts.fixture
@@ -38,13 +38,7 @@
         "incomingViewKey": "aa1d9f2b0c6409b24e0e0b7a36f6c0fa593011e562f5c71acaf1ff71b0019a06",
         "outgoingViewKey": "42cd8de3af23eda4db16009ea06d4bb2229039cb70995eab04c928a16a513ada",
         "publicAddress": "50d261f111fb62b751824b69099c7fb1385a14eb2e5451ac70d27e1db7641af1",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "1ea2051904c22241ba80ec35beeff7df19986b2fa8023f92e5cc64baf1fe8f0d"
       },

--- a/ironfish/src/rpc/routes/miner/blockTemplateStream.test.slow.ts
+++ b/ironfish/src/rpc/routes/miner/blockTemplateStream.test.slow.ts
@@ -11,6 +11,7 @@ import {
 import { flushTimeout } from '../../../testUtilities/helpers/tests'
 import { createRouteTest } from '../../../testUtilities/routeTest'
 import { PromiseUtils } from '../../../utils'
+import { toAccountImport } from '../../../wallet/exporter'
 
 describe('Block template stream', () => {
   const routeTest = createRouteTest()
@@ -52,7 +53,7 @@ describe('Block template stream', () => {
     // Create another node
     const nodeTest = createNodeTest()
     await nodeTest.setup()
-    const importedAccount = await nodeTest.wallet.importAccount(account)
+    const importedAccount = await nodeTest.wallet.importAccount(toAccountImport(account))
     await nodeTest.wallet.setDefaultAccount(account.name)
 
     // Generate a block

--- a/ironfish/src/rpc/routes/wallet/__fixtures__/addTransaction.test.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/__fixtures__/addTransaction.test.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "7782e7c2df4928e08cec882c102c829c2e06d14016d0b37d275fe766b8c06302",
         "outgoingViewKey": "f4f4371bfb3a3e27feb85027759759fdd2cb9215b5eca96ef36571c4ea928c67",
         "publicAddress": "8738d2869de49156f979aa6a78e8d1ca49d26f5e2b33b14331ad5ed8a2a2151f",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "b6d0868ce67e1afc2ad02337bd8b8950acecf88064dceb2dbd175ee5381dce0d"
       },
@@ -70,13 +64,7 @@
         "incomingViewKey": "6df33d446566b706e1179e56bf1836b58b052f3e7cbd0072fb7fa130e94fbc05",
         "outgoingViewKey": "b09f37b8d3e46b6d2f2b21cb4e2a10110009c150dd162e6ce926aa2156098819",
         "publicAddress": "49430833b83534a04f6f2aabe9776a1718044871526e8c6cd88504fc572bd095",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "4646945cd454d2d95b83093603f2da71bcaa70ba0ed94b6d0b0032a150915401"
       },

--- a/ironfish/src/rpc/routes/wallet/__fixtures__/buildTransaction.test.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/__fixtures__/buildTransaction.test.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "849717589844d4e42c9be13d713df837cf97d02ce6ed6f2dfff875ccc4addd04",
         "outgoingViewKey": "81f131c9386cf723baaa43f8a76f640d2fdd5eac75c851b939865b11b6288dff",
         "publicAddress": "1177d57efbb7f96700435b3203ec0329d3e45e63dc48c5cc8b3bded938245814",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "155de11aa23f4ac0a50b6fbd29e07f74ae085ac5bad5e9f6e74094020d756e0d"
       },
@@ -40,13 +34,7 @@
         "incomingViewKey": "5b0868aca4ce720601cb9ce78ef60d7e291908da692b3b687e2be739754e7c06",
         "outgoingViewKey": "e745b95a7bb3a5bde4c583280f338930cc4c82d0349f265bfb0555f2a6086415",
         "publicAddress": "b75cb540d8226141ca2a5a91bdc97aaa138999b68c89cec2b0ecc1f14a8a2c66",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "2dd41964382ba2a0c3302cf671c782846c66f86f14c3c53d3da7b8c5c55c1c0e"
       },
@@ -96,13 +84,7 @@
         "incomingViewKey": "b355667fc634bc7d180c5537414a791e9bc9470a26e94b4d8646ee5d3e432501",
         "outgoingViewKey": "c5e8362fd2f9e59ba132d90954f4ae35ac21299925002a4848034864f52aa2f1",
         "publicAddress": "46317c39273f2703ae32946c4c1da6c5014e363aeb3429813da569788bcc7710",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:w0CZimMp/grNx4WBQ130MuO0VZJ/mzDO8F0h3CWo40A="
-          },
-          "sequence": 2
-        },
+        "createdAt": 2,
         "scanningEnabled": true,
         "proofAuthorizingKey": "928e3bcc1edcaf60a089e5ca0ba5dac0b41f08cabca30bf8af3a9d61681fc806"
       },

--- a/ironfish/src/rpc/routes/wallet/__fixtures__/burnAsset.test.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/__fixtures__/burnAsset.test.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "27128ae89a37f8def7d7edc19353514d229de06cd2351bd92a919e574316f900",
         "outgoingViewKey": "03479d64b8caba9aab030f460d5c2f512a74c28b0230ed9e7052270ed521dfd0",
         "publicAddress": "62e773d1c334b2553316eb498fcd1ff738fc336156880bac33dbb5bc6323f6cb",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "2828c0e9cd9641737a770f47e0abd0aed9773d5efa66010975ef4de632bb2c09"
       },

--- a/ironfish/src/rpc/routes/wallet/__fixtures__/createTransaction.test.slow.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/__fixtures__/createTransaction.test.slow.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "8e0bb4196f2749a2b0b6a7b31846ec36355cf59bbed7ce1c56901b4de429a703",
         "outgoingViewKey": "12afb3e5ef593e1aa5969af9c16a752b721ae30be51ebd501280ecb43dc14bf9",
         "publicAddress": "9132e1f07c14820e4f8072f685e3f4e7ebe12ad4f3e2959ee67884fcc2c6b9c3",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "717e7bb82caa3d918881dcbd89cf15b11517672f1207315e17560fb9539af302"
       },

--- a/ironfish/src/rpc/routes/wallet/__fixtures__/createTransaction.test.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/__fixtures__/createTransaction.test.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "2045ea6aaec5a16b2d3282facccf2bde81df3939eb99a0d579174c67f506ee02",
         "outgoingViewKey": "983510949d37ab79fa05e4572d22a13a8dceabad002a9bf1cea0c6c2b540a6b1",
         "publicAddress": "b9cbaeef74d8b660f06e9780fbdb438c5235bf57dc42dec3eb50c34e431471c2",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "1658f9e8141dd808b33f6adea2e1113000756f69fe248585406017e3b624aa01"
       },
@@ -40,13 +34,7 @@
         "incomingViewKey": "d2b6eee322e5b57d8e81610173fa7d6a321e5f674983dcb8129ce6e26223d001",
         "outgoingViewKey": "e503eac79fc36d2adcd9f2622e0036838a17011a24bed18cfba248ced5499a36",
         "publicAddress": "46618b84143dce15e4dac117ee8378f7dab9e5e760f80c01082f0e34835721ce",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "64f777f3f246a20ea104a43a6cca5112acac2fe6682b343441b8c721fc3b6c0a"
       },
@@ -148,13 +136,7 @@
         "incomingViewKey": "4b1a5aded5f981c8b12826b64113162c1b2560035c0bd410920a4d0012198001",
         "outgoingViewKey": "1aa5a6d5a0bd9292bc62a6d6aaf58d7e89c337b16e7b59e13670c736b69a66af",
         "publicAddress": "01baa99b4adf4f7922969aa818e24d185fb24e039a7e395370632ffdf12033a3",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "bf6ee10d369d74275d3b91821baeda12092f5cf35377e3afea4f1079bfe00203"
       },
@@ -256,13 +238,7 @@
         "incomingViewKey": "663cc4fc0a5389f470a2ae8dc7287fc81f26b971ee8fddbf9ca70685e2722804",
         "outgoingViewKey": "3074188d8308050673fdfbcd3fc88305c11b55f0237a53c6f026b8770691966a",
         "publicAddress": "24aab339b96e4ac35cd84d41b75c9a4e130f4d528025423f3afe48dbdf7bc795",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "9c45d6897f46b54b79331441593b70a765fd77e39a89ac529c978c1efe5f7201"
       },
@@ -364,13 +340,7 @@
         "incomingViewKey": "7d9859eecb38dd90f2ec5880ff2ea9388072890af7548c106826b5eafd45d704",
         "outgoingViewKey": "4ed0fab70e549f359dccdd00461440be4b21318ca2909a12c5776937eff6a507",
         "publicAddress": "88f99572c26de97f83dbe566fca39f1140c1f5d8e3d0e2b42ebbc4034b3b472b",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "0c445c6216b2376e8e06a0d0f3b30ebcde141ef90e71f12dc2b34e2516f5b708"
       },
@@ -472,13 +442,7 @@
         "incomingViewKey": "1b74ff6f37dfd54e1cf8f817acde9c6954a3552d47b13399b40e333a651aa005",
         "outgoingViewKey": "0e663c8953be8d36c24fbbc2c2f07af0a47b24c54950b703bab6c22312fd6e52",
         "publicAddress": "3548e4ce6ff25fd36fa32631b08572b5a67dd0d3e737b85eb473a743a1458cb5",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "aa13cecf43665bf40ea90f64965a9d4ab8a857a5901d6fd1c42d5db3c3d24007"
       },
@@ -580,13 +544,7 @@
         "incomingViewKey": "50306d222691fc1fe3ff8419d54f177499ce51fc0df2030c80978f01f61ffd00",
         "outgoingViewKey": "1861f1eb299f1b0f44bc4fa641acaf41dfcafa6a140a606d219ba66b05eaa5e1",
         "publicAddress": "192c35c35749e9c6d9a6fb866106b1abbfd3b5a0feb04b7e61ec7257a0c292f1",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "5485161e24bdd974d7a28ab32ffb234c4e256267187ca86fc54d5b3d4bf92309"
       },
@@ -688,13 +646,7 @@
         "incomingViewKey": "1e3a9be74b02dadb9fe9c166caf82890075c1bd81f013349ed2e0d0969728c04",
         "outgoingViewKey": "e41c87be55dce5161c17bbcf8923cd966d37880603e3ac952f5f9e1c03795d9a",
         "publicAddress": "9d6c3d4003691eed83a3ca5c2734143acb9bd6d7dc3a768e29374b183b564909",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "8fbfe12dce6f74c8f6745911d8357a2b224ca180b9c7487c178069a6c1f08901"
       },
@@ -796,13 +748,7 @@
         "incomingViewKey": "1cd8512c88329559ac671e5d6d96e6701d3a7c688545388020ad33eae668ac00",
         "outgoingViewKey": "a0e70917d1f0295400ff6077ad2c25f7212fc0a0ca7c1aaec2c1676a6035fae5",
         "publicAddress": "68fb225612c1824945f2a30b017c1d694db2b8e7c01336c3f355ab3f574428e2",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "32dfd73fa6a1482a10cac2334242d101bb49bd7c796ae7d287fdb5cb7f8b5a0d"
       },
@@ -852,13 +798,7 @@
         "incomingViewKey": "f3481b9b5745e1d4a6564f6b0e4e8cd12c284796fa4c5d75fe9d946279f18c07",
         "outgoingViewKey": "51b0f8c8a30111229b63e3be0295298dbbcb961692a304f25693c5ffb4135b96",
         "publicAddress": "dee7040f22f8774551b571f474bdf6472b015217bb4ffced86edf13e7db9b74c",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "cb5fbb8d33d0bfba981cbe9571088e490885bb773798d74618c5c0fa6ce42b0e"
       },
@@ -960,13 +900,7 @@
         "incomingViewKey": "7a641a4f563c5c01fbb81d0de0a82a106e3d3fb04e19225489ff9c1209853600",
         "outgoingViewKey": "3105b686e35c271f7b8d73f7a755753955c2895c59406bb2080ca433ab6e43e4",
         "publicAddress": "43de91537f790775d0a82555cd16cc39151b20578d41698e4ca15c7c356f53da",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "0d2d72f80c036de27ced09e1fbb2427836a77d1826ccc249a54e4628cd373008"
       },
@@ -1016,13 +950,7 @@
         "incomingViewKey": "cdbef6c0d53fe7dc58ba6edcb18948a362a3d8293dfd913a330c0301dc7a9500",
         "outgoingViewKey": "fa73270aed4d6311f184f55beb87ad0c41fff16a4dd2047ec2629d8d37cefef5",
         "publicAddress": "af4a2fb8d7247d0b327a96ea81281b72d2bfac0a6510b5b8702425b82b7974ba",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "7413f136c1639bf77a324fbafab58e934d7a820f61394f9a26f34c3250b11f0d"
       },

--- a/ironfish/src/rpc/routes/wallet/__fixtures__/exportAccount.test.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/__fixtures__/exportAccount.test.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "ae39e3705c743eeaea88059de7268210da9466129ccba9287f3bf41d256e1803",
         "outgoingViewKey": "85e2ebc57a0c56d268bb5e8f0bf99bb5e5956b13e3aca328d0252780bd6e2823",
         "publicAddress": "0bd6b11903fbcc630679c1010f179bd1a1e5a8d0de9c05fdbb9ebe282376a54b",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "f61d253bb43b46757a77fa5822d8bf4f9589074d01b7cd2dd80e6b066fef8d02"
       },

--- a/ironfish/src/rpc/routes/wallet/__fixtures__/getAccountNotesStream.test.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/__fixtures__/getAccountNotesStream.test.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "c03d7ad0a7150a073b94f9ae3b8666fc3be4f5c8d69e57961d37831aa141fe04",
         "outgoingViewKey": "6ac3f6c051825021f15619e16246398c603c8cfe76987777913e299e6c4f4b1c",
         "publicAddress": "b482623535be678cc3028fa6e404890052a88f6c7125c3e121376477bba728ad",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "ba82df6bbfe24bd8d35321411be7231ad2104353dc356d96651ab12dad7d6a00"
       },

--- a/ironfish/src/rpc/routes/wallet/__fixtures__/getAccountTransaction.test.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/__fixtures__/getAccountTransaction.test.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "54edb69f408607e7a685b32927a11dea0a67f82d3bae4cbeae76344716fc4b00",
         "outgoingViewKey": "32a603667265453b52fa0f09bd78bed1e44f2fcc0261cb8e94fbc0b6ee59fcb7",
         "publicAddress": "951464fc3016ded45a8244c019aba5819aa4773867a660d2d7a6eb2bd235cc9a",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "b0e77ff3208e9df7658c2c0f1d13c14a39e2e4694a817bfe66ea5d05974a7e0a"
       },

--- a/ironfish/src/rpc/routes/wallet/__fixtures__/getAccountTransactions.test.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/__fixtures__/getAccountTransactions.test.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "60566bcecca1ab1e41fab1bf4577dcb5bea3afbf907ba44f57d047c0e3434e06",
         "outgoingViewKey": "ecab6a979d93e8890e37b9392c63d136d3b4f06c5820389948e6b78fb45d2acf",
         "publicAddress": "1669ebd494118dd327a537f7313b7f219f36c8a8df1d0367d5fa1862a1282905",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "3c82f06289904109f2b99fdd75f9d57013c79a1dfeced5309c301e8a0e574f03"
       },
@@ -66,13 +60,7 @@
         "incomingViewKey": "cf35a6a7662567b6afc85119c5b2e4607173390f0dda199cc34c24b01e97b002",
         "outgoingViewKey": "9972c1973d3cdbf0ca9e3c89d297112e4a633f260a1ae4e8fe803ac8a5b3ae77",
         "publicAddress": "651e9efd2f33806f5932340e5bb25e6c269b57b8418adec2c4ae7e2cdd339284",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:t+mxzH/fp+FaoQn6sCUggzOA+WZM4aBjyWht6rR67II="
-          },
-          "sequence": 2
-        },
+        "createdAt": 2,
         "scanningEnabled": true,
         "proofAuthorizingKey": "93ded0114815832832d0fab6dd0eff624e00b7de5b05b5b645e76b8a00067c07"
       },
@@ -96,13 +84,7 @@
         "incomingViewKey": "8f6b0e0d6820c20ce1135451b725a92caba0d55dadd142507eb46bb24977b003",
         "outgoingViewKey": "890004c4706cc2b6b76e19b1a7f210b1a0a3c764673972920fb84a154136c10a",
         "publicAddress": "aba8bfae6ee0b62242f85d69d3743f6e034691883722b70dc020f6013086dd54",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:t+mxzH/fp+FaoQn6sCUggzOA+WZM4aBjyWht6rR67II="
-          },
-          "sequence": 2
-        },
+        "createdAt": 2,
         "scanningEnabled": true,
         "proofAuthorizingKey": "9f7db4862bf0ec9d35fd679a98d3f21221f9bda88a219dc764f7059d55ccd105"
       },
@@ -160,13 +142,7 @@
         "incomingViewKey": "1cf876df8672df27afbab68b7e9e58a38afb09f2d791ad21f4b8318fef604d03",
         "outgoingViewKey": "b19370eb29c9a01b4ff939748cde1ebbf07873a773715af4cad122b35de8a5d5",
         "publicAddress": "33a45213821885bb12acea38620ae55931fd8a70be61699b1a9b1555e4307d6f",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:pNbbBr/Y5tiJAMwxnkbM8z+uZlDeKdOpVJoOLDAAGJI="
-          },
-          "sequence": 3
-        },
+        "createdAt": 3,
         "scanningEnabled": true,
         "proofAuthorizingKey": "627a55c6a616f98a347f86219e0c7ebfd5f9a3eb76ef93653527f631f020460c"
       },
@@ -242,13 +218,7 @@
         "incomingViewKey": "b0ab6110ad674b06b859f58d844d1ff374ae4272143abfba0e40fb6a98a87801",
         "outgoingViewKey": "ca2e7c8eaf41eb59b6d4c4ab85c0c25cb41acb124d23f87674c31427d5ed5b79",
         "publicAddress": "92eb4c07d4a7ba8a0af23d1c29fb01be57b33037ce907a1957a8cfcfe2054dd8",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:S8LuedCTjYjAqo1cyrzZ0WRCidXLcYDA29KLKWKssjQ="
-          },
-          "sequence": 5
-        },
+        "createdAt": 5,
         "scanningEnabled": true,
         "proofAuthorizingKey": "3a66a21ddb2c4b7851206fd5f6935fbcd89d5abf65b7541a8e3d4de9f4d77d09"
       },
@@ -298,13 +268,7 @@
         "incomingViewKey": "62b7c898498b6a9fca8967338f9118daf305672af2e1d3c158eb8350961e8606",
         "outgoingViewKey": "8c7994e3756b18a2ed09b9368e12a17d0917c9a37cb4ae5544776dd095cc8556",
         "publicAddress": "0a8e5563a69a95a48ee38ed8852a79b53e8a1c5c5a9a2d3d943afe04e975f35a",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:/+AnFuU8fZ8zAMfzr6lbyQkX+J4JcbaE9DEQ2pRnScA="
-          },
-          "sequence": 6
-        },
+        "createdAt": 6,
         "scanningEnabled": true,
         "proofAuthorizingKey": "142ed09b033175e974c3a09226a697267f4241c3ac8ed9798d380e24129af107"
       },
@@ -358,13 +322,7 @@
         "incomingViewKey": "ed2d1c44eb809598387709e26cd8ba8170665685bb910c8075dd3399132e9003",
         "outgoingViewKey": "3b491d19af145fcc0b1b02da8cb5b993f239506980c30f81dadf98d4eaa6aef0",
         "publicAddress": "bcae24c16aa078d03317a071f5e7d9bb910f2477fdde6f1ff1971d9824f0d24e",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:TVjH3I5G+XS9w70BexUxosBJrzfFgQk3xF3zVJ97CNE="
-          },
-          "sequence": 7
-        },
+        "createdAt": 7,
         "scanningEnabled": true,
         "proofAuthorizingKey": "c41f1bd17a2959b5c2aa334be856bb560a1df1adb01f488110b543fd4ccebb0c"
       },

--- a/ironfish/src/rpc/routes/wallet/__fixtures__/getAsset.test.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/__fixtures__/getAsset.test.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "107b7a798ae9e8c45997e30d9661906b9ac5e072c85fceb2fd86902af7ce1406",
         "outgoingViewKey": "bee436bfc038e560c4f68e67cdac7b64844e22ff5bbd3634c083005f12c63067",
         "publicAddress": "f5a270059bd7a23283c0f451b4f1da8991c50e09052066959662e1e696586127",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "288c788a514ba0c686baba7ff29f7b4cc204a4191377ce566803ff34c6cc5307"
       },
@@ -40,13 +34,7 @@
         "incomingViewKey": "9aefd06a7aa249101c8e14fc449ef132df6d2c115b22881dc014af8af8a9a507",
         "outgoingViewKey": "7e9de9096a54a05db70238481f80938ae67329b51e3290d90bf71f5c13471da5",
         "publicAddress": "f74fbdfaa5360255fdc5d5aaf126096c0d947a6e73803e0951cbfa6081f0f242",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "faa478b01b4883707ebab604c10ffffd62f1f7d8ee0e77024a5d8d88c5e25f0d"
       },
@@ -70,13 +58,7 @@
         "incomingViewKey": "244b7ea6c19a314c405859c74d943c56897adbd223cc6c27dcbcef6dd9438105",
         "outgoingViewKey": "6b9640c613ff0dc646ccced7f39ae2aa33be4a988c58364b622bb6dc280bea04",
         "publicAddress": "81c21fc8be107784dd825455451f6556ebab8f31d481a076b89f9748cbe2aba5",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "8b8a14b6a63f652780c93d1cda6e0178c5f8e3965e0507eb270074fded452305"
       },
@@ -130,13 +112,7 @@
         "incomingViewKey": "7fc27872ee5c88c7942ec329f7a8fe65a6ce7a9ee3f56f8673d953ed54701d01",
         "outgoingViewKey": "35f5602ec90a226e83e441c7aea1c6ec3c2a48e5d05f1bee6cb09758eddc222c",
         "publicAddress": "e7b8914fc9ea858f8ec6afcdae7b6a9bbd9d081d074afc4dc4ba80950fd00ff1",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "5de90c77d8d2adfbee4b4f0b17d9ea79b4d79f0154c213e54d82abf96279790c"
       },

--- a/ironfish/src/rpc/routes/wallet/__fixtures__/getAssets.test.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/__fixtures__/getAssets.test.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "78ce324248806574e8c0cf9b39e98cada236ed4b2c1efd757d8f2f1fcf394d02",
         "outgoingViewKey": "93b3c34bccd7d84099457b40f97b26c3a5404b89deca0386eba536d91238c797",
         "publicAddress": "675d8fbbf60d0fb6b043cda596024e69b833859191ae3c83c3252e8e6cfea841",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "c953916cec4b3888fb7046a433bf263015c49abf6091ba4aea2745224c0aed0d"
       },
@@ -104,13 +98,7 @@
         "incomingViewKey": "d227eefb81d16e1ba951e847206e5bba1559797f01df72f58990fb308f541406",
         "outgoingViewKey": "91af063493c334a9e638a7ecedb19da986817a8165740c903c03c88018953e8e",
         "publicAddress": "4f0ce8d2c50fd836858a03f2c69dca38444e55cb372e816cbb1d82b82d4a1bab",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "24ac94b9371f40e1afd1232931ccacc8c0cceee159c8279e6375c5599fde7702"
       },

--- a/ironfish/src/rpc/routes/wallet/__fixtures__/getBalance.test.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/__fixtures__/getBalance.test.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "168a0b262ff8e611f9455ae2189bbfcc81058f996f6ccce6e21be0197e789e00",
         "outgoingViewKey": "1a7780e356f6ff92687dd172e417c1d11db1db67e2612f72bbf75d7af9f2a51f",
         "publicAddress": "729b67146151c1ac6498339f39b29854f7338137088d95dc8204fc5c5476094a",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "6fe09a2a90f14af29013780e8c8864c6d1fab8b78891c7c8981b878d214a6104"
       },
@@ -40,13 +34,7 @@
         "incomingViewKey": "d1c5a5cfb2137d7a560a7073582fbd3711675313963557a8b1da9c0745f4ae00",
         "outgoingViewKey": "9e76dbb76ca0eaab4aa1f317f670c200983a658d7173432158b924eaa601dc08",
         "publicAddress": "f0b5e7f518003051809e4fd6c8834d3dd192f08650f3b6cd0333384e5f732336",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "994201f9f78b5f6d855e79e3cb5fe411b5f1270710dce85f0eabfc61f6ee3e0b"
       },
@@ -70,13 +58,7 @@
         "incomingViewKey": "9290d8cc63d915b1f3c7379b5793babdee36788481b6cf9984c7d596b8793d04",
         "outgoingViewKey": "46f90576b523c19844a2f88366effbc0027dfa1ae0a617a0af2394bdd7a789e8",
         "publicAddress": "bac4ec835217387d0781872dff60dd24b21d94096d4029d3ad468a7209650eef",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "b12805e6fa39dc04436ee7526d503264e2fae9684bf35f6242f9907d5acebe04"
       },

--- a/ironfish/src/rpc/routes/wallet/__fixtures__/getBalances.test.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/__fixtures__/getBalances.test.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "5d9c521dd432ded4be81720d26cf4385e307cd9a5b894ca2b1b48b6056989800",
         "outgoingViewKey": "6041f88161055038d01ef544af85980ff343ced5c0f7a33c279cfb29638f6b8c",
         "publicAddress": "be1031271305adff62bfce6445df249c2b64aa436018971a036602eec012e41f",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "ef0a09efaf897fbdfa425a47dbb16fbf4ed2f02b1edb2a827c6d2efa84b8460d"
       },
@@ -40,13 +34,7 @@
         "incomingViewKey": "7f6bf359f56c9240214835fe2081b8c23b630019bd417ddc6114de03fd26e103",
         "outgoingViewKey": "f35936d612a39113f8340295fd5d7a5e41f61dc14810e6f3736be2ea821f8ecf",
         "publicAddress": "481bdc39b4258810c23bc9b15f440a4a73e579cab95fb704d50fae8e26994bb4",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "0903e10284135d4b2fb1327889ffe99e6b97685586dc9fdae61cc2a1ca8e8309"
       },

--- a/ironfish/src/rpc/routes/wallet/__fixtures__/getNotes.test.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/__fixtures__/getNotes.test.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "ca8121706b2c11c317a287aaebbe3c1efe210235c00965fdff6c83ea48dabf06",
         "outgoingViewKey": "6b8c52d684367e8e623f47f6b3fb2d8a6e105d758cff0209b9251d7cba882001",
         "publicAddress": "5cb61930c8524305f219a3bd3cd808d1f39195ccf8482fb8c10c198861c5b3ed",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "c51f6ffde06148b22139bfa0f6ba9ad2927359461cac233c518bd0c1a1b42304"
       },

--- a/ironfish/src/rpc/routes/wallet/__fixtures__/getTransactionNotes.test.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/__fixtures__/getTransactionNotes.test.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "14b3606a27b71a49a81abdbbc2c6f2ff2a39fec40b0248cde86ace043a087103",
         "outgoingViewKey": "5ac585dea19a75ffbd48294135c8ade6f121c3c32708ab2729463d7ab3b8fda1",
         "publicAddress": "f5ab8b50af42ac299232a2d36656d1ee9e21d18d96c7469fdbbee06c32b5d5dc",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "9d7bce36679ffe639b55c79a16bf83b3ec1724b32ae25846f97b8006958bb307"
       },
@@ -38,13 +32,7 @@
         "incomingViewKey": "35100c2e4914c486d98d6f05ea4ba07920ee9ea6547f0109c2506e87cfdc2901",
         "outgoingViewKey": "4bff5ad5ced8525e8fbf14fdd538e8ab87e80b445c5432e4d85c079a2a99a2b4",
         "publicAddress": "27aafcf1550d220c448a3ef1b9eb92491beac3e0ddb499e2004b0a8af7e01c91",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "c804581507015ee6f6cc30e16312f3f742fb46635d7b979219f4973187b44b01"
       },

--- a/ironfish/src/rpc/routes/wallet/__fixtures__/getUnsignedTransactionNotes.test.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/__fixtures__/getUnsignedTransactionNotes.test.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "78817d17dc41694e3e806e13a66012889963fa41185d66d6a1edae94991de404",
         "outgoingViewKey": "066ace6a5c11451e614718216ea3558b10f0ca4ef08f27838ec4e02ef6aa6db4",
         "publicAddress": "4129f6494c5101f8e7177f82bc11264dcadbb54d97fa6ee9183fabff41e162b8",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "0ce243f2905ae7105d693111f170a966d64f7589f3dc4bf619ccfbe8c9948406"
       },
@@ -38,13 +32,7 @@
         "incomingViewKey": "bd8c69196842c2979f632a3bafa5d34ee8dc8f74ebf90e67084c56cffed0ae04",
         "outgoingViewKey": "aebf4465bbf6fe59b7c25046f47f891b9b227c06472c4895681a0b6816ed5aca",
         "publicAddress": "c6fc59f105063250464d876bca49d23d03e62073847cdd4f9eddfafe71ed5dc7",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "95aea7d3156e041144b540487a2de6bf89469bf250081a1134d4c20ee3e4f508"
       },

--- a/ironfish/src/rpc/routes/wallet/__fixtures__/mintAsset.test.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/__fixtures__/mintAsset.test.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "448d66e460352bebb9951258ef9b611391f3f01434c26818a42a7dc403de4307",
         "outgoingViewKey": "7a8d801b07a8fd291973ed4f7d40c2ab239a9b0d9c28111e4e0d42ed1e5ec64e",
         "publicAddress": "7021f0c26cc14b99bbf89cca7311fcd2bbb1fc8023798d4fca00fa1b2c9c384d",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "ed8c14ca163fa6d0b8cbfe5c7bc8223073345b6bf7b74ed4919cb6ed1d527508"
       },
@@ -38,13 +32,7 @@
         "incomingViewKey": "3d657f7dd5f2e730bbac79ad3dcc2fb27a8ed1076c6cdd5052ee4b71e95a3c07",
         "outgoingViewKey": "7cd6eff862c8ee13641c28259ce06e3ccbc5bfaa03101d516c65dc1e14b04a6a",
         "publicAddress": "ce985aaca169731d12b8f765c1f0cf82df25afb1a9000a720194c7702bf7c441",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "6e5e4129715f7933a2d7faa8b29938c09fedcbd340505b11284c3766aebea202"
       },

--- a/ironfish/src/rpc/routes/wallet/__fixtures__/postTransaction.test.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/__fixtures__/postTransaction.test.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "835449d5721253096be408f89d8a7e1a1a440fb65d7f9b82ed525f2eed703c04",
         "outgoingViewKey": "a1e656b8aece5eb2be32bc2d54bf87d29a0e68c354368a78897025cc346750c6",
         "publicAddress": "90b44771984afa2b97bd70d59ae89c25ca018d2903e95db669cfe585b935f907",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "2de9491efcb8ca23572eee0866049b7d38525f6da4bd0403fa159aaa49b41b0b"
       },
@@ -40,13 +34,7 @@
         "incomingViewKey": "605e8dec543130288a5e40e3a0d81e4da2962bd97e20d86e7e0e50d5574b0300",
         "outgoingViewKey": "53bd186e30b1c0438e2f6348fc73197eacb9587fe0f4a26dc7512d59ca520a9f",
         "publicAddress": "004f5a65ce2aed82df88ecf6ba62f7df951a83251cd2f28cdd05f10b3a0035ab",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "ff3bd380b2977ead25e330da99838692f2812307c1d07c7b19ba13c51ee6040a"
       },
@@ -70,13 +58,7 @@
         "incomingViewKey": "ae4bc1deedad3be5b5a4047265e5234aecfd969166954786d45fbe8b99e5ab04",
         "outgoingViewKey": "bcf9c2370625608975f43186dfa1b5933bfc4bc860c0da1052aae6d5e9bf62b7",
         "publicAddress": "d772dbc9d3faba19e1aaddc5d92d7bd829a7079601bfe3a3de5229ac8238a590",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "389c732ca113bed77d50ca0c546c6e80de4e33c185f9a844e79b9c58de93f707"
       },

--- a/ironfish/src/rpc/routes/wallet/__fixtures__/rename.test.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/__fixtures__/rename.test.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "c3d0fc879a7306e25cc3597a9365c5ffdaa1cd338e1e7b6fab845d085d9f9106",
         "outgoingViewKey": "a8f37fc1f5173f05ab709f8ed06541198a4964b2e0f87b726d4f14eb4813ca4c",
         "publicAddress": "a88db5652d4d613c3086a6ac198d0f449d5a389b46189780b3b10b021cf6e800",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "5b25ea2304e9c27b0e91720f25d40670aced1b837378427c0eb8e12ca87cb90d"
       },

--- a/ironfish/src/rpc/routes/wallet/__fixtures__/renameAccount.test.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/__fixtures__/renameAccount.test.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "6f21ea316d55e76d28e06320b8b7f0fcc44409a281fc5c628c2bec6704c09604",
         "outgoingViewKey": "7324cb7e93bbec6336492cc55a6818cd1ee3fe797899ca3341f36897e21928cd",
         "publicAddress": "92a34aae04c8d01b3e97a1f43698ec14a88373bd457d9e8eccf0ef2f50ac1d0d",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "6751cac5f8a52448bdcea6856295cd100a1731ac96f073be888ff1060eb0c103"
       },

--- a/ironfish/src/rpc/routes/wallet/__fixtures__/resetAccount.test.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/__fixtures__/resetAccount.test.ts.fixture
@@ -36,13 +36,7 @@
         "incomingViewKey": "80c7ae2d4bda582b4931513e07184cdcd167fa8617023af4a07a52800a28e904",
         "outgoingViewKey": "b627d9fffe01f46c01084d85a83f3b28af9e63f99ac4d2a11889732b440f566a",
         "publicAddress": "d0487a45725597d62e4b0e49db9185be99424d34c8c400cfa3be2d25624ddf29",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:JCB3ROYUBKhfAUxkvukmQHEn72y+JJ0vsJCS5We8YiY="
-          },
-          "sequence": 2
-        },
+        "createdAt": 2,
         "scanningEnabled": true,
         "proofAuthorizingKey": "f5aed41d6fe7cd728a3bb290b161bb7e4690caf1c7dc363bd3ccbd6dca25ea0c"
       },
@@ -118,13 +112,7 @@
         "incomingViewKey": "15614de2f441165033639f7ffb3b22389eeb233de417390df1f495c2c27fba04",
         "outgoingViewKey": "da3a87a4ac3fc9eca1f2da4bca164b68eccaf4419811abab0984cb66fc2ad607",
         "publicAddress": "12ca7e3c5ea70a1a07f9fc9e055b84f19c5b48a2865a1c10358bd68df35cab67",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:aqtCIjNR+xIa6laFO0cBpIUGI9zF0i+xehQZJjxj8jQ="
-          },
-          "sequence": 2
-        },
+        "createdAt": 2,
         "scanningEnabled": true,
         "proofAuthorizingKey": "27fa4092ce1a948c12a6dd8c2a559a768d4f914a48853a3fa40279c4be521f0a"
       },
@@ -174,13 +162,7 @@
         "incomingViewKey": "7ebe3dd7dfe592c5f00212df6d6b185823e87d2785b768db142278fb84a1e300",
         "outgoingViewKey": "3839711cefccc3e5dd813f21dc681d0419907e29bc3a3f6423727736bdab6bc7",
         "publicAddress": "4777b44c0249ba457de05cfbdcce70fcc18ff31c04ea8d0d4df1e3bbacfd9487",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "170ff8d2f758c3d2e93823def66293942050c9b9b66904b44692af38812d7403"
       },

--- a/ironfish/src/rpc/routes/wallet/__fixtures__/sendTransaction.test.slow.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/__fixtures__/sendTransaction.test.slow.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "2d2e7d14a72b97fe222bec3f18b31409415562d87f45e0a053d9945df6399705",
         "outgoingViewKey": "cdd02c3f54fd634ae0b7abe0d2dce4119e3f18b2fe310e9b0471c1c91f3292d0",
         "publicAddress": "571ca98303db245943b813da0e304b62799eeac13dab4a4d963032b173e812bc",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "360e056044b3b9dd20467325c20034758f28e9f4e7ebcee307a3996797489e0d"
       },

--- a/ironfish/src/rpc/routes/wallet/__fixtures__/sendTransaction.test.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/__fixtures__/sendTransaction.test.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "15764feace41955c00262af20114b1e7b58d6a43f0b535b347a7a579c1a21c04",
         "outgoingViewKey": "8c6cadba724f8592dc9507ed9f61eb2741359257a270f72c934b2bf67dc82a98",
         "publicAddress": "70f5854f5b3ade4103359302a767a052df050ea16a5a31356ddaabb78b4409c8",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "8c27ccbabe0ec63aebd1cb86d572d9d70596d2a2de0d95526d7a1156161e1c0c"
       },
@@ -40,13 +34,7 @@
         "incomingViewKey": "8e5029aff5854d26770cc8e21aaa500f68eff3ca2ffd5900d9d2f0c30a3c1e03",
         "outgoingViewKey": "27580db2948fdfc7913281bb49079ee5a4fb5b47e58b5f9d2f6be701daa6d027",
         "publicAddress": "49c5001e590c22fec19e7129012070482a7180e08639ea763980f9e54deb4a1c",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "d4058828a632e777bacfb01b1ee0062760d8e371f4aeddfe758b88bdd56c610d"
       },
@@ -74,13 +62,7 @@
         "incomingViewKey": "a1d788a0802a414e39c14a71077c76b02d7bed20cecd928a99f53bea39c1ec02",
         "outgoingViewKey": "d8cb7863a95db6f5c1f4df76ada81ee2af438e26a9a510204ef521c3f431d57b",
         "publicAddress": "59931555d82a7e0636b9a05a603b7000fd2cfa0773a0dd62a2b14e1ffdfc006f",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "98e80dba4dbc668df2b3f5538b4bb1f31718486dd381765d83b2eded36a4b60d"
       },
@@ -108,13 +90,7 @@
         "incomingViewKey": "9c6330722e330f799eb70031e56dc831f538354a05a265b0872bd64e99396a03",
         "outgoingViewKey": "b840aabc7d8b0b46d9a0112b9abee731379d4ba063816cc8d4980ba3a1a1fce8",
         "publicAddress": "36b4e6de88f58da11e4b82d2d91a617f3d8e25e60816045e059ea574b7d74137",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "534fd31a050e72119c7ab15f5eec0c5e1ade2e399117bc177448b58ca2801d0e"
       },
@@ -142,13 +118,7 @@
         "incomingViewKey": "daa49dfe2675cef75c923402264de423f84247bb596f9a002bdc5265650d5702",
         "outgoingViewKey": "cc1859327b56f18b337a096fab92314fcf08731a8cdce09f50c703b991fcf5ea",
         "publicAddress": "78b7a7b4e17dcd40fbebdfa45bbcb5cd4a2ce4564ac79a005efe0e881ac49a4d",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "b8da5305493476e4183d178edb424a22f29f542bd9ac76eec786f2dec1a4b90c"
       },

--- a/ironfish/src/rpc/routes/wallet/__fixtures__/setAccountHead.test.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/__fixtures__/setAccountHead.test.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "370265e9c26ad957717170c7ff5b7de4dcb2e3a557d1e596bfd4573eebfd1104",
         "outgoingViewKey": "40ec5f622de672affca2b8326e3cbf472ac0c98bcfb37d8aea516c8be694d435",
         "publicAddress": "b28a46051bf6ad754ef532c81e3d4387aeb774f6d3e53ff37804313e3323f085",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "839b99bad38b80ebc25718072a7885c42cf64bac1cb7d4389515e66bb9fb500b"
       },
@@ -66,13 +60,7 @@
         "incomingViewKey": "ae7cc3ef1d82442fe562957149abe3133a33444a8f3147647a302a3e013f8c00",
         "outgoingViewKey": "0394aea6e1e82f0dc9f8fd97bf4f70a5d57ea53c1790f18a0b843dbeaffcc475",
         "publicAddress": "026ebc87db0dad0cd9f583a764f070799c1f0982e69c902a6e6ebc333987688b",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "eec28b36a332dfe0f34e13e9c65e6a83855bbbba60f8c1e5b00b97f45c41f803"
       },
@@ -148,13 +136,7 @@
         "incomingViewKey": "ceab5f2aa87a5c138bf32e05e5968b7436d358715f4db83529e414be5207ee06",
         "outgoingViewKey": "bb799b9ac5ab4cd359560cdf1994ce8c2bc71750b08fc06c04ad6f44ef305515",
         "publicAddress": "bf89f8fe948f840b858e2f536382c5190286ee1dd7fad961946bf349546345a0",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "5a064f3fdc6d0c77d404640f8e684f844bee7f2478d230faa7b53f817d3d4104"
       },
@@ -178,13 +160,7 @@
         "incomingViewKey": "0b0092c441ac29ff8445d4c3b361c9a64e90cef1452be06b6a95be8de4d43c00",
         "outgoingViewKey": "e337328cd763e1d5708682ddb3a6878e4bfab7a9e21ab093fe1c31487a8f3c7e",
         "publicAddress": "81ad71b2e0cb4412ea36d9c9866d01ce1e2c40f6c76a9d7c9d1781fa67d6045f",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "58f1cb9a490cf5d82744fb124c5d6cfd6d11ed30e1db7d8fc3a283c968f24b01"
       },
@@ -252,13 +228,7 @@
         "incomingViewKey": "92562ad50f0d001ca2b50d3389fe035667386a5d3a85092b9b3f85fe83ad1003",
         "outgoingViewKey": "b74b9f27f5b4d5417a38c953f32291e2e8651e04944598a6d6a0fab931056ae0",
         "publicAddress": "0b09729975193c3a4bf9834f5b5a0cba4e73aa21ac9bdfe29585e4988be48ced",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "e0fe9d4338e7b368f4999a8beb1dce4bd130fe012bd1d17e6b329dd37804a708"
       },
@@ -334,13 +304,7 @@
         "incomingViewKey": "c470db1cefc884ba0ae0269aae1cb06a72b9fa6bea73bcff70490aa5dcf68506",
         "outgoingViewKey": "d014ce8819af236fc0ae23ff07ad3d0f446704a078c8a7f876dbe38f9142c345",
         "publicAddress": "57f06f5b9a9a5f4cab00110c4628f9d5ec56fd4863ecf667a7a9bb663411d905",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "29be39827288418dec21aaf79b6a6eec07a39d1344469d69837a310e4d900f08"
       },
@@ -390,13 +354,7 @@
         "incomingViewKey": "9a5de86519dea39a0c129ef2ef5a9552b4bb204db2d5f95d97756e9900bc6305",
         "outgoingViewKey": "8cb50d16e612d6bddefc06831fef247f56b4ca73fc8f3498d20d054cd71b1f07",
         "publicAddress": "555105a1c62559433156ccf2ba4af5e062743a5395bc38bb5fa72918bcfd1639",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "99d9035ea09a68ba945d3835a220d2e000f23c047d49b9f62bf4938ade60a008"
       },
@@ -498,13 +456,7 @@
         "incomingViewKey": "fafd997a718e5dc392b774531381c4b691399e22057ad701e076278876c13a03",
         "outgoingViewKey": "c8d175450fc753d98133414be93d0416da7149e2b0088dd2a33f80502a344c3a",
         "publicAddress": "3e70527fb955ea2c2d45360a02d77990c562662de4543a817fea04989e95384d",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "33410fc1c7a0d5a8d3ef49630515087a7e1243410555553d02ef84fc90118f02"
       },

--- a/ironfish/src/rpc/routes/wallet/__fixtures__/utils.test.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/__fixtures__/utils.test.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "8294eccc6a689b0d5cce925e6cc05754e472c9e39ad60cf0b02fbb2c1d4a3403",
         "outgoingViewKey": "e029d4ffd3bd609b431d70b088797f17c4d8114bdb5eaf009b0e7083ba0634f8",
         "publicAddress": "b76e655eb59acb7980d40735625bb2d7fd8f0e97979b3c5fe0d672f62fb14c9c",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "4a709ca1196e3757ce603988dfb65828b682721b190a8204f9ac354c202cad0c"
       },
@@ -38,13 +32,7 @@
         "incomingViewKey": "c8ab089d6ee3e98ca56625bd634c0c9df36712be752471eec4ebdf520b4bea04",
         "outgoingViewKey": "c6346f9eabce5f3e3c0453651dd98c0e3c2bd650ea8bceb99f372fffcd92c91e",
         "publicAddress": "0dac70e13bf50a80b3ad913d171a6e01350d37f7a9df0b72c12746840cd19a96",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "e50332dbb5c6919cf29d3c59680448549196423790beef6315341ede5e705301"
       },
@@ -124,13 +112,7 @@
         "incomingViewKey": "e66dd6caa9d868c0daa1526b4446d0344eabb99f7bf27e9db22e557b582eb401",
         "outgoingViewKey": "dfb4de4b5f71952c05776ea187ba186d7b73297ad43abfacca25c3396618b773",
         "publicAddress": "e9a1b144a070916ac803c339f3060aba29c3cefff4dcda4c17964c67080094bc",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "f34448ba49d2347650a0b791c58c79c373aeb815b9b7decf0a20b6757f48f802"
       },
@@ -152,13 +134,7 @@
         "incomingViewKey": "ac89f7b83bc1edb7018f33fc06bc3190d0f1383897272f7a4c14878c0aa97807",
         "outgoingViewKey": "34993950723c0ca52f0d39f06e40f74a324ccf6f7e5d210d42bd07aa1ada8868",
         "publicAddress": "0b981ee59b9474d26bea0cdeb4401d02cc2824cfd764f983641bf51cd1bb5e13",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "787c60aac6b445dbf3eff7205784022299d23a58d370bf816bdb670cfb793b07"
       },

--- a/ironfish/src/rpc/routes/wallet/exportAccount.test.ts
+++ b/ironfish/src/rpc/routes/wallet/exportAccount.test.ts
@@ -30,7 +30,9 @@ describe('Route wallet/exportAccount', () => {
     })
 
     expect(response.status).toBe(200)
-    expect(response.content.account).toEqual(new SpendingKeyEncoder().encode(account))
+    expect(response.content.account).toEqual(
+      new SpendingKeyEncoder().encode(toAccountImport(account)),
+    )
   })
 
   it('should omit spending key when view only account is requested', async () => {
@@ -60,7 +62,7 @@ describe('Route wallet/exportAccount', () => {
 
     expect(response.status).toBe(200)
 
-    const accountImport = toAccountImport(account, false, routeTest.wallet.networkId)
+    const accountImport = toAccountImport(account)
     expect(response.content.account).toEqual(new JsonEncoder().encode(accountImport))
   })
 
@@ -70,7 +72,7 @@ describe('Route wallet/exportAccount', () => {
       format: AccountFormat.Base64Json,
     })
 
-    const accountImport = toAccountImport(account, false, routeTest.wallet.networkId)
+    const accountImport = toAccountImport(account)
 
     expect(response.status).toBe(200)
     expect(response.content.account).toEqual(new Base64JsonEncoder().encode(accountImport))
@@ -83,7 +85,9 @@ describe('Route wallet/exportAccount', () => {
     })
 
     expect(response.status).toBe(200)
-    expect(response.content.account).toEqual(new SpendingKeyEncoder().encode(account))
+    expect(response.content.account).toEqual(
+      new SpendingKeyEncoder().encode(toAccountImport(account)),
+    )
   })
 
   it('should return an error when exporting a view only account in the spending key format', async () => {
@@ -103,7 +107,9 @@ describe('Route wallet/exportAccount', () => {
     })
 
     expect(response.status).toBe(200)
-    expect(response.content.account).toEqual(new MnemonicEncoder().encode(account, {}))
+    expect(response.content.account).toEqual(
+      new MnemonicEncoder().encode(toAccountImport(account), {}),
+    )
   })
 
   it('should return an error when exporting a view only account in the mnemonic format', async () => {

--- a/ironfish/src/rpc/routes/wallet/exportAccount.ts
+++ b/ironfish/src/rpc/routes/wallet/exportAccount.ts
@@ -44,7 +44,7 @@ routes.register<typeof ExportAccountRequestSchema, ExportAccountResponse>(
     const viewOnly = request.data.viewOnly ?? false
 
     const account = getAccount(node.wallet, request.data.account)
-    const value = toAccountImport(account, viewOnly, node.wallet.networkId)
+    const value = toAccountImport(account, { viewOnly })
 
     const encoded = encodeAccountImport(value, format, {
       language: request.data.language,

--- a/ironfish/src/rpc/routes/wallet/getAccountsStatus.test.ts
+++ b/ironfish/src/rpc/routes/wallet/getAccountsStatus.test.ts
@@ -8,6 +8,7 @@
 import { v4 as uuid } from 'uuid'
 import { useMinerBlockFixture } from '../../../testUtilities/fixtures'
 import { createRouteTest } from '../../../testUtilities/routeTest'
+import { toAccountImport } from '../../../wallet/exporter'
 
 describe('Route wallet/getAccountsStatus', () => {
   const routeTest = createRouteTest()
@@ -45,11 +46,8 @@ describe('Route wallet/getAccountsStatus', () => {
   it('should return true for view-only accounts', async () => {
     let account = await routeTest.wallet.createAccount('temp')
     await routeTest.wallet.removeAccountByName('temp')
-    account = await routeTest.wallet.importAccount({
-      ...account,
-      name: 'viewonly',
-      spendingKey: null,
-    })
+    account.name = 'viewonly'
+    account = await routeTest.wallet.importAccount(toAccountImport(account, { viewOnly: true }))
 
     const response = await routeTest.client.wallet.getAccountsStatus()
 

--- a/ironfish/src/rpc/routes/wallet/importAccount.test.ts
+++ b/ironfish/src/rpc/routes/wallet/importAccount.test.ts
@@ -407,7 +407,7 @@ describe('Route wallet/importAccount', () => {
     expect(response.status).toBe(200)
     const account = routeTest.node.wallet.getAccountByName(name)
     expect(account).toBeDefined()
-    expect(account?.createdAt?.sequence).toEqual(createdAtSequence)
+    expect(account?.createdAt).toEqual(createdAtSequence)
 
     const accountHead = await account?.getHead()
     expect(accountHead?.sequence).toEqual(createdAtSequence - 1)

--- a/ironfish/src/rpc/routes/wallet/multisig/__fixtures__/createSignatureShare.test.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/multisig/__fixtures__/createSignatureShare.test.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "f113511328200f07d260f607f09c81ea2237637cfd29538d8b4a4f1df377df00",
         "outgoingViewKey": "8cb031c8c8bff795dff350cb2d14615f5f9c165dae8ff8ddb2008d9fbadfcb5f",
         "publicAddress": "cfc1c6c5c2b63bd5e1431a5e6465c3b31430aca4368c8c09e9ef0f88d216d2f0",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "8fb7fd8c3b965ac133b29570b0c95f62d9c7e65d03df7569978a7349146a6506"
       },

--- a/ironfish/src/rpc/routes/wallet/multisig/__fixtures__/createSigningCommitment.test.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/multisig/__fixtures__/createSigningCommitment.test.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "1814a18f9964bb2311bcae655b3d35450d47daa31b481f208710f7d349969f04",
         "outgoingViewKey": "c41670518528c64aa72cadd91e195e97beb5349105f75786c82882aea30e9195",
         "publicAddress": "6f711122ec12c51ccfb6890514518a64b96897d2b011bb7025d4f29078e17d98",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "70b44340ea5cad1b607c7908ac9a64df6e196f1a122fab8eac9a7f3fe0177106"
       },
@@ -70,13 +64,7 @@
         "incomingViewKey": "4407489602997ccfa885cb05dd51470740f6d5c6c342d7a2c5102802640fc300",
         "outgoingViewKey": "5d6d5dae10eeb5f6b8a0ae46a1234392f2357725f56972921672df5efd0987c4",
         "publicAddress": "003c68aa2a273e8ae917ab4132627826db1c6d60ba2a61c02b37f4a08a0b23a5",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "5e595db985afdd1eaa0dbc72d677128a679108d17b6f776f4cdcb411a0dd0505"
       },
@@ -130,13 +118,7 @@
         "incomingViewKey": "08b37ecf01d87bfaead7599fbe10009792072e0525fa5d553465667e2b454501",
         "outgoingViewKey": "b63af3eb714e74ccf7832a7385c0179075c16cb574d4e87e12ce8a07aa11949e",
         "publicAddress": "ff0a48b5864a97f775d7c543ff52ffe6140ef7517a9c827e78bd38764b54e847",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "361889196ddc701ad80293ab40576fe4a0bcc2db09476949c526bcef3281a703"
       },

--- a/ironfish/src/rpc/routes/wallet/multisig/__fixtures__/createSigningPackage.test.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/multisig/__fixtures__/createSigningPackage.test.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "700d2f8c9cf4261438ebada2b6503f3096faedb6f25dfb9b69f9cb20fa937505",
         "outgoingViewKey": "096855fb39ce83d8b51b95ec646999e03fdd569849e09af36d5621eb4f35094c",
         "publicAddress": "1d59e219070af34aa4610d7affb7421b687d9559109a0b9d820a38f0baef344e",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "7d75d744fc85a5db9a2d460fe0c36fc2dadf083663dfef270e31e3a7ee82ed04"
       },
@@ -70,13 +64,7 @@
         "incomingViewKey": "cf534d445eb5e3efa1ac6f35e7d96085249d24b131118eaad8fd6b7b40ae7604",
         "outgoingViewKey": "09913234f7d1807ea95920f95e4ff45839a2531066a94e0679fb47c9e8fafd08",
         "publicAddress": "335b25dda6b38ed7b1bec8205494781d58e2eca3c13411060ae54fbeb15b05f0",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "8092ff6318ed0819a02e3678cbe2e6baf1a5ae524b6546a621c255662f25b00b"
       },
@@ -130,13 +118,7 @@
         "incomingViewKey": "5423d9f2602b794884bb4f3a406b6146ea8d25fa5682838c1f14b09555258c03",
         "outgoingViewKey": "a841e76c4725ed657fa81ded9639ae74935bf4689ce77a8e7cd6518865a88c2e",
         "publicAddress": "b39091fc75b275b4383aa3ae1b29c54caeab48fadb3c2c57315ca363feb01553",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "b16f7beb2df42804fc35b932e2a3c8425f7588a44338f8e4b24b16d1a482c307"
       },
@@ -190,13 +172,7 @@
         "incomingViewKey": "2b2fcd374b2edc174904e3f24bf42853cef47a91255aa83b882951524cd6d606",
         "outgoingViewKey": "5647464b83ebb8b8c0f51e3e370f82be2cf6bdeb9c91a79e03ba7d35b1dce4f2",
         "publicAddress": "78f5c9c779fb74b9797af910044ec9b0f14c478d7cbb8920985924387b4e0d55",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "54e5a8306d666035b2b3a95d7d3dc66cb13dd2a9849b3ac9b0a8bbe42b9c2702"
       },
@@ -254,13 +230,7 @@
         "incomingViewKey": "b491386f616eed4d5d2e226084904d0986a172c251d1b64be02eb77f79c83903",
         "outgoingViewKey": "883cfc9b13e4f6b38f3404a397116d6a1a097261706829aa6ec3896a7af96d64",
         "publicAddress": "a5e8a9158ec5435bf1017328231b5a08b79b7ffdb38ac1e3f79aaf504247e3a9",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "0ffac3e999930e467eca3036268b42c0f4e7a94160d2c6cefb4d13ec8ca53901"
       },
@@ -314,13 +284,7 @@
         "incomingViewKey": "45d53a5a4240ed12101e1903ddaf8530bf904a3a6c0da9260c693732b0d35807",
         "outgoingViewKey": "39d9639b3eb6c29ffa1acff3ee847488758e0aa0047af592865f604bd1abb49b",
         "publicAddress": "08b662b49541cd101a55d402b403efbba2a4bc5e6f9544f5b8b32d10d5cab3bc",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "93c940773ef12c6f8cb57805e690a9de8bf28c604eeaa4b372d646af64993403"
       },

--- a/ironfish/src/rpc/routes/wallet/multisig/createTrustedDealerKeyPackage.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/createTrustedDealerKeyPackage.ts
@@ -80,8 +80,7 @@ routes.register<
       keyPackages,
     } = multisig.generateAndSplitKey(request.data.minSigners, identities)
 
-    const latestHeader = node.chain.latest
-    const createdAt = { sequence: latestHeader.sequence, networkId: node.network.id }
+    const createdAt = { sequence: node.chain.latest.sequence, networkId: node.network.id }
 
     const participants = keyPackages.map(({ identity, keyPackage }) => {
       const account: AccountImport = {

--- a/ironfish/src/rpc/routes/wallet/multisig/createTrustedDealerKeyPackage.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/createTrustedDealerKeyPackage.ts
@@ -80,10 +80,8 @@ routes.register<
       keyPackages,
     } = multisig.generateAndSplitKey(request.data.minSigners, identities)
 
-    const createdAt = {
-      hash: node.chain.latest.hash,
-      sequence: node.chain.latest.sequence,
-    }
+    const latestHeader = node.chain.latest
+    const createdAt = { sequence: latestHeader.sequence, networkId: node.network.id }
 
     const participants = keyPackages.map(({ identity, keyPackage }) => {
       const account: AccountImport = {

--- a/ironfish/src/rpc/routes/wallet/resetAccount.test.ts
+++ b/ironfish/src/rpc/routes/wallet/resetAccount.test.ts
@@ -22,7 +22,7 @@ describe('Route wallet/resetAccount', () => {
 
     const account = await useAccountAndAddFundsFixture(routeTest.wallet, routeTest.chain)
 
-    expect(account.createdAt?.sequence).toEqual(block1.header.sequence)
+    expect(account.createdAt).toEqual(block1.header.sequence)
     expect((await account.getBalance(Asset.nativeId(), 0))?.confirmed).toBe(2000000000n)
 
     await account.updateScanningEnabled(false)
@@ -37,7 +37,7 @@ describe('Route wallet/resetAccount', () => {
     Assert.isNotNull(newAccount)
 
     expect((await newAccount.getBalance(Asset.nativeId(), 0))?.confirmed).toBe(0n)
-    expect(newAccount.createdAt?.sequence).toEqual(account.createdAt?.sequence)
+    expect(newAccount.createdAt).toEqual(account.createdAt)
     expect(newAccount.scanningEnabled).toBe(false)
     expect((await newAccount.getHead())?.hash).toEqualBuffer(block1.header.hash)
   })
@@ -49,7 +49,7 @@ describe('Route wallet/resetAccount', () => {
 
     const account = await useAccountAndAddFundsFixture(routeTest.wallet, routeTest.chain)
 
-    expect(account.createdAt?.sequence).toEqual(block1.header.sequence)
+    expect(account.createdAt).toEqual(block1.header.sequence)
 
     await routeTest.client
       .request<ResetAccountResponse>('wallet/resetAccount', {

--- a/ironfish/src/rpc/routes/wallet/resetAccount.test.ts
+++ b/ironfish/src/rpc/routes/wallet/resetAccount.test.ts
@@ -37,9 +37,9 @@ describe('Route wallet/resetAccount', () => {
     Assert.isNotNull(newAccount)
 
     expect((await newAccount.getBalance(Asset.nativeId(), 0))?.confirmed).toBe(0n)
-    expect(newAccount.createdAt).toEqual(account.createdAt)
+    expect(newAccount.createdAt?.sequence).toEqual(account.createdAt?.sequence)
     expect(newAccount.scanningEnabled).toBe(false)
-    expect((await newAccount.getHead())?.hash).toEqualBuffer(routeTest.chain.genesis.hash)
+    expect((await newAccount.getHead())?.hash).toEqualBuffer(block1.header.hash)
   })
 
   it('resets createdAt if resetCreatedAt is passed', async () => {

--- a/ironfish/src/testUtilities/fixtures/account.ts
+++ b/ironfish/src/testUtilities/fixtures/account.ts
@@ -10,7 +10,7 @@ import { FixtureGenerate, useFixture } from './fixture'
 export function useAccountFixture(
   wallet: Wallet,
   generate: FixtureGenerate<SpendingAccount> | string = 'test',
-  options?: { createdAt?: { sequence: number } | null; setDefault?: boolean },
+  options?: { createdAt?: number | null; setDefault?: boolean },
 ): Promise<SpendingAccount> {
   if (typeof generate === 'string') {
     const name = generate
@@ -42,13 +42,13 @@ export function useAccountFixture(
       value: AccountValue
       head: HeadValue | null
     }): Promise<SpendingAccount> => {
-      const createdAt = value.createdAt
-        ? { ...value.createdAt, networkId: wallet.networkId }
-        : null
-      const account = await wallet.importAccount({
-        ...value,
-        createdAt,
-      })
+      const account = await wallet.importAccount(
+        {
+          ...value,
+          createdAt: null,
+        },
+        { createdAt: value.createdAt ? value.createdAt : undefined },
+      )
       await account.updateHead(head)
       AssertSpending(account)
       return account
@@ -60,7 +60,7 @@ export async function useAccountAndAddFundsFixture(
   wallet: Wallet,
   chain: Blockchain,
   generate: FixtureGenerate<SpendingAccount> | string = 'test',
-  options?: { createdAt?: { sequence: number } | null; setDefault?: boolean },
+  options?: { createdAt?: number | null; setDefault?: boolean },
 ): Promise<SpendingAccount> {
   const account = await useAccountFixture(wallet, generate, options)
   const block = await useMinerBlockFixture(chain, undefined, account)

--- a/ironfish/src/testUtilities/fixtures/account.ts
+++ b/ironfish/src/testUtilities/fixtures/account.ts
@@ -10,7 +10,7 @@ import { FixtureGenerate, useFixture } from './fixture'
 export function useAccountFixture(
   wallet: Wallet,
   generate: FixtureGenerate<SpendingAccount> | string = 'test',
-  options?: { createdAt?: HeadValue | null; setDefault?: boolean },
+  options?: { createdAt?: { sequence: number } | null; setDefault?: boolean },
 ): Promise<SpendingAccount> {
   if (typeof generate === 'string') {
     const name = generate
@@ -60,7 +60,7 @@ export async function useAccountAndAddFundsFixture(
   wallet: Wallet,
   chain: Blockchain,
   generate: FixtureGenerate<SpendingAccount> | string = 'test',
-  options?: { createdAt?: HeadValue | null; setDefault?: boolean },
+  options?: { createdAt?: { sequence: number } | null; setDefault?: boolean },
 ): Promise<SpendingAccount> {
   const account = await useAccountFixture(wallet, generate, options)
   const block = await useMinerBlockFixture(chain, undefined, account)

--- a/ironfish/src/wallet/__fixtures__/wallet.test.slow.ts.fixture
+++ b/ironfish/src/wallet/__fixtures__/wallet.test.slow.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "be9299d74d8667704c6e3a484f3d2ee462c79498ac4b754a3c51e8404aa1d800",
         "outgoingViewKey": "6377d5152f1939f971ce05bdaa453143ec8fb39ea4a5434c23559e6c046554b6",
         "publicAddress": "77541c0e1b262fa1a4193d9270a2f8d12ea034409e723db7f3d7cc0820d6a071",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "a6f6561e51be1099b3bfb865495cb34b46d846a3b9a11e1b5a23fcf8665ebf06"
       },
@@ -40,13 +34,7 @@
         "incomingViewKey": "0aac6f79b62c3a59ca0dc43a5043bb4cae9272e1c48e874c82de1499e33bd406",
         "outgoingViewKey": "1af1a216bbf52956770b57b0ab5e57cd87dcc31821d25e0da80a6d4e23eecbb9",
         "publicAddress": "73e96fc50663dccfb555066f1bee538f1bb91d4b377f779439da71288a4891db",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "8594df096cefd63e28d80cfee0c7a637fa9483f69a07929bba62916572f4cd0a"
       },
@@ -70,13 +58,7 @@
         "incomingViewKey": "4c59f0ac2de6966af3970e3331708b5a4d554536db4ce29caf4097634542c905",
         "outgoingViewKey": "037c362d068141a31720963027d502392db8a671f1aeba1fd9ae745d28dd908e",
         "publicAddress": "2f1f9adbe534fd191234842d9fcb9cd0e85278ec0ab9593b0daafc8ab5436a44",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "38f218d335e6c00e611be05b34338686bea9aedf100142ee2d2956f00b7c860d"
       },
@@ -100,13 +82,7 @@
         "incomingViewKey": "8c378daa9ee25d4a61d433a71ed9cb35d070dafe50ad74a0f82adfbc921ec503",
         "outgoingViewKey": "f76c8b3b2866bf82e495276464b436ef8e5607a5afe3bab7580b857d215ed2d3",
         "publicAddress": "7c1c0c002b9c327be5462ebec26d7cb6abe9b88cf5a907f02827acb351c91e13",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "cb0cf09d762cc4c4e34378a61260046de463a647989a1193615a0353a347a306"
       },
@@ -130,13 +106,7 @@
         "incomingViewKey": "a2638b82446dab4ef1372daf1c64013006635c761e8afeecc10ff3ac7b6a9a04",
         "outgoingViewKey": "5f3f0d4428b60beef032d7c77dce7e40658e2000f22e5a7faa2c48f2be6e3fbb",
         "publicAddress": "ca0adb50725c9a1188d293bdadb79f7c620ad7cdd15451de9aeb329a29fb2200",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "f4f2afcbfbd96bcec777b2269a2b318fa7320e971b19c3973847556f0604500a"
       },
@@ -160,13 +130,7 @@
         "incomingViewKey": "c953be8bf8138298897643c629525c1e7fd15c0de97ebf2e8d2611dc65cc7601",
         "outgoingViewKey": "dc1ae928b194faf30475571fc0051a1b88a2f72154da5cead7efcd8af110812d",
         "publicAddress": "887bb49ad3a5908279b23e7adef1d2e9139e66e6dbb556a8a051e9c0b4cfd98b",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "09c8873c3c3e916cf1d9659a9c21a55fb46d4eeecb63cd42a83dc4e34d692209"
       },
@@ -190,13 +154,7 @@
         "incomingViewKey": "6660bfbec5b3878b0b9c22c1702eab91a4bba8dc84af895350b2bbdb8d7e1601",
         "outgoingViewKey": "7633a48beda245e7a41432200bccb0c8813b30c55d298a0f084acb997aa81156",
         "publicAddress": "602e31030a5a6e73fa1ffe981c00a167ce6328456f0e80158eb900c4fa7a02d5",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "298add7a27fa4ed576a413dc3cfc5be7d6a0f19079e96b368ba6ccbbb90e4202"
       },
@@ -220,13 +178,7 @@
         "incomingViewKey": "896a0991ccfe0feb0aa01f8c925b2425c71c313439d35ab262a54b8a9883dc04",
         "outgoingViewKey": "30a0009b875018fd6600ecc267665288093a9d05ae83647a2b085b0e8f7adbf2",
         "publicAddress": "082e8fbd5b4a20e3fa2da3fde3c60ada5cc98cc3ddd99db5c80a59e721a8ca22",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "15464e521ffe70058b66df82654a2feadfa20445ab9f9e36a7dd307bac68ed07"
       },
@@ -248,13 +200,7 @@
         "incomingViewKey": "703c8141d8c584711c20bec2085bb6659e09d473ee0c2fc89ebf9da128c2e900",
         "outgoingViewKey": "9bb1863c1514aea4483033a5f2cac603df247d17e7a04f4c16f402228760121b",
         "publicAddress": "4fa55aa6b74bee48a297861143dc874962e4d60d987f7ab1ac6e055514428823",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "1ff9af307a93c8ccf0aa9daa6737b6f975f2590a3bfa4bfabf1d47b09926dc03"
       },
@@ -276,13 +222,7 @@
         "incomingViewKey": "da3d57acd5a4d9a9de5bfc9a6e1b2fa06b7ee8a076e81e8914d33d70f8956305",
         "outgoingViewKey": "06d0bb3a51e5f7a6e19edc80d51a26c7a0ad7f9413e7f14a719421a7563b13ef",
         "publicAddress": "5cedc32fbc42f0dbf54a2043c3e0a953e93675fc82bb3f9bbc1bd8c0fb14b5c4",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "6082d4f68caa57eaa8a0095a8c4f76e6658d64306f12c4e4c4648bcfda9a9d07"
       },
@@ -474,13 +414,7 @@
         "incomingViewKey": "2b9cfa694af0f6f45f20e5703258b846e526b791d183af80b3a15f36c4148001",
         "outgoingViewKey": "6bc844d5314ae9cfb7ed51cba881d3ca7c8ff445af54f1f9dbed4f546cc4adc8",
         "publicAddress": "3c68f35cee425b6558a84dc0fa4ea511513bd5874afda504c7f7724b59fe34ec",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "4a4b47842f0d36eb350fbb32e3be05de9cdaab8108b1a4a2c9633d85cc80aa03"
       },
@@ -788,13 +722,7 @@
         "incomingViewKey": "ff14c0b3590b677bd85cb202c2ce4f2b051fb617817d1f9161e33033f0f9b602",
         "outgoingViewKey": "504343491a9c3456353aee3c359ffd706ca2218d0b48333926734ecfc6f1a5fa",
         "publicAddress": "132253857a520a5667b9d620535ed9729ac496004a2b46dc217a3cbdc8582f2b",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "8bb879fa26b7dca31d55fa4955529e161de8862d29277d91d86f8f971c2a6504"
       },
@@ -818,13 +746,7 @@
         "incomingViewKey": "3c2d5dd46158008abfed3a75a6ebd082bce7c6f7fe9d3375884072a72d0dc403",
         "outgoingViewKey": "2cd96d74ed149e900c579374879dc6db9bdb6285576bda0a8043158430a04704",
         "publicAddress": "b5a66672b505bea0e8e2983b1c12d2e4df9a8270a105563438fbb976ce76b692",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "5f5bbde771a035f3d07b47eccfd4ae4c9c6c49b46303d74de4985bbbdbc22b0d"
       },
@@ -912,13 +834,7 @@
         "incomingViewKey": "8a5c06d3e0abf9b5e92d8dc4088d3c7374219d9057d0c701c23a1c3bba90a702",
         "outgoingViewKey": "4fc5e7296dd5eaa1026ddf7f6441d22dbce7c181ea543162fb1e4c11d15e6afa",
         "publicAddress": "d5d514541a0b44a83743c129e002e3724252d32d0ffd3f0301a2354f9bac5bf1",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "6c8bae0282f0fc7c01e334f47dcc8aaa2f38f008c4453bd809d3f9c8abefd509"
       },
@@ -972,13 +888,7 @@
         "incomingViewKey": "ddd276d19010311bc3ddf310989642dc02eb201e480f394d40c4f98cfcf63507",
         "outgoingViewKey": "9dae429a6962114f9c53bde513452bf4c6904ba290a18a112255a3397ca1def7",
         "publicAddress": "178e68b62fd1d1e19672b05ddceee673e81185f294dba2fd436e20c3a8e8c58f",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "f70fe347601dc7f4a9f1dea925f951ae71c0806123bf0757ab2c8661e2b4af05"
       },
@@ -1062,13 +972,7 @@
         "incomingViewKey": "aaf7d5043821ff4935249ac935f2724ecc2e841915da05bb22ecb1c1a4303403",
         "outgoingViewKey": "3fb40616af231b770687c7c7a41f188d392b91d3ef193ae1cf7e8c1075d060d3",
         "publicAddress": "f7981ab63147a297798a1a48ed9761d63c52baf0e026623848acb47751076d03",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "634fcc81c198ccc7a8bb2bdbb408d8368ec2baa01fe978b12dcea29014dd030d"
       },
@@ -1156,13 +1060,7 @@
         "incomingViewKey": "d5ead664c36dd19a082cc3e07a202712130b48cc36a8ec5b6bc86b983eff7e00",
         "outgoingViewKey": "6724f4701c92b3be693442ccaca0fc6f042539e97a3afa3d8f56ed3873ffdb76",
         "publicAddress": "2b942391def5544f47beb2512035a77232a7707d61221b07c7d1a80d73d3635f",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "f5c8198a5d5c613d09930c1842f11d2e5bffa6739954fc20f4cf7114d3814204"
       },
@@ -1280,13 +1178,7 @@
         "incomingViewKey": "5d88ba33c68e541246ee0759096762b16fa6d01c00d45ecf8101d0550e061f05",
         "outgoingViewKey": "38fc79fde20c550d6e8b8c856fd05f63163bfc954c68d4951124f796972f56fc",
         "publicAddress": "e74cbbde37b8fa4d8e434de175e1de154987030da6d95e9a95920e577a32a8a3",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "71faf1d050449d5cd8885e9e551e2eb816b0817be7b05cb810bd0316effdab08"
       },
@@ -1308,13 +1200,7 @@
         "incomingViewKey": "9e8221be0fc5eb6de3ce69d1c90076c1d8523cc2e6891eeed53009632ed30903",
         "outgoingViewKey": "f17f5a0d9ccadcf3e46fc2557bc22b4a07713b492800642fb77e80b7776f5483",
         "publicAddress": "c84d302bb4451005e05ec815ca85a82dd3486843fe06eb9bd78f4b070674f3b8",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "0023603acd62f19b8fcd3432686784b929712943cf963282c25c423ee5566203"
       },

--- a/ironfish/src/wallet/__fixtures__/wallet.test.ts.fixture
+++ b/ironfish/src/wallet/__fixtures__/wallet.test.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "18d60549690eb85223b770f55e3430ef090d6b484f6ade922ebbd3e5ebfd6d02",
         "outgoingViewKey": "9a49fde72f73d899776e875e4fcf0e76893d650a636d7c3e8ebd90d4fcc09252",
         "publicAddress": "97db40051b3ba68f9d32c3d74fb1021ff64789733135f87946b901c9e68e786b",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "7c18670c819879ec5794add226b36bdb82ce9dacb687da7c0663f481c0ab7702"
       },
@@ -38,13 +32,7 @@
         "incomingViewKey": "1d030ee2193b2357df8e16c83da80f41fe94cf99d76410acd268d8154e832906",
         "outgoingViewKey": "9338845301d0247faf65a110c06f0b2c2c1592aefb9095fdb48762e5b9a2bd3a",
         "publicAddress": "3c98da17b0fe89694378b1dd991014531bf79c00eba181996843a10b7a1e0073",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "c9eadf13cd29707b1f3904bf8543eb288f95cdcfac6f3f9bb077692777c26301"
       },
@@ -150,13 +138,7 @@
         "incomingViewKey": "d2cfc8139afac2025196eee404cbe9a176abc56770bc49376110488d87ac8e06",
         "outgoingViewKey": "2034a9f9a0693f58a4fef22548cb4cc3f6be4af451e98c6941cdd531ebb714c0",
         "publicAddress": "07e288b5c34fa2ae88fb941a8c78a71c53047d97fc44a0856407230ef94fd0d8",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "125c31650aad7eb88837dd6957ff624345effd9c20bce5fdf32a5de7e4de0f0a"
       },
@@ -178,13 +160,7 @@
         "incomingViewKey": "cb1bdb4eddb9ade75be1f7ad39d583553f5a7092c312f63ae8c98b73dbe9fe05",
         "outgoingViewKey": "a17792602d1ee8b0bc8984366e06c898e47ebc5e68bed76519440a2c5a9d08ab",
         "publicAddress": "2e78d58ee1838af65b056fd161aa7e6c95418514e3503dd1baf39eeca552d404",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "a6f5cbc25522d4372969c89a487278beb1b8fc9c94d9586dcc25f4d008c03c0c"
       },
@@ -342,13 +318,7 @@
         "incomingViewKey": "70e0991739ba44ebec8c593c2d6e22d71deb22ca3626b2001b8f89d909333b01",
         "outgoingViewKey": "7cc27038f0ef519d505771b6581eac2c6cd96c5abdc1969b4e7768f63d8848d1",
         "publicAddress": "9f82d0919be7c6dd5b52f85216c121776e8d880cc87e40d00b4cfa03f4ab0564",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "861bf855bac9d76ae8396448b0768c2a47058dbffe3d1344aed0310b8ceb7901"
       },
@@ -370,13 +340,7 @@
         "incomingViewKey": "a5f8fcc521d4316db3258828a9205e8d8c63c8b29332f466469ae1e554c96c04",
         "outgoingViewKey": "c1bfbc165474f9b377d812e2888fcc2b74579bf4c07e23d0452d31674936b32b",
         "publicAddress": "c5be14da80815cc4751b2908e762b42d2ec219a31bd7e5c9a220c8c3c080a657",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "8c8471e501e1a5176770406feaf18508087f166c46e7fad01aba09608d595d0e"
       },
@@ -538,13 +502,7 @@
         "incomingViewKey": "fb2f79bc12fd38a9f3c13db6e409a0d830a3b9ed767dcfbc9e1d87bfda4fe804",
         "outgoingViewKey": "282c20230932d7fa62714e883f2d65cc17435a43dda64bec7b7b68ff9ef17afd",
         "publicAddress": "566fc5c4abcd1453da088f69d50b330dc9430d20df1eb5e305b700def10ecc9d",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "7b2477a85faaf419aa21c181db9d8b35f1802c4ae705a33d3ea35767a2f0af0d"
       },
@@ -566,13 +524,7 @@
         "incomingViewKey": "7f2fbc50864fbfa464a1997e1184685387acd33d6bb0777bb5e9be93589d0c04",
         "outgoingViewKey": "804a6c7165ea7a86e7a833687d96c13175fc217b7475eb8963e2ee665e4240d4",
         "publicAddress": "9289566fe4045dffa71d3864a5fdf808b0754faa2a1aa5324f546052882973ce",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "69f22d5f882164c0b96283c4c091249eb079888b7beb70fe4a413fb98fc55108"
       },
@@ -734,13 +686,7 @@
         "incomingViewKey": "677f4c00e532a82db2e814e6bdf895faf4284402c222f09500416a83dc955d07",
         "outgoingViewKey": "ab30913b8ccbe2f17066c0528e70b9e026d69b947593a2b1a97ef82b1eb4393d",
         "publicAddress": "07d400b4204072a1fe1550449c226a00b407be7245762fb0f94d758f5530ff37",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "7536abc779ec7d8d92dceaa02eaedba69a5b2c590cc5a1d4b56a933f4392cc0d"
       },
@@ -824,13 +770,7 @@
         "incomingViewKey": "487c38f12d8202399dc181dffbbcb8fa5849d03b3f4bbaacd3a849618e053704",
         "outgoingViewKey": "a3c46b0c39994658b9015d8ba1bd6c152290c9d0da69ec64633c126e74785b9b",
         "publicAddress": "43e93a8c9999e5309cd7e9fdb1d48c8292199f49ceaf68b9947ac895fcd2e7c8",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "99202ae63d475afdb8af3c6051c5511adb7046f652654d33a34467a520a3df06"
       },
@@ -878,13 +818,7 @@
         "incomingViewKey": "c547a97c5e869f2ee6e96e6d04e9d59ffb89eb82f99e6fff6e6cfb63028eb604",
         "outgoingViewKey": "4fd093595f3b09465a051d5f3957ffc79bc1e596835d02cd492174f4bbc379a8",
         "publicAddress": "70a9a20bbc1b89294c5ebed55fe8f7d2d47e3239642f22247ba4b6c4b28dda39",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "7853627bacf25dcbad75c48b90e87be18659956ad8e295ecce97c1d229ed1e0a"
       },
@@ -978,13 +912,7 @@
         "incomingViewKey": "742a1d92e2a9f302ca656b76f3dbf44b19ddd56ab33c384d58471c6bf00ecd05",
         "outgoingViewKey": "7620e2ace2aa60dc6c308ea536269e10dcfd0210a27158d76c58e133a4116d96",
         "publicAddress": "9f63309b91ab572cc62da68abca5466cb86cf4cde6f23884171b0f264649cd4b",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "0d5b025ace9fae3d647412695a525ca88c61f468dd51aed31d7ef7bd080d670b"
       },
@@ -1006,13 +934,7 @@
         "incomingViewKey": "97b0c9259a4ccf9c18c7fda88e14341ab964cbca042065f7d49e4d44895d6403",
         "outgoingViewKey": "455a5629f056d1ba416a0cff8a8adcc0fa5e44167e4c8fdfae4621e3070f1be8",
         "publicAddress": "4a668a655e54660b48e4187d5891cd3e47a4243104421d1ca1f308a7a998eb59",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "360cd6f3b0ae1b0c7d36d67d80d0b77410d2031a5b60f19b04c53ae9828e4b0c"
       },
@@ -1062,13 +984,7 @@
         "incomingViewKey": "7faefc508132988390ee91cc6655bea31291af6c697898f5ec8fce0f51936405",
         "outgoingViewKey": "abf325f312f8dcdf82175341c9b04c68629bab895bd916b4aefd9ac7e071241c",
         "publicAddress": "a6e7a50946974ac2e0851d546c68afc2858dc3617fdb820d41db4b19b75fb23b",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "2bd98a5e5ad9e109c207736c5768362861e19c9b5a6f1e0c89b7878e6bd17208"
       },
@@ -1152,13 +1068,7 @@
         "incomingViewKey": "729aa83bc6e13d32e70420bbb2e6192a166876b57448747c9147b1277b3a8601",
         "outgoingViewKey": "634ddd1a0fbf4cc0abe7dc6ec4ce8303c3feb6e92a3f582e4f118ff49205bbcb",
         "publicAddress": "b2f022b352bac0460520ee8dc9ed672270abc7bb9f717112d82d0600aa74e73a",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "17a2c245780ccad2351d6e473b7d4810bc304633b4db69aebdb9b6e6252d2a00"
       },
@@ -1180,13 +1090,7 @@
         "incomingViewKey": "3086dcd6aad7c756ef14461a84226b6a2f315ed90265386ed507af084bb13302",
         "outgoingViewKey": "000cb9043646a7452408d72a467bee48520e095a50f5de954c747fb4c4026f02",
         "publicAddress": "6d5f85675ee4b5d6a246c46cb86d7c8784a6021331098eb16bb1ce331c5a9eb3",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "1bd4103602e3b0710ccded63d9238d5623287b64fe61815b1f2e8c12f78ad101"
       },
@@ -1444,13 +1348,7 @@
         "incomingViewKey": "523a3187c5336d27a7252c1104d3e7b136c671559bbbf42f3d4dd942bfe54b01",
         "outgoingViewKey": "dd2950393f98feabf755209df37c12b627e4372a16a0a793e5e3f59c3a5c6e42",
         "publicAddress": "2a5fa529543b15ab1d5e3012f1680db6ea372fe030a38257c4de18d046e87eac",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "eb0ff1301e60f117984d394d6158e535b752a8d26ca84d3214b8f6a1b8add000"
       },
@@ -1472,13 +1370,7 @@
         "incomingViewKey": "13d20d4b8dc19c742fad954d52972565b0953345c07436b5ec55ae2a5f17d506",
         "outgoingViewKey": "195b1dda6696efd627d012ac4707a6fcc769ba4a9a028bc35b32c3ac4f1cc4b3",
         "publicAddress": "dec7c7d5f31d2970a89fe9a26c084d77b4b06e25d11f441b9599d391107250b1",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "e4297ad98b64126017834ce4fc3cd82584b1fe61465ba3580e76e2e262a3d501"
       },
@@ -1500,13 +1392,7 @@
         "incomingViewKey": "9a3e56d06dbe2e497ebaa24e91c0f914150de8f509bdb2045beb56f8cb0e3003",
         "outgoingViewKey": "aff0270dc52aa1fe5af378d65f10e5d4a96dc5df980757b8f6a554a75d8e6411",
         "publicAddress": "659d8e27f3c3df437ef4913cda307e0cb0a85896a8089dd10b44a02e33489e94",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "0d75daf5d25016964cc48bb5cc14b837dd297486d86164f5b2485ec9f4047e0d"
       },
@@ -1528,13 +1414,7 @@
         "incomingViewKey": "6cfecaf913ecf63116399108551bde4df5bacfc5a8d55f55d855f585642f7302",
         "outgoingViewKey": "44c2091eb43bf971b61b992f9f5b3c085297ec5f3a2dad384a58000ba0af4384",
         "publicAddress": "47ba0cbc0b517b5814fa89e10df51204a6ab010dbb7469b1cb770f71b272c74f",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "5d6c4bd30a75327ad7f2ea2f5ed4b1c83d0bb5433d22ac568c20d69d1d2a4708"
       },
@@ -1610,13 +1490,7 @@
         "incomingViewKey": "0cdb776873205e6b9b3f99d6f136c1ed3eb72d4b28d23fd202c3efdc7b9b8506",
         "outgoingViewKey": "428fa313790dd10a1ce04085cb19b077c5310a0645d7effe8cd6bc834e8120e3",
         "publicAddress": "1521437460db8eeffbef208cdc7b5962789678ece99603ea300215e3a7d0c266",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "c3cf8c134774a2f89aeea73a0e7b599af0b8b1f012a964bc6c6dfae8b3664003"
       },
@@ -1638,13 +1512,7 @@
         "incomingViewKey": "39023482fcab76de1f8a4b2c3287ced14109bdb9636ecd4f8d70aebaa6a4c901",
         "outgoingViewKey": "59cf12e586d0b9333d26c6ef898b0d07a4896319333a7af0f7928f626425c117",
         "publicAddress": "05b0ccf13f8e8c7f647cc75a23249b50324f632d4f17caa4aa9f9ce5285bb04c",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "0b04a3a0fc11c1bd8f9de078f766801f312ce0c5f69a92fc2200d4bbe51abf02"
       },
@@ -1720,13 +1588,7 @@
         "incomingViewKey": "d6cb1df2ee3680104f766158c73e1e81668c8c5170ed55943ccad89adb80a806",
         "outgoingViewKey": "6a8e546555706916004f58489058c9ef0b49f987e6656b6b339db8b88b1c26d7",
         "publicAddress": "2ae67398ef9218a9bb728a6674cf75ddf5e2e3a6671cc33bbc4d021c0da334b3",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "6f7e0e39f7d87dc6c15f0ffe7d73179b35a92daa115ef972f8264d745dc2bf0c"
       },
@@ -1748,13 +1610,7 @@
         "incomingViewKey": "e27412282abe1f8854cacaf2100fbaa03d289092c1974bc2f5ebc72e1fd87902",
         "outgoingViewKey": "aecf19091ffeba9ecf8977c3b907b337fcf3ee2e1f1e63bd1282010ebda20bab",
         "publicAddress": "07bfd5e5f4a2fe8a5d0c11f12e04d2c1afa547d49f993c7311808241397fe4d0",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "ae8621b076bb131825e6018ac0fd82c975ff101bdb3b26bd4a8bb33774e30d06"
       },
@@ -1776,13 +1632,7 @@
         "incomingViewKey": "1f847e945cec32d22c0b36887e2c40e700747be3b9c2f2ce0a53d727d6fffd07",
         "outgoingViewKey": "e8d6c1d763d690fcbc7a8939f4d91da92c55383ffe9ac27403233b8fc6ce7a08",
         "publicAddress": "784799a0a0abcf80004f5ffc106fbdabdba1042ac0d4d728670ea5d23f35d78b",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "9c3b1a5a377227866c9fc285f492d02e47ba28a1757b0d245a3247efb3c7910c"
       },
@@ -1804,13 +1654,7 @@
         "incomingViewKey": "df773396c7ce0cb3ef47a9a9c65dff42e23c998edeeed74cae3f107119aabb06",
         "outgoingViewKey": "2151dd2dcc7270b380366c4d94a6b0bbe5c4d6c74277c1723e7826c615919a14",
         "publicAddress": "3eea373b8a34fa8d809a4592e06990ea5d9db3907647114ddc6a225d6384d9ba",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "c54e37a8dd8b5d241227f445cc3d01f938d75fd6043f0cde6c641c61ed9a3f0e"
       },
@@ -1886,13 +1730,7 @@
         "incomingViewKey": "9b08ec30b5be72d6d3fca6e709b800cbc86e88219bbceacc0830f5b39ac93a02",
         "outgoingViewKey": "72e458c30abf30738dacac7156a6441d69af4cd40d97a526d1cbfdd06591668c",
         "publicAddress": "e19911d0156d27fff52b9cc5b23b6247bb7122e3c759315ddfb8f298fd0a4641",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "c532f23cd2ea02d90ad8a60e537566226c01ab4d0dd6ec466ce6f60afcbb9a06"
       },
@@ -1914,13 +1752,7 @@
         "incomingViewKey": "8c03b8a28d662cab25f596926b7dd154c1544d9899c5a35e05d6cf9459b84901",
         "outgoingViewKey": "dd91d3adef2f850b3c85de32baca45eabaf192498fc5d8a0f05272d408352f19",
         "publicAddress": "e8196445df0b480d525f644246756c2b839a3b8acb6dd02825599489d4ad4cb9",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "0afa3847ec1ef0fdb5b0b24db84fe50a54b02b244fe95f9fe9eaf2d6336e7308"
       },
@@ -1996,13 +1828,7 @@
         "incomingViewKey": "5902901f2dda5291ad4325368016ba989a933751ccc4ed6a47d5d7b04efe0104",
         "outgoingViewKey": "19cfc410c247722be5bc5f8306e8d584c348dc39597557b9431a2783d7b6403c",
         "publicAddress": "d9933197f4a7f000e843a12d86cbac557b3c127e600e0e2fdfcaa9a49fc5bde1",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "00e6fe4ecba6a532ce7a15efec17b36ee58065239cd950a5660b0b01e3c52005"
       },
@@ -2026,13 +1852,7 @@
         "incomingViewKey": "6b30cbb7a35e45374b91167f51b0052dd16faf4a8f66bd7b146286c25e540a00",
         "outgoingViewKey": "fe829af5aecf58d0fe3477f0c91db72f4e787db423c7e23c69253be188f00e4c",
         "publicAddress": "2717ffc845f5eb8eb3f966c53e84245db1b915d5cbf13c4be110589b040b233a",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "2327b658d1e473f951cf8d5af3a27dc38fb922991761ce813a4abde3e3bae803"
       },
@@ -2124,13 +1944,7 @@
         "incomingViewKey": "98f6b5171139b69d4d621307903ad86651ce098ace904db42880ead30d297a00",
         "outgoingViewKey": "fb1060a7d6dbaea1ae6231e266386b778dfeb0acb6b752406b8e04c3a46bc06b",
         "publicAddress": "c7744f1e4575c251acaf6e6d04f1fd461d4c6aca4567d18cb5bb6832c4da36f0",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:Q3agWvJ73i9gmr0xOcMBccxk3mvfD6P6QfXc/xTegr0="
-          },
-          "sequence": 3
-        },
+        "createdAt": 3,
         "scanningEnabled": true,
         "proofAuthorizingKey": "2a993ef806d614276490f176891f01ba2006f99beba659b0a1fc257ae781f203"
       },
@@ -2222,13 +2036,7 @@
         "incomingViewKey": "57a1898ef4dbdef4ad9b970525fa0332a9d1fc8570a68d2c4d15502afb85d902",
         "outgoingViewKey": "d5b9d37a1ac10028a2a17a17a89963f737437a1795eff3682abe4efc1f438e93",
         "publicAddress": "bc80cb6b801f78c27afa0ac4b1982506d4b7ba17c6abcdc758683b4d35956795",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:lvEaYZEraHX9++J0iht4i8X4IJGGicQhjZggsxT+1yA="
-          },
-          "sequence": 3
-        },
+        "createdAt": 3,
         "scanningEnabled": true,
         "proofAuthorizingKey": "4cc5bb2ce6c23bc0026dab5a8c72df100637a32792c165688bfff1ff3f2aae03"
       },
@@ -2320,13 +2128,7 @@
         "incomingViewKey": "59f035a16c40c4db13a4e15d9fa8f393cab40da8a15349320ee637bdd25f9e06",
         "outgoingViewKey": "e150d8bb9da66398a7a182bef6528dbc69560027ce60098693ed0f8d6653cae9",
         "publicAddress": "837f4f7d2eba4ec94cec9a599ff7f09d2da3497da0542c3760a113b4bea6acc2",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:5sGMw6nsoJg0YAZ2wgGgVJWTfkDnSZcLo6Iodu21Qmg="
-          },
-          "sequence": 3
-        },
+        "createdAt": 3,
         "scanningEnabled": true,
         "proofAuthorizingKey": "95696380317d555d3708462aef0a17ea9b648f686443d3d5ef4e83009573c308"
       },
@@ -2350,13 +2152,7 @@
         "incomingViewKey": "d9fd5a8f1dcd8d19f7edfc7728a949d7b4bbbf90a06d2398d78048a36d5cc002",
         "outgoingViewKey": "e73c14758a5df387d30365409a00e5857625e10881e0472a532378a9df708da9",
         "publicAddress": "b664709959513a8ad1eaf3ad062ff560dbef3c018a9ba0776e69b63538255f5e",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "51a01e89802da3c0154565ba0dbc714d26c3c26591d9812ca4245d7208760300"
       },
@@ -2378,13 +2174,7 @@
         "incomingViewKey": "a5f48436993b293899bb6b8e9cb22e9d701d57f47caaa3016521f2ec3b6fb904",
         "outgoingViewKey": "106e6056b605652e636a07dae0f6e1dbb0593e66f8f07cc7cf76bf017be05955",
         "publicAddress": "54f3498af84e33f83a99f45b8786ac7383f224850130c0427b8d2cb5305522d0",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "f6b7a97e8ccf093446f69a94b7db9ae10b906ddaa904bb138b5875c3f76deb00"
       },
@@ -2438,13 +2228,7 @@
         "incomingViewKey": "81063add7a4e0ebf1bcaa9f714ff0754c2930fae9ff1abbc081acb27df553704",
         "outgoingViewKey": "93789b8ba70be57f55762519d99f94e09ccc43860cb1a5d7ed660429d294e20c",
         "publicAddress": "e341029ce046d92bf5615a293d3c5d7426d3228e7fb6df3265db8f425abe9d65",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "fc3eb9ac05c64d8c7a3805d63b6c504c353c88b4647a5b1668e421ced1605e03"
       },
@@ -2466,13 +2250,7 @@
         "incomingViewKey": "3b3f340b99d36ce835d339a29dbf646107ae99d64d6d1a28a9f75ddae0a91406",
         "outgoingViewKey": "6e67297a5641f5f6eeed55123b5d8f01eba0aaf60557e8aaf980d27868415abc",
         "publicAddress": "853d690693981b117fcf6551e4e38989a36d38f1afac4906df08e41e75a789a8",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "96aae41dd8082187cbc592053b2418b70c2abb3abced531d2a733951a4ba0e05"
       },
@@ -2526,13 +2304,7 @@
         "incomingViewKey": "f3ef87de0eb22e788cf90386f359f6f9ef3f4ecb2cbf486934ca03f70f463a07",
         "outgoingViewKey": "084d3c17a4ed12bddf81b0817869fc58ff543165bdf17728a601ae6dd17644fd",
         "publicAddress": "4fb6b7d948531dafc9e5c744a38a4ff201e78ead23f6ab3236ca3e5aeb7f0307",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "873c0078848bd0b7db29bc45c6431c56933835096c3e9d82c0f7dbceaa0b6107"
       },
@@ -2554,13 +2326,7 @@
         "incomingViewKey": "6e8562687c7808fb67a5652b136c3bcb6befe4824a5c67ac93b93905f2ef4007",
         "outgoingViewKey": "99c48b12b74dab845debe7f7477e9ac50be8595a286135c7c9cedad76a5042b3",
         "publicAddress": "19e23736b99981eb4836a1f361327735dbff05de994d7d3eaff10d5ff3c5ee82",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "524acdc83733a48612b315776cf9f295f45605c03ba2073bfc2268fdc0b76a06"
       },
@@ -2640,13 +2406,7 @@
         "incomingViewKey": "0645a385a2c66d22717d1d7336c1f444567459aa250c5c178c4a66d680758403",
         "outgoingViewKey": "b75de0dca00b4bcd888fb37fa7e07add8933f82383851d3ae1890ca7b6ba1eb7",
         "publicAddress": "0528f13506da98272e3bf236415f0ef46e8e3a7be7f615cb7e2542feb06d1460",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "9860ad9850773444bc63b3ff2b86c45ac24f0d2778db0fbdb664c11d9b88170c"
       },
@@ -2668,13 +2428,7 @@
         "incomingViewKey": "e642925522cc0906bc7b0d14e9633b7979fb3d99578f08b4c0af02f8c24c8606",
         "outgoingViewKey": "a964fd0345aabae03e50d9c49ef464afe333b94aa285f1b43affd3dc4f398b7e",
         "publicAddress": "3c122e7f28d9a21449efd32adb44f537ffcbcf1b6b7109c6ba9156b30c232f40",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "da9fdb63f84549e996c4de4948a8aa48fb2a264228ec80d7b3a6384387de9506"
       },
@@ -2810,13 +2564,7 @@
         "incomingViewKey": "83e9c77f3303d0ce787af55afd058ccac7d425ca21ec11fbe1a4186100c5a904",
         "outgoingViewKey": "aa54c6129fbd3efdd77c012f36bb03911fa8318cc6df9962305e1393f6d315f0",
         "publicAddress": "ca619acda27cc27dc971ce2e91dfa25a8d69e27891a2c03d6054326f847d5e62",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "b4d23a9503aa56955f537cd96dae4dec15364c7735302797d87215e5e1fdbc03"
       },
@@ -2844,13 +2592,7 @@
         "incomingViewKey": "e4789783015734f9bc466067d6aca102e73e75c29ca907cfec7053aaf6678801",
         "outgoingViewKey": "0829a6972bdccee8570acc532ca8b86d6ea4d394302fd825d319e347cc3b6c79",
         "publicAddress": "ccebd478ae4d838601492b33a1e9085a627ddce9595d5e3df274340e985904af",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "b91cb3a8c199461703213ccca7348c6c8ed9bed6fc2fc3fd249af7476cbdc702"
       },
@@ -2900,13 +2642,7 @@
         "incomingViewKey": "75477a57d773ad19c6cf13e68cbb1b277ed74e208819261dbfb07dac80edaa07",
         "outgoingViewKey": "a606225016751d516bb041100cd53178371511e20e24f5f26e54a78cf5e85d2c",
         "publicAddress": "7d4e7e56e77621642eb7afe3e95efeb268c1e489e7c3f185518eb75c384127e3",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "85252338e4ee796092549f8b832d47e1268aca05369b05f91425159e69c0af0a"
       },
@@ -2930,13 +2666,7 @@
         "incomingViewKey": "048d508618dd940fdb39a97bed744aad7b50f92328b68dcc003324a09dd97801",
         "outgoingViewKey": "97cfd34efdc837fbae7924fa7fb10ec335fbfd8653c4c499dff765aa81affb49",
         "publicAddress": "549cd2c9aff38d8c8181e663f3ec8d542ef45e2bd75b7d5d76043f1897d153cf",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "4add7cf82c21228f33534d112eeccd530bdcc865251176a1d66833996bfa4609"
       },
@@ -2986,13 +2716,7 @@
         "incomingViewKey": "73eed24fba8e9c6514ebe2cfa30be2502db1019b45f335d8218adb1f1eb56003",
         "outgoingViewKey": "ab9cd785355b3a0436a0edfb4abadd384933a89119fbd5d843bbf344599a47b7",
         "publicAddress": "c68d42d2ba76e02876ddf3d6a4ba2359517fc673ae392dbd4874a91b957f5ae5",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "16092bc7ad413bd8940c30bb5212dec18a595ec0ced3a9d80b50f1fcad661600"
       },
@@ -3094,13 +2818,7 @@
         "incomingViewKey": "2cbb74ffbe335a50df81acc8d05d55a03c1713027989f6cdb4486356d578ad00",
         "outgoingViewKey": "aad4eb453293e8312680a2b3700043965770d62279c299e5a3ed28115e6a3e78",
         "publicAddress": "6cf27da7ff70b6fa6ce68587605e37f9c9c11a225d5892aaa341d87d9e56802f",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "c6f69d46cf77d0b606b19039b04eabcacd34b37190e4f536ddc5dc0a26640907"
       },
@@ -3202,13 +2920,7 @@
         "incomingViewKey": "d2a2d2a6b52ebf984b37f712d383dd866dad7abff47aebe0b9f8fe8fa8aea105",
         "outgoingViewKey": "59ebbbf2b998bbfbb6343cf0a5c07732bd36328764a01db022c8fef963498db6",
         "publicAddress": "0c141e4fbbc829d161d0040a446dc7b6ced18b00be127a27cc04670dd334b957",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "53ce3931667fe2c3b46c573d24f7c810a09c1113b7215c29b16e85b90041db0b"
       },
@@ -3310,13 +3022,7 @@
         "incomingViewKey": "bf5e8536c80c12a081720380408229e6c47c9c4e5fcad7bb832cd85b370ac501",
         "outgoingViewKey": "87448c7e42c8ff2595cb9c3d760616aca80acb9fc38b6b18646c201adf73c04f",
         "publicAddress": "3d325ce8f26128c877dff0e7b48717321f5b2e1e823ccba04fdfce8e63779897",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "2a713c19d49a4326491c606371718ead04ad6abcd71003f4c9620161d9445e0b"
       },
@@ -3338,13 +3044,7 @@
         "incomingViewKey": "9f9cf8c7dbcfc153c232e5ecd8245291e24b7c9102022490aab9afc7db33db06",
         "outgoingViewKey": "6bbbbf4dd28b6117e88957b301417c41e26f9873dd9879e58034afbb1032b7ee",
         "publicAddress": "9882a6f1ccd595fe0473aafd0acd7e458c81d67fa14284627815c30fe1db4f16",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "e2c1b1168c1172188b9877134f5b4036a7daa602bc5a6cdfc7034de1908afd03"
       },
@@ -3474,13 +3174,7 @@
         "incomingViewKey": "700c5c4622d0abc3dc8d1aae8d32a73aa2c4a2e6a264a92c9de56d934eb4c705",
         "outgoingViewKey": "84f58706af9078ed76c9611124d43fe11d71ce2a7b0c1c51ded0665bf8527771",
         "publicAddress": "255d36c881772766dc97f5fb32753637154255cca5353b161f903a989dedd1bd",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "bd3f2e231d3476e457bb957465f52f26cdc6fbb3e79a3a6b3e319b0296ae5907"
       },
@@ -3530,13 +3224,7 @@
         "incomingViewKey": "f0d51ce8eb08e3f247befc60fdc8dbf4a9b8c7372be0d567fa118e6791631605",
         "outgoingViewKey": "f2792a5d80f0e3a17dfab93ada5453c06a397818661e4315b2d326c3a7ad1be8",
         "publicAddress": "e999d0605cdc725d89aed54254e01e1267234482cf25dd27862067dedb496a6e",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "c399f3a7bdd2df1a8fe2099588f0f8fbc6d485790ef3ba2e91c39be975675b03"
       },
@@ -3620,13 +3308,7 @@
         "incomingViewKey": "c45694765354085b98173ebf687f8565bd3c27c67473767d7f7e50254f5db206",
         "outgoingViewKey": "a60dc95c76f36506aa763c4d239ee72ef7afeac7c1d2b25faf63ed344007f01a",
         "publicAddress": "01bbcfb98ea62a15270828ae691b539e5e315e9cf32409d6dabf907d28199345",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "974137781de81247b4f44bf88bb411cd87f6798c2a44eff0d5ca4e2e2c647505"
       },
@@ -3676,13 +3358,7 @@
         "incomingViewKey": "0f0329196e20efb745683c83180fbe9ee618e2b9179d2034c6d4de3b413ec601",
         "outgoingViewKey": "f2acdee1c508f63749c1ca6d8858674c981e28984aaa41972878927a53925662",
         "publicAddress": "82246b8a1904814012d9660648fd881c670584086a7202baf1af4837b3362ff1",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "2fc625fd72f6df15d8bb65d1b9eb28b13bc4bc9d1017943c2b2b2960cdbf4c0a"
       },
@@ -3732,13 +3408,7 @@
         "incomingViewKey": "594993150a28f8fb59753a560daebb296e5b10facabc1abdcaaf170477a62b03",
         "outgoingViewKey": "bef7ce6c710acc74bdd39354c3363a67bc75912e7190f1bd929f0d9bbe952e67",
         "publicAddress": "341978dd15d5ae09fe61c6e47f0b55f73bba6e9af650fde2f939bf4733793be4",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "6e334284ce39b133888c2037079529e780f73458fe6c633ca98aebfa2f07f00d"
       },
@@ -3760,13 +3430,7 @@
         "incomingViewKey": "673a4327bba3288bc18d31c50f2f55fce410409d2ae4b555fab65babc9596101",
         "outgoingViewKey": "ae678e64056cef4d466fde470cb03937bef0233962cada091f3472b08df4cf51",
         "publicAddress": "44a8c7a0544dcbebf7d3e79c38fb99bcd30fe04c522e8c0a4040dbedf68c384f",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "b362fe906c7411ba64bbacefb6a12573b71f8e4a2836dde3a05131ea744c8102"
       },
@@ -3820,13 +3484,7 @@
         "incomingViewKey": "ce255bed31f94300381d86d506767aabf70e34038714b9e40baeb2b7d0fa2703",
         "outgoingViewKey": "bb1d7c81ebeecfc4afdb2473196e0a656a3b33c8cfa92b748240491f3bc8a40d",
         "publicAddress": "521113c0e3e5e6456cf5f59ac426b0325aa68951c96de838d6049779e7dbbdbe",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "ef7af34e47f5abc7f26a01efbb429b4f4bbcab39b7a7ba828934a367f267ff05"
       },
@@ -3848,13 +3506,7 @@
         "incomingViewKey": "895bb528f4ebbb8bcacc5e4e217caf5c0a8e25c841ca2d436ff882bbf0052604",
         "outgoingViewKey": "d5222480902addb9baa67cc9e57c1b6093f7de4dff39e2382ef84c9dd125c2c2",
         "publicAddress": "1cabafe87e2cdad8e07e46a1929e9543d1c961979854a84cfcb4f274c15aca49",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "1aa2a497835fa1e5f2c9cd88fb8996f9ae89dde7c239bca556a7c6ab4e4f7306"
       },
@@ -3934,13 +3586,7 @@
         "incomingViewKey": "b56d7eed593fcb32ca3c9305f7647572c057fbc2f50fb86c8aeaeb6a7b662400",
         "outgoingViewKey": "c2606b7ee74abc8cdaeef806851ad214b69b808c2bdffc07ed614dafc5072a4c",
         "publicAddress": "998b71f590eb07242bcd9da906d5f8169e6fe896d9647b394e71dc441bbdccc4",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "a4002050e012e4e950c6347b65976036abee842c1c355fee6ab401de1217100d"
       },
@@ -3962,13 +3608,7 @@
         "incomingViewKey": "3df5fe43c2aa03b75514b0382cbc0da5cec21f8e6456ea5d935bda1dd6788802",
         "outgoingViewKey": "e685cc8ac05ff93bf0799af40cd51a359ce2058af63d7371ce15a8f2efa41735",
         "publicAddress": "8f962daba578a24f702dc4f7ec49cd4e56e63ed37d2809717aef1f632eebcb0e",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "8c971a3178884efc8f4cdd1cee58109b3f962066ec036df54e4fe722d293f602"
       },
@@ -4022,13 +3662,7 @@
         "incomingViewKey": "f7758179f7bd5e6bf9e4d50d09fa96db307ebe2cc064d641b230c8051b420405",
         "outgoingViewKey": "87996c645a79a65e08bac9d494a73af7fdc68879681b4a8304710d460adc33cd",
         "publicAddress": "54ba5aa4c8dc570e74f0fc1c48a0ea53b88e31c6bcd9b19a3f0256ca34f221ee",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "4293110fc3ea8a1991d8a9738f6461df8122b10338ba379d6f61a9051605f101"
       },
@@ -4078,13 +3712,7 @@
         "incomingViewKey": "b0c44c47475b93bca350e8a7fb3dff67385980346a2779e8acefcad8811e9007",
         "outgoingViewKey": "cfa368d1730329f201788210888b1f6a8683277c5bfa997825968e8713673a0a",
         "publicAddress": "866515cde795c48214cb26173e058ef3d9874659285c98ca1934add93b86eaa1",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "60dda4e07b84f777d809af2719dd18d1892e93b28b25df5594c65bc02fbc010d"
       },
@@ -4164,13 +3792,7 @@
         "incomingViewKey": "d1ba21293e62c7b7aef8110252cf1348e9c8cdcbd8e29e57b5e472e6d14a5603",
         "outgoingViewKey": "50122caf58467fe56f5b3caa7c92730e9cfac35947bcdbecaa85cc40e6fd5e34",
         "publicAddress": "936ede26241c40a59212b251e194e683c0130cd6d4a29a7bf42a7890c94f94ae",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "dfacafd9f5dd332346d82aa71fa9ce34aa0c9c7acedca673f089badb95216606"
       },
@@ -4192,13 +3814,7 @@
         "incomingViewKey": "dc2512559d78c35497352a0fedad32e62af8222db66b8b5cce2422549764eb05",
         "outgoingViewKey": "b7c4c2775f1fb999a5cce2ceaa46282022aa81aaf9f44aae39a422702234fd9a",
         "publicAddress": "6cec5bb2c9277b843538df44ce549cee9bbe87796d26f7993f17fdd037b43200",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "4fa2f8ccde38a658dfa573baf3e92a404902706b14d32639a2eace47ccbb2203"
       },
@@ -4252,13 +3868,7 @@
         "incomingViewKey": "45aeba13496ada13e2eef2fc6fe608771dac01cdaf725eafd379f644eea82207",
         "outgoingViewKey": "f8771b7f507974adce966efe9ecb8ce476d5a1fb224b9f8b351f9a2c79d5067e",
         "publicAddress": "73741afc87ffd04a26d3265e5318baa355b175e61c5921f02917bd90fdb590c0",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "4d3eedf5701f80a6e1d5f0baf2d0739725358de326e97525e0666a8dd9343300"
       },
@@ -4280,13 +3890,7 @@
         "incomingViewKey": "03b807c9497241fdde722b7d7898840273c2d91ed25942515d034a833876e407",
         "outgoingViewKey": "f54b1a3b861c566c276b947593eb3e81cac158c4e051159bacea1266b36fcec0",
         "publicAddress": "212ea518a951ce594adf965c5e2dd65d622946ca3eaae9fbb77f1e2525e86695",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "d606e1c56cbaa2367e8bce4c1d90753d7048b30beb6d5efd5ad41744c8cac901"
       },
@@ -4340,13 +3944,7 @@
         "incomingViewKey": "078133d8b9f9055417dd4b03653ee4b8f251e0fefc32149aa7425c9d3fe6ae06",
         "outgoingViewKey": "815fe80a2f67cf8e8228acfe9c3d6bacce5dd4c9f5afb3162f9fc73d58e1f526",
         "publicAddress": "92f7010e34896fd468dff5af5afcf15b2ec2c126cf324bd7d7f58c02994c0a0b",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "4f062833d1893d42e79808851b14d82392a2053853f6747334ea4db38a5ec60d"
       },
@@ -4368,13 +3966,7 @@
         "incomingViewKey": "f9a76c3c240dbe1053a9cabe640386259fc6f8a0a7e86bfddfcf14df8fb72a04",
         "outgoingViewKey": "1000c09122ba07b31e1a053808e1ee52ab4fcf82b1f58677b14bbf6664d90612",
         "publicAddress": "7f6229c26f5ae7ae1d2460f66a49e21a0043738f63ab9919e29ce8af0ee227ce",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "815ee445b678ca104c39396e10d94589ab3244a3852003099fe553f88fa79c01"
       },
@@ -4480,13 +4072,7 @@
         "incomingViewKey": "1d8b5c646e4dc78dd5b114c9d6b9985ac3b157f2b1f3b88d6dc3274285087206",
         "outgoingViewKey": "c0c68212bfa326b18a81662901f02550f36cdc6f902d5fda40f059a5012ed429",
         "publicAddress": "1d36110d2e6c8dd0f700b747596cf63d62f743d13b8d8924055d96911e9333d8",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "63c9a8367bb057cdce77b16f994e828cdbaa5203c41cc2e904f2b12252639208"
       },
@@ -4508,13 +4094,7 @@
         "incomingViewKey": "04ae8d2c315fa46c1280ad3d773e5b9af5651516439929fddaa7a652f07fbe07",
         "outgoingViewKey": "c239e74af1eeee7d96916801a4941f2cb7fdd9339281ab9d1921f75523cf6268",
         "publicAddress": "e04def37fc0cab193e44a31390d85c0090a2b89a0610bc16e017f520aecf926e",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "502fe91c0be9444219abc053a14247785e8eccf5794d8af5d91dd3ee7ac4bc0a"
       },
@@ -4620,13 +4200,7 @@
         "incomingViewKey": "14afb756bd4dab75ea541ca2395a5a43cc7c2d28d2604c9e2db33dc8a6b54a05",
         "outgoingViewKey": "2f8bf7b9a052db1c5fcb25b85ad93523fc865c9493a12889dafeec82e1c98ba5",
         "publicAddress": "2db05c91321a5e96af2303c9c9164bfc0a2789ccce25bbeb4213cc986fa755b9",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "ce1df7be9844e830b02a603d25146aeb1cd88d47b28065115d8701dfb9927406"
       },
@@ -4648,13 +4222,7 @@
         "incomingViewKey": "e3fd9ad198d5d57eb446d439862b8e4b529c5e186999aaf5319b0c6043205302",
         "outgoingViewKey": "fd5aefcb77a84360379cb42ca1575af92af0fef6f9d585e00671788f5ab7fb69",
         "publicAddress": "1bc946448310c4b70c9a0ad476741a0b0afeaf02750bdb5ca324ceb3c743dce8",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "12baa42c0cac30b9bef37d863528b3d2f6005299c8f545bf7bc219f4b7792904"
       },
@@ -4734,13 +4302,7 @@
         "incomingViewKey": "904fc0c2542b4054697441a9aa09651ca4d23f87e2b009ded9ce9c25f86e0602",
         "outgoingViewKey": "ead9f6e370a250d3e6f6a8bd26aeec8832f31fb29bbfde24bf29154c3963bfe7",
         "publicAddress": "3c91103dedc461acc29cf0f2c38ea8b68cae02594cd61f007418ba4ea91e0b4b",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "d9abfb17706f10f70a61c41f88d4a3e931835f3c98912e20edfcddc0b567370e"
       },
@@ -4816,13 +4378,7 @@
         "incomingViewKey": "2de5acbe99b326bae9267b2471d58ede40cec3138fe156599d599b1403d4a107",
         "outgoingViewKey": "eb45a5a3b4a9cbb1cfe22c1efea45c29e55e1c83d925d3ca892d693b28681235",
         "publicAddress": "580336448b2097ac9f598d4aa6e7300219c49bb861bf11c24a9278ae65934f46",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "99c3f6bed5f5e73d8c291e95c70056f43dada58594cba4739e833e882301ca04"
       },
@@ -4898,13 +4454,7 @@
         "incomingViewKey": "6914a8b8060ebd61f489938c8f76f5205cf2c5f462599de32b9656a237457605",
         "outgoingViewKey": "3ce0a0bddfe06268060f00fe2baa4a5ad48cacade1cf0baca6b0df0e1d456f37",
         "publicAddress": "d7a73845f559cfe20c840c3e944a439b3c6d89bfe93aaab4f4f6062d69a033d2",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "690371ad8dd629b94449613b54e6715962d573b21a7e39e772167e575dc6fb09"
       },
@@ -5006,13 +4556,7 @@
         "incomingViewKey": "e9ecd4dd525a226e840dd9a524ee807709b1220068b1e502409fa32799ee9c04",
         "outgoingViewKey": "31eb8cad991687c2132c3fc08be99c62296423e26d4afffcda306ca9fbe658ce",
         "publicAddress": "dd644113f8e1fc1d324f34060696d8352e97a17edf0a3a78dd54e1d246f1a6e0",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "a6ecfe0bcd13494281d7b3c00288ce5c6141d3948cc0c888bec52ac3d187c50c"
       },
@@ -5034,13 +4578,7 @@
         "incomingViewKey": "768e419a67825b80983a529df92f94e16db370f6a78965959c6c7cdef0471101",
         "outgoingViewKey": "3835258a93bbc9f8273c4b67d74f47a3b70a6200b1be82f2ef61d97ab09a492f",
         "publicAddress": "340d2b8c66eaefd69d9ed97d9e047903e9693f6223ac370da7f3ba3c87b7cfa9",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "f942c2ba94cf975969ab70c6d62a2ef0bb097a75c09bba385ae2beed16fdee08"
       },
@@ -5116,13 +4654,7 @@
         "incomingViewKey": "51b77328b548d6476845925043b2b68979db966a80045974ab1faff3eabc6b04",
         "outgoingViewKey": "82631567836d529fed8d550459aeb2d0fd89b09a6b197da028b3e730edff61d1",
         "publicAddress": "0c0e73741390118a4965ef6590ff7f76e88355b6c514619e6334733c19ca1bc3",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "846fc1e615e263752c522a1847bc2300a7c83bffd013d792d8bdea4b6c354e02"
       },
@@ -5232,13 +4764,7 @@
         "incomingViewKey": "1ba43b83564d50c2d89c0380d692cb0c9605d8dd28622c9b9dfac26efaa4fa02",
         "outgoingViewKey": "61893a6f08648028a4bff39a7586a70082bab7dcabe6fb0597068dd1c2089af3",
         "publicAddress": "9d042d3a4438807b1225f6e9883c6af634460304362b1e1d1d11a985b47f0823",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "7b5f73a54f417ff870e556af7c73696488dc3c7515256ad261bcb7389d73520e"
       },
@@ -5260,13 +4786,7 @@
         "incomingViewKey": "3cc5ae32de87f1f557533e5a7c6c92fea4822b30b314e0c4e7ea4fd4488ac802",
         "outgoingViewKey": "2170357e32352fcc6eafd2fb4b0659dba71d142a6038b157925f1ebf66577582",
         "publicAddress": "ce2bb4c55cbec067fc8ba9d94f780b3def2ba2cef6c0a612c8d88ca3741c4c85",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "9c3e2cbf70b994d5b3dd251a21630a7e03be438afc52a076361c9c7563c1e508"
       },
@@ -5384,13 +4904,7 @@
         "incomingViewKey": "875532d7b4a7a26386ddf29eff49a72b6a25b268167b4858af04f10c30a9ac02",
         "outgoingViewKey": "66408539769523de7eca2418517b62cb02be7c401f0a7501bd13640d080e9c3e",
         "publicAddress": "460d857e7d44100aadb1635d84a2d792131ccf3b111a3142e3551ec4c2f2c239",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "ffb1665a2739ebc9ace5a30b71c5b20c5957c6e25b937450b187028e80833107"
       },
@@ -5412,13 +4926,7 @@
         "incomingViewKey": "eadda34d84590dae853bbaf51d2c2f7e5b4d9e529d2a939d27d1ac32614f9501",
         "outgoingViewKey": "4086253445b82ef43620ec4c013f76a684d7f60777b27e308dc9956369a79669",
         "publicAddress": "3e2e7615c181f2afaa6423465e3b3a9ddf8d89020891cd5f1fa77627beac0d4f",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "ef3245c0bc7b577ad96755d1401d21318f5c2325a6c9ec635e2860e3b8447c05"
       },
@@ -5672,13 +5180,7 @@
         "incomingViewKey": "01ef479369c340c617803aaebe5749807fc5ba8f24a44f2f8efdff2f57e37203",
         "outgoingViewKey": "2a16e7d2db5541a55d55bacd69f5a5077d3aca6d64482032a74405042dbe23c4",
         "publicAddress": "002e67c1b367a11cfac003e4c6a22352676c6db67ee482a6cf425614a3903be5",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "bce77800905da0e98d479dbd811ac2b941bc7fe0743093aab2d1c2d5548cfc09"
       },
@@ -5752,13 +5254,7 @@
         "incomingViewKey": "d93d88278fb58013b1ba30bfe8a00f4adc907274fe9f91c5a53e61acc4f5e003",
         "outgoingViewKey": "4a6df989a0340102fef6a71b03df8cba0e0635bee1963791fb900b8dc705e383",
         "publicAddress": "40140a86a5071c4985e1ed66c2b8a0682e9a60ff45cf51e464f8820db66dc701",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:zlABkHbPDQPcYhD7AzaIX5QOulfKN5eNG9QdRHEh3RU="
-          },
-          "sequence": 3
-        },
+        "createdAt": 3,
         "scanningEnabled": true,
         "proofAuthorizingKey": "22d94ff922e50cd7fe9ae0c514968f3e52badb3d1e835ab0975d66e80c398801"
       },
@@ -5782,13 +5278,7 @@
         "incomingViewKey": "3f80e3b0bf87fc10a7823f349b97858efc9c9ad62c3d5e3afe76f2eced7de002",
         "outgoingViewKey": "4da65b8bd524c0f9e5b6e98998ab575d8cb912202f42e9ea73e1f4c1e2ff955b",
         "publicAddress": "17eec804ae83239ae38c8849008c0864f2b4bf1ff70b341e71e7a2b126d079b8",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "b0020a642ac5a40462d3d4cec61e1f2701d63385ec3980df5916e3fffee4940b"
       },
@@ -5810,13 +5300,7 @@
         "incomingViewKey": "93050c8e56f3b603eb59f5f3185bfec01549efe873acfa463009954e3ad8aa04",
         "outgoingViewKey": "8436e444dc23a2d8d5712f536a14ac56f0cc27e7aa691602d8c2e5fcf4ef4ff4",
         "publicAddress": "a085e2b5c5beed24baf419e0d5d48d1c28acc6ff4aa941e6d75f509450fb888f",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "252642d09a7431a7e0dd31bbd9324588f794a7ed55154a9a8a563d2e34be8407"
       },
@@ -5892,13 +5376,7 @@
         "incomingViewKey": "a133eac24bf5a25cc97053c90946ce9463c4504cc0cd1ec5197c2e0ffab3da01",
         "outgoingViewKey": "85720d0846bd0c593b496c79637b57e4b6a0f2ec525d157424918d23724d4bfa",
         "publicAddress": "bfcc2c07f689708132f5bc4e04d9457770885b1835152dc8d5a78a11ebe32eae",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "9da0cf11902fe7853a0efd7737c8d409f3f06ad031eceb3f0bf2d1759431b904"
       },
@@ -5982,13 +5460,7 @@
         "incomingViewKey": "559be50c376636b333867940c56e5adf3bf14102891c12e2df915bde0148ed03",
         "outgoingViewKey": "fda80687cb6b89197a2f474bc395557aaa78e8ee775375a65fb46fb9c8d4db8a",
         "publicAddress": "77f8f0f146065f36329224ae5b3e3f12cab487ca04d4f589754f97872dd08e2e",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "c12d8e4220df0aed7a6089a41f1b3f95198e22fb300fa9a81737065a9e235403"
       },
@@ -6010,13 +5482,7 @@
         "incomingViewKey": "d4779702213d80c09cf32fcf339675fd42f7df41c5881aee93fb05a858c0db01",
         "outgoingViewKey": "aab99e3522c644aa7a35fd99242b012530f7c92e5f7d09883345a3617711f332",
         "publicAddress": "9b88b5a458a7f981f54b9ffdda6532677519dd0c71f71559207e4df60b5f2e6e",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "4b7a55b3ca8d174f7858f62bd1704173147c2506e7e0110a43972abfb712bf0b"
       },
@@ -6122,13 +5588,7 @@
         "incomingViewKey": "85be2a194babc67ca480a7fad7fee31de1e22b1bf6a42c180b7957f804bb3b03",
         "outgoingViewKey": "37dc14d6db97de98a5cb417b4878abee0da710aa9852b78509457db265a7bd9d",
         "publicAddress": "a04b7f87ed8da22822fd6e12d8e4f1ff026e075d81170fa389619687fc09bba3",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "82ad3b2281fed4dc1e6688d397fb8c821cd31958addf28d49bc8759fecaf4e00"
       },
@@ -6150,13 +5610,7 @@
         "incomingViewKey": "24375314e92a44b3ffee23a1ede3db99417d78ed573557002190bcc6168a3604",
         "outgoingViewKey": "0170cde824d36c7b73510632c2eceaead5abdcc3cfe0f3dea276c1fcd2784f4a",
         "publicAddress": "4df7683042db7b5452447fec67f8705fb987eac27dbc7a90b3952631fc9eef14",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "6f056d911f82921ee5b80b302cfb83be49c6a6d9f14ef3f0bd514733161b9d06"
       },
@@ -6262,13 +5716,7 @@
         "incomingViewKey": "af17c73970552539f2392f4caff51cd13ca17b635e01e1957aef25a55650a506",
         "outgoingViewKey": "e1844f59394714ab1dee5d294c06f4b05884c1cb4cd78e4a68d25ffa121421e0",
         "publicAddress": "e76c858e25070012fcbf5126dfbd4318959d300f4e0bd9e659b0beb1bf771cde",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "311edf69e8789151f2348e5705591d1511a2964e218061c450d24c9fa7951f08"
       },
@@ -6290,13 +5738,7 @@
         "incomingViewKey": "c7f1775e88f82bc6fadfb27c3a443063aa22b9dd692f3a0ba8caa77fb2b78d02",
         "outgoingViewKey": "7ac5c5eb4054140b70697ca4e896c329c5fb55ffd98e1c1b352692b6adc9710c",
         "publicAddress": "7788a27f2d1b3376f6d36b386bacce08a33724fb0565d47c6a24a5d0472f945f",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "e4407cadd714bbbda77c092f4b9409732dfcc15842945fb45b073d2793a8bb0c"
       },
@@ -6376,13 +5818,7 @@
         "incomingViewKey": "8a7496e08240c340567d2689c03fda557d0fafef3af918b0cd23bb6d2f637004",
         "outgoingViewKey": "4ee2db77355e1431706c7cce644bfcb43c102a7d4ebbfe5b5ea70685c17e3a5a",
         "publicAddress": "cf135210deb44de9cff4bf804acbdb5ecb8afdebf15642b16b98c4283068d62b",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "5116aad81f2c1c4cf7a0132eea2889d7541554b366731a448c9a656883718607"
       },
@@ -6458,13 +5894,7 @@
         "incomingViewKey": "f636c40ba00c10270a2e4f47e935ad31ee0a5ecb382dbc184408aa0ab1402400",
         "outgoingViewKey": "6bf7751d5aa48ea23c6ff551afc76814e1ca5da64e6f50506505c115cacd6272",
         "publicAddress": "3ad02fc5efcbb82261f4e1ee206e30125ec84b708ca463f94cd0a8f60422b563",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "f3291c52c0b33405b81cb6a60460c3678a169d5ff146e595794386980f77f308"
       },
@@ -6540,13 +5970,7 @@
         "incomingViewKey": "0c6d858f2365bf1de92b145432f2e938cdfce1fa2e0e9168196b603b84645e00",
         "outgoingViewKey": "9ed004a9bd5c88b0cab75aa01c29916a40f67a07d3c0bacfaac041a5e06d7cb5",
         "publicAddress": "9a8787574625ba72f6bb0707dc3d055bf29b9810910f0e75ab20d64a1b0e2610",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "c2c64c5284b54d248abe1bb97082323ceae5448b78f1b647d24095a882453906"
       },
@@ -6596,13 +6020,7 @@
         "incomingViewKey": "42594ce61502059464feb01764689c46fafcabdc62d178e0888b1f4fde333505",
         "outgoingViewKey": "e250f39b02cb196bbbe57e381ab199ea21ae82e9dfaabd95f82aa6dcad713e5f",
         "publicAddress": "135e42de661dbade17189fb1b52ebe7b73af3f00b0a22236468c3fcd5a60cc09",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "7fb4be33957e2929393f676c52a61da3fd30f7d07cc9e324c63ff7beeeaf5f08"
       },
@@ -6624,13 +6042,7 @@
         "incomingViewKey": "a986bd3bca479e5ec9a5a8f26a0b234b49d1ff9c5327b9917d57913d4bfcc503",
         "outgoingViewKey": "eb4440e0bd5787b009ae6a71d0b2d7b493fdfe0d95d33be05e6e6dcd0da49eb2",
         "publicAddress": "92056c5da34c774e45c9192f4d54cdc7b4e5bfc068897e49cffe47f797f0a543",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "7fcdfc565d9816e4c386cdb82217885c7ae2e603033177bd4c91d7a9d85b860c"
       },
@@ -6706,13 +6118,7 @@
         "incomingViewKey": "082730efefa0ab9c386a1ed5bd0a064f42240aeca8e9a3fd5a5311d06750b204",
         "outgoingViewKey": "26c142151e6a3c3c88f0e6c863722b32b76ae10f2e39d4bb13060e7baacdc5b9",
         "publicAddress": "518cdb40b18edcc515f251ab82e56b1b33850a5a9ec837c81973bb2274f85654",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "9f3a339fbf57675eda822fe6434f13822ce64a5d2d5d6884fc98c77615195402"
       },
@@ -6822,13 +6228,7 @@
         "incomingViewKey": "46eab4105e43d0021db1fd1fe3140e7e23e951efae0c6c13d130282b1e3ec000",
         "outgoingViewKey": "b788c45b68200423b608cf34888daeb2f56938e76c8d0297a572e43c989655f5",
         "publicAddress": "95205789be04b75526c4c33241dc8a94add1e0ac4455a66786bf53c84952cc3e",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "6ae14be9b436bfecba83f6fa2bb91a9de744591bb43f41746e5aa965690c8605"
       },
@@ -6850,13 +6250,7 @@
         "incomingViewKey": "c8933e4fc82fb3d0b145ad385e9db66ac6e6fcbf5ae274991eb5c11226ae0f07",
         "outgoingViewKey": "92af0cd3d4f015a0c6bfb0caa6ebf667a2851436b7445fece8766cca68a0bd78",
         "publicAddress": "c703444078753dffeba8416cd0b152f9317bd190474ee6206328d166ba79cc9b",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "2700d803eb6def99a93347f9b798e663c4420ca874a559582c24d868bfa4fa00"
       },
@@ -6932,13 +6326,7 @@
         "incomingViewKey": "6109c2999c98a2e918b72c61e86da7f0e0abe9149bdcc850bc27a1eb42f44407",
         "outgoingViewKey": "1f5613cf9e3adca3828dbc5d240fb945f8737681782080eb49a4f7e5a97a144f",
         "publicAddress": "9219c0cded1632973b6f30fe89a1ef5d2ee497a43a9e8b4f327ad5e2c74bdd09",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "363be292208a39201f35e92ca187ce0c4cd09dff07b555edc2b1af6d38158705"
       },
@@ -6962,13 +6350,7 @@
         "incomingViewKey": "e19764232ec43709b83322ddb76d7a1cba8276194e97bdb6ccf0c457aa19d200",
         "outgoingViewKey": "3dbc7a26ca52b85339ae4dfa94e90394a15e162081d537657b565c1a65554a57",
         "publicAddress": "b4230d53076043fec8aa43688879cfa6a3286f6a5f3ac64719cf9fa33744d206",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "b623eb9b8d6578c459eea70e0e562faa59576cdaba377cb66bc6e49e2ad06b0b"
       },
@@ -6992,13 +6374,7 @@
         "incomingViewKey": "169016b8098a97c18599273861c150e2232c7ea5bc93189d0eb076405920e807",
         "outgoingViewKey": "ea8bb7fb76575ec9e5c3f5ab3ed106882d99b9b7fcc9afc224e0ce595e3f52f2",
         "publicAddress": "8336fb0657aa4cd82cfb5fb4b6723300af8d8cd64f86b14ece8b0230c6c807a4",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "42a275b3cb8c60e9b90cc9e4d8ae72487cd3af1eff1dd61ec1b2cda588ce460b"
       },
@@ -7022,13 +6398,7 @@
         "incomingViewKey": "f16815402bf70f6e6ef3b167a3a940419db3d05f8b6eb56cff9d09373bef4900",
         "outgoingViewKey": "92a38016572d0afc6a1c7bb92632134c761b4ef0dc82e6083b61c8ffd5a7c1cd",
         "publicAddress": "2b617eadeb40c7e6679212318210dd34de44ae591cbb1245a80563bade2e9706",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "c35690ea9aedc88905087aee7b51edb296caa78169107d016a7c2e785676bc0b"
       },
@@ -7052,13 +6422,7 @@
         "incomingViewKey": "f35802b507f06f6c9f0bbeb9875da6d290b147a0586c7cb83e341c120a005c04",
         "outgoingViewKey": "0f418c817a72226b81e89cd2bc1166bb593d6469aadfb758301a5972a99f849e",
         "publicAddress": "98648a14194cd07bc1fa21d34bdb15fd41d556250dcc10f35888f24191cab41c",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "6f473605fc3fab9a66ea0f715ad6aeb36d624045086bd6c442497af0d9771103"
       },
@@ -7106,13 +6470,7 @@
         "incomingViewKey": "3b7294d5f761708107d3de2fe1988055dd54c68e4718af20d7fe1acfd7532702",
         "outgoingViewKey": "a9186f68b889911d78461e9b5576aae0b2d97547ba4fe809b36b53a53651ad70",
         "publicAddress": "bccc050a0c7444743fb01d59230dde81003021d6cea4d8b239afe021102463e7",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:mZq6o8uyv4LYoSbNLuuK+fF4tYM65yBRkmI4JuPAnok="
-          },
-          "sequence": 2
-        },
+        "createdAt": 2,
         "scanningEnabled": true,
         "proofAuthorizingKey": "43394e75285fa9d2c1785fe2758c26820966f0e0d38803ce0b21d8cb406efd08"
       },
@@ -7136,13 +6494,7 @@
         "incomingViewKey": "368140c29ca137998fedb7e6e51f20411db9dd56a796764d9e361590ed23de07",
         "outgoingViewKey": "acd19c3801777aa4fd97cf7819d08d3bece3d14b83245fe29b24acec1bb4fe96",
         "publicAddress": "81ac0d338d2048bac791a3cfb92818638d183465c3fc20d24dccd73e0e442d8d",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "eebe1953bc0241b2e20885684b0c533e110ee701b2efd97afea2ef00c999360e"
       },
@@ -7166,13 +6518,7 @@
         "incomingViewKey": "514c3812e86bf59e651f35cdf5797b41d1c3dafa1d9f3a6005781b18ac9ecb06",
         "outgoingViewKey": "702f217dc84ba67dfa4bc09a3c8f6491514c9b5b1b05891ec4b9bc762ff9d4db",
         "publicAddress": "60f29d4d089cbefe816d8892bc7a9e39b14541f4e8ab805819b3381ea3cd3d01",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "03aec8ded54e30e5422791974a8fc3ff5f0b9ec7ae7ff71b599962a024983508"
       },
@@ -7222,13 +6568,7 @@
         "incomingViewKey": "15b6ef66795b5a640221a5fe863b69542ca92aaade03e33d4c828b1aee050205",
         "outgoingViewKey": "ee464e9cc173682b92fe04a12db52e03e8951d02d58049776c774c450cebec77",
         "publicAddress": "fc1b87236e98d329028c59dcb55139dece067d9a8092fc02f92bb83d5afd6cbf",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "dd2c457f45e3131857b78dbf882f21d5f825f81362f7211860f565ce9ada9d05"
       },
@@ -7250,13 +6590,7 @@
         "incomingViewKey": "13de79e7e2ef97fea168a875f3f78d0b4e40bc17757c46d673475b992b6dce01",
         "outgoingViewKey": "539ea34dcb6523714f018c29b17dc0450fe1735f0acc7980e74038a1ac7f88b7",
         "publicAddress": "5ec695f11f12ae8e29f508edfef57acf4a2f1ec4a157c803c9d6365ce119143b",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "640914444bada025c574a7553cbad78e573d6ec2fae65c1df5321db909d1e609"
       },
@@ -7362,13 +6696,7 @@
         "incomingViewKey": "e1d116d102f3832dee495bf0b8e22e9ac241e394c839f4a3cc6c17b70a1ec701",
         "outgoingViewKey": "c481bc21735be6f39e11cdcafba614db85f4183153b8b539641ea0830fd3c11d",
         "publicAddress": "f0fbe34510ec326ba09245a4d54837dad8b32031a2d9fcad7cc79e66f3effd17",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "ae8e40d882b798ec0ad76c8cd52bf7930efe746e038b86607520c2016388910c"
       },
@@ -7452,13 +6780,7 @@
         "incomingViewKey": "f9203e5893973e234d850b65573003ba04f89c231195d0598a4198c446d89102",
         "outgoingViewKey": "641d47cd60fb9991e6c62561f53f3b557f04a285ae6924cc5914718e9fbbe138",
         "publicAddress": "cec7be662b6bac78af667994b490f26857d18dca1e728488ffe7de0b01c4404e",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "23b064a3b8d0933b948996bf738832e9f7c65e859c7112dd9b3ab9309db3d507"
       },
@@ -7576,13 +6898,7 @@
         "incomingViewKey": "6d2e22e99680c3c63fe31d6398793f9b87454432b01ddb8482692eb597d66606",
         "outgoingViewKey": "6c88876709c07716f48b19d8056980876a7cd803854f30c6c70091577a6ef8c1",
         "publicAddress": "6ca52578ba0d94daee94af9fe5603043acd6efd1b1a9e8c54647f59b1cf18f99",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "a8b6d0e280b9332339356cd93dc93653375ce5aa88d013394e07a8dddea9d409"
       },
@@ -7604,13 +6920,7 @@
         "incomingViewKey": "9dff42b9726e1ac5354bae32ce2462d85dd985488ca3fad3579675b65cf4ce04",
         "outgoingViewKey": "1801e8be9cce2b842805bb8d05744ed4b9073d1f2047c2e718c09715892d336c",
         "publicAddress": "3bd5dff2753a8a2b0761c27f468cea32effcca7fa479d66abd38a70a32062a64",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "f942a40b3b8b18debe70aae80f451b1fd280934cac610a51a82fe75264946503"
       },
@@ -7716,13 +7026,7 @@
         "incomingViewKey": "74d4b2b2c1cc39f4097b90c8b50a3bae0c85c04a3e588e922a18742b70b53304",
         "outgoingViewKey": "7f7a01e7efdb53e7b4a12ca4664c0277429205c6b21e5532965f6add9967f36d",
         "publicAddress": "74f189128d5f91e129af0bd86d986b948f21ab00561e7b47285000968b8df845",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "d4da17a97007808a389d636669d59efcae825d66cced3bb52c813e5dbf9b8e08"
       },
@@ -7772,13 +7076,7 @@
         "incomingViewKey": "ee7d2844f24f69e6b7ac13b9016cdf6ebfd3281ce832bf9aae209485bfc02004",
         "outgoingViewKey": "494d3e951b10776159af788756fc79169babd1c44674fd36abcfade121882735",
         "publicAddress": "71fb7ef377bbe2d80361b858ab2d8cd2dc526bd5e1591f794e7d213f890d1644",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "b8510ed4d78dab26b05034300b9192410c0f91ebf109c60f9d3261835d5f960d"
       },
@@ -7828,13 +7126,7 @@
         "incomingViewKey": "d64cc966ecd93fea10610e78803648f34b2e9d084ea9dd909e4a06b8a126ba07",
         "outgoingViewKey": "851ee2cb193f56a66e242c5d2ba4ace7a653fb1d6b11476cc78d98e1e0d3525b",
         "publicAddress": "132e02ec40e55f3f0b5e53721f41539e2559c3da3435a4128e2de74cc6ec9bad",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "18813dfc16bf034f84e3213c1e7d10d2f5b86da87d0520e2e063b9c899095409"
       },
@@ -7884,13 +7176,7 @@
         "incomingViewKey": "31b3d71788afbcccdf4e8b1aafaee039bfc41bc768c6d9dc04c1774f671e1106",
         "outgoingViewKey": "2f1b93b172f76c3cd8db1e33fbdb4d09ad2f56e53b8756496201f8e69f94cc20",
         "publicAddress": "3c0e7e7752ece79518668342353f58c0e2ded73c5f8ff59bab2dc934a650dc5d",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "a09f3fc03ef8e59fc4b7f4e5c90f920ca113ccb6572761da439cbb0bbf6cce0d"
       },
@@ -7940,13 +7226,7 @@
         "incomingViewKey": "ce8f3645d46a27302d7cf8f50b925fd6093efa5d0fb1281f2e05a6f299b07505",
         "outgoingViewKey": "cc5eaab7ea9948a69faf90cde50994cf5229b3d1a4ed346009895e4089b3deeb",
         "publicAddress": "58ad1cffd3236ef303e9543a48ea92784f46233e97de4f739abb432860bc7244",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "2a24fb483ca3e2f2d5e1dc91513da2b6026b6c89b92e0fa154e9d05d4fe56502"
       },
@@ -8022,13 +7302,7 @@
         "incomingViewKey": "ed5859e15f2ad48861e603e4b8fcd74cc22637a12e9a4e3ddd8a4c5c03908b07",
         "outgoingViewKey": "6ae21c18dd5b081ecec4fe73fc417ea7c83213e218403b3b80a92d8f0420ab20",
         "publicAddress": "b6a489a014a64d0113c110531b99e19927088f301bedd11034121c28ff977848",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "8083d151507df2903b0e39ad090c3467a8035e6d230348638b5c8fa4a53e2607"
       },
@@ -8076,13 +7350,7 @@
         "incomingViewKey": "217269c4aa780e41dd102d3bd6dbf3a192a637b5cebb4ca730be5b8bbd5aa403",
         "outgoingViewKey": "8e6945c8a702223641536e38de45e76cd64ef9e8ce64f2f901ce7ae8ca6e8288",
         "publicAddress": "b85eb15dcc56677ff073dea9ebf79d284f6f34a83466dab734cb3f5e3afb53b6",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "46af1b8daf03a4f4aee94a987e6d590bc7ffa7cb6781ee82b5bae126e53c6006"
       },
@@ -8200,9 +7468,7 @@
         "incomingViewKey": "d8583ba3434d2eb97366178fa7a9ddf636ebf7293c9e06c288c09258dc540105",
         "outgoingViewKey": "3bc37bade27d7fe6720958660bcfdbd53e3141b7b8334390428ea4a41a718ce9",
         "publicAddress": "3fe256c202622e4305e68472af4ae9f501c039d94631dc37fc8d6729177796bc",
-        "createdAt": {
-          "sequence": 3
-        },
+        "createdAt": 3,
         "scanningEnabled": true,
         "proofAuthorizingKey": "20ba22cbd154861c40372b71c1c16c844b07792a06b4ccb9ffeca39caadcb60b"
       },

--- a/ironfish/src/wallet/__fixtures__/wallet.test.ts.fixture
+++ b/ironfish/src/wallet/__fixtures__/wallet.test.ts.fixture
@@ -8120,5 +8120,99 @@
         }
       ]
     }
+  ],
+  "Wallet importAccount should set account head to createdAt block if networkId matches": [
+    {
+      "value": {
+        "version": 4,
+        "id": "1cfa1c4b-9469-410d-818b-499732c4dda6",
+        "name": "accountA",
+        "spendingKey": "9386f49fc3917ef2ac19c4c43ea5fe190e7e84d68c460567cc6c6d7b6622f89f",
+        "viewKey": "22d7cd6e351df091396e68bdaa5d5c1d8fd5a451705c900dcda845ebaad0bb1419d3230a78356124db7b6433db754caf4b005abf77e129bfd8abcab4a4edb16c",
+        "incomingViewKey": "94373f5549b8ab388c665437a899c20932e021adb7300c9adaa258732e824303",
+        "outgoingViewKey": "239a72ad9904a46eb1495bb48ef8082a85f1afb1281ad2e3ea77b4397269da35",
+        "publicAddress": "c8eb185ff6cd8ff1c2e6f18915aa0e71fef577e18b1571d71dbf3d02d1a5fe95",
+        "createdAt": null,
+        "scanningEnabled": true,
+        "proofAuthorizingKey": "a57597fcec4957dcce1838ad2c7d36e3e0cb12419c22b3fc2a3cbaaa8709e507"
+      },
+      "head": null
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "4791D7AE9F97DF100EF1558E84772D6A09B43762388283F75C6F20A32A88AA86",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:wzsvFpPmAOvtXIsljK5XNobTkqs5Xtotw0nXuX3JTQw="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:188b/A4pUo828d3NBiYzH7ZaOCIanUO2qxfh3Gq1STg="
+        },
+        "target": "9282972777491357380673661573939192202192629606981189395159182914949423",
+        "randomness": "0",
+        "timestamp": 1718381989541,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAhQD5097sI/IFhO6TuyG3rfU9y1CiT8EWY20h7p9YbserUaVDpfi3NIaH7jGzmHG9OH9wUVLrd9Q1lfX5aLb9Slb6LfaMbI+rD06DsXai6QKn9/LLJs1x/uFKZMYns+fLP8sd6vRqPSXDGNHYgtgwGlpDwukFWycalQ6pO0WryDwBmyoZodmhUg1OSxfFQ8aChFBH43T84bQVz8babkmXkNaQPD4sJT3TvFMNJRihNraifTDW5pHRiU+8V2pIk9XtoMapMMhya6Oh3i0oLBNINVKKW3z7u8mExDFPcQZQL8Lp9YtxOmOUXs+OfyEYErboK2Mef/jcUyI1wMzVASMgHn8y1w8c8GIerWrWiocaw5Ya2aqptLBeRUTppqGB5UIAbqm72gYdz1tQw8AlyfiwUSijrOLd8DJ7c8h0vo2wgB+65diXt6JG/TCoaseA17x7GDsYNHWPSH7oxAKYZwXXEq5WJomKOyRALlSnrVbWeg39MM2ebfaL76CZpfMhXB2gIZE7JWoLavpHaaIaYGblbwRSmIpJS7N9s8PMp/JuVnPGhEItHvxAPWUIDLUhwA03lcLfo1Ik79k86YdUCDEPhc4qa1FbsbZ3CW8vT80nsUdvHi8Tf+FJwklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwYJxUDgQ1mX3+03V6X52YtF/OT6Xy0RlmprKdJC3Fr8EsXMLzb9TQI97zDJGueHrkYWGPyfLiFUXxXc57Jc7hAQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "7FECD7B03A22A0BCA19ECD5A8E415A833604E098FF30BBBE6244ECF86DCDF97B",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:4DDoJfcQrbCaeh5k6nBiCcJMA6mLC4VKBwIWhVJfiz4="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:ob0o4uqNZX7fOF+4vmUYe+ervjkPjrw38mIkRYRZuxw="
+        },
+        "target": "9255858786337818395603165512831024101510453493377417362192396248796027",
+        "randomness": "0",
+        "timestamp": 1718381990103,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAzWYXsEoFkx2J5JjTstJiLkql6oXHlkhZPg79us7biCSVNXXcKdmBnotDePb5scIpuRGyZdQGRcgwijMCOF5ozWUgV+C9SsNWa9zMaMim2aKU9AGzAjxqu1WDzcKkoTvfavmUgQfuVvoUppLlUl5F/ZVp3vrtoepFBYYa4NSVMPkNMM9PuetPXalnxZY+SnBY8BRkQmt3vLNI70ESFz/vNL4rfJilDMr1M0iE2qYih3mXfKhcNJw4LI7Qvh3cE/Oy1Q8x5cxHZak3iA4bGpvKW8FV5IExAcy8LYPbtAsZl809EPgp4JWJ9Gje1o5/LsfHWJ0ZwTwIOhrakZHMmXUfmTfoEYyCAxtQmeIOkK59FG9j5Evbs6jDzZx8ofpmYF1DsHLBZGTvsAYGgJNuO4gPlszR2kPblrkKUMWISzJo2bBYbOvm7IMlBNLSLvS9yeVHhsebDgVTEBQHBAKf7uTjSGDe3Cjw2G3VA+ESguQs7xFFZkTF1kxfhYwmvPzmdCEeVk0PhQof2vgynXfe7yLjIdQM3LWcHk/JeAA6bBLDFfeWHVHwIUECzvoN6Tu/0DXt8SsXQEv9p6rZyTM2j99V4InPpQaOr3vFWPI/gM3ncQYfGFSc3VepXElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwqclhppfbPuX2YqSrmb1LFYiizC2IrYO6As3ZgbJr4Qdh3Yo5FH9UQ9QZr2FTyaKZJ22vUsBlLFtX87ixhD8yBA=="
+        }
+      ]
+    },
+    {
+      "value": {
+        "version": 4,
+        "id": "c4b25ce2-c377-4644-b294-ea846a65aba5",
+        "name": "accountB",
+        "spendingKey": "32052006723989ede67b4c4b6f3f86c1a4e63f6e0242cb66debc792b3ec3bdc4",
+        "viewKey": "920635733ff14130e34930ebf511bccb3505486c89bf713a06c23e0cd76353c213087d491356f8a26594e14e717e6685f3b2819a5c9b363de24f31a93421dd71",
+        "incomingViewKey": "d8583ba3434d2eb97366178fa7a9ddf636ebf7293c9e06c288c09258dc540105",
+        "outgoingViewKey": "3bc37bade27d7fe6720958660bcfdbd53e3141b7b8334390428ea4a41a718ce9",
+        "publicAddress": "3fe256c202622e4305e68472af4ae9f501c039d94631dc37fc8d6729177796bc",
+        "createdAt": {
+          "sequence": 3
+        },
+        "scanningEnabled": true,
+        "proofAuthorizingKey": "20ba22cbd154861c40372b71c1c16c844b07792a06b4ccb9ffeca39caadcb60b"
+      },
+      "head": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:pY5uYNGX/9BBOtjfCWlZRdzGZphcn/tX9Qu2CuPqt9E="
+        },
+        "sequence": 3
+      }
+    }
   ]
 }

--- a/ironfish/src/wallet/account/__fixtures__/account.test.ts.fixture
+++ b/ironfish/src/wallet/account/__fixtures__/account.test.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "7e87b959bebc3fea6550e552352da81e3fd959cb2884f4079b28e9e6c7dbd003",
         "outgoingViewKey": "b18c908916adab5f7c32e2ef098e1fafbaa5fe9bb2eb9bfa388fbca0e3b740f6",
         "publicAddress": "3f49624ecbc2d05cfc0abb3a1efb9e904c910e9a2e1723cbf2d1f73691386a42",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "5f5f5ca2b69bdc0209df721fcaa79f1c8d7a292d2472ad48d8c5b645a9772304"
       },
@@ -92,13 +86,7 @@
         "incomingViewKey": "51452b6caf799968aa0e145a5b9a14d25414d6dc8f60002f9e2852f44fd22e06",
         "outgoingViewKey": "33070566a268006e71a6c93f3a4d53d844562b4c54b9a68644e1248497e20789",
         "publicAddress": "e520c0f003b151f6e3de21e721d24abe9a34115e6ae2ceea2e41dafea1fa6030",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "480918d0779d0d5f38c22b8f437e8edaa2bbd7deb36fdffcff4794717fa28d05"
       },
@@ -148,13 +136,7 @@
         "incomingViewKey": "ebb4e7518a1ef68924410b0f3acb3994f112e74600d25ba1761b6987ca75e803",
         "outgoingViewKey": "375550b61fb01688883fb63609b8a85b9f7dd8eafda1c893e94517218bbfb264",
         "publicAddress": "4d4d54d33d9821fc6ab6d5ba64753d431d69f737a5a64fcb990434fcc6a8fea4",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "fde714f5f773ce83527180b9e2747f7c75905b7fe11f3620e61aecd27e9d3f09"
       },
@@ -208,13 +190,7 @@
         "incomingViewKey": "d54c693b78bad30762cbb6409f7f27e3a2acfbb71f87a7f3d7e747855441f307",
         "outgoingViewKey": "966d8c89da8e6ef5d72d68a447948193bd4f97363dafd2563f154bef33b04cf2",
         "publicAddress": "341891a33d3766afe947db236db4ba033e36413f0562d02406d2a640e7ce8bcd",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "af00ebbfc13d14fdfdf646441ca02648ea05423ebd7504de86ec51bb3eca0e00"
       },
@@ -268,13 +244,7 @@
         "incomingViewKey": "4cc4898b02b81a6178efdad50929d73b05bb1834cfc443fac1063dde4409ee06",
         "outgoingViewKey": "95020805131dba23c01825ab7e574396e1654616a71caa23ea69286bb149181a",
         "publicAddress": "129c97b922b8379f367d27d00d3e506ddc79a89af0b767eba8203f5e532588d3",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "8218e4ac05264442e5ba0143b2801fc673f78a220451f1fd288536f4832bcc0d"
       },
@@ -328,13 +298,7 @@
         "incomingViewKey": "9078cae3f7f946f1892fa9611e37ab0afec31bda66f4fa756b886ada43807b02",
         "outgoingViewKey": "94f72b4704a06c69e02f72871cca2029f8d6a0adb852588db4e5b25a6587b0d4",
         "publicAddress": "42efc95b2c8f7fae8e74538a4c1b1ce3839c2ba0bbd5e39a4460e1c9713b4501",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "5b95848ede3275705adf2a50ed5d09866cab3ca8f3efb176476b91e3e1878b00"
       },
@@ -414,13 +378,7 @@
         "incomingViewKey": "a11be60def7428e2c3c5711036c8b8b6172885723beef318012cb03ee2597b00",
         "outgoingViewKey": "f76e6253c3672780c381b1347e212cfda484b0535354febfb2ac7c8f77f5f465",
         "publicAddress": "eed7a318e89cfbb1b6f8dddc84095a991d5e7e870ae6baf7db0c160924cc6743",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "edbfc471dc788ee3410f2151d05af1f72cfabcc24daa0d6da283a1384fbc2e00"
       },
@@ -444,13 +402,7 @@
         "incomingViewKey": "dbe72baa19e895ab3a4fd32a11d1625731a90fe81cf7cccc03b1c5cd58645102",
         "outgoingViewKey": "6892fdef3ad6095beb72ab3a194ad99aa259620416704d9a1faa812c1cb91181",
         "publicAddress": "731b7002a42644a751f217ab2a8421a41f15febc9a227f398c6e7ba3f206798a",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "44d39b3ae6c7bd0b77cbf6e538a901ae4b9678c376c2243ad1f5e76bf810cd0c"
       },
@@ -504,13 +456,7 @@
         "incomingViewKey": "1394e23eef2ac8b1d10fe50ae6a5c38947eb45790312cbf320cbfb1f611b1503",
         "outgoingViewKey": "eaa91d76eccb3902438194afc5ad79f0a4274677b2d4aba618826d8e7b89074d",
         "publicAddress": "767a4b0219dea215211390930abde11526f2695b3aca3576dc2c9e1e4b93dbad",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "b88c24d66993259a9d08e3a0e1fcc57cb2043f66a6f62594556b3c98a5a72609"
       },
@@ -564,13 +510,7 @@
         "incomingViewKey": "783766808cc3fbcf4a088604bed3f420ba472bfa070338ec52d1dbeb6abdf401",
         "outgoingViewKey": "b39a594b7669a6dd116b0db245ac6f8b65f67b079233ef1a4699ba55a9b77eaa",
         "publicAddress": "9472e986132e8ede887f640d2dbce65437ca661bed6144a9e4c8bc6a2bf725d9",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "6c7f50d2038392d37269fa0769ded35d95d154c32a55f3dd0fe61eb85767d707"
       },
@@ -624,13 +564,7 @@
         "incomingViewKey": "801a01ec00caf5fb3541cf73f5ef16d2bcc53a9d00abad5c513f1e1dfe9f9506",
         "outgoingViewKey": "6caf703b0e5e72ac7b2a5a86e6f458840d97fcb6e7bca1a98d61b097e64c0725",
         "publicAddress": "a04382ec95c41b019d3aec27de9e6f5f2740787690e7512b9df54c211c276b46",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "2230fbe8fa8f75abca2a58f90748f5cfcf1192949414f8c77996e86722b94c09"
       },
@@ -684,13 +618,7 @@
         "incomingViewKey": "0af03f12150a68fe87de8239cacab3f8ab507ad4d4bd5adfefa3844495821a00",
         "outgoingViewKey": "0f2ab686374f065809a195852d44b6166f8765db7b865b39d19b9c531b82a7e1",
         "publicAddress": "95d56befeea15827bb2a2387855b26ba77491e34284377836e7b2f6f1ee49b67",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "6aa0a53d5a531d6ad37c06fbf969b68b5a2c993d4e85518b2d1634bd3696d402"
       },
@@ -748,13 +676,7 @@
         "incomingViewKey": "116bbbd78d300a7504adea19e1c6cb46e03773383db10cdee4ea2c819d2daa05",
         "outgoingViewKey": "2484c6a5610d532d6d4ff95483c99d3bf6cfc85c86956acf234154132627afa1",
         "publicAddress": "bc25597cd139fb58357720ba0076170a86e22014a16700681ba27ccc236e1726",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "9dc34711ebbe4705c234af86253d85e780995c8a58af96ada13d4431d21d4c05"
       },
@@ -776,13 +698,7 @@
         "incomingViewKey": "09900704527bde337ba25971cf2ca001b27d550bbdfd5a97cf4db7cba6c43103",
         "outgoingViewKey": "12c72c52a0c91dea2fad1ab8ae4d33a0b8b83d6b581d3234dca283d02d5cdf43",
         "publicAddress": "887b5bfa5bc03dd02c3323280b6aea4f7834b5cec5e527808ce5952e722b5cf3",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "ae6034c68c366e5620e0d551ac8bbaff96411bdd63ca5986932c7ab03da01402"
       },
@@ -836,13 +752,7 @@
         "incomingViewKey": "2bec8441524a374d83af4441793e83e0b29b704ce6ac7730c2ede61cea38f805",
         "outgoingViewKey": "b7b5f67e20861a944d930a50b4eb1196e384786806e500c2f23f429a5c27fd37",
         "publicAddress": "213da4fd030d02f65fb9319bc6dd2dd223c0f4a8d42fcecf7baa001c8571e480",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "02c41f2e660d120955cc59d4689f7bbf994f3acda6c9bf79ccd8724ed58cb20a"
       },
@@ -864,13 +774,7 @@
         "incomingViewKey": "5efd434e80caff309708ebc7b262adaddf9efbdfe8048e6bdfd41182e0a12f00",
         "outgoingViewKey": "1cd8608b0ad5c9035d8645c189aa839b3a08e815766d482b73448663f11e90db",
         "publicAddress": "d249a351a4a49aef6bbcf7bb49cb7f7eff89bc23d95f86b6a506da6fa44b6f3d",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "80782e1d35a9810f769231f9d96c5a958c5a4d2ce1f1bb2ac536a63e7fd34400"
       },
@@ -924,13 +828,7 @@
         "incomingViewKey": "9bff8a1f44b134d511629de11e2d1762df5a4828cdf3a37e5a6a99743ae1b800",
         "outgoingViewKey": "92a5f4809bae9b364e5facaec2c753de9d5284aedc1e9bbad715b757744283d7",
         "publicAddress": "5e623592e63417a09e98879744fc203bb857cacef4f2cc3079cae4ad51586702",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "032db8a24a9cef7879193f93cde2c872a3fded49baf3d88d5f18a5b80452cc05"
       },
@@ -952,13 +850,7 @@
         "incomingViewKey": "27e9826150c73cd310e466b63d4b0390a84897492201c7575ac1cd63557b3605",
         "outgoingViewKey": "f73e1b9dad4722670aff54562e955746350b9cb26d9e64ab5ea062405a0234fb",
         "publicAddress": "a44b26d9e9b3b16bbe833204907a341daa45ac9ab32f579a804b6625a048b39f",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "442bc5c249cc3faa04ef593ed63cba5b9aee0595a3e22cd0a5febcf6e7bbb00a"
       },
@@ -1012,13 +904,7 @@
         "incomingViewKey": "5a983c28a30417400b0e5ba863e7c667c709b60b62ba4557ffcf566c4d50ef07",
         "outgoingViewKey": "443e0e2fd88b61e77d0589eaa21968931ce68ec38a8d288a8ef66201e0303094",
         "publicAddress": "2c1b2798fd04fdd7a4e1364e673050dadd646dff8c4c06945eac230ec7db4191",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "250529184e440ee5ac628db0f930a7fb1a4bdbf4ab1dd0931235237e69414f0b"
       },
@@ -1102,13 +988,7 @@
         "incomingViewKey": "3fc46dd5b7eb702c17b47ee151e067c20a6b9a31468153694876e066b29bbd05",
         "outgoingViewKey": "329ae99721991dfcd1ecc149c6cbf500f57dd5c7de3c8008b115702cb40a2729",
         "publicAddress": "1c8f76d5a887c23314d95a49921e442f48c2cd943440f47c4dc2d14f234114de",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "93a162e07720d3bf57985bcf8b1336f901e68da932fec27c6240bd054a1b6b0c"
       },
@@ -1192,13 +1072,7 @@
         "incomingViewKey": "fcf0e6a954e66812825be837ad018c51cafaafd22e9348e3187d329208d5b200",
         "outgoingViewKey": "83781599c4c64a50564a3a63e00a7783f3d9760e1d2accec9f8f5444f78e49ce",
         "publicAddress": "f29a3062b368550b32db41fa30339fceaf43d5aa6ea2ccb3bdfdfb7dd4c094a1",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "ef7c9b375de69311f9fcf4a63f6d2f918ef9210d70e3fea5b1367bc3ac27ad0c"
       },
@@ -1282,13 +1156,7 @@
         "incomingViewKey": "696b5e1df5435e470f77d0a03fad93b4902880d30eaf5c8ff07070f4ad3fc806",
         "outgoingViewKey": "cdabc02da8947b85f640753695e61de06c3af89db6ac7bb9263035da3d9fa32f",
         "publicAddress": "bd05c7a763f6f03abe31fee861f9986635429364dbed4aaef45f8919e7e675b9",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "146a2eb258e1bed5c6b7cb31f26220def5cc674efd3180cdcf8062d1a1871606"
       },
@@ -1372,13 +1240,7 @@
         "incomingViewKey": "cdd4157bf77d69d4100b6e2518f443af87292eaf742dde2809d320bf27e2af03",
         "outgoingViewKey": "1a077e174d146dade031b5a4b2b8cbb5b9e83baccb8c7f1368909c53611c7a13",
         "publicAddress": "cc4083c164429cc9f7bbc57f639dc71071c471b118d656cb88bf46cfc255fde9",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "ef8488bc772f647e0a10c0c23a04f5a67b1823e7187c3c1cbb6587fc7e0acf04"
       },
@@ -1484,13 +1346,7 @@
         "incomingViewKey": "c7e76284349083f250aef585f218031f07b69d4a76e71d33d49f6c05cad46b00",
         "outgoingViewKey": "ba41b94f3d18c7d0d3a8722a709c75d85d083ac1f395eac08015ea43afa053ae",
         "publicAddress": "2dfdb4ea610437c5ab0d495219da54d8c9748eab65cd2cc3cba836449f541980",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "a1a025de583b68d2d66064f295a04d663d320dfd6b8e5f8e5981ed9a4f7d0504"
       },
@@ -1574,13 +1430,7 @@
         "incomingViewKey": "d9c973f01dfb6d13c7722f90423a346ae019374b8d2169ba7e35e142d1af6005",
         "outgoingViewKey": "8c596e327a762700cbfdc66109f684b2b6b78efbc6cf58b9ed492276cd2c014c",
         "publicAddress": "081414c6cfd5027f700334269459b21684981b1b258e17d723f9303e909666d7",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "9ce4121b94f8f292ae686c5c4eb0a60b892b7e96429349b0137b21afc8f66403"
       },
@@ -1602,13 +1452,7 @@
         "incomingViewKey": "6bf093813413fd6d8f5c7d8ea869fded4124729572c7a3c4c972bf9fa2a43504",
         "outgoingViewKey": "27fd1bf45b314db7dc0d2817da5735ca2d0ee252340c215a0cf1c3b6358fc450",
         "publicAddress": "47c23087cf276488239759a0bad6cd0a4e1c61ddcdd084449f5da5133c35b885",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "86c7cdd965abc0c05704155cee6191927b00139b42fb73fcf53563c2a6154f03"
       },
@@ -1692,13 +1536,7 @@
         "incomingViewKey": "8782627c3ef604b5265bd7fc0d166f971f139f125931eb1496c0d0a15fa6d904",
         "outgoingViewKey": "ecaefd2715dbfd671f9e56a344a1b2e5e9052c8ef4e7e4902f04d863b8156271",
         "publicAddress": "def9acc76e8657f224e7f9de4de9b9189f3ce33e92e5115aab5f26fa3e0122bf",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "0ead400cadacaa8f852abfb69491a0bb776bd9a8f51c596aaa6f6ca5c8e17c0d"
       },
@@ -1816,13 +1654,7 @@
         "incomingViewKey": "769e71abd46de80e91b1d8ac95d1ef6e7363c7c59873893207f23adabe128605",
         "outgoingViewKey": "932a0ee2cebf96126e034b4f42febbabe4182634afcf91e5670518e7d7ca24b3",
         "publicAddress": "47add4da83cde3f837e3c83f923a62be67c46024ebaab75ca628ab63d5117bc2",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "6b7d2f5cc82fde275f180e3e732060ec13d138ba2ab9c832e3f66dc761f39e0c"
       },
@@ -1844,13 +1676,7 @@
         "incomingViewKey": "3af85d913cd0d613a95870f7e2a21e8178e9ba4e7aecf0936d7c146ff6c98a03",
         "outgoingViewKey": "aeb3f44de3d183f4beda06da4b189ff05bcc9134d36d98edc34084382c53185e",
         "publicAddress": "2ce168a41537392e6b0504721e056f4d08c803ae70886526a1c04c41aa85793d",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "af03972b7b3dab1c8896c24181ee2d8e9bb6962c797be6333b0e85bd67da1800"
       },
@@ -1908,13 +1734,7 @@
         "incomingViewKey": "89169ef7735a5973c58848dae2f22d8a7f6aa444b8f5c7149807417aa0dc2906",
         "outgoingViewKey": "3243869c6514827b9014e6fc0de1e5aae6e43ba05b16fad4d97c0c4647cbfdb3",
         "publicAddress": "4a73bb07dcc20ccdca41b97c380340b41c1806e365e9c6e509c4d7230b35940a",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "7227e498ddd1f99c0462dfac46d9e1286b2f90713d42c2df98c1c1b5680ec409"
       },
@@ -1936,13 +1756,7 @@
         "incomingViewKey": "1398f96fe8e4706dd9d3bdf595189c542e94eee942ec2773d2cef3a7c56cff04",
         "outgoingViewKey": "a3b486d1a21815d426948ce415b1bcb981537a68800d72ae2bde96044a3f9450",
         "publicAddress": "9aea7f79faa96852124a70410b3aff9903844f68ff87411072138d7f4f7e2124",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "cfeddec27c8ca9866f17f192e37c9147007190459c9cdecc961cb9d3cb5f9a03"
       },
@@ -2128,13 +1942,7 @@
         "incomingViewKey": "e64725f3f8270a60ac1c30a076ee0b7db3edfe4c8c2f103f4e6b14acb6f60304",
         "outgoingViewKey": "cbfa51a70ee2389fb84f1258f95ce3202cb369f80fc413310279dea7d8142980",
         "publicAddress": "53ffdd6e6ecf898c4c4a31ee3d0f21e0157fed422c9b346afcf6bc2aaf69a5b2",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "eac3fac7f4e89d5b7a1892aac668392d115bf1187fff667baaf5fdc917a1040b"
       },
@@ -2222,13 +2030,7 @@
         "incomingViewKey": "a3ca15f5dc56f6f21edada7e076ec2c8829f73a520df89f5fa332cc2d1e17105",
         "outgoingViewKey": "df0486867cd25a2541b59f49e00cb1e61d4bbe30fdf7673e28f1e03127d47534",
         "publicAddress": "6e4649fedf65bcb1047fe8bf632e05cecad19d670afaa9b806fa845100dcd282",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "a1d04e0a5914a0444abd60f619db8714b8c48c7ebd6c9067d9cc27564f8bd708"
       },
@@ -2278,13 +2080,7 @@
         "incomingViewKey": "67bafde8d61d58575153af3a95b1e522e22e0a758aca9c865e8926fef970ac06",
         "outgoingViewKey": "cd4f6a6b9a89c5da5926618ee145c109cdfc6a84732cbdc23ac326a823e660a3",
         "publicAddress": "4e13f8947e082724b6456610fa73589402c0cf44a889340ae1cf05ad28b64582",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "d381552f63cfb9017dc79522eff4176c74451562485be648f0caad2296de760b"
       },
@@ -2368,13 +2164,7 @@
         "incomingViewKey": "e9f41970f9577b0f6ce881e121cd27f5ffa368ddc7efc5610247ffefc7789900",
         "outgoingViewKey": "5ef8f7ca0ed6983ccd38541244240aa9cd50635899711c7f410b2b00811e7066",
         "publicAddress": "0933f0aedd039d5b798394cd1b645d6ded893a0d449f066d4d57fed11c9c7c0c",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "8fdd4ea8cb68f87d896a21d25d854b122d46e5279a52344a437a75f708f2d202"
       },
@@ -2458,13 +2248,7 @@
         "incomingViewKey": "4b0feaee160baaee2b3d95ed8337a8304df7d2f031c04b13a2501698c6512e05",
         "outgoingViewKey": "12b51e7eb8c9294a7de10021ac5f7a2619cbe13fac4affd38dc205f8c71f92db",
         "publicAddress": "cd8934eaaa0f8256a645c37b06dfb35f0eca99bb553520434f0fa44cc391a051",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "22cb98343a17810537fe3a04aaee19603c5d1708dabd8a13c55a81c7952b6b0d"
       },
@@ -2548,13 +2332,7 @@
         "incomingViewKey": "b6972c5b45683885a04927ecb2dd13356ce23c316c62cb30fd5259a09ddbb300",
         "outgoingViewKey": "13fd2bad9807c39e782daec40c978f2418d75825d340ce99bdf26118908524dd",
         "publicAddress": "f032507ca858e16b5328366ddae183be953e94ebc4424b90a674539745630302",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "91992a1fbbec1ef3e0f9402d556156e5336e787a819808c49cad087ec4cd5508"
       },
@@ -2638,13 +2416,7 @@
         "incomingViewKey": "7981f814d1740e5c0d24ae6e28d2c86ad9e6b679c34008be014db8222b1b0d07",
         "outgoingViewKey": "f03bf4592df6b0faa05481bce128f15fbe743efb398f63fa09debb42299bd2b2",
         "publicAddress": "558a5c9c93b33a1a74211e50f62af3d2d2435f96feac906dd11a8811cddd54a2",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "704b9a41ced4f5e904c5a88b6777758d5ee4cbcca020624a4272a2453ac01b0c"
       },
@@ -2728,13 +2500,7 @@
         "incomingViewKey": "89577aa274f44b861982c5af3d260ccddd471701e4f62a63132455e05bae1c01",
         "outgoingViewKey": "e088397eb2ae4309084934a067ffe32055471933883ce1eea4de38c5a742309e",
         "publicAddress": "900f057354aea66db6da4843ae0542cff43a8a39c4f54a2dad66a8e86c660d8d",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "3d08fc848325265158be983fe6d8982ce5ad8d85eef66e921b5d8023b965980a"
       },
@@ -2756,13 +2522,7 @@
         "incomingViewKey": "8e9108ec7cbb2241987bc578b6cfe9a95e41b81bb15a0b7e86ff7a874ab6c800",
         "outgoingViewKey": "40ecb267ff5f57e50977ed2bc4b2aaa62db15e8b5daaea9378e6c2d351089286",
         "publicAddress": "ab6d3b8e8100f7c80096b619c528096e090b32706118aeb78c5affda0f77b529",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "cdab3963fbd56e0014f18128218ef6365b5a382d441d6974ce9e3d51660aa302"
       },
@@ -2880,13 +2640,7 @@
         "incomingViewKey": "58a4e9c315cb2a0655d0b34e07f12ceb15e64e996ae1077ab524acdb05f66c05",
         "outgoingViewKey": "64afb70ed31eb05a0b8d7057b545747b86210681a3e2acff71d7baeee68cd6a8",
         "publicAddress": "53a4b53ecb59c47715840d1f4df65beef82679f742baeb9f29fe7cf4b1687966",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "7bf505db5bc5bcb541cfdbef04fd547d9beaef6e3cb3d003549cb716af130905"
       },
@@ -2908,13 +2662,7 @@
         "incomingViewKey": "1284969556599bcc425cd36faec4b38c32dc1afe74139a1aa82aef878b4bd703",
         "outgoingViewKey": "4a07003df338a0410949be1ad21ccd1f9ae5e58652bba088a520da1fa627e86e",
         "publicAddress": "7eb97f282aaa0c267681fe8b42ebfbdb9031b70c6d1e7bf1fbf7ea5b6a1529ee",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "b7e4fed204068ae5da7553b375632d99d2ede867da20a872787fc2b5f3e04204"
       },
@@ -3032,13 +2780,7 @@
         "incomingViewKey": "9a687d74751788d368b0ecb64b2f15744f6e4022e0db615edd45e0bfba003b05",
         "outgoingViewKey": "44ee41ec9ccf6d7628dc5f2c6fd0fe036ea9bfa9fb967f8c0beadf82eaf790d8",
         "publicAddress": "763b6eb7292662385461734398559a9eec21a04fd62aec2a2c3246fb5c6bab1f",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "21358f11160b1d0b7994584c7e38324dbd5fb9b46f9f807063cb28b950aa4309"
       },
@@ -3060,13 +2802,7 @@
         "incomingViewKey": "d28766676988d59002da3a466cdbf0e1436fdf6533ddcf6a857fe302368ee600",
         "outgoingViewKey": "299ab11109129ad8dd41ff35e3fec0ef654fa70c87595f8f6905dd25626cabfd",
         "publicAddress": "ee2080f7e5ce526199e171e944d5fd8ee0acf43462150075b05d6b666d01af3b",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "30c7e5abd2a2448d1fa047fe6c06811d37ef13b4035db06631362437ac4c2f0e"
       },
@@ -3252,13 +2988,7 @@
         "incomingViewKey": "c149d6cad2ec7a4998c207db4e6ae93873e6dc489369a1354cbfc576bf177700",
         "outgoingViewKey": "6c1ed124dbb7a76ebee7d1b34cef1f518ee50fec27e7655afcada4ac0aa4495e",
         "publicAddress": "8903639a8f6a83fc68aa6b2132368863c1d1a4b5639f894e5f071531af1ff212",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "a80b6f036f89b981a08047bfa57112e0c1dd4678416a1fbb287dd5b170dda003"
       },
@@ -3280,13 +3010,7 @@
         "incomingViewKey": "1edd29ebd52cf78b86b3019935f5a8dd5af2e057d3adaaba390cba9db7cce600",
         "outgoingViewKey": "8833aea97a7eb9dcf3b004b059cbe085b2e47b85d6940b685ec8177d55266a3d",
         "publicAddress": "6615387cc2f76766439bd205bc8b0be0a6acaab2d8a71318456e44e564d5fc21",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "a1c6df2be0f621ae6a22a6817ee61c4894bc2e7fab980c377d9a573591da5700"
       },
@@ -3370,13 +3094,7 @@
         "incomingViewKey": "6bba75f928c16396d47b5482f03cd9c998e643a701d4ed99801cdaf8602a8d05",
         "outgoingViewKey": "f299ad24f06f398206cfdba970c389a08cfc585b24f1f48815bd422117426bcb",
         "publicAddress": "2b507f5be19ed8c1936e37a01859b4d444e704a66cc655168d51afbfb0c1609b",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "f9742271314677022d45917e50a84dfb29e4cacd4640f144d94bf9accf494808"
       },
@@ -3426,13 +3144,7 @@
         "incomingViewKey": "afa5c6435c9eadfba8938a77cb826609c911ede586ccf23f149c302562d7f201",
         "outgoingViewKey": "b7a3b6083e6e9dec8b612bfd3f19222226821bc2fd786f15273c313dc9d2b9a9",
         "publicAddress": "c2ecc73670eb0cc9315f12f0130cb2a0724d719530e653e42d2809791ecb3b1f",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "a19d08959927ccd427c7010837eddd1a03a081a727170904fe322fa0d7eb8a01"
       },
@@ -3482,13 +3194,7 @@
         "incomingViewKey": "83cf7a62f87e6089cad6386108d0b2d9550e28fb4dda91b02ef7c6102ffb4003",
         "outgoingViewKey": "48d704eb34763ee3f0199403b7f9d74745fe2a91f211f8186f87b98887885757",
         "publicAddress": "3e05ba92905ef8ecfc830ddc9226fe641b3af2f593c61f8f3bfde409cb38be91",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "ff85e0c1380f0fb5675e322c58f2632148f4ce3772e4cdc35e477c82f2eba00d"
       },
@@ -3542,13 +3248,7 @@
         "incomingViewKey": "430a0f8c084075dd20d62808d72382e0d776c698da44affa1d00e802ab0dca05",
         "outgoingViewKey": "8f6ddd5f3803ff35251c71b6f530d6e0fa9757000a0d1f49a891f2c4c542a9ae",
         "publicAddress": "b27491dccac9fedeee504a4c074bc4e9e38a05d6f2e4db67793803e8a5b13e88",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "db4521c68ff162498fe7dbff02d096541a587d2cc57b14c998f9501c84238804"
       },
@@ -3570,13 +3270,7 @@
         "incomingViewKey": "a0999119fe0e0f9423a2a9e4e417707787125df5ce7e1c23da3b5971acbeee02",
         "outgoingViewKey": "6bf1d7a5ece33504f023554749186f508cfb0e247f3ebc78f60ee126ee485a2a",
         "publicAddress": "5395635a189710d8b800867df03d4bd116cf7171d1b074003fc83fcee6c24f71",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "eb924930c8128e708e7a735f7b25bc1eb46cf96c7c8bcafcf754df71cf5a4401"
       },
@@ -3656,13 +3350,7 @@
         "incomingViewKey": "63b6b447c8e0013c0c426026c2c506f29476d26d321439a9f1814ab936704806",
         "outgoingViewKey": "ca32e39c6a62182e76349fe91872c942148c41dd1326424de8c419ac5b815529",
         "publicAddress": "7b5f1b0e343d3b1bf4cc7ba58413f4d545c3247a6a9533be7405fb6d752eaf86",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "5c462ff89b5b3730b2a5c4ee09fd66fba577441f584217b78e806b2480408103"
       },
@@ -3684,13 +3372,7 @@
         "incomingViewKey": "caad404d3dd7a9f5c9b129688f6f2d378315e1549a73fd360a1121efcb874606",
         "outgoingViewKey": "550f1c5977777e18058626f1ffbd2bdd7986db808a4dd7db1ad8b627c01297b8",
         "publicAddress": "f5a49089524a6b11473ec5710ccf52bb69ce5906054b41a2b3eb72cbba80c416",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "9e8035c4f9619d70733f2f0c922a26b48c8985fa26cd2861521860468f06140b"
       },
@@ -3800,13 +3482,7 @@
         "incomingViewKey": "97cfbddd03e606e29678f0fb0bbcee5e8c58976cfcc51e1e4716d097ca3e9607",
         "outgoingViewKey": "b00950790b15c742c29430fec4f3c62d8d733d3bb903602358fb34a8c933bf0f",
         "publicAddress": "1a4c61f6834acf1324f9090cdf270e325984f09641a111f77169b1342bba34e9",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "fca86880a2f0ddb82ae4bfcb66f1ba6d608002c6147eef8586d9783a6131dc02"
       },
@@ -3890,13 +3566,7 @@
         "incomingViewKey": "4394911b44f1174f1de74581acf6dda0ce5f6bfdbc9b0e38054e96404dacab04",
         "outgoingViewKey": "9ec1076107b67e49f6ab935a812a57a82c70640b9b2c440c105a1d9bb7843f21",
         "publicAddress": "986296ac20dae0a4b22e49fc2563f22881422a15176518194054f482d855b867",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "83dc8500f025fe07a4e1134865500c96cd5355d356123f8382524fe1eba4f608"
       },
@@ -3918,13 +3588,7 @@
         "incomingViewKey": "9c9415ba0011076907cd8d1de97d15ce20a58c1684f1bc27720a65d7950ed500",
         "outgoingViewKey": "c584804c92166e2fc1d0e82a2586002f3a7607fc1771d082c6dd5b460dfb51a2",
         "publicAddress": "69647ec8942334a069823e284da48f002ae5abf0cdc6d1e64aa5ad20a182aa21",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "c067bd0f1bb7e0671938ab5e43a0c6c8673e6845472fd3c4f9c3573cfa973000"
       },
@@ -3978,13 +3642,7 @@
         "incomingViewKey": "6db94bef05e5829ea7fe288a6f67161bc73772126c59acf5e42bad34cca35403",
         "outgoingViewKey": "ef2195dc8ae2a34734dd12a9c27522223dd6aec3444f89328b256c4f3132ae40",
         "publicAddress": "2200a09d4b6208ffa74a71203063ebc42879bcf6214f24ecd18307b7a79baa17",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "41e64b7f8b222962e7752c7d5746711711ffa5a21f1bd7e6a014d7a09d151305"
       },
@@ -4006,13 +3664,7 @@
         "incomingViewKey": "a2b8e66b9cf93c4e76b12391852f225fccbd0fbd50a5658a22c11acc5a702907",
         "outgoingViewKey": "486fd1346a96eb36061183302bdb8708e4446d6a466a43b74099e3b3b1975b91",
         "publicAddress": "7121c16ce957dc99bd2761795a48c632799335637d02019126a70dff6639ab0d",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "b6501630e1ece208d21da8288c6839e53594375a47dd246c30dcd74670fba106"
       },
@@ -4092,13 +3744,7 @@
         "incomingViewKey": "200db595afe84481edfe8273ea8920d668a8ab94bb63b840eedb8cfb56b95700",
         "outgoingViewKey": "660589070fac6beee4b4222954e90780cad2ad362163754725302d667688f2ae",
         "publicAddress": "afb1a5a17b61aca1d843bf6db72b12b9b44bd2127442d94d0d8f89d3fd28fc1f",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "7a460d0fe20dd914a69110f685707f8b1abd10c515153eff5fae2d1ec14f6104"
       },
@@ -4120,13 +3766,7 @@
         "incomingViewKey": "080ba6ea0e5af6e2ddb0b00d185eebecc3149d1e973bbaace21633497094c500",
         "outgoingViewKey": "fc65e83023f7df1e1b9bf5158682757dfacdb1740f7f05b2a1915551286b3768",
         "publicAddress": "d361a969842fcc9786ac13bc8b17941f971251156d41fb40907fae47c317fb1b",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "a6fc021e9a7de24a16f1cf4487c94685d0a292306e85a7bfbc0e953090ceb106"
       },
@@ -4236,13 +3876,7 @@
         "incomingViewKey": "3ff1048efe5bd76d01ff643d4b0ef474fa1880bd001425bd261b807700fe4804",
         "outgoingViewKey": "bf26681ed89a20ef84db0fab5a0de6b8d21dc78b2409d692d4bed268d7f9d2e9",
         "publicAddress": "27b36c92bd91061ebc8aaf21f08ba03b1feb80900fcb27ce8eb8a592ff7b114f",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "de089f9431ae2ba3926b5edd8110e190fb469cf952b4580c0bd52f76044cf80d"
       },
@@ -4292,13 +3926,7 @@
         "incomingViewKey": "e3a5b80a858289b16cffe0f7a9388bbe722d99c8baba832e64b9a9d76502fb06",
         "outgoingViewKey": "98ba87a18d9f8ba51a5d0ffd7a283e9059d43c182a372e5b54ac9f76d5d51cea",
         "publicAddress": "626019ddd48af3941e8e2508a4fceb06d741458f09326e0b009b33a1c9f53091",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "c8fe7a71143ff42f21f7b70bd72cbd85dd4ce0736af41415b4d572bd30287f00"
       },
@@ -4320,13 +3948,7 @@
         "incomingViewKey": "533a5c4e318c268b65cb0c1353489d47b0ea5900ff8fd47ebce4060dbd324102",
         "outgoingViewKey": "d0de2eba473509211af1c0179b1951f79b300cd5e80c31675d5fe9f58216c54c",
         "publicAddress": "0ec5c3bb13ec333b075eaf14c42592a26c0d4c88fb5f9ebb72b01a82b1cd7e96",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "3ab483e9150464eed8ae5e985bf0fd8fb845b033f39493ecc2b826d95b0c6e09"
       },
@@ -4380,13 +4002,7 @@
         "incomingViewKey": "aa66f26a4fc836ee17a99ff2e32faddaab6f61024a70b81d46dc2635f9053704",
         "outgoingViewKey": "64bc64bf4050b085b5f681376d3edcfbdbc009ae44e98da62c215ad4a075f43b",
         "publicAddress": "92777755667cf8aec04e2daf3284ad8ac2b943d284bfb98fc0d1b0f6bcc10623",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "e6373bb79c06d1fae0873a241cb08b7940580b1dac44558be4e9d2c2da33960b"
       },
@@ -4408,13 +4024,7 @@
         "incomingViewKey": "1d42d7443fb128ee08bdcc5828552122885df74f2e54b215371e46befa370506",
         "outgoingViewKey": "1a9c9ebb222cea79b38fbdec85bde99bf16e5a342503a5146ccf9d6556a9f524",
         "publicAddress": "d02e528eccd6dc2915ebc1060af8bd9acc2ecb5b21d9580e7ff6e4045510e88c",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "565b5b7c02e233bd085b480ca0998d515884d9e2dc50c23ea3663bc6458f210d"
       },
@@ -4528,13 +4138,7 @@
         "incomingViewKey": "b9cba6668c400607eeb8fd1250aec4dad2c4d872b59cfe85ef577b89dbb9c406",
         "outgoingViewKey": "0c52e5c23550c403e65506f8c9e44072166374e932542f9244c3414beaad27d8",
         "publicAddress": "9ce0b1f26bcf060b623a9a363877f3fcff728f2fbee361f1026192bef48b88cc",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "68acc678e60acc86df98c6b4d4ea9fb5e106634e65b2cb656ce1040f138ac50c"
       },
@@ -4618,13 +4222,7 @@
         "incomingViewKey": "6bd5b5ca3ea74464307520b6fe6aac943c2479c693f0df8b38947b30537dae04",
         "outgoingViewKey": "1754fe76af30537060fb79bdf77f80fd18a056780fbf43bb4653c1bc6c81f740",
         "publicAddress": "dfddde5e152615683837887cd32e76279c0efb7f5a14c5889305aa8abeabe6d3",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "0e0602c88278ca575580d2bebb7c7c624688add326a6e65b2444db118b4c0208"
       },
@@ -4678,13 +4276,7 @@
         "incomingViewKey": "e5d1459957ffc4365d6a6b9e404aba441ede025b8960e57c4b87358166aea302",
         "outgoingViewKey": "6a1e6b40e31108ca0dd0ac7a6a9a81ecdb06f636a52dad794c2eae5c90db7bbe",
         "publicAddress": "854ac0db4f915a001d86a278fd533f4a9aa2e4747e583d719d4dd494f7b984a2",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "efb5be0eb9e01b18f6acb53d744bfb4108d3350509c2cddf76ee81ed104ee409"
       },
@@ -4742,13 +4334,7 @@
         "incomingViewKey": "c61021b5ecddf5bda61efa86a96ed8905d4f8d2c5fff55f438facfdcc707da07",
         "outgoingViewKey": "8abf62370da721c1f0f3c8022f9e290dcf0d9402e22204977a22f5cfe215b81d",
         "publicAddress": "7b2a978f9d3e4a101802d3ef6953140f53482c279c92a7e6957bd4633f667181",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "5d091bf8a41fc6098132eb9a7b1b5837c96c66b02d56b49d4bd75c94b0852e0d"
       },
@@ -4802,13 +4388,7 @@
         "incomingViewKey": "e4407291db36acf678d2fca7d3d1159a935748a0849a43a3c5caaa82732ffe01",
         "outgoingViewKey": "1e610e1b727cd8308769254c94e795d1aab32dab939da68065176aa416728323",
         "publicAddress": "ec961e80a92abdf29fe86f656e8564b0c4600533dcf5486ca8e856dc9a3cb3bf",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "23d3e58fea40ee702e64a7412360a9b1995041455bbc06aeba7b55061f51c504"
       },
@@ -4926,13 +4506,7 @@
         "incomingViewKey": "beef693724666f37328e15ab95b7cbdeaf1de94958f48090a803aa9630670104",
         "outgoingViewKey": "133ba38cfc6fed34b6004a56778cff418fa2007d4aec70077f57d7366160891e",
         "publicAddress": "7c3e58b99491e82c9777f1b375b5682204ea00e429844efead5325d0b1d66fc4",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "889454b1d324b01c61f1e41bba72be500d5f2b7c22d8623691daaf52088df80d"
       },
@@ -5008,13 +4582,7 @@
         "incomingViewKey": "b343ae4a33b5746b7c5d24cf55d90947f4d046687d2404f583c9036a1aa7e705",
         "outgoingViewKey": "7a1030c39a890fa87ff0ae1b4fe6fc1a911768531f17b039eae56eb6212ad893",
         "publicAddress": "6c0e7cee97a7f12bf40de4467ec0b9e1f7464d363eb54a8140dc880c9ca9b79c",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "cc90c57f9e53b5cf3d6b5fda96d5140993476e10a844fdc28cb151915ef05000"
       },
@@ -5036,13 +4604,7 @@
         "incomingViewKey": "f9f4c63013135c77540bc292907ff32d81d65941d03fea9442da2be44610c207",
         "outgoingViewKey": "0fba7bbef0ef966fea0b51bf326da66e05546483b70ecac5ebff4a4e86a3ec3f",
         "publicAddress": "526f8688c1a3a69f7eee74d359c9e1ea68d033e6b8076ffd78cd811160efd5f2",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "ef1c45560b63307bff6d40b80a99419e195c9cee1517cf67deeb2728c2525800"
       },
@@ -5262,13 +4824,7 @@
         "incomingViewKey": "574944b5713f7ac8c28a0e2537f38c59c032825eb8f42f4e20d1ca40b5433202",
         "outgoingViewKey": "48e44490b92d9b185148caf83766ec0342d0d070487e5f7847025c9ef34a8801",
         "publicAddress": "c62e39de9246dbcf0865195b4eafc5e66213a95f9879259bb68964654e1cb080",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "77416980381b4b49796f08cbf4a4cf1ca1bc5ecba5a95e17bf4ad30d116f960d"
       },
@@ -5344,13 +4900,7 @@
         "incomingViewKey": "ae780899104a217c5167fb796d0295d896a81adc90e9b34ce82d0a0febe3f101",
         "outgoingViewKey": "0a0a47932e395a7aa8918ad0e2eee3b59c95e007481fd78f02c083d17c333584",
         "publicAddress": "7cc6046cd7d11717c96e376fe8c024fc39c2e73e664df05ea5f6b9dff25e2411",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "fe48ff5e3b202cecf8207f9ff5518b512887a31f73c4c640c626df623473fb0c"
       },
@@ -5400,13 +4950,7 @@
         "incomingViewKey": "dbaed6db088748dbe5e2cebe1d52b222dd2494c948278a1bdec29e45ee39fd02",
         "outgoingViewKey": "57cf1828472f3cb501555910fd2721207d9aca0e946bb3090bd267200b46af6c",
         "publicAddress": "f825b7e01ba3bbe383b11882bab2b890132e9c44a0fe5b539bffc7417f35dc71",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "4b436fd8c8fd0bf578839f976f439957666123a06aa7d6716cac5ec6ededaa04"
       },
@@ -5490,13 +5034,7 @@
         "incomingViewKey": "57678c5c0cdc1ebbe59b13d6d2f7d2c7bb92f779d706296f22a75a03bda69f07",
         "outgoingViewKey": "4e763e2d4a17725b9708ae8b4abf9b35890ed665e848608b34d7b7017aacadda",
         "publicAddress": "a4e71fcd90fe3154bae11504368a4503175f577ff5918ffa5ece7fa2fd4755ef",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "0dcc31584ec2e8779de7ec34f07a747a8cfc93ec1eca190239c99380fbce6e09"
       },
@@ -5546,13 +5084,7 @@
         "incomingViewKey": "f236a39d8cb4b691bce5eb6e6b20b36f8a9d906ef7394f80768fe7e4f1f0bc01",
         "outgoingViewKey": "2be239f107aacb7904ed74da32dab8a19e31ac5ed64d19a7ea417a717adae007",
         "publicAddress": "f82d8c9b141f0d58bb3fc3275e06a69bc36ca598492b2b3619986bdcea680a60",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "424be80eba38bb9b986640f9db4129bfb55743cd925a7d5039f9c2477d3fae03"
       },
@@ -5574,13 +5106,7 @@
         "incomingViewKey": "459937e9b1b1d68b383ad0fb4be3e55a757a69d311f6a8e61c17bedeac932102",
         "outgoingViewKey": "8d696d3e23f63ceb0d5343718b0493ac7d9fe4829c10981f6c1067e39d51861f",
         "publicAddress": "a40de31d12aa99c6c3d89e3d6dafec11c7f115b7b97b3f09c36442a5255f345e",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "aa4fd654e90753bc768d875541d963a4317b72dd47be64825a33f33aceb13509"
       },
@@ -5698,13 +5224,7 @@
         "incomingViewKey": "17add37fd33e3c961c272628ca8882adabdf7d5d81dedb44017f507448370007",
         "outgoingViewKey": "038a665c0eb728e70621f00bdd03cf19bf24983a4f4894e27bacb5d8fefe4431",
         "publicAddress": "a3cfa297e7b56c9064dbcfeada016da0f94e168b9856f8d9dbbd67b3a141c790",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "42199af9998c061037a01abd8319b54031cb32c275b354d37c7c5dd1f6547a04"
       },

--- a/ironfish/src/wallet/account/account.test.ts
+++ b/ironfish/src/wallet/account/account.test.ts
@@ -389,7 +389,7 @@ describe('Accounts', () => {
 
       const accountA = await useAccountFixture(nodeA.wallet, 'accountA')
       const accountB = await nodeB.wallet.importAccount(
-        toAccountImport(accountA, false, nodeB.network.id),
+        toAccountImport(accountA, { networkId: nodeB.network.id }),
       )
 
       // Ensure both nodes for the same account have the same note
@@ -628,7 +628,7 @@ describe('Accounts', () => {
       // Create a fresh node and import the account so that the transactions
       // are synced to the wallet through the block and not through transaction creation
       const freshAccountA = await freshNode.wallet.importAccount(
-        toAccountImport(accountA, false, freshNode.network.id),
+        toAccountImport(accountA, { networkId: freshNode.network.id }),
       )
       for await (const header of node.chain.iterateTo(node.chain.genesis)) {
         if (header.sequence === 1) {
@@ -922,7 +922,7 @@ describe('Accounts', () => {
 
       const accountA = await useAccountFixture(nodeA.wallet, 'accountA')
       const accountB = await nodeB.wallet.importAccount(
-        toAccountImport(accountA, false, nodeB.network.id),
+        toAccountImport(accountA, { networkId: nodeB.network.id }),
       )
 
       // Ensure both nodes for the same account have the same note
@@ -990,7 +990,7 @@ describe('Accounts', () => {
 
       // import account onto nodeB to simulate connecting transaction not seen as pending
       const accountAnodeB = await nodeB.wallet.importAccount(
-        toAccountImport(accountAnodeA, false, nodeB.network.id),
+        toAccountImport(accountAnodeA, { networkId: nodeB.network.id }),
       )
 
       const block2 = await useMinerBlockFixture(
@@ -2147,7 +2147,7 @@ describe('Accounts', () => {
 
       const accountA = await useAccountFixture(nodeA.wallet, 'accountA')
       const accountB = await nodeB.wallet.importAccount(
-        toAccountImport(accountA, false, nodeB.network.id),
+        toAccountImport(accountA, { networkId: nodeB.network.id }),
       )
 
       // Ensure both nodes for the same account have the same note

--- a/ironfish/src/wallet/account/account.test.ts
+++ b/ironfish/src/wallet/account/account.test.ts
@@ -17,6 +17,7 @@ import {
   useTxFixture,
 } from '../../testUtilities'
 import { AsyncUtils } from '../../utils/async'
+import { toAccountImport } from '../exporter'
 import { BalanceValue } from '../walletdb/balanceValue'
 import { Account } from './account'
 
@@ -387,7 +388,9 @@ describe('Accounts', () => {
       const { node: nodeB } = await nodeTest.createSetup()
 
       const accountA = await useAccountFixture(nodeA.wallet, 'accountA')
-      const accountB = await nodeB.wallet.importAccount(accountA)
+      const accountB = await nodeB.wallet.importAccount(
+        toAccountImport(accountA, false, nodeB.network.id),
+      )
 
       // Ensure both nodes for the same account have the same note
       const block = await useMinerBlockFixture(nodeA.chain, undefined, accountA, nodeA.wallet)
@@ -624,7 +627,9 @@ describe('Accounts', () => {
 
       // Create a fresh node and import the account so that the transactions
       // are synced to the wallet through the block and not through transaction creation
-      const freshAccountA = await freshNode.wallet.importAccount(accountA)
+      const freshAccountA = await freshNode.wallet.importAccount(
+        toAccountImport(accountA, false, freshNode.network.id),
+      )
       for await (const header of node.chain.iterateTo(node.chain.genesis)) {
         if (header.sequence === 1) {
           continue
@@ -916,7 +921,9 @@ describe('Accounts', () => {
       const { node: nodeB } = await nodeTest.createSetup()
 
       const accountA = await useAccountFixture(nodeA.wallet, 'accountA')
-      const accountB = await nodeB.wallet.importAccount(accountA)
+      const accountB = await nodeB.wallet.importAccount(
+        toAccountImport(accountA, false, nodeB.network.id),
+      )
 
       // Ensure both nodes for the same account have the same note
       const block1 = await useMinerBlockFixture(nodeA.chain, undefined, accountA, nodeA.wallet)
@@ -982,7 +989,9 @@ describe('Accounts', () => {
       const accountAnodeA = await useAccountFixture(nodeA.wallet, 'accountA')
 
       // import account onto nodeB to simulate connecting transaction not seen as pending
-      const accountAnodeB = await nodeB.wallet.importAccount(accountAnodeA)
+      const accountAnodeB = await nodeB.wallet.importAccount(
+        toAccountImport(accountAnodeA, false, nodeB.network.id),
+      )
 
       const block2 = await useMinerBlockFixture(
         nodeA.chain,
@@ -2137,7 +2146,9 @@ describe('Accounts', () => {
       const { node: nodeB } = await nodeTest.createSetup()
 
       const accountA = await useAccountFixture(nodeA.wallet, 'accountA')
-      const accountB = await nodeB.wallet.importAccount(accountA)
+      const accountB = await nodeB.wallet.importAccount(
+        toAccountImport(accountA, false, nodeB.network.id),
+      )
 
       // Ensure both nodes for the same account have the same note
       const block = await useMinerBlockFixture(nodeA.chain, undefined, accountA, nodeA.wallet)

--- a/ironfish/src/wallet/account/account.ts
+++ b/ironfish/src/wallet/account/account.ts
@@ -69,7 +69,7 @@ export class Account {
   readonly outgoingViewKey: string
   readonly version: number
   publicAddress: string
-  createdAt: { sequence: number } | null
+  createdAt: number | null
   scanningEnabled: boolean
   readonly prefix: Buffer
   readonly prefixRange: DatabaseKeyRange
@@ -1243,10 +1243,7 @@ export class Account {
     await this.walletDb.saveHead(this, head, tx)
   }
 
-  async updateCreatedAt(
-    createdAt: { sequence: number } | null,
-    tx?: IDatabaseTransaction,
-  ): Promise<void> {
+  async updateCreatedAt(createdAt: number | null, tx?: IDatabaseTransaction): Promise<void> {
     this.createdAt = createdAt
 
     await this.walletDb.setAccount(this, tx)

--- a/ironfish/src/wallet/account/account.ts
+++ b/ironfish/src/wallet/account/account.ts
@@ -69,7 +69,7 @@ export class Account {
   readonly outgoingViewKey: string
   readonly version: number
   publicAddress: string
-  createdAt: HeadValue | null
+  createdAt: { sequence: number } | null
   scanningEnabled: boolean
   readonly prefix: Buffer
   readonly prefixRange: DatabaseKeyRange
@@ -1243,7 +1243,10 @@ export class Account {
     await this.walletDb.saveHead(this, head, tx)
   }
 
-  async updateCreatedAt(createdAt: HeadValue | null, tx?: IDatabaseTransaction): Promise<void> {
+  async updateCreatedAt(
+    createdAt: { sequence: number } | null,
+    tx?: IDatabaseTransaction,
+  ): Promise<void> {
     this.createdAt = createdAt
 
     await this.walletDb.setAccount(this, tx)

--- a/ironfish/src/wallet/exporter/accountImport.ts
+++ b/ironfish/src/wallet/exporter/accountImport.ts
@@ -11,6 +11,7 @@ import {
   isValidSpendingKey,
   isValidViewKey,
 } from '../validator'
+import { AccountValue } from '../walletdb/accountValue'
 import { MultisigKeysImport } from './multisig'
 
 export type AccountImport = {
@@ -30,14 +31,16 @@ export type AccountImport = {
 }
 
 export function toAccountImport(
-  account: Account,
-  viewOnly: boolean,
-  networkId: number,
+  account: Account | AccountValue,
+  options?: {
+    viewOnly?: boolean
+    networkId?: number
+  },
 ): AccountImport {
   const createdAt = account.createdAt
     ? {
-        ...account.createdAt,
-        networkId,
+        sequence: account.createdAt,
+        networkId: options?.networkId,
       }
     : null
 
@@ -54,7 +57,7 @@ export function toAccountImport(
     proofAuthorizingKey: account.proofAuthorizingKey,
   }
 
-  if (viewOnly) {
+  if (options?.viewOnly) {
     value.spendingKey = null
 
     if (value.multisigKeys) {

--- a/ironfish/src/wallet/exporter/accountImport.ts
+++ b/ironfish/src/wallet/exporter/accountImport.ts
@@ -22,7 +22,6 @@ export type AccountImport = {
   outgoingViewKey: string
   publicAddress: string
   createdAt: {
-    hash: Buffer
     sequence: number
     networkId?: number
   } | null

--- a/ironfish/src/wallet/exporter/encoders/base64json.test.ts
+++ b/ironfish/src/wallet/exporter/encoders/base64json.test.ts
@@ -76,13 +76,7 @@ describe('Base64JsonEncoder', () => {
       incomingViewKey: key.incomingViewKey,
       outgoingViewKey: key.outgoingViewKey,
       publicAddress: key.publicAddress,
-      createdAt: {
-        hash: Buffer.from(
-          '0000000000000000000000000000000000000000000000000000000000000000',
-          'hex',
-        ),
-        sequence: 1,
-      },
+      createdAt: { sequence: 1 },
       proofAuthorizingKey: key.proofAuthorizingKey,
     }
 

--- a/ironfish/src/wallet/exporter/encoders/bech32.test.ts
+++ b/ironfish/src/wallet/exporter/encoders/bech32.test.ts
@@ -57,13 +57,7 @@ describe('Bech32AccountEncoder', () => {
       incomingViewKey: key.incomingViewKey,
       outgoingViewKey: key.outgoingViewKey,
       publicAddress: key.publicAddress,
-      createdAt: {
-        hash: Buffer.from(
-          '0000000000000000000000000000000000000000000000000000000000000000',
-          'hex',
-        ),
-        sequence: 1,
-      },
+      createdAt: { sequence: 1 },
       proofAuthorizingKey: key.proofAuthorizingKey,
     }
 

--- a/ironfish/src/wallet/exporter/encoders/json.test.ts
+++ b/ironfish/src/wallet/exporter/encoders/json.test.ts
@@ -12,7 +12,7 @@ describe('JsonEncoder', () => {
   describe('encoding/decoding', () => {
     it('decodes the value into a AccountImport and deserializes to the original value', () => {
       const jsonString =
-        '{"version":2,"name":"ffff","spendingKey":"9e02be4c932ebc09c1eba0273a0ea41344615097222a5fb8a8787fba0db1a8fa","viewKey":"8d027bae046d73cf0be07e6024dd5719fb3bbdcac21cbb54b9850f6e4f89cd28fdb49856e5272870e497d65b177682f280938e379696dbdc689868eee5e52c1f","incomingViewKey":"348bd554fa8f1dc9686146ced3d483c48321880fc1a6cf323981bb2a41f99700","outgoingViewKey":"68543a20edaa435fb49155d1defb5141426c84d56728a8c5ae7692bc07875e3b","publicAddress":"471325ab136b883fe3dacff0f288153a9669dd4bae3d73b6578b33722a3bd22c","createdAt":{"hash":"000000000000007e3b8229e5fa28ecf70d7a34c973dd67b87160d4e55275a907","sequence":97654}}'
+        '{"version":2,"name":"ffff","spendingKey":"9e02be4c932ebc09c1eba0273a0ea41344615097222a5fb8a8787fba0db1a8fa","viewKey":"8d027bae046d73cf0be07e6024dd5719fb3bbdcac21cbb54b9850f6e4f89cd28fdb49856e5272870e497d65b177682f280938e379696dbdc689868eee5e52c1f","incomingViewKey":"348bd554fa8f1dc9686146ced3d483c48321880fc1a6cf323981bb2a41f99700","outgoingViewKey":"68543a20edaa435fb49155d1defb5141426c84d56728a8c5ae7692bc07875e3b","publicAddress":"471325ab136b883fe3dacff0f288153a9669dd4bae3d73b6578b33722a3bd22c","createdAt":{"sequence":97654}}'
       const encoder = new JsonEncoder()
       const decoded = encoder.decode(jsonString)
 
@@ -30,10 +30,6 @@ describe('JsonEncoder', () => {
           multisigKeys: undefined,
           createdAt: {
             sequence: 97654,
-            hash: Buffer.from(
-              '000000000000007e3b8229e5fa28ecf70d7a34c973dd67b87160d4e55275a907',
-              'hex',
-            ),
           },
         }),
       )
@@ -41,7 +37,7 @@ describe('JsonEncoder', () => {
 
     it('renames account when name is passed', () => {
       const encoded =
-        '{"version":2,"name":"ffff","spendingKey":"9e02be4c932ebc09c1eba0273a0ea41344615097222a5fb8a8787fba0db1a8fa","viewKey":"8d027bae046d73cf0be07e6024dd5719fb3bbdcac21cbb54b9850f6e4f89cd28fdb49856e5272870e497d65b177682f280938e379696dbdc689868eee5e52c1f","incomingViewKey":"348bd554fa8f1dc9686146ced3d483c48321880fc1a6cf323981bb2a41f99700","outgoingViewKey":"68543a20edaa435fb49155d1defb5141426c84d56728a8c5ae7692bc07875e3b","publicAddress":"471325ab136b883fe3dacff0f288153a9669dd4bae3d73b6578b33722a3bd22c","createdAt":{"hash":"000000000000007e3b8229e5fa28ecf70d7a34c973dd67b87160d4e55275a907","sequence":97654}}'
+        '{"version":2,"name":"ffff","spendingKey":"9e02be4c932ebc09c1eba0273a0ea41344615097222a5fb8a8787fba0db1a8fa","viewKey":"8d027bae046d73cf0be07e6024dd5719fb3bbdcac21cbb54b9850f6e4f89cd28fdb49856e5272870e497d65b177682f280938e379696dbdc689868eee5e52c1f","incomingViewKey":"348bd554fa8f1dc9686146ced3d483c48321880fc1a6cf323981bb2a41f99700","outgoingViewKey":"68543a20edaa435fb49155d1defb5141426c84d56728a8c5ae7692bc07875e3b","publicAddress":"471325ab136b883fe3dacff0f288153a9669dd4bae3d73b6578b33722a3bd22c","createdAt":{"sequence":97654}}'
 
       const encoder = new JsonEncoder()
       const decoded = encoder.decode(encoded, { name: 'foo' })

--- a/ironfish/src/wallet/exporter/encoders/json.ts
+++ b/ironfish/src/wallet/exporter/encoders/json.ts
@@ -12,8 +12,7 @@ import { AccountDecodingOptions, AccountEncoder, DecodeFailed } from '../encoder
 
 export class JsonEncoder implements AccountEncoder {
   encode(value: AccountImport): string {
-    const encoded = serializeAccountEncodedJSON(value)
-    return JSON.stringify(encoded)
+    return JSON.stringify(value)
   }
 
   decode(value: string, options?: AccountDecodingOptions): AccountImport {
@@ -58,7 +57,7 @@ type AccountEncodedJSON = {
   outgoingViewKey: string
   publicAddress: string
   spendingKey: string | null
-  createdAt?: { hash: string; sequence: number; networkId?: number } | string | null
+  createdAt?: { hash?: string; sequence: number; networkId?: number } | string | null
   multisigKeys?: {
     identity?: string
     secret?: string
@@ -79,7 +78,7 @@ const AccountEncodedJSONSchema: yup.ObjectSchema<AccountEncodedJSON> = yup
     version: yup.number().optional(),
     createdAt: yup
       .object({
-        hash: yup.string().defined(),
+        hash: yup.string().optional(),
         sequence: yup.number().defined(),
         networkId: yup.number().optional(),
       })
@@ -98,29 +97,6 @@ const AccountEncodedJSONSchema: yup.ObjectSchema<AccountEncodedJSON> = yup
     proofAuthorizingKey: yup.string().nullable().optional(),
   })
   .defined()
-
-const serializeAccountEncodedJSON = (accountImport: AccountImport): AccountEncodedJSON => {
-  const createdAt = accountImport.createdAt
-    ? {
-        hash: accountImport.createdAt.hash.toString('hex'),
-        sequence: accountImport.createdAt.sequence,
-        networkId: accountImport.createdAt.networkId,
-      }
-    : null
-
-  return {
-    version: accountImport.version,
-    name: accountImport.name,
-    viewKey: accountImport.viewKey,
-    incomingViewKey: accountImport.incomingViewKey,
-    outgoingViewKey: accountImport.outgoingViewKey,
-    publicAddress: accountImport.publicAddress,
-    spendingKey: accountImport.spendingKey,
-    multisigKeys: accountImport.multisigKeys,
-    proofAuthorizingKey: accountImport.proofAuthorizingKey,
-    createdAt: createdAt,
-  }
-}
 
 /**
  * Converts a AccountEncodedJSON to AccountImport
@@ -142,7 +118,6 @@ function deserializeAccountEncodedJSON(raw: AccountEncodedJSON): AccountImport {
     createdAt:
       raw.createdAt && typeof raw.createdAt === 'object'
         ? {
-            hash: Buffer.from(raw.createdAt.hash, 'hex'),
             sequence: raw.createdAt.sequence,
             networkId: raw.createdAt.networkId,
           }

--- a/ironfish/src/wallet/wallet.test.slow.ts
+++ b/ironfish/src/wallet/wallet.test.slow.ts
@@ -17,6 +17,7 @@ import {
 } from '../testUtilities'
 import { acceptsAllTarget } from '../testUtilities/helpers/blockchain'
 import { AssertMultisigSigner } from '../wallet'
+import { toAccountImport } from './exporter'
 
 describe('Wallet', () => {
   const nodeTest = createNodeTest()
@@ -560,7 +561,9 @@ describe('Wallet', () => {
     const accountA = await useAccountFixture(nodeA.wallet, 'testA', { createdAt: null })
     const accountB = await useAccountFixture(nodeB.wallet, 'testB', { createdAt: null })
 
-    const accountBNodeA = await nodeA.wallet.importAccount(accountB)
+    const accountBNodeA = await nodeA.wallet.importAccount(
+      toAccountImport(accountB, { networkId: nodeA.network.id }),
+    )
 
     // Create and add A1
     const blockA1 = await useMinerBlockFixture(nodeA.chain, 2, accountA, nodeA.wallet)
@@ -715,8 +718,8 @@ describe('Wallet', () => {
 
     const accountA = await useAccountFixture(nodeA.wallet, 'testA', { createdAt: null })
     const accountB = await useAccountFixture(nodeB.wallet, 'testB', { createdAt: null })
-    const accountBNodeA = await nodeA.wallet.importAccount(accountB)
-    const accountANodeB = await nodeB.wallet.importAccount(accountA)
+    const accountBNodeA = await nodeA.wallet.importAccount(toAccountImport(accountB))
+    const accountANodeB = await nodeB.wallet.importAccount(toAccountImport(accountA))
 
     // Create and add Block 1
     const block1 = await useMinerBlockFixture(nodeA.chain, 3, accountA)
@@ -825,8 +828,8 @@ describe('Wallet', () => {
 
     const accountA = await useAccountFixture(nodeA.wallet, 'testA', { createdAt: null })
     const accountB = await useAccountFixture(nodeB.wallet, 'testB', { createdAt: null })
-    const accountBNodeA = await nodeA.wallet.importAccount(accountB)
-    const accountANodeB = await nodeB.wallet.importAccount(accountA)
+    const accountBNodeA = await nodeA.wallet.importAccount(toAccountImport(accountB))
+    const accountANodeB = await nodeB.wallet.importAccount(toAccountImport(accountA))
 
     // Create and add Block A1
     const blockA1 = await useMinerBlockFixture(nodeA.chain, 2, accountA, nodeA.wallet)

--- a/ironfish/src/wallet/wallet.test.ts
+++ b/ironfish/src/wallet/wallet.test.ts
@@ -306,7 +306,10 @@ describe('Wallet', () => {
         hash: block1.header.hash,
         sequence: block1.header.sequence,
       })
-      await expect(accountB.getHead()).resolves.toEqual(null)
+      Assert.isNotNull(accountB.createdAt)
+      await expect(accountB.getHead()).resolves.toMatchObject({
+        sequence: accountB.createdAt.sequence,
+      })
 
       // Add second block
       const block2 = await useMinerBlockFixture(node.chain, 3, accountA)
@@ -414,7 +417,10 @@ describe('Wallet', () => {
         hash: block1.header.hash,
         sequence: block1.header.sequence,
       })
-      await expect(accountB.getHead()).resolves.toEqual(null)
+      Assert.isNotNull(accountB.createdAt)
+      await expect(accountB.getHead()).resolves.toMatchObject({
+        sequence: accountB.createdAt.sequence,
+      })
 
       // Add second block
       const block2 = await useMinerBlockFixture(node.chain, 3, accountA)
@@ -739,7 +745,7 @@ describe('Wallet', () => {
       expect(accountBImport.createdAt?.sequence).toEqual(3)
     })
 
-    it('should set account head to block before createdAt if networkId matches', async () => {
+    it('should set account head to createdAt block if networkId matches', async () => {
       const { node: nodeA } = await nodeTest.createSetup()
       const { node: nodeB } = await nodeTest.createSetup()
 
@@ -767,8 +773,7 @@ describe('Wallet', () => {
 
       const accountBImportHead = await accountBImport.getHead()
 
-      expect(accountBImportHead?.hash).toEqualHash(block2.header.hash)
-      expect(accountBImportHead?.sequence).toEqual(2)
+      expect(accountBImportHead?.sequence).toEqual(3)
     })
 
     it('should set createdAt to null if networkId does not match', async () => {
@@ -2061,7 +2066,6 @@ describe('Wallet', () => {
       // create second account with createdAt at block 3
       const accountB = await useAccountFixture(nodeA.wallet, 'b')
 
-      expect(accountB.createdAt).not.toBeNull()
       expect(accountB.createdAt?.sequence).toEqual(block3.header.sequence)
 
       // reset wallet
@@ -2538,7 +2542,7 @@ describe('Wallet', () => {
 
       const accountA = await useAccountFixture(node.wallet, 'a')
 
-      await node.wallet.resetAccount(accountA)
+      await node.wallet.resetAccount(accountA, { resetCreatedAt: true })
 
       const newAccountA = node.wallet.getAccountByName('a')
 
@@ -2776,7 +2780,7 @@ describe('Wallet', () => {
 
       const account = await useAccountFixture(node.wallet)
 
-      await account.updateCreatedAt({ hash: Buffer.alloc(32), sequence: 1 })
+      await account.updateCreatedAt({ sequence: 1 })
 
       const block = await useMinerBlockFixture(node.chain, 2)
 
@@ -2788,7 +2792,7 @@ describe('Wallet', () => {
 
       const account = await useAccountFixture(node.wallet)
 
-      await account.updateCreatedAt({ hash: Buffer.alloc(32), sequence: 3 })
+      await account.updateCreatedAt({ sequence: 3 })
 
       const block = await useMinerBlockFixture(node.chain, 2)
 

--- a/ironfish/src/wallet/walletdb/__fixtures__/assetValue.test.ts.fixture
+++ b/ironfish/src/wallet/walletdb/__fixtures__/assetValue.test.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "30ff684b10d7de8b9f23280f8fbfa272d8da46efea6759949fa62faa6d706902",
         "outgoingViewKey": "83dddfcb9c47a43f6a463a6ddd558ef9bc971cd139295a00c3183528db778456",
         "publicAddress": "137ba12fb2999890c0096c9f6f975f7034eb29bc83f994b913c9d54106e41c62",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "eac1f7f1215358bdc134227170ac5026e95a190f373e64d25402b8c24f603e0b"
       },

--- a/ironfish/src/wallet/walletdb/__fixtures__/decryptedNoteValue.test.ts.fixture
+++ b/ironfish/src/wallet/walletdb/__fixtures__/decryptedNoteValue.test.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "f1b2cf8feb9762d087eb9c187c9e436d40a80e823f849b764a25f179fec3d607",
         "outgoingViewKey": "b69d6eeedf237d2f376b588dfc097ee02cda113eda1246e9f5d8dd088837255c",
         "publicAddress": "5b75f5f1730af9967eb714d1964184d171f5ae6fe4ba178a05d3aa8a28465cb4",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "41b798564c21296084bf8deeef0225c1286ca5c81140773fa0e9fd9dc158e00d"
       },
@@ -44,13 +38,7 @@
         "incomingViewKey": "be08e7988af7c22d0d01bf51d4893520eb6959c65a7ec98abdbb24d8ca77d001",
         "outgoingViewKey": "6df1a8829d02621b6b2e3a1afd132585a8665456d44c111ed88d20e7c5e14fea",
         "publicAddress": "7810e37574e8958de2c4d072a2aad403d97b6395e444766404d862993cd2f3af",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "564b098d0a8324b0730a6984e184f1567f673ad83ca2a48b44fe9f50430f6605"
       },

--- a/ironfish/src/wallet/walletdb/__fixtures__/transactionValue.test.ts.fixture
+++ b/ironfish/src/wallet/walletdb/__fixtures__/transactionValue.test.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "e0e71d6b3c2d2e87e111171d469d41da9897393d3cafc53c8b7afb1861b5bd02",
         "outgoingViewKey": "1df1d675d8dcc3c603cbf1261f344ad30673e4feade7bb7e2b5b2316d3442a40",
         "publicAddress": "f727de41be04c2cf6e343c8e81eca1209d8af4c265ca5284cc1f3b7b7bed2303",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "553e22453d3548d431f86eea9bfb9f835bac4cc352bb66ff818c12934bba7702"
       },
@@ -44,13 +38,7 @@
         "incomingViewKey": "2770e2c08f7d2f9963b067aafbaecd0eb5621585027a606db085280dbd843200",
         "outgoingViewKey": "d10e03d482de739d3dc1b97daabf9f5a49ab6c901d588096f43ff31983926e30",
         "publicAddress": "49c9ed48e24cda10abb40bc7005424a29962f3bd820918bb41f7df089af1e832",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "8c6739c880b457331fa57772af592b0568941a92c97f4a49579191ce06a2e006"
       },
@@ -78,13 +66,7 @@
         "incomingViewKey": "04838fa07d30459ef7d4bb950f44270cb0bb4f3cdde1b9029cf1c936d03b9b07",
         "outgoingViewKey": "9af5cd3fbadc1e4781ff1af05594034956b5d7961476e3988c701cc1398cd66d",
         "publicAddress": "c6b0a3f850b3099e293e0d5b16cc79344ac2b7fef8e6ba0d7741b9efed89aacc",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "7de5ffc538d8e35ec6da49456a1cf4671c20cae211f9139f1c41045b67db4406"
       },
@@ -112,13 +94,7 @@
         "incomingViewKey": "cfd9b86a7827eff2393a659e4d440aa81a8f844cd34ead605159d4071e5eeb00",
         "outgoingViewKey": "7414c9f0641a50688700b095667a258ed808a2f6bcbfb76e9f9d1ade465bccef",
         "publicAddress": "e525b78bd88c85c89c89b1c4c15ba125d05c2d9acee0fe5dea960e62120d4e94",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "33469782640fed7f0f143db0f51d6a5601562c55a5f13c14344369295452300a"
       },
@@ -146,13 +122,7 @@
         "incomingViewKey": "fe8fb8c0efe462a159fc5e183c7a643b84fa7d0ab10785af4c8ce7f39c84a301",
         "outgoingViewKey": "2f6e794e6a52f0850043f1bedeb63868826548318f028613debbc1bf23135632",
         "publicAddress": "6e729466f45069943bc55fdbb9f35be733e888ffbff06e0e364ad98f578c222c",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "1f8567f6d9c59e25a34a0be1f25904882e6ab538aac2a172f6e0ff23a45e6503"
       },
@@ -178,13 +148,7 @@
         "incomingViewKey": "ba309ecda5232ff509fbabb51f71b2eed58158bad2737ede3e7cf8e561325807",
         "outgoingViewKey": "c5163fdab7ea32326ec8ac5e51330bddf78f5b0c302acbac891257df661f207f",
         "publicAddress": "e977dbbc97f942df21e729572e8030e639fea0436167f876f5f853bfa4263538",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "1e45ebe4bc023511ae06cfce4eda5edbf0ef447c2ef2269a0bdfd0ac37592303"
       },
@@ -208,13 +172,7 @@
         "incomingViewKey": "baa58c743b491392a5194d34c72ca41f69bd8ce262bd8cce2f8f4d68f1c28400",
         "outgoingViewKey": "30a3e3182bfbc5603354335cb408ba44b94aa97309261fbc97bb04e1bc815985",
         "publicAddress": "5385e34f39e1e3f0c0193eee68e8da5676a8ce7f6bca46e29a0dfdd89041785d",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "8fadcb3f5daa5bc0df20dc0ff7cedbee88990d65808e2476164d43211b72db01"
       },
@@ -242,13 +200,7 @@
         "incomingViewKey": "1a92c7272ee81a134c37b86b773282ea4e70b11ee7bcfc66c52f9aecef93b806",
         "outgoingViewKey": "6193eec71a1b67769cfdd76aa562a6666d254beac4a585abd5b245b15b7f1350",
         "publicAddress": "625b29181821b9991a4f6ae34198c4b9d57eff99d47d3b8927b1ce9f37c5f70c",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "1d205f1bc951a0ce33543baa889401fdb757a176ae3d56307117e60587b0000d"
       },

--- a/ironfish/src/wallet/walletdb/__fixtures__/walletdb.test.ts.fixture
+++ b/ironfish/src/wallet/walletdb/__fixtures__/walletdb.test.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "02152b6c75c952e8f3d23339230e60a1101dc51370dd4e1e74197d4d82418703",
         "outgoingViewKey": "38d0b71890263f7ae873c834a86cfd8c7debb856d5558eaa17b048dfea52c1dc",
         "publicAddress": "df5dd91c46403560964dcc1c4d9462932775bb61dbc469285e2abad6e299f858",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "e4e4b4eafb4c59c6a5990207e3785a6e13af15ab51f4eb73e48a5869c89f910c"
       },
@@ -40,13 +34,7 @@
         "incomingViewKey": "90e6732e87e81ce93ddf3981136c010f09ed962509239febb941ba1d40080000",
         "outgoingViewKey": "1423d36d9daaa4598a4cdb76fefd6d37822ab0f62a8b58115c37a1aef55d9e3b",
         "publicAddress": "457db891b144364f68100eed5936b4f24cb28ca9f2baadf625f0232551ce639e",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "94e1e10ead951d7051e8deed9070f4067976153f2a8b6e39dff7a59865f1fe0b"
       },
@@ -164,13 +152,7 @@
         "incomingViewKey": "23e6ea2ada518eaed70e03d028bec701bc33bc918aea9d962de6904721131202",
         "outgoingViewKey": "574db11c63e2a88637257b08be27e5b6c33db6d2c029d289bb4d893a0d34d5ea",
         "publicAddress": "da34efa7725c6a6ed32648ed14ab77640e8acebcf521a6908c5f0bd59cc3a3c5",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "73cb58bad461cda2df4ced7844eac7fa0b7a1875dd3c4c38b41328ff82716801"
       },
@@ -194,13 +176,7 @@
         "incomingViewKey": "4e6fb05d3acc82f974a2cf04c0f51379efeaf9e1c9aa590f38386ec2a2446a04",
         "outgoingViewKey": "57cd20ca9df88429f5533e5ad0e450c8c9b72e2be960977ce8bbe9e671ebc149",
         "publicAddress": "b782216d4ae965d886f30f8f6c54b76424ad5e4c86f26e87b0f02dce6c5b9fd5",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "5800f73d9f7fcd6345abbd1d7643d79cf2f016f1446be7dfab32f5c3631d120d"
       },
@@ -250,13 +226,7 @@
         "incomingViewKey": "51bf8c3e84b8bf6f72eaeb09ca0be2bb42921cb00fc0390bf0c456d944b85107",
         "outgoingViewKey": "6ad0420aec2b010fe2b51e81066b8d1f2a000f05473078bd5a15a049957e6515",
         "publicAddress": "2350bbe227a6e95ad0c3278a904edffb4ddd19d55de726f2ce7d006919c7119b",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "42a94128143fcdce8442a099799bba187c9dfc2c0962af609e8aeb19403d5100"
       },
@@ -280,13 +250,7 @@
         "incomingViewKey": "e3f7355e2d6d0b35c6367d1032add10fd78bed6212c1b6efe4331a06246ab201",
         "outgoingViewKey": "80db0061643c7a8e1f656a6f157f48bcb12f1dc2cd3c29cc358302d302e2d410",
         "publicAddress": "865862686f68cf5a4babc8b53f548d37a9d5eb1946cae93e44f0f3fb9c6ca927",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "86ac2b151d79d7d83b6cc2f1b2a23fc431671bc4a6884592daab2999cb735705"
       },
@@ -310,13 +274,7 @@
         "incomingViewKey": "01f037b454b53e2785519f636a150a2397b25ae65778431756375b99212ce900",
         "outgoingViewKey": "0fc5f6ede6992cf840243ed44fa7366ed96bbb65812ec3d71598fadacecbffb6",
         "publicAddress": "03f1411728bdb4635921158c3ef2d1044faf03d3e4febc649f6aca2af027b42a",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "49c4a4f3d49222a918fa42d07c33f66c994fd1f41ad1a15835f3271231df5304"
       },
@@ -340,13 +298,7 @@
         "incomingViewKey": "37ac46d0e499ba4b90e46fc18e6311b4b4c61f0e05bd4347296d9517a5723806",
         "outgoingViewKey": "b7bea33267e82c89d78d0e8385cea9ab57f849a5489c15c1c97ce49d91abf1b3",
         "publicAddress": "733e08a1817fcb6c13054c7e4aa21cefbe4e5548c3562dfd07b9dce196fdfc6f",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "ceeb1acc8c69f360af3728e2dd2ccf9dcc347163b3f0bfe95adaed2845055809"
       },
@@ -474,13 +426,7 @@
         "incomingViewKey": "a178913949a1ba9eb230948bcba5ee81e3300443ae8b8f57290f3592dc0aa703",
         "outgoingViewKey": "6cc6b324db922e5e7feeb2de7b785a1e883a6282f232101578da354b74ccc32d",
         "publicAddress": "a9a915c9c3969b6da27f23ba75b8e60a79ac8265c75b39784d6c8120fd3411e8",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "363eb2503a6d05f3049ccc448b5696b786ccd617fc9076f7160a3e3fde0c2f0d"
       },
@@ -608,13 +554,7 @@
         "incomingViewKey": "c62534d44edc5239875e160fc2d4fd6a8f6e843c1114e49ce20675b089552900",
         "outgoingViewKey": "3ca324b9bcffcbb6be6ce16bd658075828d17ebd04af239beaf7abd3e9e38f09",
         "publicAddress": "5f8b3902b7d4fb1e3673fbc7263a391bea92b8967924075ce36b08a57c461b4b",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "b0211a2643adac73b56c076fcba022fc675b90fcbc9e8f9ef527ca384b3ede0d"
       },

--- a/ironfish/src/wallet/walletdb/accountValue.test.ts
+++ b/ironfish/src/wallet/walletdb/accountValue.test.ts
@@ -18,10 +18,7 @@ describe('AccountValueEncoding', () => {
       spendingKey: key.spendingKey,
       viewKey: key.viewKey,
       version: 1,
-      createdAt: {
-        hash: Buffer.alloc(32, 0),
-        sequence: 1,
-      },
+      createdAt: { sequence: 1 },
       scanningEnabled: true,
       proofAuthorizingKey: key.proofAuthorizingKey,
     }

--- a/ironfish/src/wallet/walletdb/accountValue.test.ts
+++ b/ironfish/src/wallet/walletdb/accountValue.test.ts
@@ -18,7 +18,7 @@ describe('AccountValueEncoding', () => {
       spendingKey: key.spendingKey,
       viewKey: key.viewKey,
       version: 1,
-      createdAt: { sequence: 1 },
+      createdAt: 1,
       scanningEnabled: true,
       proofAuthorizingKey: key.proofAuthorizingKey,
     }

--- a/ironfish/src/wallet/walletdb/accountValue.ts
+++ b/ironfish/src/wallet/walletdb/accountValue.ts
@@ -21,7 +21,7 @@ export interface AccountValue {
   incomingViewKey: string
   outgoingViewKey: string
   publicAddress: string
-  createdAt: { sequence: number } | null
+  createdAt: number | null
   scanningEnabled: boolean
   multisigKeys?: MultisigKeys
   proofAuthorizingKey: string | null
@@ -51,7 +51,7 @@ export class AccountValueEncoding implements IDatabaseEncoding<AccountValue> {
     bw.writeBytes(Buffer.from(value.publicAddress, 'hex'))
 
     if (value.createdAt) {
-      bw.writeU32(value.createdAt.sequence)
+      bw.writeU32(value.createdAt)
     }
 
     if (value.multisigKeys) {
@@ -86,7 +86,7 @@ export class AccountValueEncoding implements IDatabaseEncoding<AccountValue> {
 
     let createdAt = null
     if (hasCreatedAt) {
-      createdAt = { sequence: reader.readU32() }
+      createdAt = reader.readU32()
     }
 
     let multisigKeys = undefined

--- a/ironfish/src/wallet/walletdb/walletdb.ts
+++ b/ironfish/src/wallet/walletdb/walletdb.ts
@@ -41,7 +41,7 @@ import { MultisigSecretValue, MultisigSecretValueEncoding } from './multisigSecr
 import { ParticipantIdentity, ParticipantIdentityEncoding } from './participantIdentity'
 import { TransactionValue, TransactionValueEncoding } from './transactionValue'
 
-const VERSION_DATABASE_ACCOUNTS = 32
+const VERSION_DATABASE_ACCOUNTS = 33
 
 const getAccountsDBMetaDefaults = (): AccountsDBMeta => ({
   defaultAccountId: null,

--- a/ironfish/src/workerPool/tasks/__fixtures__/buildTransaction.test.ts.fixture
+++ b/ironfish/src/workerPool/tasks/__fixtures__/buildTransaction.test.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "6eae22fc81615f004244a4b49cd3f91c27f0ac77eebeb002159b024cc7658504",
         "outgoingViewKey": "bbc9ae7cb0b423b055975e0a743a79e9925878fdc2c90ac2e928d8f24b7ae44e",
         "publicAddress": "822cea0c8ba6d7befe2cdca17b169af77af1020c39c5a2ba7b69a502321fbc3c",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "f263790fc168dc19995df124896371f3030f5f6719fd9aced3d8891376eeaa0b"
       },
@@ -66,13 +60,7 @@
         "incomingViewKey": "bc55d10ddde46f6685d961e2a158ef7eace3f9922e7e5a0ec7ed3dc07c2bbe05",
         "outgoingViewKey": "d6bfeb2fb714f46ee3f36f652639898364fde0925c455343c30a63240cee8d9d",
         "publicAddress": "3da09cfd855c88268f6b5d5d52c7739bc95f36cffca5f6aab380569579bc8d4f",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "6a333e00f867118645770628cdd45b000faf3fac031055930f7193d1dc3a700b"
       },
@@ -126,13 +114,7 @@
         "incomingViewKey": "a2fded576950ba2c19a372bccec6e6b9f936c6e5eebba6f3042b38672c50a205",
         "outgoingViewKey": "0bcf6a7de21357a0e66f2f811a8f45066c1e86c6ad3e5f4db6c69ba8dc42cd6a",
         "publicAddress": "d6008ac673c004db0dcf514bd2e0160b9da3c75193856833235f0190c4daf4eb",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "ca27a2363c1646a45b9f83584b64fbb598cc4eca6de68cf1b6dc0e141a70bf0d"
       },

--- a/ironfish/src/workerPool/tasks/__fixtures__/createMinersFee.test.ts.fixture
+++ b/ironfish/src/workerPool/tasks/__fixtures__/createMinersFee.test.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "a5869707993c17bde08e7ee001f34580d661f3784d0868e49e3bbc4ef7177901",
         "outgoingViewKey": "454bbb0bb377f5b47789bdf67dbe02dd82638837d09f6f94e189e44a217f2298",
         "publicAddress": "8e682b65721c34bff195424374c376dfa23ec736a118b2d1b9febdf89dd9b9dc",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "873f3b30ab6dc060f7ef791c2f2eda3540b9b19f514bfd7c84e5eb6fe1732102"
       },
@@ -40,13 +34,7 @@
         "incomingViewKey": "40c120be9cc2df52fd80ffd8e5dce581af849b82b0eb17dd1085f9ebeef53102",
         "outgoingViewKey": "912a3af11e929016fbdfa097b9d9f43adc51fa9338797fc07864d57ba582e9cb",
         "publicAddress": "eae823d3859e9ac3eb5f5cab0511045925200a0f6912e4d39d863639ab831b62",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "03cd048ea145f76b9c000bed18a64150670d80cae6378ae0917fddaa0fdd300c"
       },

--- a/ironfish/src/workerPool/tasks/__fixtures__/decryptNotes.test.ts.fixture
+++ b/ironfish/src/workerPool/tasks/__fixtures__/decryptNotes.test.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "81b70ae0108ac999e9e9d73446378bf01dd93bb015394aba82822cb70cc8ac00",
         "outgoingViewKey": "773588f4197f32ed2fe39e8d9bf36ea006a7dd9f05721f734c60f382902c75a0",
         "publicAddress": "02adb43d8419bc9876af1be710dc538ac61fd599c07630f356efb8a5a303cb43",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "a104edf4801d61bd41a7b1c12c1c9c4e2da8211e5303aff292165f7b7dd1eb07"
       },
@@ -44,13 +38,7 @@
         "incomingViewKey": "79c49d077b25a207b167a58a2208a95dd3ba0dc7af44da67f5c7837e15a4a603",
         "outgoingViewKey": "b48765aa521c39337e06ade3c200d6adbc31e98b29a9d223a5a441ec9fb65191",
         "publicAddress": "d7fc67312e8aac8d5e726f7ca5a05fbed2014aa596302e280d5a9d73bea7edb7",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "3feb7ff4b1fb671bc64a2241365c42c0a4e6202c85234815e29597eb637d1109"
       },
@@ -72,13 +60,7 @@
         "incomingViewKey": "51ac9726f0bce3af775e0889f9678989ae8dfc4700e560fd0806b634e13fe200",
         "outgoingViewKey": "41b4bb83e6deb03cdb44a98275e62c37ef38f3f4cb5d5ed0f7e96aaca0846674",
         "publicAddress": "9b8e652eceb3881051eb96d7e4d97d41294a69a1faa5a6c76dacfb95bc3d6e6c",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "057a3e07a67659b48ff367e3ee827b488632c96d4701d380c014a7782680d103"
       },

--- a/ironfish/src/workerPool/tasks/__fixtures__/postTransaction.test.ts.fixture
+++ b/ironfish/src/workerPool/tasks/__fixtures__/postTransaction.test.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "e281b17975e444b72682fdd933b493cd9b7343e754b3bc7ce42fbe3c0f5d2305",
         "outgoingViewKey": "bd6e20fc98627d71299d78ed4f9fe9addca20ba81a4a328767264ac537094c51",
         "publicAddress": "c21b1004faea7f6ea9796c720cdfd54a5bacd6c656de9c21da5a31ce0393bdc6",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "67439ec498742efe65eb3ca1d70049c181025d148a6ece10aff7e85d05025b0c"
       },
@@ -66,13 +60,7 @@
         "incomingViewKey": "17bf53f22a780ab2cad867558d14f40eb2789b869384a66d2e275b59066f0306",
         "outgoingViewKey": "9e99baf683fefb0a798ab30d51d1cc666db7ee65670156b100573056fdf15004",
         "publicAddress": "e08f4bb6a8ee008a871b20226f7732c7220772a01ed38a3a5f25825e1edd92e7",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "21c2a2b2fce4bea86843b8ecab25d41ee63cceb126bacbf10d55a23973fea20d"
       },
@@ -100,13 +88,7 @@
         "incomingViewKey": "044bec660c73d655c7fccd533f94e72a9075ce79a44e94e64affe46073ae3e05",
         "outgoingViewKey": "81cac10c2d64fe95c6cedd0243d5dd0d6c215502c60a0c9fbd277ad1e82925a3",
         "publicAddress": "3b2b189820ab4570c123b6719dac5ed1937a590365001c27d591eead211cfba8",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "dda0b21156feafc0dbe8a5066b54d4caaffc866b62bbf6866e799042b97d7c05"
       },

--- a/ironfish/src/workerPool/tasks/__fixtures__/verifyTransactions.test.ts.fixture
+++ b/ironfish/src/workerPool/tasks/__fixtures__/verifyTransactions.test.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "10223be450232d9c3a2d7385ccdb32a8c0aec2709ad184f139d47b843550ca02",
         "outgoingViewKey": "37dc78ba1d45f12e36cd34568ee7dfe2d733bd3a1606fb8651fed83101a3500e",
         "publicAddress": "a4e186a4d17525ecfd77cfb0ac5f4647c23b9124e7c1a2073e083ff95d832cb3",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "9faab2d118b534b5dbbc740ace7c019087fda19bfdcb0e30a7450809e5367d03"
       },

--- a/ironfish/src/workerPool/tasks/__fixtures__/workerMessages.test.perf.ts.fixture
+++ b/ironfish/src/workerPool/tasks/__fixtures__/workerMessages.test.perf.ts.fixture
@@ -10,13 +10,7 @@
         "incomingViewKey": "8bac3a41ff7ddc79210247c3f0701bf7c6c25e6b49bc0ed0b279379c02140503",
         "outgoingViewKey": "8213c8a9c4ac12b5b47da90ac6bf0a6a3b52a0078e44fe6b391092241b8d16e0",
         "publicAddress": "3fb65c3bafac91b10ce54e6847576b4d8a0376ff14369295ebba039038d246e7",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
+        "createdAt": 1,
         "scanningEnabled": true,
         "proofAuthorizingKey": "ea93819f760d3832e7d7c699010a163609bdc6b403ed818da4fa31c6c59f7207"
       },


### PR DESCRIPTION
## Summary

sets createdAt sequence to 'head.sequence - confirmations' to mitigate issues with setting account createdAt around the time of a chain reorg.

adds migrations 33 to migrate existing account.createdAt values to use the existing createdAt.sequence - confirmations

removes unused function chainGetPreviousBlockHash

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
