### PR TITLE
Fix transactions cmd not handling streaming errors

### DIFF
--- a/ironfish-cli/src/commands/wallet/transactions.ts
+++ b/ironfish-cli/src/commands/wallet/transactions.ts
@@ -73,6 +73,9 @@ export class TransactionsCommand extends IronfishCommand {
         : Format.cli
 
     const client = await this.sdk.connectRpc()
+
+    const networkId = (await client.chain.getNetworkInfo()).content.networkId
+
     const response = client.wallet.getAccountTransactionsStream({
       account,
       hash: flags.hash,
@@ -82,7 +85,6 @@ export class TransactionsCommand extends IronfishCommand {
       confirmations: flags.confirmations,
       notes: flags.notes,
     })
-    const networkId = (await client.chain.getNetworkInfo()).content.networkId
 
     const columns = this.getColumns(flags.extended, flags.notes, format)
 


### PR DESCRIPTION
## Summary

The error here is that the error in `getAccountTransactionsStream` becomes unhandled, because we pause the event loop to wait on `getNetworkInfo`. The error handler for `getAccountTransactionsStream` isnt registered until we await it's content stream later on. Unfortunately because `getNetworkInfo` prevents that form happening it'll be treated as an unhandled exception which crashes in oclif itself.

## Testing Plan

Revert the code and use `ironfish wallet:transactions gidhjfgdfsgfdsfgds`. The account should not exist and it will reproduce the error.

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
