### PR TITLE
Change `DecryptNotesRequest` to require a common list of accounts and options

### DIFF
--- a/ironfish/src/workerPool/tasks/decryptNotes.test.ts
+++ b/ironfish/src/workerPool/tasks/decryptNotes.test.ts
@@ -19,14 +19,20 @@ describe('DecryptNotesRequest', () => {
     const request = new DecryptNotesRequest(
       [
         {
-          serializedNote: Buffer.alloc(ENCRYPTED_NOTE_LENGTH, 1),
           incomingViewKey: Buffer.alloc(ACCOUNT_KEY_LENGTH, 1).toString('hex'),
           outgoingViewKey: Buffer.alloc(ACCOUNT_KEY_LENGTH, 1).toString('hex'),
           viewKey: Buffer.alloc(VIEW_KEY_LENGTH, 1).toString('hex'),
-          currentNoteIndex: 2,
-          decryptForSpender: true,
         },
       ],
+      [
+        {
+          serializedNote: Buffer.alloc(ENCRYPTED_NOTE_LENGTH, 1),
+          currentNoteIndex: 2,
+        },
+      ],
+      {
+        decryptForSpender: true,
+      },
       0,
     )
     const buffer = serializePayloadToBuffer(request)
@@ -35,22 +41,26 @@ describe('DecryptNotesRequest', () => {
   })
 
   it('serializes over 255 notes', () => {
-    const length = 600
+    const numNotes = 600
+    const numAccounts = 200
 
     const request = new DecryptNotesRequest(
-      Array.from({ length }, () => ({
-        serializedNote: Buffer.alloc(ENCRYPTED_NOTE_LENGTH, 1),
+      Array.from({ length: numAccounts }, () => ({
         incomingViewKey: Buffer.alloc(ACCOUNT_KEY_LENGTH, 1).toString('hex'),
         outgoingViewKey: Buffer.alloc(ACCOUNT_KEY_LENGTH, 1).toString('hex'),
         viewKey: Buffer.alloc(VIEW_KEY_LENGTH, 1).toString('hex'),
-        currentNoteIndex: 2,
-        decryptForSpender: true,
       })),
+      Array.from({ length: numNotes }, () => ({
+        serializedNote: Buffer.alloc(ENCRYPTED_NOTE_LENGTH, 1),
+        currentNoteIndex: 2,
+      })),
+      { decryptForSpender: true },
       0,
     )
     const buffer = serializePayloadToBuffer(request)
     const deserializedRequest = DecryptNotesRequest.deserializePayload(request.jobId, buffer)
-    expect(deserializedRequest.payloads).toHaveLength(length)
+    expect(deserializedRequest.encryptedNotes).toHaveLength(numNotes)
+    expect(deserializedRequest.accountKeys).toHaveLength(numAccounts)
   })
 })
 
@@ -103,16 +113,22 @@ describe('DecryptNotesTask', () => {
 
       const task = new DecryptNotesTask()
       const index = 2
-      const request = new DecryptNotesRequest([
-        {
-          serializedNote: transaction.getNote(0).serialize(),
-          incomingViewKey: account.incomingViewKey,
-          outgoingViewKey: account.outgoingViewKey,
-          viewKey: account.viewKey,
-          currentNoteIndex: 2,
-          decryptForSpender: true,
-        },
-      ])
+      const request = new DecryptNotesRequest(
+        [
+          {
+            incomingViewKey: account.incomingViewKey,
+            outgoingViewKey: account.outgoingViewKey,
+            viewKey: account.viewKey,
+          },
+        ],
+        [
+          {
+            serializedNote: transaction.getNote(0).serialize(),
+            currentNoteIndex: 2,
+          },
+        ],
+        { decryptForSpender: true },
+      )
       const response = task.execute(request)
 
       expect(response).toMatchObject({
@@ -140,16 +156,22 @@ describe('DecryptNotesTask', () => {
 
       const task = new DecryptNotesTask()
       const index = 3
-      const requestSpender = new DecryptNotesRequest([
-        {
-          serializedNote: transaction.getNote(0).serialize(),
-          incomingViewKey: accountA.incomingViewKey,
-          outgoingViewKey: accountA.outgoingViewKey,
-          viewKey: accountA.viewKey,
-          currentNoteIndex: 3,
-          decryptForSpender: true,
-        },
-      ])
+      const requestSpender = new DecryptNotesRequest(
+        [
+          {
+            incomingViewKey: accountA.incomingViewKey,
+            outgoingViewKey: accountA.outgoingViewKey,
+            viewKey: accountA.viewKey,
+          },
+        ],
+        [
+          {
+            serializedNote: transaction.getNote(0).serialize(),
+            currentNoteIndex: 3,
+          },
+        ],
+        { decryptForSpender: true },
+      )
       const responseSpender = task.execute(requestSpender)
 
       expect(responseSpender).toMatchObject({
@@ -164,16 +186,22 @@ describe('DecryptNotesTask', () => {
         ],
       })
 
-      const requestNoSpender = new DecryptNotesRequest([
-        {
-          serializedNote: transaction.getNote(0).serialize(),
-          incomingViewKey: accountA.incomingViewKey,
-          outgoingViewKey: accountA.outgoingViewKey,
-          viewKey: accountA.viewKey,
-          currentNoteIndex: 3,
-          decryptForSpender: false,
-        },
-      ])
+      const requestNoSpender = new DecryptNotesRequest(
+        [
+          {
+            incomingViewKey: accountA.incomingViewKey,
+            outgoingViewKey: accountA.outgoingViewKey,
+            viewKey: accountA.viewKey,
+          },
+        ],
+        [
+          {
+            serializedNote: transaction.getNote(0).serialize(),
+            currentNoteIndex: 3,
+          },
+        ],
+        { decryptForSpender: false },
+      )
       const responseNoSpender = task.execute(requestNoSpender)
 
       expect(responseNoSpender).toMatchObject({ notes: [null] })

--- a/ironfish/src/workerPool/tasks/decryptNotes.ts
+++ b/ironfish/src/workerPool/tasks/decryptNotes.ts
@@ -9,13 +9,19 @@ import { VIEW_KEY_LENGTH } from '../../wallet/walletdb/accountValue'
 import { WorkerMessage, WorkerMessageType } from './workerMessage'
 import { WorkerTask } from './workerTask'
 
-export interface DecryptNoteOptions {
-  serializedNote: Buffer
+export interface DecryptNotesOptions {
+  decryptForSpender: boolean
+}
+
+export interface DecryptNotesAccountKey {
   incomingViewKey: string
   outgoingViewKey: string
   viewKey: string
+}
+
+export interface DecryptNotesItem {
+  serializedNote: Buffer
   currentNoteIndex: number | null
-  decryptForSpender: boolean
 }
 
 export interface DecryptedNote {
@@ -26,72 +32,82 @@ export interface DecryptedNote {
   serializedNote: Buffer
 }
 
-export class DecryptNotesRequest extends WorkerMessage {
-  readonly payloads: Array<DecryptNoteOptions>
+const NO_NOTE_INDEX: number = (1 << 32) - 1
 
-  constructor(payloads: Array<DecryptNoteOptions>, jobId?: number) {
+export class DecryptNotesRequest extends WorkerMessage {
+  readonly accountKeys: ReadonlyArray<DecryptNotesAccountKey>
+  readonly encryptedNotes: ReadonlyArray<DecryptNotesItem>
+  readonly options: DecryptNotesOptions
+
+  constructor(
+    accountKeys: ReadonlyArray<DecryptNotesAccountKey>,
+    encryptedNotes: ReadonlyArray<DecryptNotesItem>,
+    options: DecryptNotesOptions,
+    jobId?: number,
+  ) {
     super(WorkerMessageType.DecryptNotes, jobId)
-    this.payloads = payloads
+    this.accountKeys = accountKeys
+    this.encryptedNotes = encryptedNotes
+    this.options = options
   }
 
   serializePayload(bw: bufio.StaticWriter | bufio.BufferWriter): void {
-    for (const payload of this.payloads) {
-      let flags = 0
-      flags |= Number(!!payload.currentNoteIndex) << 0
-      flags |= Number(payload.decryptForSpender) << 1
-      bw.writeU8(flags)
+    bw.writeU8(this.options.decryptForSpender ? 1 : 0)
+    bw.writeU32(this.accountKeys.length)
 
-      bw.writeBytes(payload.serializedNote)
-      bw.writeBytes(Buffer.from(payload.incomingViewKey, 'hex'))
-      bw.writeBytes(Buffer.from(payload.outgoingViewKey, 'hex'))
-      bw.writeBytes(Buffer.from(payload.viewKey, 'hex'))
+    for (const key of this.accountKeys) {
+      bw.writeBytes(Buffer.from(key.incomingViewKey, 'hex'))
+      bw.writeBytes(Buffer.from(key.outgoingViewKey, 'hex'))
+      bw.writeBytes(Buffer.from(key.viewKey, 'hex'))
+    }
 
-      if (payload.currentNoteIndex) {
-        bw.writeU32(payload.currentNoteIndex)
-      }
+    for (const note of this.encryptedNotes) {
+      bw.writeBytes(note.serializedNote)
+      bw.writeU32(note.currentNoteIndex ?? NO_NOTE_INDEX)
     }
   }
 
   static deserializePayload(jobId: number, buffer: Buffer): DecryptNotesRequest {
     const reader = bufio.read(buffer, true)
-    const payloads = []
 
-    while (reader.left() > 0) {
-      const flags = reader.readU8()
-      const hasCurrentNoteIndex = flags & (1 << 0)
-      const decryptForSpender = Boolean(flags & (1 << 1))
-      const serializedNote = reader.readBytes(ENCRYPTED_NOTE_LENGTH)
+    const accountKeys = []
+    const encryptedNotes = []
+    const options = { decryptForSpender: reader.readU8() !== 0 }
+
+    const keysLength = reader.readU32()
+    for (let i = 0; i < keysLength; i++) {
       const incomingViewKey = reader.readBytes(ACCOUNT_KEY_LENGTH).toString('hex')
       const outgoingViewKey = reader.readBytes(ACCOUNT_KEY_LENGTH).toString('hex')
       const viewKey = reader.readBytes(VIEW_KEY_LENGTH).toString('hex')
-      const currentNoteIndex = hasCurrentNoteIndex ? reader.readU32() : null
+      accountKeys.push({ incomingViewKey, outgoingViewKey, viewKey })
+    }
 
-      payloads.push({
+    while (reader.left() > 0) {
+      const serializedNote = reader.readBytes(ENCRYPTED_NOTE_LENGTH)
+      let currentNoteIndex: number | null = reader.readU32()
+      if (currentNoteIndex === NO_NOTE_INDEX) {
+        currentNoteIndex = null
+      }
+      encryptedNotes.push({
         serializedNote,
-        incomingViewKey,
-        outgoingViewKey,
         currentNoteIndex,
-        decryptForSpender,
-        viewKey,
       })
     }
 
-    return new DecryptNotesRequest(payloads, jobId)
+    return new DecryptNotesRequest(accountKeys, encryptedNotes, options, jobId)
   }
 
   getSize(): number {
-    let size = 0
-    for (const payload of this.payloads) {
-      size += 1
-      size += ENCRYPTED_NOTE_LENGTH
-      size += ACCOUNT_KEY_LENGTH
-      size += ACCOUNT_KEY_LENGTH
-      size += VIEW_KEY_LENGTH
-      if (payload.currentNoteIndex) {
-        size += 4
-      }
-    }
-    return size
+    const optionsSize = 1
+    const keySize = ACCOUNT_KEY_LENGTH + ACCOUNT_KEY_LENGTH + VIEW_KEY_LENGTH
+    const noteSize = ENCRYPTED_NOTE_LENGTH + 4
+
+    return (
+      optionsSize +
+      4 +
+      keySize * this.accountKeys.length +
+      noteSize * this.encryptedNotes.length
+    )
   }
 }
 
@@ -104,6 +120,8 @@ export class DecryptNotesResponse extends WorkerMessage {
   }
 
   serializePayload(bw: bufio.StaticWriter | bufio.BufferWriter): void {
+    // TODO: the majority of responses will have 0 decrypted notes. It make sense to
+    // return a more compact serialization in that case.
     for (const note of this.notes) {
       const hasDecryptedNote = Number(!!note)
       bw.writeU8(hasDecryptedNote)
@@ -201,51 +219,51 @@ export class DecryptNotesTask extends WorkerTask {
     return DecryptNotesTask.instance
   }
 
-  execute({ payloads, jobId }: DecryptNotesRequest): DecryptNotesResponse {
+  execute({
+    accountKeys,
+    encryptedNotes,
+    options,
+    jobId,
+  }: DecryptNotesRequest): DecryptNotesResponse {
     const decryptedNotes = []
 
-    for (const {
-      serializedNote,
-      incomingViewKey,
-      outgoingViewKey,
-      viewKey,
-      currentNoteIndex,
-      decryptForSpender,
-    } of payloads) {
+    for (const { serializedNote, currentNoteIndex } of encryptedNotes) {
       const note = new NoteEncrypted(serializedNote)
 
-      // Try decrypting the note as the owner
-      const receivedNote = note.decryptNoteForOwner(incomingViewKey)
-      if (receivedNote && receivedNote.value() !== 0n) {
-        decryptedNotes.push({
-          index: currentNoteIndex,
-          forSpender: false,
-          hash: note.hash(),
-          nullifier:
-            currentNoteIndex !== null
-              ? receivedNote.nullifier(viewKey, BigInt(currentNoteIndex))
-              : null,
-          serializedNote: receivedNote.serialize(),
-        })
-        continue
-      }
-
-      if (decryptForSpender) {
-        // Try decrypting the note as the spender
-        const spentNote = note.decryptNoteForSpender(outgoingViewKey)
-        if (spentNote && spentNote.value() !== 0n) {
+      for (const { incomingViewKey, outgoingViewKey, viewKey } of accountKeys) {
+        // Try decrypting the note as the owner
+        const receivedNote = note.decryptNoteForOwner(incomingViewKey)
+        if (receivedNote && receivedNote.value() !== 0n) {
           decryptedNotes.push({
             index: currentNoteIndex,
-            forSpender: true,
+            forSpender: false,
             hash: note.hash(),
-            nullifier: null,
-            serializedNote: spentNote.serialize(),
+            nullifier:
+              currentNoteIndex !== null
+                ? receivedNote.nullifier(viewKey, BigInt(currentNoteIndex))
+                : null,
+            serializedNote: receivedNote.serialize(),
           })
           continue
         }
-      }
 
-      decryptedNotes.push(null)
+        if (options.decryptForSpender) {
+          // Try decrypting the note as the spender
+          const spentNote = note.decryptNoteForSpender(outgoingViewKey)
+          if (spentNote && spentNote.value() !== 0n) {
+            decryptedNotes.push({
+              index: currentNoteIndex,
+              forSpender: true,
+              hash: note.hash(),
+              nullifier: null,
+              serializedNote: spentNote.serialize(),
+            })
+            continue
+          }
+        }
+
+        decryptedNotes.push(null)
+      }
     }
 
     return new DecryptNotesResponse(decryptedNotes, jobId)


### PR DESCRIPTION
## Summary

All the use cases for `DecryptNotesTask` involve passing a bunch of notes to decrypt for the same account(s), and with the same options. To save bandwidth, and to allow future optimizations, it makes sense to group all account keys into a single input parameter, so that they don't have to be repeated for each and every note.

This changes the request serialization size from `O(accounts * notes)` to `O(accounts + notes)`.

This change may not offer a huge performance boost by itself, but it allows future improvements, including:

* the use of faster decryption algorithms when more than 1 account is involved
* fewer (de)serializations of account keys
* better batching of decrypt requests, and larger batches of encrypted notes with less memory overhead

## Testing Plan

Unit tests

## Documentation

N/A

## Breaking Change

SDK breaking change:
- the signature for `WorkerPool.decryptNotes()` has changed
- the structure of `DecryptNotesRequest` has changed
- `DecryptNoteOptions` was removed