### PR TITLE
Maximize decryption parallelism during wallet scans

### DIFF
--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -305,6 +305,14 @@ export type ConfigOptions = {
   walletSyncingMaxQueueSize: number
 
   /**
+   * The max number of blocks that may be processed in parallel when syncing.
+   * By default, this number is automatically calculated from the number of
+   * workers available (see `nodeWorkers` and `nodeWorkersMax`). You may set
+   * this number to limit the memory usage during syncing.
+   */
+  walletSyncingMaxConcurrency: number
+
+  /**
    * Whether or not to build the full fish hash context at node startup. Setting this
    * to `true` will slightly increase node performance but use ~4.5GB more RAM. The majority of
    * network users will not need this speed increase and so should keep the default of `false`.
@@ -390,6 +398,7 @@ export const ConfigOptionsSchema: yup.ObjectSchema<Partial<ConfigOptions>> = yup
     incomingWebSocketWhitelist: yup.array(yup.string().trim().defined()),
     walletGossipTransactionsMaxQueueSize: yup.number(),
     walletSyncingMaxQueueSize: yup.number(),
+    walletSyncingMaxConcurrency: yup.number().integer(),
     fishHashFullContext: yup.boolean(),
   })
   .defined()
@@ -499,6 +508,7 @@ export class Config<
       incomingWebSocketWhitelist: [],
       walletGossipTransactionsMaxQueueSize: 1000,
       walletSyncingMaxQueueSize: 100,
+      walletSyncingMaxConcurrency: -1,
       fishHashFullContext: false,
     }
   }

--- a/ironfish/src/utils/asyncQueue.test.ts
+++ b/ironfish/src/utils/asyncQueue.test.ts
@@ -1,0 +1,135 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { AsyncQueue } from './asyncQueue'
+
+describe('AsyncQueue', () => {
+  it('yields items in the same order as they were added', async () => {
+    const queue = new AsyncQueue<string>(32)
+
+    await queue.push('a')
+    await queue.push('b')
+    await queue.push('c')
+
+    await expect(queue.pop()).resolves.toBe('a')
+    await expect(queue.pop()).resolves.toBe('b')
+    await expect(queue.pop()).resolves.toBe('c')
+  })
+
+  it('reports correct length after push and pop', async () => {
+    const queue = new AsyncQueue<string>(32)
+    expect(queue.size).toBe(0)
+
+    for (let size = 1; size <= 20; size++) {
+      await queue.push('a')
+      expect(queue.size).toBe(size)
+    }
+
+    for (let size = 19; size >= 0; size--) {
+      await queue.pop()
+      expect(queue.size).toBe(size)
+    }
+  })
+
+  it('randomized test', async () => {
+    const sequence = []
+    for (let i = 0; i < 10000; i++) {
+      sequence.push(i)
+    }
+
+    const queue = new AsyncQueue<number>(128)
+    const pushedItems = new Array<number>()
+    const poppedItems = new Array<number>()
+
+    let i = 0
+    while (poppedItems.length < sequence.length) {
+      const action: 'push' | 'pop' =
+        // if the queue is empty, the only possible action is 'push'
+        pushedItems.length === poppedItems.length
+          ? 'push'
+          : // if the queue is full, the only action is 'pop'
+          pushedItems.length - poppedItems.length >= 128
+          ? 'pop'
+          : // in all other cases, flip a coin
+          Math.random() > 0.5
+          ? 'push'
+          : 'pop'
+      if (action === 'push') {
+        const item = sequence[i++]
+        await queue.push(item)
+        pushedItems.push(item)
+      } else if (action === 'pop') {
+        const item = await queue.pop()
+        poppedItems.push(item)
+      }
+    }
+
+    expect(pushedItems).toEqual(sequence)
+    expect(poppedItems).toEqual(sequence)
+  })
+
+  describe('push', () => {
+    it('blocks when the queue is full', async () => {
+      const queue = new AsyncQueue<string>(2)
+      await queue.push('a')
+      await queue.push('b')
+
+      // Queue is full; pushing a new element now should cause the returned
+      // promise not to be resolved
+      const pushPromise = queue.push('c').then(() => 'pushPromise')
+      const otherPromise = new Promise((resolve) => setTimeout(resolve, 100)).then(
+        () => 'otherPromise',
+      )
+
+      const resolved = await Promise.race([pushPromise, otherPromise])
+      expect(resolved).toBe('otherPromise')
+
+      // After popping an element, the promise returned by push should resolve
+      await queue.pop()
+      await pushPromise
+    })
+  })
+
+  describe('pop', () => {
+    it('blocks when the queue is empty', async () => {
+      const queue = new AsyncQueue<string>(2)
+
+      // Queue is empty; popping an element now should cause the returned
+      // promise not to be resolved
+      const popPromise = queue.pop().then(() => 'popPromise')
+      const otherPromise = new Promise((resolve) => setTimeout(resolve, 100)).then(
+        () => 'otherPromise',
+      )
+
+      const resolved = await Promise.race([popPromise, otherPromise])
+      expect(resolved).toBe('otherPromise')
+
+      // After pushing a new element, the promise returned by pop should
+      // resolve
+      await queue.push('a')
+      await popPromise
+    })
+  })
+
+  describe('iterator', () => {
+    it('does not yield any item when empty', () => {
+      const queue = new AsyncQueue<string>(5)
+
+      expect(Array.from(queue)).toEqual([])
+    })
+
+    it('yields items without consuming them', async () => {
+      const queue = new AsyncQueue<string>(5)
+
+      await queue.push('a')
+      await queue.push('b')
+      await queue.push('c')
+
+      expect(Array.from(queue)).toEqual(['a', 'b', 'c'])
+
+      await expect(queue.pop()).resolves.toBe('a')
+      await expect(queue.pop()).resolves.toBe('b')
+      await expect(queue.pop()).resolves.toBe('c')
+    })
+  })
+})

--- a/ironfish/src/utils/asyncQueue.ts
+++ b/ironfish/src/utils/asyncQueue.ts
@@ -1,0 +1,151 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+const EMPTY = Symbol('EMPTY')
+
+function assertValidMaxSize(maxSize: number) {
+  if (!Number.isInteger(maxSize)) {
+    throw new Error('maxSize must be an integer')
+  }
+  if (maxSize <= 0) {
+    throw new Error('maxSize must be greater than 0')
+  }
+}
+
+function assertNotEmpty<T>(x: T | typeof EMPTY): asserts x is T {
+  if (x === EMPTY) {
+    throw new Error('Expected item not to be empty')
+  }
+}
+
+/**
+ * A fixed-size, async queue, implemented on top of a circular buffer.
+ */
+export class AsyncQueue<Item> {
+  /**
+   * The circular buffer that backs the queue.
+   */
+  private readonly items: Array<Item | typeof EMPTY>
+  /**
+   * The position of the first element in `items`. Calling `pop()` returns `items[start]`
+   * (if non-empty).
+   */
+  private start: number = 0
+  /**
+   * The number of elements currently sitting in the queue. This can never exceed
+   * `items.length`.
+   */
+  private len: number = 0
+
+  private onReadyToPush: Promise<void>
+  private onReadyToPop: Promise<void>
+
+  private triggerReadyToPush: (() => void) | null = null
+  private triggerReadyToPop: (() => void) | null = null
+
+  constructor(maxSize: number) {
+    assertValidMaxSize(maxSize)
+
+    this.items = Array(maxSize).fill(EMPTY) as Array<Item | typeof EMPTY>
+
+    this.onReadyToPush = Promise.resolve()
+    this.onReadyToPop = new Promise((resolve) => {
+      this.triggerReadyToPop = resolve
+    })
+  }
+
+  get size(): number {
+    return this.len
+  }
+
+  get maxSize(): number {
+    return this.items.length
+  }
+
+  isEmpty(): boolean {
+    return this.len === 0
+  }
+
+  isFull(): boolean {
+    return this.len === this.items.length
+  }
+
+  /**
+   * Adds a new element to the end of the queue. If the queue is full, waits until at
+   * least one element is popped.
+   */
+  async push(item: Item): Promise<void> {
+    while (this.isFull()) {
+      await this.onReadyToPush
+    }
+
+    // TODO: should we consider allowing only powers of 2 as maxSize, so that we can use a
+    // bit shift instead of a modulo operation?
+    const index = (this.start + this.len) % this.items.length
+    this.items[index] = item
+    this.len += 1
+
+    if (this.triggerReadyToPop && !this.isEmpty()) {
+      this.triggerReadyToPop()
+      this.triggerReadyToPop = null
+    }
+    if (this.isFull()) {
+      this.onReadyToPush = new Promise((resolve) => {
+        this.triggerReadyToPush = resolve
+      })
+    }
+  }
+
+  /**
+   * Removes one element from the start of the queue. If the queue is empty, waits until
+   * at least one element is pushed.
+   */
+  async pop(): Promise<Item> {
+    while (this.isEmpty()) {
+      await this.onReadyToPop
+    }
+
+    const item = this.items[this.start]
+    this.items[this.start] = EMPTY
+    this.start = (this.start + 1) % this.items.length
+    this.len -= 1
+
+    if (this.triggerReadyToPush && !this.isFull()) {
+      this.triggerReadyToPush()
+      this.triggerReadyToPush = null
+    }
+    if (this.isEmpty()) {
+      this.onReadyToPop = new Promise((resolve) => {
+        this.triggerReadyToPop = resolve
+      })
+    }
+
+    assertNotEmpty(item)
+    return item
+  }
+
+  *[Symbol.iterator](): Generator<Item> {
+    for (let i = 0; i < this.len; i++) {
+      const j = (this.start + i) % this.items.length
+      const item = this.items[j]
+      if (item === EMPTY) {
+        break
+      }
+      yield item
+    }
+  }
+
+  clear() {
+    this.len = 0
+    this.items.fill(EMPTY)
+
+    if (this.triggerReadyToPush) {
+      this.triggerReadyToPush()
+      this.triggerReadyToPush = null
+    }
+    this.onReadyToPop = new Promise((resolve) => {
+      this.triggerReadyToPop = resolve
+    })
+  }
+}

--- a/ironfish/src/wallet/__fixtures__/wallet.test.ts.fixture
+++ b/ironfish/src/wallet/__fixtures__/wallet.test.ts.fixture
@@ -4329,1558 +4329,6 @@
       "data": "base64:AQEAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/5M1dwAAAAAAAAAAy3pc2+JAD/A6NPIf91xdfQOKHCPwRJUvnVM/HlHbMHGXLfvuZ6UWoYCmQLyttYvDz1YqcfEHFmDQ2Ag9R0xbUNcPHtTmSbnfFN/MfB3aWrexE/5tgi73cO5zwZbC3z2TiObav6rtvfnpo20tO9YyiSHuvtscWXu/QS1Vx9HxvDcPQldpH4/MG72Qbgnon9H3eYhlwERwmncUu7kJNuqEghy54cs+YEN3KuwMJOhlFcyInhQbGKbXwODN2nfYeYtoks/hE/PXrI30SScVifsGbhkF2zvdlhAp1xvRhXF8a5lpjF/HPIsIwAbXG1uk9OJsIkCVqCOCgWtchLEd3lVo03jonQzOjkdfLNraJxUVavJ/Z6jrz6wUDE3Lsfq5tbVTBAAAACSLreEcoFC5KqBtvB5xKHIti9ukKYEWL2XCBFIKZlMNspPwzvSk2F/86DM5iEy95xtjj7lbvTESBobNj4nK2yl/RwpwrmdRG46vDtDhZSmvHL7tYtuHfPdlYQBjX1XBA4cxv+RKuQAi8CIr6F1tA0bBu014pHPMEO8z7FcR2+GkvrYdHu+0/osVqUFP1ADbvoFSQGjz+yWC5UbdqBtLMSDs5BJ2DMJRw1bH6OO/PrA/Zjpmp7/goKG20XRI1eMBNwDbXnR+dFMCYKJDaglonp1wTTY1XMMBTtZUpTf8W7qNirvCSpk42Ye+dBVvlzzREKDxZGn/+ZQeArr1NMaEKZhdk8Xt5YF1Iq+AouEEG8iABRtWXUS9A4kthpRSysAxey8jQdNEYUCeqBe86jutnfx/O0aSLhNcBtKD9u+nFOuGeHvcGMs54SB79DWe+MW/RxjE3dvxS1qDINNf4Y6LbDfpSS31Iko2I7xXVR6KxNI59Ki5GDDlXO/YmNwKWceMNyMMlI5SyNy5fyuBzv9sxEXfuouDNsztUvbgGf4z3Ny7IcILbGG2/3U8zXS/lqUn5rbU9ev/chBkC2gS6pZqQLl2pdpuw5lVUkEnT/+osEvNZxNkAtah8Zhw0hwv22tqTv2jtQzp9fePG5gKQZGW+RJGKauYPaHdjH3IFen7WDNq/2aXUOHdMxeMMKFVyCMl4FtDl7fP0co9PxtyUH358Z9bXt0K+ENmOvH0MgBkIXvZz/f+EYzSTqnrIYT+wJ1Kp1BtL206RByfqHE0ts63KH6WjH6+B8B0Jf0cHfvMOmKyvvyM7IbHlFNKCHOchA5kd3Zmz19NujaFoWY+87LlvDykuCnkP7TcH7slZlymjBm2vvO6CxP6BOuazMARTZoNvzQ/jHWJigcD"
     }
   ],
-  "Wallet connectBlock should add transactions to the walletDb with blockHash and sequence set": [
-    {
-      "value": {
-        "version": 4,
-        "id": "98f0d037-134b-496d-a85e-f90a7500162e",
-        "name": "a",
-        "spendingKey": "5976662788b5abe5463fea3d9b0d49bc66cb02787a76c8f1f48da6034c6b0755",
-        "viewKey": "a773dfc42b64c93c64f49db6923ea489c8c59c33b0cca1ccd991037363e5da54d4617e933c0468cdd701c88989701372fe97a41e8697bf561eec28475bf5f60a",
-        "incomingViewKey": "078133d8b9f9055417dd4b03653ee4b8f251e0fefc32149aa7425c9d3fe6ae06",
-        "outgoingViewKey": "815fe80a2f67cf8e8228acfe9c3d6bacce5dd4c9f5afb3162f9fc73d58e1f526",
-        "publicAddress": "92f7010e34896fd468dff5af5afcf15b2ec2c126cf324bd7d7f58c02994c0a0b",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
-        "scanningEnabled": true,
-        "proofAuthorizingKey": "4f062833d1893d42e79808851b14d82392a2053853f6747334ea4db38a5ec60d"
-      },
-      "head": {
-        "hash": {
-          "type": "Buffer",
-          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-        },
-        "sequence": 1
-      }
-    },
-    {
-      "value": {
-        "version": 4,
-        "id": "d1ed30d5-7bd1-42b3-a2cd-d8d0646f31c9",
-        "name": "b",
-        "spendingKey": "60c168e2d9582bfd1a68e86cfcea846b6c7fb5be8fe85450cf3900a39532aa49",
-        "viewKey": "edcc327edbde105cd7b3c5ec014a9018ed879418c0220b0da681bb0fa78bc1010a6ed96bfe3523853608a906d2fd2ab4b4fd3bed9376a00e01c00787e7f4a7af",
-        "incomingViewKey": "f9a76c3c240dbe1053a9cabe640386259fc6f8a0a7e86bfddfcf14df8fb72a04",
-        "outgoingViewKey": "1000c09122ba07b31e1a053808e1ee52ab4fcf82b1f58677b14bbf6664d90612",
-        "publicAddress": "7f6229c26f5ae7ae1d2460f66a49e21a0043738f63ab9919e29ce8af0ee227ce",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
-        "scanningEnabled": true,
-        "proofAuthorizingKey": "815ee445b678ca104c39396e10d94589ab3244a3852003099fe553f88fa79c01"
-      },
-      "head": {
-        "hash": {
-          "type": "Buffer",
-          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-        },
-        "sequence": 1
-      }
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "4791D7AE9F97DF100EF1558E84772D6A09B43762388283F75C6F20A32A88AA86",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:tKOY0dLABR77M6xoQzhdVHhV0mHHw19i2WaSx+XiAxU="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:QrmgOXZtL3Oi3eI7bEPgD9dCzI20mna6NxPw6f7Dcf4="
-        },
-        "target": "9282972777491357380673661573939192202192629606981189395159182914949423",
-        "randomness": "0",
-        "timestamp": 1717538675075,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAWS90h4QTrgg8wrRxgd/n+DwC4c2h1SrvjjTyV8W9PpmAVzt5CoHiZPXsHY/H/jJS6+xm+oP4KSshoiqJUQC/KGZACTa7PlEPWeSB97LIzQyuNFxWCVP+7wXwUA0fmizNXKj/slNYz+pFcg9RncilXi1htyTanKlHBPuoqKwyKBQF87i+yN9YBwLK8may0ETBN19Rsghcx32qQwEvhIvJWz/z+9OKX1Fw8It6DdNtPDyuHFSQthQHFKBm49dfVmW1jhrfyHPknsz4xHrCgoqcUgS76yxm58bJ2DKeJz7WysBOxBcEqYomsGuVvwpmove93CkdWd6BYzEzS+SjkByCyzdU2sZr2gwfAn+Qxq7PefzpzCzkC5i6+hyEymlfy78jIlO4cNrA3XkKkgrJCa6JAmrxjWmigT/fRJglVWDiJjyaqDxe8w/pOohs0UebXPQwkqo6gwJjzXbpsx8Ol+9V1c0KqigMKY84ybMM0/ovUygzgYFivqXg96NxO7uvqACg5cs6vwpiQnxZ1DvFMODqdPJ4p5uxqxZPvH7wGnglto2CeBj3eNl3NV5iaVSW88Sh8hnCwrprHlQesAesS1H1IkuHQR7pffrGiNwh9GSuzGc1xmOAf0umq0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwaUm+Qeppu0oF8bLu2SPyFpZEZ8aI80YIUGjJMXyYKbpEm5d84nUItiITHfCLsauZHRUYJrvp7kPE7/5xD/x7DA=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "8C7D69EC69350E99BA5134807E12DF7D509035CDFD43503A05FC9957663218FB",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:MfFAgIf3mNhgU5WuhibYCyeKdt6aYTW21hIDNub5/TA="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:e7Qh3UOumiT6B03yJGggqNQdEybG1VbQk6/IXU+g0kY="
-        },
-        "target": "9255858786337818395603165512831024101510453493377417362192396248796027",
-        "randomness": "0",
-        "timestamp": 1717538676699,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 5,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAVo+0WQyMVWVrfe98CdaUMQbSU58ekKeVpOwWOApWdIiJftxH3+Uz4XWhZe++7z0kyJDB+qVzUyprfDYd5hgq4BVbmgzUu5yhxS9x6MM3U6i5f3OiWKK0Xh/TfqK0KAhi/gkcnlafw2Oxs95MQzi/gwAjP7AwjdlHAwUmHR+DrDkGl7sRNcmH0U1aSKjIU/CCB10HAUfwDikMsPalDBfpx8RL439M49dLi5rCuXavzQqI2vrH+TwbXSUxoEhEw5BX/b4f1FoBAInvu31/lVPkD7ioyZgplC8k/UAPEA8acw0ErHekvWuUqyxVcOEp8t1NPNR5z+V5ux84xSe2hv8mvbW9mnIdgf97eeoJu8Ho2Xyr1udQvG0DYwEeJXOww6s6NCWMyqT6HIv8vyE68tADSKX9vKoIHr0rSeY7b9yfTsDTSBuhDA6Gw/jKmxsdNqjHX1q7wFxWYlRPeQs0QAzV4G55Fu9dSsX2ZYvr5cdZF+CaF1NVJIiT6rM45KPwwDurmUTedy8QxkzQ+0PABc6dqtMRvwzI1VPvPJInHijJVvb5oR2F2yb9K0jKvS6mupUT2DnmvlEjKJGMqOrSZ1ESxSzFdS0ZobMa+yCUrb14lZWknVDjiXTTxklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwEL/U1HhIULe4WugQkf+rt3766vBmuBndiy+Nr9Kn08benLWssKAVpF2pln8P7kikD1jfWfqyoK6TfeZGN/fEAw=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 4,
-        "previousBlockHash": "6848F80E8EF39DA1362D4CE54E888666B6C785AA6F390293BEC242B8D916C2CB",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:Rvq8x9E7Bj3wp8V9I+x+GMw7t90akR/qhUkCa4u1LyY="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:EyITUATYp4ngn6mMIil6iSCEuvhBdVmZn1HplouA/qU="
-        },
-        "target": "9233318228143625020618577701423519925017621426082203201059080050516648",
-        "randomness": "0",
-        "timestamp": 1717538685227,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 8,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/2vKiP////8AAAAA8FKDUmlqZcbfq+aA4V4hXtwi/Mw7Jnwj54EuUFcXk4SxpCGQbSE49dntwcqkRHKjwAl2rXEh2EQ3C6PbDZJU3tIliBwJ0ErNm68C5BHux6Wy5FM6BI9pMiYvbFFZx/t9AmwKOc6hLvX1aTHbntRWW4BKfPWTV5QcW8O9mZXD+tQGtMLq8oHNBHQDx2VlUzPR2OPA2ScQ8r6hpEpgs79i54faiPoSGgmRcExNUBJQxeOJoJzRPREEBYS1FA5VZ+fYs41cW6m/9qcxEkavxd5RwYHMh9pj4rOXGzqVjbJGJtgLRTOjv/yQpIMFRVKsv5NmFwVBEbJuXJ+wK0nVxLYAnTNQtK4nosXm775hZhy4FOYcRWcTswpFE1oIHnUaGeRCV2cYWfH3qoO17INMMQDuTzmo7J0mK1HqRPtV6ksWX8iY5ylbeoxjf+lNE6n3BTE1q2Q0VJwGprm1J3+N0qXOOWvP6S38bSvtsLGqQYbs4SeJDzuwWOshAXVfZBjzMTQkN+Z7Q24a/gameEWs7LdYi9FfGrTUSauXCoPO4eAqmEybC7XFrRBSlUMqN14KbBTZwx+hYYNyIsP/QG0JtxonVO/6J0cONGRgiAAqEGhGrODlXz09t1Mm2Elyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwGuZvcRvviO4INw0bFf9Zd8V7bLANBBmjSih/otrU8WnuId9HT3kcGA/jmhOqMnSqwTi6YoV/Pq7020hleE8+Bg=="
-        },
-        {
-          "type": "Buffer",
-          "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAA/Zecsdz5QXXjPvoG4n9bM6ifxwdMbWAR4vXIX3nayNmWtr0nOoEfDZnZ5ZZ1chEWv4HUJ7H+oMYTIkm0Lthr4FrAfo6mloz+MPWKr0zzSqC3ySFPzF0hNsdp6tb2oo5YVjRAmuTgIBrBzsthqlkYM/7qcEecOOYhLvSzvHzNQhMAqClHVAoj39QbVHfZBWHyTUnanUxVFFMgeO20436j+RWBsvj7sE+3FEJ48q+gm/etUpa5zXG+KZ9VHtjD/GLzdb5k/Ojl3zX5mNj2NGVAuTGOOLPv1X2fplrypruaAyQ5jXKX+qbJEXlzC2fOnLVHg6hmNgJ2QRxMjcyswbr/TzHxQICH95jYYFOVroYm2AsninbemmE1ttYSAzbm+f0wBQAAAPFNUhwZrRkUfPtW6HLktSpJ7Le1oyzo3SCAWzXqITrwfNeEZ7i4oGvrhtWntpDOvGAeeNFJm8G/eygqF1lF9OCscbSzj/4xt8DzLarIIU6Ce37Nvja8rM0LWdFEZoeZAo4Ens+z4DW7sWjftqSzRYtvUTR4wl65r9UlsXZ46XxLis7ZXtTkMVHaJa8gHAs0U64vg/lWDS+kBTdw/M6SlWOvVJDBqIvknThEYD2BFGOSBjcaxqmoIAE7trJNaqibvwq+GwLNf2kq26LipGgj1BuTnyjVQESQlmiRKRXCkqm2pAjggmjScSXIKQcMrLmO4o3d8+/UkcYpGU2uFTOKOMwC0ukIjkAGEQhRK1fTbZJZWso1o4SIhIce88uZ0JzACtGhEZWKUmu01WrW/vTC8UJzxyRwW3lbAK1dZXC4YMLYKSHvPbC/lHrdnK/I/ZOSfO3VQAUBtJ0CZpsgbScXiRN0IngYLa4HoiWQ/efOmIK3p8gj1ZsYQlVEFR9xiQGG6UrODTaZh3gRHftJokTiObM1l8il2dkep5JgCk3R77h/hGPVi7FydkGGsMq7zfgVm5lu0PGPJEuY/Q7SkO8hPcox39lmpOGRK4dTLxosk1HqpRBybj8eIJtgpkggQZvZjMM0n1jRB60ssV3wVwoPkQoYTe/IAXG9q7q+moRFMhyRsxRWYtPobyNJKaTTWSjXUEA2jnr5i6rlyCMHsPehchTvtjyzLik1U8kW0PikxrNltXYbwVZ2VHNgNBkbVX+i1x0fX2j0wvlvWrg8WX2ZmxywPze7MQ2g1RZflj940d9onEtwJaDLCteTkK4PtS+s5HY1xTcbmNSmLvATmI/ZLa2F4zR7HLZbMPMAjruPkWaRiOZCF4/JDjmyJQFB21sY0FcVuSZfaTeC8jFlh9H201pheuLz8/4dwgpFT7xthQ70fhTB0QgHP7cDDJ2GJcrjCbQI2vvNdpL/d4DP9ToZIucSRDhRFHEmtSpFjUuRzExuRoGbmUZ6sce57omN2DQAyzHuAOL9gRsVGXvC/9BxIvyeVwe1al0z8c3/JM/jAP3yAv4c1PqfUYhRG5h5GwdmMD+I3AEzJs8t4K/sea4VzazqcLJrzqq+OfmE7QCb+XrVQi9eaSq0DPCytU5hqlzMbJxFdiVZrfka2VwnkvPFBpTYOfXwOEClLqs1qVReV+LfQK0KKwVTitfC+INA7jM7u05crvS6VYfSznIXDGZS/UjqhbBGuaVU5Yq6FQjQnz4g5hYg1XlhonFOHehZ99mPq/3WthP7Zp0gJHfVJztKqXdailAayhQuLPjtFzjVIklAA9mRGSjXGU0QG0KtNtqAHsCC254gNhLKnZXewHV8whs77Y8onC7TLWaqTKTogaIwqnIPqfCFk6WXnY1n5PGRcerzF+aeygElp4u/00Ad71i58iDPDsG1mfsJDtj3q9SyrlkqOxuPG4UEIc1Mi+FEALwSc7EPTNPHHioLLR0cCOJuqHiL2pirJ8/EXDbM9fz5SMfo7C6BUWla37QCa4l+VKzLlBJUDLKpqUQBuGMAOG2UOXt5K3K7rebyQwkZQJvtwj6AxCb8igGyPXgdr6sKCQ=="
-        }
-      ]
-    }
-  ],
-  "Wallet connectBlock should update the account head hash": [
-    {
-      "value": {
-        "version": 4,
-        "id": "203693aa-71d8-4bde-bd3e-678f96086a70",
-        "name": "a",
-        "spendingKey": "5b1eff525bdc0d699700370b4c464428bdc20b2f8901f07e9dbe025eda98842d",
-        "viewKey": "523b241521730831004ee05525dc7d80d949398e042370c55efb282ba0a6fc94690a8b2ec4bda70bffb676ac1b3af78558727c749797bb10074866795422233a",
-        "incomingViewKey": "1d8b5c646e4dc78dd5b114c9d6b9985ac3b157f2b1f3b88d6dc3274285087206",
-        "outgoingViewKey": "c0c68212bfa326b18a81662901f02550f36cdc6f902d5fda40f059a5012ed429",
-        "publicAddress": "1d36110d2e6c8dd0f700b747596cf63d62f743d13b8d8924055d96911e9333d8",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
-        "scanningEnabled": true,
-        "proofAuthorizingKey": "63c9a8367bb057cdce77b16f994e828cdbaa5203c41cc2e904f2b12252639208"
-      },
-      "head": {
-        "hash": {
-          "type": "Buffer",
-          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-        },
-        "sequence": 1
-      }
-    },
-    {
-      "value": {
-        "version": 4,
-        "id": "c182e51d-7e0c-4074-9498-d47d48d35f17",
-        "name": "b",
-        "spendingKey": "4c456f3b38c1731304e5d4df3d0ec6b0cc06261dc58f7873eff2d598038bbd11",
-        "viewKey": "3b027acd91b59518793f55287f1b2811abaf5b2b0cf45fd5750d2573d8609cf32c15fab25f110e798d3cdc0a8840b8abfb7e4385bc5f4b70e17499eff43f463a",
-        "incomingViewKey": "04ae8d2c315fa46c1280ad3d773e5b9af5651516439929fddaa7a652f07fbe07",
-        "outgoingViewKey": "c239e74af1eeee7d96916801a4941f2cb7fdd9339281ab9d1921f75523cf6268",
-        "publicAddress": "e04def37fc0cab193e44a31390d85c0090a2b89a0610bc16e017f520aecf926e",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
-        "scanningEnabled": true,
-        "proofAuthorizingKey": "502fe91c0be9444219abc053a14247785e8eccf5794d8af5d91dd3ee7ac4bc0a"
-      },
-      "head": {
-        "hash": {
-          "type": "Buffer",
-          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-        },
-        "sequence": 1
-      }
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "4791D7AE9F97DF100EF1558E84772D6A09B43762388283F75C6F20A32A88AA86",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:8ZWbGvok4PJT2Na5ti76UPQJxVICBSKArkfCrCz5VG4="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:ctdXcichGfVii7/ebZ4DB8mOr6WQ6szgnpV0msPeOag="
-        },
-        "target": "9282972777491357380673661573939192202192629606981189395159182914949423",
-        "randomness": "0",
-        "timestamp": 1717538689366,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAATQiUeasNPZ0R+nL18MSm1AQeYU6LCBnTQgQUjMbUXoiMjLW6uTSiNmZLMs+2YlY4YUdt2rjyjmnsZYDxfKy4ZDm+fx8oD7oWy0ptSJ0TjBmTE4noa2ggEkQPdcfBYBZST3j5tMQZN7qGQED/6wNGyLr5QnsOe3f2fSx1vjv2VgcG30Vb6ss6jROh2rRliFfdLler/1OBds31Ec/ceJ7dValxNOfLgSur6Gewky9NiayJ3CRZLeGAH9pXg/W3KPhL1vVE8Qgx7oYwsjGYTM2/PNftNPhSaJtd5BEgQT5/v9s1Hc5sl5ezbKRZijzdFE+X645t2Ed4wM7wgcl9jWxKtQk/fUmTELjol8Si79LCEtVDxgpel1SYuIix4ZLV+LwBeNnEn0b/2/V+U13A16JDnxrycaNSXeHwxk2t5BsOVpqAD343MpH2QlnJ6jOCUnycnuUmFggjCK9Mnc7HjAVX7u2UDaSz5iLyuSSeBLGrbjmJldeSUlnJUgGPFCRuDsad6cyCQQcvxrqQkNRGwkmgwpK02umxDDNMqFSOHCCi9T/NZxH86r2pLdECJ1zLikmSEo9sGG+uMhJQ1GiSl4h+cUrVPo21d9CgSZ9ZnHb6mSiGEW/LSrFc2klyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwlw4U1DmDT5USNY4ERWMIjyTF5P4+ggRbiAErPcr8gHLtDQTVMGjQi1AYNQHEizcXU3oKfZKAR7+g9RzevUkSAg=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "C0ECF2D4F0A085EA8A0ECC2C4E3787BDF860A49AB80C867F2E780CA41024998B",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:nVr9NPL3fyAsgr4Rcz1CMjGYm1134UIZcnCQeibt+0s="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:gZLBGDeTqRWU+lMcr0wmUPa8co0ta46GKmaTmRei1LA="
-        },
-        "target": "9255858786337818395603165512831024101510453493377417362192396248796027",
-        "randomness": "0",
-        "timestamp": 1717538691121,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 5,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA8mrZ8TJAL5muTNSgi2cTHoeI/kzCXiKKb6bDkzSZmQqDQFgBZQyv0vPQVxJCl3lCzEXxJi4tNQJ9fV3WZM/WYHA5iMF4YguK4f7ZQOSlp4agu3Dj/ngJVx8FcBW+UrdGKe+IR+yJtah3XER3k33zFucVaGXavwB++fSi6jzwXCMQE14xzYW7Y7Wjq7eUw1eKqv2rE5NsXrTkUlsOpEhWDf7anq/W2sH5StYdxqor21m0DivzRapxmD+jMBvn1Js/Vr/j5gtFAVPTPxa0klPqqOZ9o5c0bMg06P+DrgzVzofjNaD/KzevGEP/j8ZVyAJu/F5oGpT0yiscWdWBZJf4nkvyP75qnYVYwkpBuhnr7f8fZ6bT/EDnDBir1eN+zi1REjDamn9iq6/FYHwjv3vCw5aLpE1YkcBokpBoFX6F+tWQd+lj0bqimdkPsmJAC6m17dzQ1bN+IdMPgq1BsnlylnXubX6M6PfsmXNTuAYop+P0g30m+5FElQX8YMCn3uLGX6d1DLyOADNL5BHIcFZervsNJ4XJTGj0gZx49GBEyQ3g4qAPtOtdtWHxTQgXyJAB0mm/OnevHnYkhSk8tPIYTHGKT0qVEO/nEyIc6q6ttNaFj7nEwaNj50lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwelwwhjLv951EXCpMcJpo0IGVP5H5puiSHrCnkVpqn1Kkw+1zhq1zStuxmfdypNHnCvErus+K9fHMAYGthRthBw=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 4,
-        "previousBlockHash": "BB35CF6F245C5407CA73F847AC5487DF8C60F61348474D5D7F94683F2EEEDB8A",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:CHDdyjgaJ2slNneDkRbyaSqkBW5ijPjY9nHek+782D0="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:r57/zAhw8CpWeINyFnybI5UjARfD3hFhIHK8ZmIPGbg="
-        },
-        "target": "9233318228143625020618577701423519925017621426082203201059080050516648",
-        "randomness": "0",
-        "timestamp": 1717538702961,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 8,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/2vKiP////8AAAAAdbblmP6WgplGVE9oz0WKWiH+g+IU+YvLlW2Ir1dowlWxZssjBm6KcJnDVMMyXvaIQrMpgAujtEXahv9iSq4K9SP4T8ZuQZ7CsOq3HHos5z+5lsGUgQI8rhYLy0nGu4qhGXKxxnMqWUN5C0jrehx6uijRjrZ2yz+ykTEh2e27HhUGg6mOyukbi925EFl6n7jnI1Ihl67wViryHrT2zcWBMGyk3LWpkEuGvPkxj3kUzPqozMxkyGc8ggHl3CpW9YXi+voM+oD/J8n5L1VBW2bHErYTKAO1wuZhU5uza+7ZjNPpuo67vr073h0hnnwu8aFCD4LZWE7ZJpO+ukY2GreV5q1tNPFYIBPn2Uk8ZHy8/imeQxu/Y8fj/7qFHEzoFdATeOYJb1kGaMW/wpLJKgQ5pKvn7pQJPdd24WxJWdKwS8nWkFRu+/d/cxwyWwdzLZyevMP7tXDaNOmp4LdPoTP0FNIUevUa99v4BZOZRBFGngc3RW5BDnWVWMjlP1O4qOq/erpGxvj9B+OjbxepuosUPjNaCVMduRI7/tJulGuQdMdzpJzYmQK+my41TLcBRJQlNyuqMHw6QpLaTTU5ilTUCpEOSuKCxXh1CQxcYwwbnWuexo2kkvHWMklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw1jbbfpY0TGw2ogdTk22dVss6hp/8pSYPV01t7zB0tNInXKQBj/BSEdqe/6UfH70iD4+/zW7l395Zb+FEkl+wDA=="
-        },
-        {
-          "type": "Buffer",
-          "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAPD6mDMtouJiBFtRKIl3sieS/Wdx0hti1mnO+LmJWJ5q1f16S9kOPjPTme6WfZ3GHV8OWrt3mpsx9FEslQJddvC5J9Y8vWc0EwcKreCqdQPeYknY609MAHspJywh9hcRxFbES8l1EN4lA5OxAxixR+lwkObwhXfeLp4+VenZoeLwLtqJx4HUp7ZsX/h4qKskmilDwZnXaAChFw0jXfba7vvO47dRxPcs9JxochaNi40+zLsx85qMF6pjh0tN2pmJgNCBto4Yf7j4SrP0djw0xvJyYIPviKd/icdlLlGeS+CCZi/Hjz+xna8KBMniN3ORaHxCjWXQTFxoPrJE4Ny0/AJ1a/TTy938gLIK+EXM9QjIxmJtdd+FCGXJwkHom7ftLBQAAAE5z1IQcbD8btIqPHbqMde2kQn2izI0ffpmBxQKYV5N3nZmV8yZRYCGs3GiM3qDRG/mbv2LF63aK4GT/EN3/M1dXkCmSssZpwMobsiujqML2R1eECIMgggI3os1e45cUDbknNtxY3nX+AXBRna1DLpxXxbGI2MXM8CaZKMUcrnTmlTM8nuywtUZlgjVG7/KiOpc/rmG4dZisxQeMakvXR9AdQfBSAU+LfJ9ZNV6/pnUzZJKUHV7C0bV0yUGn6JuBmRW/JhbTPZcD3m3sl/947CTNN3CQ+aZeyK8mGNJ9UbLLFwWzIV2NuME/5Rzs8/bCrbf5VKEHgcgkqgwtFqI05bLOIIuzec+iSIxQtY4Jm8TlL40HndGOFGnwxTk6A00rBq188D/1hiTc8zErDTAwXtxNjeG8rOuvIwwk1FlwBnCGOU7XjVZFTRx/QM/a8eNf+H6A+iOcOo1mRLXm1aHHGwjfSqFXR1ehs6MXqSu/hjGsUk/LF3CDpDgkZNO4xfIfc0M80A03M4BtvPMGzcZxe4jIYkRRcLk0hNSbhM+EQpm+MpFTjFICtLLAMohPZqXL4oqjOJ1QVaki8UejkhOMTqTztzqAK2VBfWI0Kium49axlipAdHm1+qEVxxHatDhriQRoAcPztq8gCrhetjY+/Td6AjZsGXdYkLWdIn05st/Es+XYBsMEj69R33XmPwarwpsIc9BJt3qUkzc3CJ3fODKgAVvCBiSenJw5smwNlVX/jqoQU5gxvXztmYGXaUS85Aa78m5yuSHocyitTxBDnqBsI7l4eGGLHXP9rrZ/3iScjdf1ZaogSUWmA4owB6cGkR4areyP1+cUbf55RuPbToE/9TLMCLS7EY/R1o6G+aCzOLQeYB5jaU2hbuyqH/7QOjxPGgLVU+JT2ddU9imRFoDkshoQL0mY/BPxpcnZt1XbNZbp1gm88FQYV2zQb2spsjhw+VLRK5bdO7AuMyRuKoTuIVKDavcvDWQsLY50J21pDqW0d5vCRjSzUawKHEFc4NaBGL7GInv41XUIYCpmBtTTzPfPD+r8QrNxQRF29PSnHNipmsjVJS32qaY2Z7zc57C+awUe6A6gwLMbAjtmhtyVfjAsIlArVxUnEDsDwdRBeOCzPwVrkJ3CfujFNBxhrvIkba/fuXtlYZHiVcV275f3Jyhr9mJisFy0A7of7TVCdCGJ0Ou5F8lDMG35Wf7DlGJmYKLFfY8IcQFUMHkTLWDMMjrrVq+QUf8bd78zINjiAw07AvkpHM00a38EmHK1/bbRiz8SEHdY/7no2yI/KC/+T+Ux+yMakkFulLtdfh6+uX9AwvtOaM/170YvobYlp2wo3D/U9Dw5Jz/fmgjfHO7TolzhWEx+Fs3RL9uBxT7+Fpo0PeFI754i2+39Oo8qitirtDoHtpXkDevVWi6VeZp9pohu/H+u19EuEvxadllLnIahkVSwNMAoPSl7H+bAZJCjGH1gnqI9B7Z0nx076cX17BPG/VnKwnRubKvv5F1bae7eBkk7uMeo7hIthg6AlYJZyLSbMT/8DO0U7HdgrBE5EGlwGn9zscLDNPZuORy/5X7D4N2xy928iMicOT8oCw=="
-        }
-      ]
-    }
-  ],
-  "Wallet connectBlock should update the account unconfirmed balance": [
-    {
-      "value": {
-        "version": 4,
-        "id": "e6e07578-1ad4-466c-93f6-d4e2c086ca46",
-        "name": "a",
-        "spendingKey": "420843092f654880ea9945307acd50f4a5cc81dae58f0886f1f18ce25c1d8d32",
-        "viewKey": "41b69bf61143f22ef34c11b53eb201f7489e1ee838f2944685e45aff0f13044ec36043c8516e8ac93133f1d7d2e6c62886d5787f89bb366abbe265efa64423eb",
-        "incomingViewKey": "14afb756bd4dab75ea541ca2395a5a43cc7c2d28d2604c9e2db33dc8a6b54a05",
-        "outgoingViewKey": "2f8bf7b9a052db1c5fcb25b85ad93523fc865c9493a12889dafeec82e1c98ba5",
-        "publicAddress": "2db05c91321a5e96af2303c9c9164bfc0a2789ccce25bbeb4213cc986fa755b9",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
-        "scanningEnabled": true,
-        "proofAuthorizingKey": "ce1df7be9844e830b02a603d25146aeb1cd88d47b28065115d8701dfb9927406"
-      },
-      "head": {
-        "hash": {
-          "type": "Buffer",
-          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-        },
-        "sequence": 1
-      }
-    },
-    {
-      "value": {
-        "version": 4,
-        "id": "ba507d1f-eaa1-43b5-a3d5-e3f0835b2163",
-        "name": "b",
-        "spendingKey": "ca3241bdf3377026987473ae97f74ea32fac0a76bd7afbe5aa099a1d5eee3737",
-        "viewKey": "4a3540f5145e4781a31d65cc17b2ff8a807a1d4b565b854d9bf88d17a5215f5898807830f904d96c28fe93ea9137dca15ac7a84101c0eebf8854103f934d1cf0",
-        "incomingViewKey": "e3fd9ad198d5d57eb446d439862b8e4b529c5e186999aaf5319b0c6043205302",
-        "outgoingViewKey": "fd5aefcb77a84360379cb42ca1575af92af0fef6f9d585e00671788f5ab7fb69",
-        "publicAddress": "1bc946448310c4b70c9a0ad476741a0b0afeaf02750bdb5ca324ceb3c743dce8",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
-        "scanningEnabled": true,
-        "proofAuthorizingKey": "12baa42c0cac30b9bef37d863528b3d2f6005299c8f545bf7bc219f4b7792904"
-      },
-      "head": {
-        "hash": {
-          "type": "Buffer",
-          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-        },
-        "sequence": 1
-      }
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "4791D7AE9F97DF100EF1558E84772D6A09B43762388283F75C6F20A32A88AA86",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:E2EZVHjeLvWcAa8IT7Ni2Ux80EXU834VWaIr3z532nM="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:JdGMfWzvdPdPqLzGnPg9qbyxaaRTn78az489TPlJ1Kc="
-        },
-        "target": "9282972777491357380673661573939192202192629606981189395159182914949423",
-        "randomness": "0",
-        "timestamp": 1717538708585,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAgSWTdzyDmJymRS92zJ6fgFZXXdCw35XCWCRH7lIZpQOi/86a8KBnJAuMLY459E7oJaWl0uBXAtbvdworkuYoqsYWdX1miS2mq/GdiKy4srWWb8E2TM7twOJ5bb1wGk5x5wr8Eu3NvI/SaWujCe9yHptG3CPgENEt2jNdfDJI/nUCi8Xa3VewEt58G66eRKPwxpmEhQGTfFOw7HhO9Uat+8Rp8ZPJtEkKZnQy5ABMPICUDiTYnn8I/XX6nUFYwguKfotH9L2k1E59oIod3+8hSj2lTMmu5mLi9L/U6tkLAJdmtVUuLYiGKJE/F/PS/50gRl/U72Bjn0D68pPWyX38zuzJ3FcjnWgbIdeMLgGp7m2aZH06hNBCjFWfI3D/IpIkPJsK98MQ94gzN0lUXkNy+c2o19MOZlWcTfg8GRRjN7DCEav+1Qgqn6LnyZMJ9KPFnOGEJs3fd6UllhUiWiAHAcSQnq8b0ndA52LelRK/2qpVJCKONCoiW9GS4KNReZD8S6bKMusBUSESKIn7Xbz60zzOFpCi/yJVqRsjZwG+QPjSiGy6lsFiofURqGFtWpDtz31uvkhB5zvs+DBwMqxED46GLuP7DrQgZK5y2pqDGNg7Mf4hLgkgpklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw2cQJDVa+FJ7fx5sNcgq4p9gC9CqEPIpmNnUmPaBLHZp2Ge+G4csJGsjeKEcKyBCTslLzmuLNXHlMi25iEb8HBA=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "42DBCBB13E03695E976497A2432B740A14864A5C55AEC55A756C2AF0D19ACFEB",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:HOIPwfKSv4AOyIExevqAx1L2fz/yxsgMfKpg8rjYpGo="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:6iEUo3N+XYPWM49f6kf6gljcIUjIkPmhjUsVWsBYbuw="
-        },
-        "target": "9260366780148527510972123832573278885902566341756516011968728852484845",
-        "randomness": "0",
-        "timestamp": 1717538719107,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 7,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/2vKiP////8AAAAACZUa6EoIZyCC8ZqizUMtc1BG88YzWcApg7Xrlj3+yQSBPyB34rE7MvJb8f6VfQw18feDEV9FG+5ZWcnmYD14uotAMdtUPi26Kzw6ZO23OQeKYW3sjRVagdVQquvPXgshh3rBWEj7IcrcjA1ZCVYaGtn0bJVuL00YhWIzN45VgHcLFYPwLnFdVI/ALyqXtQ/BfWU1cU2RXf9CAYYMZUL5f/qWk7HgpaMvdYv2RJjJK6W4rJ9f1LdBtcFOizPRgfMwgUTqp+W5Izq5cViYhSUNbHRd4Xgy8m9Awsnrtxe33yDCERXj1zlEnZmNBG6tQ/GwOhYlJiberemmvVzl2/uVaxRgr3CnaizVdPRleCIb7xrEmlkmWnSSGVEWZDBALgRVyoopZaZyrKZKLJrPXXuazLFVWeax96pvoU2fer7oQz1rYdTKDw7zfSPNnQGvVCuqbwYmz3lqHimBHnuJg32RGszxK3NusII1lsrINTaRPK8NTDm30Rw0ZtzjRT5gcUKE62DybkU5m3r9cKMoMF9vq2IpXUmJlqjn0tTUf5GFoqyFxmGyiHfHZrUvI42aLpWqZRzSMp4Gv1Pi9xj5KILu69Xh++gYYH5iK61dROhLX40jH+HBFnRqJElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwo7KcKsMXQ0jYoWFUAeEweCvg9iJEVCanTe5cMzboRzDR+meyxr2aJtHviqQz8NOO/LcNlrHPH0Xg9Bcc8hFQCQ=="
-        },
-        {
-          "type": "Buffer",
-          "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAtAAY8ThmuhqcQpUf0TphkomKQMN0eVjzwtGyMu+mZLWSpVb+gyh2ydR8wSopy6sh0sKHPiKwJHhDB70UCebhPPnJN0yvHuBqVbcmiqRBZYKI32O0Ovjvhvy/YKEBwEUFPQCwz5gllRoS8BVkbXJ5VGNtziCbldMaLCCQ1y9GhesNGbpsFbgADzV5WODkNb8WHjUlI8hQrgo9W5vEXuoN9f+ODpR1upViALfNthtosZqw/WnWHOZ5Q3GON6Z83brEUVT6m77LXuf/qo2x1h6U9RTcQQemOc6m9EXVV2isKtPdpCBi+P9unntLAd0ssYNyENruCC4PaEVKBTQ9D7vk2hNhGVR43i71nAGvCE+zYtlMfNBF1PN+FVmiK98+d9pzBAAAAL0kFmFW7Cb+uCgPMgQx49tlUgAh8EpgyV1zCErS3MC5mbMHSfOtEYS7cZUHucyJdu6X6eBXM4/S+DHUipaw5LWzSZcrglSdOOxp6nx0wylmm2y416rBGMNj0eXDjDl+C5OeC5vDEEMozWFMNnjrMiuE5XCao8s/tqpXW4fjdsXdAabGhemDS/Oa5hTaQccy25R70MiVre76bb63shAvJfoY2t82tIWgigvyK6dDsAoNgFemsIHo1QlDfTS2VbY+lxKsJo2CEu+n8LT1BTV3shPRgG5u0wfYaXhdx7s38LYwiTk93UKKVAynpVa57xHubbDgoyirc2Y9Ofk9iaC8Otk7ZxUP0gtkrQ+HXY7JJrOwsbSxRPVSGk7yqPsiFJz2d1vaOAlKaMLa4Gy9ADgxZP8rUmDcuX/rDBThiow31vWNyAr/rKbknYx0GQsK55MQqb5mq/lsezaXfftElNrSvz0pbmLyYCIR08kq8ruMBOZrbQPPte/YclPgILGNnMbu5EacoOxSIZEJ6J7BjjdgEZVE4d2mNo82sSA48JG0+yVXjMaSTvrALvckR7t4cV8WoW4fqFkResflba6+ewuENd/+OipGEF3It/hROoWnM9j3mQYWO41/FHNu7SWdz4ZGiuMBgtykOXkUpPzy5bqmvGqaIl66TJkOg2y0jR72E1WhNCqZatuCIVBdgE+DajUGVKnCc5QPdLy4u3aGkJu68Wo5y4WJMxceqwnghLXAHW6qxTSjBPtgnZ1zmYSiCepNVDz+s/QD+QJR7ar4ZL0H2xppUIa5sYHSiQFalM8dcMP3OZAtPoixbjSlMqMzzT8eP2f/HH/PG9/C7HXdcZoWnZGRee4buHHyAXsZ6Z6PubfVoJ5HcuqsirSifZwvtyHx9S8X4OF+OCSLZXjg3p7jLm/prXSMqGMqWLVX1lhnTonx7xL76QmriFQUcJR83hTDgGS4YC5k78s3PW+19D0GpvhayRGyGzRkn9PteI9kGZxZFtO5Oj8cYsegjjEtHqrOY53nE6+zpW7n6hW1DxnJxmW3mbryePCYeFe052oRLU/kezlckEj+RASDcUGYQ7MWgIgitGWlNXZb1KKy7ybWlw28r6nrEoUerMo+fmwCelciMMFTtkGa5gRRIcDBKw1qLze8D0e0nWkyfvbmpY3tPjYdQjDvfCQGgx32FqeMiRjKJLGdFf2USh07LXH6bj5EOIsIXNpyZcp85qm98/WUqMW0Y4Iwrp/DlJreJRNnY+U9QBNNkUC61f1MDf5VzXaida9Z/Y2pcPSZQQjy7fhU1QZQNSaOtQXsNaJ5stO+47Cm0K55NYUW1/ApYz8Xplty5v/8SK9s5mYeFR+mZeBINqxKfy8Rf/L9MticP2HKH/Mj3n6pUH5FA+QYECkMsaChZPM39u8/wziWeJ+VL1lnEX6VQvHjXtra9R+uRDJod6L8OLsa83jI+ZOvaxZyQJPTAAKAeLh2hWGIG9SC0b6uwMB4pKJIdLUOXaBQaswpFnURV6EHxmcZqHMBXvGTQ7zrXDw8AAVFx4S7pcWEssEJBGl6iXtfvQykxIk6WSH5OlQDT2UeNQJ35FvGmhjNMSZUAw=="
-        }
-      ]
-    }
-  ],
-  "Wallet connectBlock should not connect blocks behind the account head": [
-    {
-      "value": {
-        "version": 4,
-        "id": "549c0c4e-62db-48b9-bf31-17ffe7a8e31b",
-        "name": "a",
-        "spendingKey": "38392b27d4f07a540dc60359f1776dd0deff50f2b8fd2acef76e7a0330c7e5f2",
-        "viewKey": "e118d06bd3e2ef6c7a3eb2276e71bf920e048ac57f9b8278c116f0682a1075e90a52c2d2f3b022d12788c9c027525cc779c79bb0b593bc158d285767dc9b3128",
-        "incomingViewKey": "904fc0c2542b4054697441a9aa09651ca4d23f87e2b009ded9ce9c25f86e0602",
-        "outgoingViewKey": "ead9f6e370a250d3e6f6a8bd26aeec8832f31fb29bbfde24bf29154c3963bfe7",
-        "publicAddress": "3c91103dedc461acc29cf0f2c38ea8b68cae02594cd61f007418ba4ea91e0b4b",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
-        "scanningEnabled": true,
-        "proofAuthorizingKey": "d9abfb17706f10f70a61c41f88d4a3e931835f3c98912e20edfcddc0b567370e"
-      },
-      "head": {
-        "hash": {
-          "type": "Buffer",
-          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-        },
-        "sequence": 1
-      }
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "4791D7AE9F97DF100EF1558E84772D6A09B43762388283F75C6F20A32A88AA86",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:9kj6mLUHK/z49LhREuV654QfldZes68IGprirmjS3XE="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:ewxaYXo1/0UE/FqcSt3F/t3vxfBtF/I0qsZjjw2yiag="
-        },
-        "target": "9282972777491357380673661573939192202192629606981189395159182914949423",
-        "randomness": "0",
-        "timestamp": 1717538722947,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAityQygHbqt0VjDxEzaFyBVzuioP/pzHMKsNiBhmLYjyBS4p2xk9YpIcbcrPGcFMuUCpdBpq4YzcH4AkSRu0tEzBB8Dh78NnQS2Lk0ETaCaKmomParGghvWIKx/S0B7YIOP5z4exXCqEVty0fymVVpxJ4EBghJhUfKwmuaaJ/VMIYkjAye/mqpgkAKXHqVN1892zovFr/+akH4xkKcdKUPNG91oLTsoHil8TzSMxuRRu4sENH/wA3Y4Yo6o3fuVplXQBGIvC5QvxJBJXPxULMH+0uBxsVx5syITQNutdEjaReDQ3rdgpHH3TWsOGzvmBRLw3es4+dRoxGKNDiYLU7AD31T+iQP5JqiS6zRzShpstX/wzCCqdnT7FN4LjG8WctMOED+mPkCPeh1QQfjkGCA6z8Lr4bn0ihy4eIPAq4fCNwexW/WGwQS3GB/es4Ruo3Yl7lgZho4f7xtSQ/x6qFp9yhGxlTfWpGgJKX1qqmLMrJITVH4UWTqj1LkhHwYi1WFaeovH5K1ZiTwSrlnZQY9bhtc/1MoVMjaI4WXDCW3TW8pSx1q+KkfYzj9D+A2ccteQ3wJkaVGYvyD9y/i22QYwhLdhZ45NX8HM1ELq96n3vCz2tbAIX2PUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwWa5z+Y5ScqK439M9t6NQMoGwtl44CEdDcAgpq/v1xG7/IvyqH64i4aCd0oOj314uNDGBnh1i386kv+H1IVEdAQ=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "F061890B105D00F09F2D22D79916B8915E63660D4F8613DED1003E1626F3554C",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:we4LwRNXxKAUFs9XFZpYKZZ5lrVuY6Knfoa/mf2JYjk="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:A0rjOI1sM2RqCm7hRI/ig82QVItLkR124lCsen0kF/Q="
-        },
-        "target": "9255858786337818395603165512831024101510453493377417362192396248796027",
-        "randomness": "0",
-        "timestamp": 1717538725161,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 5,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA1Qt/MhtPOUbbH1Dq5Nwe5NYf5mgOF9qahSi+qXgQbCaU6LsxbSB3o9/imSy10i1TSmTchg6ks5Rp9fNtrGMfGwa1P5RpUECCJfvdNP5/DPuI3eNktr8KbgJcATJbTHnxs02dunV9Ai/lCEJXIFjxGV8kecG3kfwRWQSGdwGf1X0QenJ6mU/cQAHE3HA/LJa9cdG/y8LwUuZU0PvKq3yLpjufC0DYkQTJJYsffwSDQ82u70eGfQ+Z3wy8UCHYP1/2rBg8wFvQ81KGwtKOM/09uf3cFF86wJ8ySW9R7ys/bicUeoQJBP/FOi7GOgtRJw6wwuv9C5qwsLPau8nOfQIVG32PhpPX/Idzgw8R32Enuj7rvukdT3/9nccHL/HYpb8G/iEp8ajRMkUluuRP30/GHjhMxuP8Rb7rt2fsY/GZTV7xb5Rx6+RQ1zFmkyeIq781DzfhujdO+xF6iqOk7QROcYPK2PnZdmcoEZ4r8TO4aEm1qcI4eRDH79OBP73/60cJJ7LkKw+hFdq+lkqIq0SQZ1bkSEtZpw4RclWfELY6vUg9xaciDa8xWbmMGLVTo5oVNLmv0YBz6RlxmEH98piaznqd6XCuexTl0EYVZ0r/zb4cOUuHuciRr0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw0xRvTW9fTJlsGdjoJU/AfEzHYSusIArbgU1x2eFhDJ3HuGPuWQxfjtKfdzOJBTlEzoU+OeEiLwfWwjqNE1yRAg=="
-        }
-      ]
-    }
-  ],
-  "Wallet connectBlock should not connect blocks equal to the account head": [
-    {
-      "value": {
-        "version": 4,
-        "id": "876ad5f8-678a-4b18-a7a4-bed4748da70a",
-        "name": "a",
-        "spendingKey": "2cf20f13a0e93c09e06e8edce5c61eac5b4750afc68810661dcef81bb513f030",
-        "viewKey": "6a7590f9e9ebfef17356dc80f13812be8590f42e619149e3a139aef0e19f7dd9915255079068983b47871df78020a0f2027790b5a959794fd37cac0b4aefe0a9",
-        "incomingViewKey": "2de5acbe99b326bae9267b2471d58ede40cec3138fe156599d599b1403d4a107",
-        "outgoingViewKey": "eb45a5a3b4a9cbb1cfe22c1efea45c29e55e1c83d925d3ca892d693b28681235",
-        "publicAddress": "580336448b2097ac9f598d4aa6e7300219c49bb861bf11c24a9278ae65934f46",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
-        "scanningEnabled": true,
-        "proofAuthorizingKey": "99c3f6bed5f5e73d8c291e95c70056f43dada58594cba4739e833e882301ca04"
-      },
-      "head": {
-        "hash": {
-          "type": "Buffer",
-          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-        },
-        "sequence": 1
-      }
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "4791D7AE9F97DF100EF1558E84772D6A09B43762388283F75C6F20A32A88AA86",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:PANqKX16ed46OhXoTdcTbh109NRTEL+0nkdSUSNcr2A="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:2tlanU+nqFhfh+6GDGPHfRQrducErz4W+vk/nOeYhbg="
-        },
-        "target": "9282972777491357380673661573939192202192629606981189395159182914949423",
-        "randomness": "0",
-        "timestamp": 1717538728400,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAvy5s0E6Tr8GHS9Mv3Su1NfDF4q5kJwm0Qr0BxrGU/mWN8UY7Ga1iEFfUCpkc34j1lhNrUqG0dQM57Uc1OkJAs4oK3sASDF9xWwFwaCCn8GqXqnZKRdKjCB/elDjYeRQP58TOvPB32nxH3SeWIO5/zaUWY5swnUoXhhVsiZ1hOO0K5Qiv+XIcvmt1sUMUHstmB/MaWCX/bphyphh8vkYQpq25liVFkq83a7CmFwhv/7KHEwO/fmxrE7MGp3huWnv4Ovwl/DncOZBKP24rovGWhv+SipmE8eneGy+LONh1wRf8PJwP4b6QIR33nkquWibbnIJgstjYAlk2dCmfXwUTYMfLKJrnsEfst9NvhS4jOse8sGCDjZotqLif0koQTNIblY9H5cEwZsJypurz2xTbBeFgn90E9zl835tF8Ky1RtnUAWMZrTmJG7FkQWnIOVesMmOASe2HfuUVrQa8AC5JQjFlQmmFsMm69wL9vlfKyh5eKBGVjzviBT/vHd+zod8HpkaDL4eW0pb7FxxG/ahom49ohhYTl9PojKw/q6pb00K68i6lX286HGcFwH4K3bYsJ4cPsu7FWBf3YGVxdkGhqpdhlKsDTDh3IUE9+IbEliEk/UiQKwDqSklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwutUnEeOJzCTl+ddY8OWJjeu7mUaGRv7ZQlOzZXX+x1yrHthBe360JdCB3w4e8sYzVc16+exatwibwxJ5bUKBBQ=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "38E4839FA33029B096650E9CEDBAEC98B5B488AEDBB8A4D809AAE96E9863BE54",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:t/xu3Ock79Ta12+GZid3cxt0ACVSLDWvXeF0PgbLrWU="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:u85uO2zQwGWgLkAunfsf3ZPYU6VoD9Rsu6K05NJWl6E="
-        },
-        "target": "9255858786337818395603165512831024101510453493377417362192396248796027",
-        "randomness": "0",
-        "timestamp": 1717538730986,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 5,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAxrX3vg1YM1H3yTQvlQT6ji/CdaNebbYYdDfVbug9ybaPChtHD8CQkHfo739PmAZsBDzoaf7Pv/i4SwG2tpE//aYd63qUqcLrlKZ1c/DhR+6k3J8U6zRdND01JrkK+M+dXQtn/1dkteNGDLP4LOkWNQptPbMgDScW4UhxPFb8PzwUpijs7ccxeuCiXvmauk7K0T5FKgCK3q0HQNhj4vzM7osVbzz/t9kMGTSCNdDkq1+1JIzal68440UnIa1DaC6nrBDwvsNOYsl7iVD7QFHzYK9RD9WMbZCkOueAalN72dTno7UJXmnkC9vgaU7HZFKJEUoJ75aWxpuhruwb2aHpa2qZ5wISF8vN7CJOkI27IfZ0FFJqoDAUt9xLPt4UH/RbqNJX0XrORlwYQQjF8Q3JJjxYG2aJlnuKS+dCeeHGhD+71zFQvjYkX+wnTZk8Lqu3oJXO6InzHB5BvYyOc3B3f3a1xtpA6SS+gwZdzI8JGHPBiMOkaNNzOBS46ljmWFdKUu24FYO4LTZC1r5/ArwpByOf+ZR2aarBg3bqhqBXdUHejb5wAaFunYyWDcMdvHe5/SYARnn2tcp+ED6cP1wc6zpf0iqMLQ0UsEdUwwxXw3czGM9kxhDUNUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwf4WhCcmuXWYQgLSaI6PED2JFVKnTwOsas7wTdJ24ed7dlXvuyi8JfDraJaGvgUftHODqBn97MyjIuphUh7GfDA=="
-        }
-      ]
-    }
-  ],
-  "Wallet connectBlock should not connect blocks more than one block ahead of the account head": [
-    {
-      "value": {
-        "version": 4,
-        "id": "52f3f178-cd61-4fb6-bec4-152614086521",
-        "name": "a",
-        "spendingKey": "c55214d79107e45db306830b34d5d2bcff54786820a5983ac32d6650f907f49f",
-        "viewKey": "bc12bfbf43fbb6931755d06e7568f1e49b46b2ef45db44f47d463e1635879aa97564c0970b1f81018303ec2550bacddbd41f4bacbc18c04f9d76eb641811efb6",
-        "incomingViewKey": "6914a8b8060ebd61f489938c8f76f5205cf2c5f462599de32b9656a237457605",
-        "outgoingViewKey": "3ce0a0bddfe06268060f00fe2baa4a5ad48cacade1cf0baca6b0df0e1d456f37",
-        "publicAddress": "d7a73845f559cfe20c840c3e944a439b3c6d89bfe93aaab4f4f6062d69a033d2",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
-        "scanningEnabled": true,
-        "proofAuthorizingKey": "690371ad8dd629b94449613b54e6715962d573b21a7e39e772167e575dc6fb09"
-      },
-      "head": {
-        "hash": {
-          "type": "Buffer",
-          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-        },
-        "sequence": 1
-      }
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "4791D7AE9F97DF100EF1558E84772D6A09B43762388283F75C6F20A32A88AA86",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:axaDsNs2wjUhByGtFxDUW+v5qC3s9gFC5h7FR2TJz0s="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:25ZW6iiZBiJjHP9FBDaXBr8tBIrPAPxAGxPhNzaAjS4="
-        },
-        "target": "9282972777491357380673661573939192202192629606981189395159182914949423",
-        "randomness": "0",
-        "timestamp": 1717538733868,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA7hY/V1iRONzfsyFwdBgejDxV9sePkuGCSkjpnB35oaqyYuahqgCazfU6XWV0Bqr4gGvpx9h81s0BbxEJlkRnaxkbKlcEFVnN9cZ0JXQvrTeUbPqT3Si2ug9zj1nx05J9WebDGK4bByqHH8zSlfCq9vM97PJxq59Y8C9a8UjM3bwX+URjOZBwCrtJXRTXEq8WPxKhK9SoMc4nX3bgJmPXUcetuiZtpTRUYR1zGJO/pSqQd9XFiiJMKdUgsUZZW7CFgjRBlwO9ek7cRFcErvwFAharpOg1J+Ty5lms2woPCO16BH9Zo6DLmn5n//fJcPJ41ol2PxtzI5XGh/Te5UJTK4HEh/+Rsiboqzg7a//cjV57yWERern6+/BaA3z+/hRDlsNcryair7Z444tfhWmhJ0ha0lKfR3o2iA3ivli+1lCDVevavXlAEZH34m/wvWGdovOBZJaneUeNFTJ86MjRSI6f6JyTlHuvhMUOcoFxhrAFgzywXuXw8zmux1tGlfv8qZxmAqe/vfC5G5BOvumzACXIl9Coepx1QyUHxt2+U63boaFUPYtrOmO86e8ia+muFlOsPXwNHvvYi2EFVfgXoOAFZrbMv1VKpgqxdc/uAvRQhhl3gLo4yUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw8t9NBU/LZZLTk0+ukiOf99gcMMwfxDuJLucKn4VfvcPCc5xmrtlUnAwACFflSpWPoQMQqCcnw+kplNwyriQUDA=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "8DA8A4399285E2876D74DC2DFF1649DEFDC0D47700229E473D0CD02308613D58",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:7ghr1z9O7JdSQ2GcoFgmk7//hVvET5sbM5VrhP6wATI="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:ImH2S0om5NQNg2+2whXnhJgHannGzW/3cNBQA3Tw0GY="
-        },
-        "target": "9255858786337818395603165512831024101510453493377417362192396248796027",
-        "randomness": "0",
-        "timestamp": 1717538735542,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 5,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAyHRH30y2J54NKCqZPpQ09/jnfDD589NExzehSdtNljq2eVCXDZISUrLOoowNfpqmIZQDWfeH1ECHE7htZ2kobY92l+TjtVZjZSAhu0I20/2CKQghklwUPP7t31s12QnGdaLnTX77arFjdCotgQJj5AvnLUiBvtDqyE07te66OR4Gd0AWeLLYAm80gu9YnD6uRUldDkW/SeWXSvwphhq8kqs4lnsJGwozluBg1kOsFNKOt43w812CaEkA9c2uoalwyqMKuFO/CzzWapQk6msw07DTXZVZw164e3km+jYn2o7ZSpRvi2Pp7wJX+6ElRmRqkXs8JswuqTiwOytkLDogSHAYnz1QkkdyC1cxo3GX2zK1oHEaBMvI/lxGiQIzLgpCuEDFmch8X+ni6FmKFU6LbSB70qZYIBkiCP0YDPHbmhkvTUMemgc5exC7MrJMUmKCWRBbYXgC+T59v1EY3MJJAQotn6ADKjZxLdUodmA/Pvj39cD1gpslGfZO/hSwWI7ObV1FlVxf8PAQBurJogTvwaVBVMgsqD8G4VyWMjlXZSIDAcnvkFSKzsJf6MB3iQ8j7J9Ea3SNIlziX5ZB+UNJICCoM6plvcwR1q013zXIWTYuDisbs7yZKklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwoCxJ8lTQSddh+aRtx8Y4MrqZSvGfGlxRFCNlYEGltlhLEGhdOr7RL3vBHTtEDxI3WVG/GxEMv+CBB0nlV+v9Bg=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 4,
-        "previousBlockHash": "1AF26A4624BDB9B504FD50692CDAC15B70DF2B6D618C555BD418B485078FB0D3",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:7JnKBObZW9pCkqZBeU56zV2LkIaz2oCnZcW4aiXoOj0="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:ZL6WUrM44Uwp3dJuMsZh6YQXWrK8F9gQnPge0yAy+qE="
-        },
-        "target": "9228823284279306817296266184515742822248210830185427859262273659833347",
-        "randomness": "0",
-        "timestamp": 1717538737319,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 6,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAvAQGidZtCdZYMY4HRsXMevvLIrm2v638Zq4wO2dAHOGonRQA6LBOD2KdoFixWAUYCRqtkjpIp/IqkuuQvJaS23ZaiPV2F3sQqRKBrQtnfXWmm559+q7TjwACA78K0+b+UFkncqOkZb5KF6eZ34aXkFBRQMvhRPzuthPnRcT5JpURxA/uLxwQcNLfTJJpZ02n2A0voCXogCHEt2Z0yi1PX2rvSso+rvFUGB1wGn3yu4SwFFclz20Gcpxme5k2oGCJo8Zow25zA69N7p3vvOxh3pf8qMkCt1cMV8HFpvV6kiYSCRNN5rt03Saf/O+yUrjdXO+8hiIJ1uOCSI/7fYkY4FVuqFz8ByNvYrJ4iW9XGXWu8yU/x7OUJAxY9TlBMIhZdWQL1s3cvNWdg0RCP08c+xVLwEr8e3aS9kxkSzHV04DzdKiTzrAHlZbspNbmCB74Ds5UgGVacmmtwCoytaTc3v/0+WePimy+ZdpC1MGAbg79PhATyHQ3DZ/agawTrRaCuRISHOJGW3lCmIKjy7CY6a82JLVy0Qlqmub6YJgMtbMkSrP7+W6yo05OKn+AGetWQ6H2ByXJDLV7rAhX18IwPf3TzksD5BTPNzFkKfDwNaX60SadZ9qbYUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwkw+TgO7gc74gv7XXhB5vi1jJ8SDnTY/wL0j8h9oP7z3XC6+6if+ob4fCr6saUqSSBMaki26UzSlLZrkhIklUAg=="
-        }
-      ]
-    }
-  ],
-  "Wallet connectBlock should update balance hash and sequence for each block": [
-    {
-      "value": {
-        "version": 4,
-        "id": "86d20122-a7aa-471d-bec7-095455465420",
-        "name": "a",
-        "spendingKey": "545fb9021b6cfadf2fd90b94c60b879e34981ecb13647b41bb831a559ba5a17d",
-        "viewKey": "184b832ca1f4c996130dbb9dc3b58219ef9fb02e19b8180886287fb165a39051b215287f945f58ff8118300fabccac109d2318c2cddccb0b2938677dce3e2e9c",
-        "incomingViewKey": "e9ecd4dd525a226e840dd9a524ee807709b1220068b1e502409fa32799ee9c04",
-        "outgoingViewKey": "31eb8cad991687c2132c3fc08be99c62296423e26d4afffcda306ca9fbe658ce",
-        "publicAddress": "dd644113f8e1fc1d324f34060696d8352e97a17edf0a3a78dd54e1d246f1a6e0",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
-        "scanningEnabled": true,
-        "proofAuthorizingKey": "a6ecfe0bcd13494281d7b3c00288ce5c6141d3948cc0c888bec52ac3d187c50c"
-      },
-      "head": {
-        "hash": {
-          "type": "Buffer",
-          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-        },
-        "sequence": 1
-      }
-    },
-    {
-      "value": {
-        "version": 4,
-        "id": "2675479b-fba2-476c-8293-696a1076290d",
-        "name": "b",
-        "spendingKey": "357f8ed6d40908876618b6c9a88c21da09f8ee02da5b78bc30a49f0eb3041b16",
-        "viewKey": "0eb7686fe87898e2f3fe20e62e318e46d80d21e22e313ef83d0d760c7d8d4dd23774ddce0610f05d66584a7ac28bb8df1080c9f4a6eb47a75d7d2d8fd3e02841",
-        "incomingViewKey": "768e419a67825b80983a529df92f94e16db370f6a78965959c6c7cdef0471101",
-        "outgoingViewKey": "3835258a93bbc9f8273c4b67d74f47a3b70a6200b1be82f2ef61d97ab09a492f",
-        "publicAddress": "340d2b8c66eaefd69d9ed97d9e047903e9693f6223ac370da7f3ba3c87b7cfa9",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
-        "scanningEnabled": true,
-        "proofAuthorizingKey": "f942c2ba94cf975969ab70c6d62a2ef0bb097a75c09bba385ae2beed16fdee08"
-      },
-      "head": {
-        "hash": {
-          "type": "Buffer",
-          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-        },
-        "sequence": 1
-      }
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "4791D7AE9F97DF100EF1558E84772D6A09B43762388283F75C6F20A32A88AA86",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:0cTKMW7m5/wqFGYfjkZddvkDcuZpR+4iTi7G0v4Ogk0="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:HK9zcLEUrSzUEd+9ClvZUbo/Yd2PBb0ir18/7NUx6Fg="
-        },
-        "target": "9282972777491357380673661573939192202192629606981189395159182914949423",
-        "randomness": "0",
-        "timestamp": 1717538741136,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAADxmLDI56+zX4HxzL/zq0JsCDhvaW/2vXU9L/XpDXXjylyp/BSzy5keWndulO4sLs6ESN2e+fCHch7yZeNJbm8Y7y3o413m+M5CtZxstVbiqV6DBEqPBElk0UflMYOqIH9GPnk7kohtOJG+PFo/TKQG9AocBa3NmBEM5pItzuad0SofmETSmpXbck3eO6cI1VD7xP3pxEfVUPxMvouxcY16z9jQ2mRttVgN5+AtwBPCSM9BI+aOcMthwLDBrkQ/LFzQ9RSrE3+0sizjvpv2xhuHeyyzNktl0V2bMm/BXkEdPVsMvrIzzgNN/WibMzeh7ehkgpgxbiImz55NJ3JqCRlyqkcJ3bz4qZ6uSlKlD+3Hbrlt3Dwuee39JN1bUqWtw8cIjXEzmXFLftwvuS6mlTDEqxUBGuhiiHw6+9aB5wv/O6vbxb/10oXsOXZCzgpFkPRlzKG1MPcgZehOkaBhteQU9TATcvz0aPQCDXsxVxjb8JmsrdllvjE1JhRGPyQXAdetHmVxdnmBBe4oG5RY80G2wu3qY3q9lXX2joYreTG9MHmcW8n+0ZfrvQZyD/eoi3Z6qskROAnOT6O3OeBdxk5lDkIRMJ756JDNPW2/3vGOV1gYcz3j10qklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwvXrjqeHuZLgAvok01nDw5J5WtniafAoXKYkSeB97T+pRy9GdT+WuhWx3JxWSCz3J9XQhB7x5lcObKi1YZWZ6Bg=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "6BE851616D0334EBA8E769E8192773A6DF7C8551898346777328FFC18D57939F",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:u3Qbqt8zygeR+feBF4gGS8gXTR4Xkgqe78RTy+XMSyI="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:LRCNWMKthGRqlN2eVdXY6fLgJBlgkoxVdUGuItT/KkI="
-        },
-        "target": "9255858786337818395603165512831024101510453493377417362192396248796027",
-        "randomness": "0",
-        "timestamp": 1717538743079,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 5,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAATN9filqyLp5g9XIJpl3DxoP4ZGraolOjtp/cdFFVLuOkChjTArrCoZqNawle3yTcREJd8NSP7CNUDbwGSkv75RTaCghb+eyrtsGisUNvq5qO9+gC0xkxjUBwKw19rvNE8Flg+A8kxakNX/2z/hrV7WYUJVwG8w4qVKqHwQrFb8wOYd8jxYUIy5y17kspRFtXwj9l+SsOFnJ4JrwQRb090xvvnX1ZaqcmsznOpcyS5I+ZNyjcEDRYTrVWxn8ogjLZjBS389JR4QzuLZfskOfdvBEotsf0pAZ6tyvobgv2j4l/V7wqIoNNFpJJyOgDqZ7XfvC8f+ysnHIXKwdFNfRwIPhp68mWQs5AbQHCA0uQw7CwmNPLu9zuWS/k4IPmw0w6XU6JF/vd4vR/mW2mxiF9O7EYGPxozFVsVRYaA3FkfdjO9YUsEFtQX8cgXVt9YZI04W0GOijnIHAmKSTEhF6A0V0Ac5WY6Lu0+1Zi/rwe6VzC8Cll5JcMLiOn11Yp96+hW7qblCsudQTqFtCoksGjwM45qr/ocXGWgj3EULm4WtaGb29eCrIkLL8FCsJ2a5qX5xOEmMnCa1Xpl0toZHQolLn6Xtio3xqIPy4NEB8QOmZhc70mn/Y1rUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwiW/fMXUvHCO+tq9O6wnCS6d5tTUb4Qc6A9a+yRL0JNvW86uum2qpC0uumbMBBYXidl+cRNKaLHyacJzazFprCA=="
-        }
-      ]
-    }
-  ],
-  "Wallet connectBlock should update balance hash and sequence for each asset in each block": [
-    {
-      "value": {
-        "version": 4,
-        "id": "91ff6e55-1ce3-45e6-986b-2a49f2fbc040",
-        "name": "a",
-        "spendingKey": "ef064203b33bed503b7ead158644ebbb9f4be9d997196823c4e12dbc28ee40d1",
-        "viewKey": "36c3f9ea6678efc017148e12ae4790dbea760d2a684ad4c564bafb36962469cd33cc899fc64b80e985bae058e09006fd38711fc31c3c988e109c10c5424e0536",
-        "incomingViewKey": "51b77328b548d6476845925043b2b68979db966a80045974ab1faff3eabc6b04",
-        "outgoingViewKey": "82631567836d529fed8d550459aeb2d0fd89b09a6b197da028b3e730edff61d1",
-        "publicAddress": "0c0e73741390118a4965ef6590ff7f76e88355b6c514619e6334733c19ca1bc3",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
-        "scanningEnabled": true,
-        "proofAuthorizingKey": "846fc1e615e263752c522a1847bc2300a7c83bffd013d792d8bdea4b6c354e02"
-      },
-      "head": {
-        "hash": {
-          "type": "Buffer",
-          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-        },
-        "sequence": 1
-      }
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "4791D7AE9F97DF100EF1558E84772D6A09B43762388283F75C6F20A32A88AA86",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:kqsHopOnj8uetmgQSSpqWl7NwU2AGGVQhwE+LT3bHC4="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:v30AX7dy356AAhKJ5ZNKRzrToMjb8jmWDZD4OoLulo4="
-        },
-        "target": "9282972777491357380673661573939192202192629606981189395159182914949423",
-        "randomness": "0",
-        "timestamp": 1717538749069,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAiocrxO+A0IiTliX0oV9UQcwHLKLYpdD7cJ0j2V8cdu+pnbIjDrqLdRgHN5NMOd1WLm8aG7Acv2IYX+WFCNuNC/vhnaRs5ogA5eOkkj4KRruPQtbiqoiBrwZhb28f27a+nCDCCSZBNVatKjnwYgfLLMj/HVnmGpMkIZv9a8o/BioA9cKQJjlRIq4RNreEetCSe1pCJJFlGGELr5HX7dEfopLhQU5x+afaOeq9A5etQd2EKShXQUlFmkk2+cLR40tIQQ2Op/yjRSIITmkWElVA/ce/x5i77DP6yp5k0e0lsEoHjE6ApI8dKS1A4L5+HFMNmfM6qOeSn2qSnSM9VoBGYijYDHxtNOKLJjkaCOYT8ttYwGN8wLQdm15w1C0MhWAEEi6INZq/8bUi65WvnLij6a/D62OEugmwLwXOC0EZ3cg/HIyl06L/ApuvYAzNnfCJ9Nwi1e8lf/mD2sx22X3N/QrzJ5Ff+pUTpUpb+uOnMhSLTZHq+pdWHTkRFt0sViHPCZVc+QOGfhbFhBX8HEntLEkrk0fn4Istg03/i6fwNnFRkXqmu1HBCzfplBdVCsmB8t4dZUiwW8wXSaIc9Syi3UoaMmQb1WMVfy50Ub8ci7usL3C8AJCszElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwShYcru/Bp+PpurbV4diRas83fjyjaiCN972Mm1BfxAzb6EDYy9T1Kv7qidI1hKYfqMHKJ5ga1/tyBOadOt77DA=="
-        }
-      ]
-    },
-    {
-      "type": "Buffer",
-      "data": "base64:AQAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAmnpeUzQ9D4Qb93JM92qkiCn9l3rluRUHW+juo0JZ2NeQ3UNTNjaHpGKVuB1l7fJuNkO1I6LAbAPXohfQqu9RonksgRP3hsqUoMsOTAiQtU6T+UHDrSfXpmB6puUasi0/assXd6nPOwXoUAca2hBsmEPOdZzVfl69Ln8qx9RZDWUMZLfumFNYZiKE3SDENAH44SzcdTFuBQ+aKG/xebUNvbevPfGMlZj+S9yPUx7ydvWgYr3BXIxG01i3X2XKdZpmZBPB03WvFfpe9giixiIRqdCM0qqmJHGCUXXvYlhMqklDkP1nC4wZE6oTznUiubQ1AJUt4tyHxWTOAOaZymJEotHcDarpMSsWhUAMQIHvtQPIL1O//8HwUc9uPjSDUvQxJuwQlvJ4Eu828VyV4QGieitDLs9QANVNxlatupM2SkQIThRGPfwKuTKS7MOFxRSypaLfJ5ZcrLVXao1topQTN4LTpiWLIsHKZVDzAVGUzlhYhBSf42/M+6B5m1xVD+rbjesbslzGYAqJDkkubuGq9B+fFM51VsZL3yuXCqH67IaQ20wcE9YpBWg3HDIQcXtprWKORJ2z863b0msW45yPfg+3i5mgM6GXxPiUkHX2FLF64Si03JE/f3iR4xJNl8dIL0RNl+6uOETHlxF5N+2cjqMjmuGaDlSABoK/MUKxb4rYr76ieK43LqirPB5+QP+QoEKaD71zcgH/+qe+JJq7oPb40Nxo8oKOrSN07fAFFKhE2m1XJNzyUwJEt+xrrokklCee55uymo2jsavy9ZBDVdZbeZ84PNUSsVdFLTGfXczCpVT8ZkFC16SmYjtMmtzcscwyOFp195G0/4AT2iu2K9/PPjvhNNG5ElzSUnfBL8Kv0CUuNfGaFgjM+JhBra5sCbdwVj43wip7rETwNpcxkO3gDNK5Lh7vuFKDi01uQmxJfZ2LAiKZpO3ZaT7JlgbuN4n36zQzheA4c/JYBHhYAeXoqWQOCMzhDA5zdBOQEYpJZe9lkP9/duiDVbbFFGGeYzRzPBnKG8NmYWtlYXNzZXQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAG1ldGFkYXRhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMKAAAAAAAAAENTfUHSs0oLIBLGCs8WT8AV5UUGKbuGC1+GMHbOT7KSAwe1ogeoI0RhsIsT4xTKfW6OKGZs4bsBabdHtcVL6wnzvKeMQOTpIxXZpT2MsszJJDiie1hFKsN1cPvRCsxmRYJteu+w22+DLETWfxHAvWg1qjUslhpSnoNpd8Q3dfoE"
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "08E60EA96751B6C263CB3EDE91557A5A522F4DAB0D6C5BAC27381076686A134D",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:WR4JLjZ2xt2Ol8DHhGLXMuMzfxucA8TqN93MDlofpF4="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:SjDmHRvql99ZZ4ZQwyetDTfIxxWEqNehAnuOHYJv4RY="
-        },
-        "target": "9255858786337818395603165512831024101510453493377417362192396248796027",
-        "randomness": "0",
-        "timestamp": 1717538753111,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 6,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAxN0S+vesKhTrnUKkw5yBuZtFaPwSQ79HlGuEcpcKBrq3Sx4FOedDWBV+xzWO4cOi/BePz9o50Jw7Xw9scSpxhIVPXAfan86ApZvfEe4sY9ul43jAvStK8/7YXWa5N9shmdPxUai0rns2IZW35C8jFzabCHBiQkYJTszXtxJl308L2s7m35qmjgYGyGKbUhxoFeC9kPDeL7hLgK9Kx0U801ALpnseFPCMUoYWqjmg8iiO1m+dSdDsteothPM88en15C/C/wPTTCjBcIoy6r8oXqKEC9R/b8bUL/0nLUf9ZFMqNMOCuw7TQTOg13IjwOf9hFWd7mSmT24wInNKlKm+7rHh/oDYlMsemdyfTwBa0hvdFM0GMEPDsMUe548SRUdVoIIhkvO3FJyXd1RScokm6CW8U6mGKnyZX4GWXrLAqNe/Gvw8kBQRi/v33a5IN8ygR9xv2XshNGMW1OBAcUQxBeSjP+LCXLlqOUIXSDY9ySxF92cz15Uwjru0OPzGMmbJrhASy3kiQXk42acrZ2A4Iid9tLYreOGbImSW7ZDzhCcZwCDarc5PYpSGB59RuhbYoENnPHqyGa1ICLoyu9W3yD2pEvNTpkeaHRLE7TOg1Rlt7XVj5u2RMElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwn0pwjy7MY850X+mWqQHdF8hfP/NJc9JZD5O3DYZMlTPyVIlxKM2Uk6FvARR55xSl0l4OlvEQFVRwRq1kd4zfBg=="
-        },
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAmnpeUzQ9D4Qb93JM92qkiCn9l3rluRUHW+juo0JZ2NeQ3UNTNjaHpGKVuB1l7fJuNkO1I6LAbAPXohfQqu9RonksgRP3hsqUoMsOTAiQtU6T+UHDrSfXpmB6puUasi0/assXd6nPOwXoUAca2hBsmEPOdZzVfl69Ln8qx9RZDWUMZLfumFNYZiKE3SDENAH44SzcdTFuBQ+aKG/xebUNvbevPfGMlZj+S9yPUx7ydvWgYr3BXIxG01i3X2XKdZpmZBPB03WvFfpe9giixiIRqdCM0qqmJHGCUXXvYlhMqklDkP1nC4wZE6oTznUiubQ1AJUt4tyHxWTOAOaZymJEotHcDarpMSsWhUAMQIHvtQPIL1O//8HwUc9uPjSDUvQxJuwQlvJ4Eu828VyV4QGieitDLs9QANVNxlatupM2SkQIThRGPfwKuTKS7MOFxRSypaLfJ5ZcrLVXao1topQTN4LTpiWLIsHKZVDzAVGUzlhYhBSf42/M+6B5m1xVD+rbjesbslzGYAqJDkkubuGq9B+fFM51VsZL3yuXCqH67IaQ20wcE9YpBWg3HDIQcXtprWKORJ2z863b0msW45yPfg+3i5mgM6GXxPiUkHX2FLF64Si03JE/f3iR4xJNl8dIL0RNl+6uOETHlxF5N+2cjqMjmuGaDlSABoK/MUKxb4rYr76ieK43LqirPB5+QP+QoEKaD71zcgH/+qe+JJq7oPb40Nxo8oKOrSN07fAFFKhE2m1XJNzyUwJEt+xrrokklCee55uymo2jsavy9ZBDVdZbeZ84PNUSsVdFLTGfXczCpVT8ZkFC16SmYjtMmtzcscwyOFp195G0/4AT2iu2K9/PPjvhNNG5ElzSUnfBL8Kv0CUuNfGaFgjM+JhBra5sCbdwVj43wip7rETwNpcxkO3gDNK5Lh7vuFKDi01uQmxJfZ2LAiKZpO3ZaT7JlgbuN4n36zQzheA4c/JYBHhYAeXoqWQOCMzhDA5zdBOQEYpJZe9lkP9/duiDVbbFFGGeYzRzPBnKG8NmYWtlYXNzZXQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAG1ldGFkYXRhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMKAAAAAAAAAENTfUHSs0oLIBLGCs8WT8AV5UUGKbuGC1+GMHbOT7KSAwe1ogeoI0RhsIsT4xTKfW6OKGZs4bsBabdHtcVL6wnzvKeMQOTpIxXZpT2MsszJJDiie1hFKsN1cPvRCsxmRYJteu+w22+DLETWfxHAvWg1qjUslhpSnoNpd8Q3dfoE"
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 4,
-        "previousBlockHash": "2B9E5B414C7E314AAE120E9F60A334F7056B18B2D4FEF4137F64D0A5AC5E252B",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:WsrCaDVLDY2un9xJ8QN49kaSqPBFU++DXpSooG9lnU8="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:XvzBdub5bJaan40A/CIfy59FeALOAwFbz76dRrlOMAw="
-        },
-        "target": "9228823284279306817296266184515742822248210830185427859262273659833347",
-        "randomness": "0",
-        "timestamp": 1717538754915,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 7,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAC2aq80g2qa6cp5aZ55Mqdjrj7mLP1F8VzVsJLmAODJWt5mz5Oit0CHDAtnG+xkEOrI9R6SbSE8s9oAeR07XimlMvjaQWUGllv6SfuzUQ2uSDbDZkFf+AqcIG71ku4Whp+lOmTqS0xlBoKCSSM5qnuEwuKFd5T+yXDkRKSuv6Ad8CgOM7s8tqm4skjb64EX/pLc6BbnaNUfkRUMQOWSEPxHFeT8MMtHnW5BBV4bYi9VyhkQTi80GWRS3547uI9iVnIKJBil0rEzKW/UpwsefxRtGUhkuuvilhM5hohdiWzu8OO3aSiXbkNRdJQa0Bf1w7jlXE2h3TAJa2tWLGVtWq1cseSezAAB1SHOnkWrDTC5nLWYJR6LSGw+b8KcOasMJswKMimw3KtTWwEQbgNLARZSAe6ZZEntbRfTq3Cuh/5BOvE+IixruzDz6zmAdTL130eQEDobiEi63NLiCcIkvrktYLUKsugJKxYQvtF4CjyVKoU06uitmBjwH3D8uS9WzVGATqEDfjBPDHuA/cE8be/Ue7xz6djoBBsGec9vHn2Q9yF5qXwmh4iDYdRrJlAbk4wlFjqt52D44irz3Xm+omEnb/8KZItcgIkDPYd+TFUVsIRz3/YTjrsklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwWbJzidWm4ZMmT3fo0cM8iGsjUl/GSUQFZSqFwv8Qo4JrEygtm8WPEaUnz1w83wikE2n9JGZedCZROQhUU5QxCw=="
-        }
-      ]
-    }
-  ],
-  "Wallet connectBlock should save assets from the chain the account does not own": [
-    {
-      "value": {
-        "version": 4,
-        "id": "915b4fcc-0b83-4003-abc3-b3ac8d2b3eb6",
-        "name": "a",
-        "spendingKey": "8d8da90ec36069f7ec0c039f02d5b175b15cca476f4247a3e3cfeee4a9120cbe",
-        "viewKey": "a871dada21ed96d1afd20e52752e46aea17bceeb0a86cb52da60f91ff410670e93851c697cb989036d95086b01a4d2e3cd799929e3e0594c6bd0d65bc937c605",
-        "incomingViewKey": "1ba43b83564d50c2d89c0380d692cb0c9605d8dd28622c9b9dfac26efaa4fa02",
-        "outgoingViewKey": "61893a6f08648028a4bff39a7586a70082bab7dcabe6fb0597068dd1c2089af3",
-        "publicAddress": "9d042d3a4438807b1225f6e9883c6af634460304362b1e1d1d11a985b47f0823",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
-        "scanningEnabled": true,
-        "proofAuthorizingKey": "7b5f73a54f417ff870e556af7c73696488dc3c7515256ad261bcb7389d73520e"
-      },
-      "head": {
-        "hash": {
-          "type": "Buffer",
-          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-        },
-        "sequence": 1
-      }
-    },
-    {
-      "value": {
-        "version": 4,
-        "id": "2bae3447-51c0-4701-9b4f-7fa8ea787216",
-        "name": "b",
-        "spendingKey": "cb8cf2b9ff149f3d4dc4ff7cb60493ea5c77c5fd095c169aa6dbea0a58a241bf",
-        "viewKey": "2fce17e766907f9b8baf3654be6578c0f8972156e4f3f0ecf22351df54f7fa9b009ba948524e55030ab53f269fa58ca21f5b673d8583a432e88e8556e01268da",
-        "incomingViewKey": "3cc5ae32de87f1f557533e5a7c6c92fea4822b30b314e0c4e7ea4fd4488ac802",
-        "outgoingViewKey": "2170357e32352fcc6eafd2fb4b0659dba71d142a6038b157925f1ebf66577582",
-        "publicAddress": "ce2bb4c55cbec067fc8ba9d94f780b3def2ba2cef6c0a612c8d88ca3741c4c85",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
-        "scanningEnabled": true,
-        "proofAuthorizingKey": "9c3e2cbf70b994d5b3dd251a21630a7e03be438afc52a076361c9c7563c1e508"
-      },
-      "head": {
-        "hash": {
-          "type": "Buffer",
-          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-        },
-        "sequence": 1
-      }
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "4791D7AE9F97DF100EF1558E84772D6A09B43762388283F75C6F20A32A88AA86",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:+FjNmRVawduRQiIigLK1xtwcf1a9CzZfmlf8Y/1Sa2E="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:G9DvNe65URf7a4GSV5NBWdgmRxK/6ROQDLJiErMD4yE="
-        },
-        "target": "9282972777491357380673661573939192202192629606981189395159182914949423",
-        "randomness": "0",
-        "timestamp": 1717538757782,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAABeV3VFs52DJ0tY4f1l8opWZ1VM8zlob1V2AJLaLzdRSES8ckskGQinDg0u+gLpy76K7FNTN1K669jCazuq6D4qXnpAUrahVNcpX/kw6ZUIC337uyFvN3YRaTRsAGTolWkvUlpH/xCBpDK/xCfYOkK21VyzYzmXir7hmHDzaHJZABr4Y5/F3GRt6OHP+N2Io24A2O9MXIftZujrzEtM8dK63ftB28M9J6tkHXILIDiweIu12uYwQwHZhq5xXdeW5+uf/vzYLlF7Cg4gllFD578Kgo8m0CcnzPxzKdRhvuAXFhbeo8hSPqA7Tn/tsUlGCVzF3b/Qs7H82SSPN6byjeuzpVZN7DE9mgXOHPCg/dyDWlph0mKTTglBzXwzGLohI7xNASUv1w/AR+q013pJii1bsN1mXoFrhz80Pg+MW4wK06CVIkThpjxgLP9jgswDBxW35XTroUWsxfeC7eiRuOkEF0N+OqGBO0DtL3cMyphUdjGOGIyPZgJ6XouwEExO1qfuThd49e2y7N3rn6k/89MfX9in7l3QdGhPM9XNhbL7kojUlEaTLtphdGr9NJ3l5Yi8m09YbOytJrHVIIt9MCoYbLMQWs2i4E4HKe/TtGFmkT3CZY23nYKUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAww1HQ2VV0XSjCszDQaDH12BdxxjbHz7AfRBt74JPXRes4UK1lVO1stYLA0P4RRIpfYhOjj/O6AB9IYQ6EsZZoBQ=="
-        }
-      ]
-    },
-    {
-      "type": "Buffer",
-      "data": "base64:AQAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA3cYsnSm2iYH1hnUiD7hsi+7qbQlyaJFE5X/2zSk5QqOIXnh0YsRzzfOFj6m8rZ5e6DXEjDb6UhzWSy53Gi5CFPjA5NIM8SSINFRMe99OzxeR3stc3bUXrzvarT6nMlUecLBjAMgIHGoWjqROXGLCepMQykWodbyWcY7U1dfXXfQXjfH7yBM9ggeho9fe5gHzmXlgfwnZVZxiM5lAYaljv+mM55tJdM7qzusY3JoU2QWPwwj1GEhdYpgT1IY92vp8yo5MP5fMxMY14fqI4zSoUlKclCcyrREiA2v9iJoLyvbM1RX84lb9XhbswJKwYPmepMYZlMs9vgvWJD/e1flmS71ktW3wXawnJKd+u/BivI4q7reCBhYI/wPpGOJRzI4gRIKT/H78BMjyqPKpoDMD1zvLOvoyKJ0jaTktbe76P+NJOA8MeB7PRXS4JPG2HdxqPbzF17GX5OaC+brazhjSlOq03OdRsPU7lIGGEPvkv6ODhCr1fNB1bqW3I1OT98u0Hcyii1apTA35n+54FND8FwIitKZqsKlWMNFlvQr28e68RG2+loAVpeDwdDKc4wSuZJ3tK5op1zxvlBny37Yv4DuwgkFoCBXlFMIa0BboBFripEx/mJ3hZV5/hLiVIgsg3dpkbLUIQXnmQPs2t9bD6he0Io9OuVTTprxKgz1GKh6e8PbtRZU0F69ooORb7X9PasXEitA1MbQV0vXm5kZdzShwh8+NixMcmc5I+gp4Hvj9hQlFkwnYpXrGyTVQNSfdKd/UxZHOK04Couo7G6iUKcUy480r/JifjTJbodotn9e+yTMarnt25i1K2xz4KXMnxxuJwpFTl2BD7Nt9/+quCx6144XsPkvnDpAkg/SBwtjBDa+0K/P8JyDU9nIZ3Ajh+tyEtI7Z8GtXdLl3M0cuyAifI5T3edDCkg12x/AwpGskL5W/gWoAKCvpKr1/uE5fCJpBNODuBVajrCApD6cEyByhELXbiRbenQQtOkQ4gHsSJfbpiDxq9jRGAwQ2Kx4dHRGphbR/CCNmYWtlYXNzZXQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAG1ldGFkYXRhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEKAAAAAAAAAEJ97Ic0jZXLSfwvPOD1i3qjdFAtexdxqms30odGo/lCPzwYZqco9QuayCmfeUYitQBcmx/TGhzJjRoL+JxdDgAGsyBnEpxTaQHSaxaT5dSJ5OwadNp7m3mPHcqFyQGIp155DeXcil0EpssKY0sg3M78Rr+tgbINqkuERA3Nw30L"
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "CC0B49C422C9E3044EF1A99DE6E31BADF542F6C7CF7582440C83487E33A24E25",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:45AjYssDI98rufnehnLNvEqTEDRyXVQuo/AgZ3YdIDA="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:muBBl+5id6qsKh2H35/dXNCY8LmlB56ioE1KHFJw6UM="
-        },
-        "target": "9260366780148527510972123832573278885902566341756516011968728852484845",
-        "randomness": "0",
-        "timestamp": 1717538763488,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 6,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAECBGMoUQuumHxBwbg6at0a4IWqJiFWHnLFQDKpC0OiSwVSczR1LhnKCJrHY4BS0qZvLP11LkWp2HrGr2TLal98idMdbrHsE8QMrnFLsjnXm57tOqktkpVZ7/zOsnqBi0xjsucFV3q9227+ynFBNU6XhS/ooh5zfBxPw61XEVQ3wHvJMbqRcTkkTzPEUPycpKYFTfwPmTUpLe83QhGOyHzCU2eb8GIQSmZj+ectegooaL1uyfmxEgm8B2i3a84n55AXn40S5UFdk/c5foAhYNus1GSAyWUIVSxJjK/HMSR8k5M1GaYTZwMyPj20TpKHXxOYjl0IJGHN1vKiKS64FXa43PihmoTA6q+5iAj4P/C3xWPcg/M7nQrsDCn/oFFHE0EHc+I5JMMVjf7mTqgdKWhNtv/EQm9u84KotEQ8Hdy4r7Bx5CtnwroSd85uExgoLF+BQ5vd0CBtRJyPJPy55LGs0OnFnadblffQ6UF6dyoFnJfiB8/eMMjIklqXHQJ9HOi9XHj5JXK+eGfd5GCg/bQBKNej/dop/ANHFPFphoVA4VqlgNyzjWEtR6vmyhP1q38ejAD822XegqoObHd5bf4cHyGMd6ZQvdko4gdUaTqc4GLoZv+ByNW0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwf4yI/wEIEr0qB0smpSnB/pKPPCdgG04kcHbsCGqPBJerkXjeL6WXtqFZsXgYrzwGGHhg5jmcO0ZghgrStfC1Ag=="
-        },
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA3cYsnSm2iYH1hnUiD7hsi+7qbQlyaJFE5X/2zSk5QqOIXnh0YsRzzfOFj6m8rZ5e6DXEjDb6UhzWSy53Gi5CFPjA5NIM8SSINFRMe99OzxeR3stc3bUXrzvarT6nMlUecLBjAMgIHGoWjqROXGLCepMQykWodbyWcY7U1dfXXfQXjfH7yBM9ggeho9fe5gHzmXlgfwnZVZxiM5lAYaljv+mM55tJdM7qzusY3JoU2QWPwwj1GEhdYpgT1IY92vp8yo5MP5fMxMY14fqI4zSoUlKclCcyrREiA2v9iJoLyvbM1RX84lb9XhbswJKwYPmepMYZlMs9vgvWJD/e1flmS71ktW3wXawnJKd+u/BivI4q7reCBhYI/wPpGOJRzI4gRIKT/H78BMjyqPKpoDMD1zvLOvoyKJ0jaTktbe76P+NJOA8MeB7PRXS4JPG2HdxqPbzF17GX5OaC+brazhjSlOq03OdRsPU7lIGGEPvkv6ODhCr1fNB1bqW3I1OT98u0Hcyii1apTA35n+54FND8FwIitKZqsKlWMNFlvQr28e68RG2+loAVpeDwdDKc4wSuZJ3tK5op1zxvlBny37Yv4DuwgkFoCBXlFMIa0BboBFripEx/mJ3hZV5/hLiVIgsg3dpkbLUIQXnmQPs2t9bD6he0Io9OuVTTprxKgz1GKh6e8PbtRZU0F69ooORb7X9PasXEitA1MbQV0vXm5kZdzShwh8+NixMcmc5I+gp4Hvj9hQlFkwnYpXrGyTVQNSfdKd/UxZHOK04Couo7G6iUKcUy480r/JifjTJbodotn9e+yTMarnt25i1K2xz4KXMnxxuJwpFTl2BD7Nt9/+quCx6144XsPkvnDpAkg/SBwtjBDa+0K/P8JyDU9nIZ3Ajh+tyEtI7Z8GtXdLl3M0cuyAifI5T3edDCkg12x/AwpGskL5W/gWoAKCvpKr1/uE5fCJpBNODuBVajrCApD6cEyByhELXbiRbenQQtOkQ4gHsSJfbpiDxq9jRGAwQ2Kx4dHRGphbR/CCNmYWtlYXNzZXQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAG1ldGFkYXRhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEKAAAAAAAAAEJ97Ic0jZXLSfwvPOD1i3qjdFAtexdxqms30odGo/lCPzwYZqco9QuayCmfeUYitQBcmx/TGhzJjRoL+JxdDgAGsyBnEpxTaQHSaxaT5dSJ5OwadNp7m3mPHcqFyQGIp155DeXcil0EpssKY0sg3M78Rr+tgbINqkuERA3Nw30L"
-        }
-      ]
-    },
-    {
-      "type": "Buffer",
-      "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAedLOklrBrXa6G/YBss5RRGHYAagMULHeqHtvM5xKrcyKoPph5eUMx51wYSH6UVqR/LmnHb93wCq8sdGE/3jManN0c+QbWoqcUWkoQdEFePCqybcpaKPjIPZlpoFp+iF1XCvmpxuZmFPjjhm0SRY+542gF85cp/agktDzn/yYGxAK6UV++wbBD8L2e5HViAtp6PgKRyhIN6RIvnBetatKFSCU/jGF1kTPOq90P/FAjQyTmdIzINRtAVJo6H9dm70F505fz8S2xzVWAvUu96/DT0MvUgLqA3IGQibWhNoMTSVHrQoSoxa8RoeZnsi4gsdN760TelMZWF+RrtTFPCfdh+OQI2LLAyPfK7n53oZyzbxKkxA0cl1ULqPwIGd2HSAwBgAAAEg2kYlX/ZNXTP0u+iLXVPS+2O/wVJTnCi0ynjwzJBGnkAq1IiVp2iLlOPJCo49wYHN8nto33NsOw1p+wwzY85pf0cQAWblkYceajHoNH0r+XTs6UQFSpD0GYI8GyTaIC68i1AHqpJDrPDRcn8gEpdPjVsW6zZcHQHRYWuv7cr182T49zYI/VC5+0de+iAuHZ4O0Q7lJ8eoId7Wu45O1qhxSe8Q9PGZZi6X4AqXRAQNb645/gLCaWq0ctCLOA2DcnQDfuIUZJP+gDM5GP0AUKfxy5ixtcLQs47GRyhBh0LULNOxtE3u2YXBiJ48ec1E4oq8jpNnX0u9AuQYaiEjOpcc+mPb9XsWzZ+5azJj/esJIrdMhCuTRoaMEPBPmQolbx1H2nNrv2DGbjDJBSmJz8UhKopiiUxVNY1UXqtOMgkWkF+Wknb9bDjQDzIX01xMm4J4eepOWjC14b5X6zAUjvyKYtr4h5m8+yWKMyNRt6mkMYdMTbAkBxIpODgltGP8JLN062AneB5YSWCfhzMdFCccx1a9HGHs7t2F1SeV4pYWBfAi4d/9NghUg94AWuqQrInqSf/TBi4FhK8x2eFwt3JThDcnAjRe4SG0Ny5kwxh+gI22Chc7V6IJuIROUfUQooYW6ZX7JlvzaWrbXWg06MW00I771JrOCn7m2P3PgSnRgmWw3bivugFzpKul1WxQd+TD6pvM22fWZ2BW7Q9qR+B+u5UqEf7cka/xfBiGJKKcGxO+mpsXRsfCeOBKt/8b0VUcrlIxsW9rDu8RRSMxyySVu2Kl50I2HPIW6/IfhZTvJqtxX27K34FGKc1vZRnthIqsAz1Jb3CPRnAUob66rUG+a4A6DpzjbJEZytisee7T7GMJgS3pkbFW0PRngpwa1JlT2oTeVeIo4Ca55ETq5OfQOw+y0ot7qGImKI4piQpspEp326oAFDDUKMhmjoD0SHJBmElcxulL8eanyY55ETuQDbh2HLNZX8neX626gk+WDwmZdYHumJXmMhsktULqdPzdtxOySq9fNd9T3rk1TjOtt0xNNMcJcPXURob7Egfj7NUqyPbl4oENOvEvMMFxFEJiiF01seT9nfGdiGw/veypRxR9/Whhi2fWcr623r2OuesvZaE2hmuxn8taSK/Zap5+NFo0wUncQawtSDjs3NsEl/AjPZcpuebAv8ERg09AGKstVhzkv4dY54jh4CmvzINdRbW44nRKASLA3wPeUFdttULbYyx3Nd0AGQaI+SizXW5F6oC6+dlv5x3Z/0ebiIpM6sqB/xgj3ngpas4JMzBU4Sg21RxHEdTmkgpwSAuwWDpaKXHWz7k9WZf3kxpcWaeYM9EVE7/i++f4ovASpO7oJu0cW2cJLXv8TaLPF54O6LeYTpLCPdWMU39XFJvtfQq5S6jSwW0iop6aqU5KU8BSsHoC+xWp/fHyw6ZtE6i8O1MBgQPixd544qZgP2VkxMNkuG9gRHSNWmTi81+D6Mp+hEXd2zI+vMco6Suz/L/OOdg/VhuRw9HgQTs+K/uGaafP1n2LdxB/N1yM1a9hZHBEMKMbgFOkLGz3wRy6g6KIw7cOFgMr89Bk/22f3nYKLAw=="
-    },
-    {
-      "header": {
-        "sequence": 4,
-        "previousBlockHash": "E76F7B810F96BC5B5285D71ED22892BB7C6F01E5105E7EED220B185CFE8DBD13",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:A11I7xz+8WUxjQjMmcQrBIFT9qdoltoulQ03aeIxzBA="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:N4Ld7N8M+ia5EWn5aE8HKCiYw6ZoKAFxgzgy/lEQ7wA="
-        },
-        "target": "9237815341750015092140817300043113376661752366206318446334046747329935",
-        "randomness": "0",
-        "timestamp": 1717538773587,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 9,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA05iQ60xabSSeTHFqbr84VYSNtfkbOd8+2i6CES3R+qO03Rf5BQg61ZNqnjjlReA0rV2LTBLVtldjXjd6cUPvzu5m3qKYc9u6/i+lhv2hmluw57qhpGEHEYLH2vL/tI8xlodYWrAemdWMgfJZ1TB4KjLyUlZjjymYBROlv8jNh+EGSdBlTa7m0ZS260gPui9aeQhQV6bFluPSU/4cfHVHQjFUm02pkSSGG/DfMlHoQSyAIO26NYqegK1CtVfD+iItQgZnV+5bD7J/Lk/U/bdxwuX3g0St7hqD3SRYfy03nZ3xu7LZLkCROer+UOZUrVR+tyh4e0vGZurmTuG3twY98Qv7AwqUn58jBkx7MyvjLQHOmCdqoSA8g0eR+zA6ffpGuIVmAouqfgVP8ARz7HJsOp+VbjB9famOZ9Mdze1qqWkWDn/tTAX8S87gMCpnr43bQGZCMU91bqS7fT01vZjSGgbpnJM75h9Pl8ayDp5nfwLjV6VMeNqo3dcY2GK946Thd//iqA8dNo7x/xTJogmG8nyrhRbO0pEvAZcxopuaBMmEye44Le7yCZiAuC+ApSvc9mplNs782iQUaFdZ/Suv3zJcbd/9gvlK8UwYtzkFEZ4XNAX0uy/i+klyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwqFeeYcaswJOX2ikmZG8s58NffYbgk4a45kDbXB6A3HD/WfL0TZRrq1uzb9sccPS79+Gup+2W9g+aw/E00/j1Ag=="
-        },
-        {
-          "type": "Buffer",
-          "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAedLOklrBrXa6G/YBss5RRGHYAagMULHeqHtvM5xKrcyKoPph5eUMx51wYSH6UVqR/LmnHb93wCq8sdGE/3jManN0c+QbWoqcUWkoQdEFePCqybcpaKPjIPZlpoFp+iF1XCvmpxuZmFPjjhm0SRY+542gF85cp/agktDzn/yYGxAK6UV++wbBD8L2e5HViAtp6PgKRyhIN6RIvnBetatKFSCU/jGF1kTPOq90P/FAjQyTmdIzINRtAVJo6H9dm70F505fz8S2xzVWAvUu96/DT0MvUgLqA3IGQibWhNoMTSVHrQoSoxa8RoeZnsi4gsdN760TelMZWF+RrtTFPCfdh+OQI2LLAyPfK7n53oZyzbxKkxA0cl1ULqPwIGd2HSAwBgAAAEg2kYlX/ZNXTP0u+iLXVPS+2O/wVJTnCi0ynjwzJBGnkAq1IiVp2iLlOPJCo49wYHN8nto33NsOw1p+wwzY85pf0cQAWblkYceajHoNH0r+XTs6UQFSpD0GYI8GyTaIC68i1AHqpJDrPDRcn8gEpdPjVsW6zZcHQHRYWuv7cr182T49zYI/VC5+0de+iAuHZ4O0Q7lJ8eoId7Wu45O1qhxSe8Q9PGZZi6X4AqXRAQNb645/gLCaWq0ctCLOA2DcnQDfuIUZJP+gDM5GP0AUKfxy5ixtcLQs47GRyhBh0LULNOxtE3u2YXBiJ48ec1E4oq8jpNnX0u9AuQYaiEjOpcc+mPb9XsWzZ+5azJj/esJIrdMhCuTRoaMEPBPmQolbx1H2nNrv2DGbjDJBSmJz8UhKopiiUxVNY1UXqtOMgkWkF+Wknb9bDjQDzIX01xMm4J4eepOWjC14b5X6zAUjvyKYtr4h5m8+yWKMyNRt6mkMYdMTbAkBxIpODgltGP8JLN062AneB5YSWCfhzMdFCccx1a9HGHs7t2F1SeV4pYWBfAi4d/9NghUg94AWuqQrInqSf/TBi4FhK8x2eFwt3JThDcnAjRe4SG0Ny5kwxh+gI22Chc7V6IJuIROUfUQooYW6ZX7JlvzaWrbXWg06MW00I771JrOCn7m2P3PgSnRgmWw3bivugFzpKul1WxQd+TD6pvM22fWZ2BW7Q9qR+B+u5UqEf7cka/xfBiGJKKcGxO+mpsXRsfCeOBKt/8b0VUcrlIxsW9rDu8RRSMxyySVu2Kl50I2HPIW6/IfhZTvJqtxX27K34FGKc1vZRnthIqsAz1Jb3CPRnAUob66rUG+a4A6DpzjbJEZytisee7T7GMJgS3pkbFW0PRngpwa1JlT2oTeVeIo4Ca55ETq5OfQOw+y0ot7qGImKI4piQpspEp326oAFDDUKMhmjoD0SHJBmElcxulL8eanyY55ETuQDbh2HLNZX8neX626gk+WDwmZdYHumJXmMhsktULqdPzdtxOySq9fNd9T3rk1TjOtt0xNNMcJcPXURob7Egfj7NUqyPbl4oENOvEvMMFxFEJiiF01seT9nfGdiGw/veypRxR9/Whhi2fWcr623r2OuesvZaE2hmuxn8taSK/Zap5+NFo0wUncQawtSDjs3NsEl/AjPZcpuebAv8ERg09AGKstVhzkv4dY54jh4CmvzINdRbW44nRKASLA3wPeUFdttULbYyx3Nd0AGQaI+SizXW5F6oC6+dlv5x3Z/0ebiIpM6sqB/xgj3ngpas4JMzBU4Sg21RxHEdTmkgpwSAuwWDpaKXHWz7k9WZf3kxpcWaeYM9EVE7/i++f4ovASpO7oJu0cW2cJLXv8TaLPF54O6LeYTpLCPdWMU39XFJvtfQq5S6jSwW0iop6aqU5KU8BSsHoC+xWp/fHyw6ZtE6i8O1MBgQPixd544qZgP2VkxMNkuG9gRHSNWmTi81+D6Mp+hEXd2zI+vMco6Suz/L/OOdg/VhuRw9HgQTs+K/uGaafP1n2LdxB/N1yM1a9hZHBEMKMbgFOkLGz3wRy6g6KIw7cOFgMr89Bk/22f3nYKLAw=="
-        }
-      ]
-    }
-  ],
-  "Wallet connectBlock should add transactions to accounts if the account spends, but does not receive notes": [
-    {
-      "value": {
-        "version": 4,
-        "id": "4b46528d-35ae-49fb-b3ab-c7942ea92860",
-        "name": "a",
-        "spendingKey": "312b7d60ca3fa451e1c737373acf7ce5efe871e04f978d0082765bbdebd8817a",
-        "viewKey": "8ca1af5cc4ee5b015ecfbf8eb4bce558746ee8109bc8cbe73a5a62e9cfd56098fcb36934e25fb4b61d0b0300c0a31a9e08f47f3b57446e60f9a2f0289e24d8d8",
-        "incomingViewKey": "875532d7b4a7a26386ddf29eff49a72b6a25b268167b4858af04f10c30a9ac02",
-        "outgoingViewKey": "66408539769523de7eca2418517b62cb02be7c401f0a7501bd13640d080e9c3e",
-        "publicAddress": "460d857e7d44100aadb1635d84a2d792131ccf3b111a3142e3551ec4c2f2c239",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
-        "scanningEnabled": true,
-        "proofAuthorizingKey": "ffb1665a2739ebc9ace5a30b71c5b20c5957c6e25b937450b187028e80833107"
-      },
-      "head": {
-        "hash": {
-          "type": "Buffer",
-          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-        },
-        "sequence": 1
-      }
-    },
-    {
-      "value": {
-        "version": 4,
-        "id": "f2ca9dc3-8791-4db3-b590-c1723c30292f",
-        "name": "b",
-        "spendingKey": "07cb3a95ad4fe711659a9e35412fd0ee823ed9143fa9657a240457142097597a",
-        "viewKey": "38ea4aad94993846593c6483eb17e99f5231732b1bc67eabdaa23c28c7dec6ce031d854afa303382b742cbab41f240b6ac03b473c4a6973d8c2332c938e7db13",
-        "incomingViewKey": "eadda34d84590dae853bbaf51d2c2f7e5b4d9e529d2a939d27d1ac32614f9501",
-        "outgoingViewKey": "4086253445b82ef43620ec4c013f76a684d7f60777b27e308dc9956369a79669",
-        "publicAddress": "3e2e7615c181f2afaa6423465e3b3a9ddf8d89020891cd5f1fa77627beac0d4f",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
-        "scanningEnabled": true,
-        "proofAuthorizingKey": "ef3245c0bc7b577ad96755d1401d21318f5c2325a6c9ec635e2860e3b8447c05"
-      },
-      "head": {
-        "hash": {
-          "type": "Buffer",
-          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-        },
-        "sequence": 1
-      }
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "4791D7AE9F97DF100EF1558E84772D6A09B43762388283F75C6F20A32A88AA86",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:2YEeOO7CW5anvMnCFj4+fP2zXO5y2uMz7uYPIbEqehE="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:nOkfpH8xRjxR0cYszKBVE+pynTfSn1/Im56lD3tmO+Y="
-        },
-        "target": "9282972777491357380673661573939192202192629606981189395159182914949423",
-        "randomness": "0",
-        "timestamp": 1717538776794,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA6gc0ZMKzVuYVGSGcf6ZStXbFhEhQGBdxZ6dp2MGcpBiqXW+1GeVcLuzGE0XCPoATF97RUQS93leoPPXEZuA9QxSmGG5O16C5N+NvCytJUQmUGF+f1CP1GPJYPApvqU7ZeX0gN36tFc0XmFZueRhkfaox6WXfY/nLn9sGeEZX0xEE6sBXYqru2NNST1fc9gpZn6pHTmG/DPAOF2h2eMyiy4qWAF1ZxFdry259sTpg5biUJdDHdfC46rgLggtXOG/HKqfDTgGu4seax9isDhriSqw7Wiy+RolXEN4vlsoHWTI/88nbrvNWwTMmIFNTJlnDPcQX9XbkDGtWmms61IKoBicAa0evNtu8e0lmNjnFR2pyugcjkqVshZiLwxwwL2Q1onxO+SOfIeX2bAO9svJfdisHU+bsUKya1thsnb28l8jWpPB1y2ClwGJoFznubXVfygKkwqNqJwDPnTSXoT51S3K0iCnuz7/7vkAWBc1XoMY66TKSWkrc3Y5eroOZEoxcZYgZ70I4yP6tpxRdk5aNE1269BFvGaIEoX8Wdmilyl2xdcCEDsRGCkduBs/+ndcMOrBHmHCYve6h1dgZQkSA80autapfNFaLKJuXy93FAKIq/afXZhStj0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw0nYJUIFk2FxsS5XGthmLUBbrOrEJATp70MNA9plgkBYka4DxZbDJkaqvGhhRsWlwePT751lKGeumD6oEDV3gAA=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "3D2FD56B9C13A353C03760F88498F76DE18F31F1906D694C5BD0350EABC70F49",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:2aPW4nN3mBkAjPUddXJioPN1Wzb7Ccl6GwO2JE4ECXI="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:XVIsnhJCqY4oxukCRb4wLhvgU3h/hp//zO8NKcwRxz0="
-        },
-        "target": "9260366780148527510972123832573278885902566341756516011968728852484845",
-        "randomness": "0",
-        "timestamp": 1717538785387,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 6,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAdiUEf////8AAAAA06jmlLwr+QR1va25HZIgnlFKNygW0YKgd1/hsswEaL61qnTHDAhtcJ1dgkoHHzSstl5O+27l8B6JDhV6LGmFGtzvxFU5oX/yP8SQ5gpFtoeDx4fkS70VU4jOGpulhIC3dgNsajM+mygbMVL2rGxWODo/kS9UmaXXWjKcVlbartwWNuwgeSfPbK93szYgCsHjsopG2CPWDY7+8S1T/eiI9UiSOhmpVkJ4vz5giU9YP8OIPRbJYNBDyi42s1M4oE9yhBiYmwWB72Te13hbCKXNv9klCubAoOz0hEmpHpRdia3h8t2L2mV/Px5vq+BvRLjvBuDFPxh+tXPMhLLz/Vm+gYsTXHcakQOYQKEhS78DObBm52aWXIu6NchDoqGL59pNKDa4RLzZ3qjqZKD8u98Mf0uLP3PNHppWj6MJGUSQsEYZ81wE0x83Mw7pVBxzNYV6ZcKjSW5WMGlByPpvYMsk2GK0RK4R1/KZg5u9OQ9vsy/z6Yowkn1HLgIuWhtUEzR4N9RO8tgql6xupVhTlJwhQUcvAIwIebBev9vsz6vqAXK0Bg78pDINhPO/XTdyokiKJmqhzwblFBp+ggmCebBF/TSsd9DBnLCzO3/yk+tYpb27bq2MhnYyvUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw1eoG14RNMtO9fK/cPOw1Zb5kANYygfdFNkSauFMZ98we8JoGw9PLNdVzUz3QUO/fGgEazju9WEIxJwYQyVybBg=="
-        },
-        {
-          "type": "Buffer",
-          "data": "base64:AQEAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/5M1dwAAAAAAAAAASZxlWuOu0Ps2ueBKEUuioZBPdkwkIwYZGlO5Dr5jY+OqdkRfBzzWOTej3VCj8BzOcc1jFTMeqxDJXSCgKn99TLoXpnJ6ZT7p3KMfUhuROKmA4azQ3l/1UYuH0EBA26BTu5/dYFmmveCMTqZqtOEbsqyHWrkzTbtNka1RY7z02SsZKkHCwNtS2H/Ea6kDwPyr8MmxfC+mqAt0vsoimtZc2/UG8eg1syAalj9aSVgVzoWmItbb0YhZCxSD/6osnyEo1CxTcI2UkdJNIRDV0GHmFDqd3J19m8i4Lj9oWS2MuDD5bMZN2zbfTPdrWZ4QRBU9MMQLNh+lIZAeUkp67SvrBtmBHjjuwluWp7zJwhY+Pnz9s1zuctrjM+7mDyGxKnoRBAAAAAohLf87WCUBH3JIzCIUSSf5IaT1QDG7kc5btsFcpNvmSp3h+62jTwLcX3WNCD2bVdry+ihDricLedL9aPhgIrYnwEcdZb5ULlr4w0RoaE/1S/2/mw+TJJ7Mrsk8l+8JBKUkn2RRjYdnAboJDK2HYpnTfK5fM8UMf2bbyZPGHbhHRaamIPAVpE0M0aHcf0EXlY+idaV3imHGj3sDWLmshbJzX0Dom5IL5XikGwSYS9r1gxgcJ/k6r041Ga+N/TcrqQvKj1fBzL7HI9JgV14Qk8V6x3N66L4lPxK49PL7wuPs+8fbmQmRvOuInjStaIEIUZijacDPLrvqP6ASx4M5G2MnQxs5wTsxXkDZT9B7isULVHzPT9gEYR5YDt9bx5E5sM5aUnr0Mjnm+HpxwQZqE9zjjkOKhg8NAUryUjGExwyYS1+py9WO4Zq4V5oN4JNj6z6TNN4EBIcnKUGp5P+LtADR3bN1DccBFFpMiFbVwfSaAiLJKJ3hNd03BpxjUb924lJg7XegbLq65zNuDhkD4x/asRbMPtV0Nr/wjLAAWiN8zAegPsDs7xf9e5KmbQRc2OPmRfs2xrA5/ZmRKMr2JhG46McwRlaz+fU5sQaQX9AQhsSj6cvQ84y7YRcy9pmpOyB6TRsu5NOLCe8pJyjmsJ4Gt8ydQCHMMhQjw2lEUDzvvIXELR6DR4O/HKprTFSMDSq98yTciuTsxKQBklxyze+jDs6H/32aPOP6D19W200fW4Wug1uakVtA7RzOPu8dF57JfYKJI47ARiBwiN8kaBTrF0NVSrHkdwzUF2Dox6qOMRpVCiyDRXgF+OUueqqmr/9QTljtkiC544EkgfyECFb5sRb1/KVHuVHpXqm7pORxAHt/5XPDTq3UkhnlJV/ZP1VEdIahGZIE"
-        }
-      ]
-    }
-  ],
-  "Wallet connectBlock should set null account.createdAt for the first on-chain transaction of an account": [
-    {
-      "value": {
-        "version": 4,
-        "id": "711ac2d6-ae9a-46f1-aed1-b233a9df1349",
-        "name": "accountA",
-        "spendingKey": "4856d9c63d3d032871626027578178e8c6d18ae520ee4663a70817c3d9c63fe6",
-        "viewKey": "f9b09b02a744aa8dee0af81493ff546adf008e3223150cef6adbe81e055b8010932e92de9c2a1f302b42af7c7b853eba1b0ac9132d99875752cbe57cf894a09d",
-        "incomingViewKey": "2d03b13b8c18c4e823cb9485667e5449bbf0e7bacb825d8dde531727eb0b2901",
-        "outgoingViewKey": "d91a8e7dbf4c56531ad3b17a7ab626718642c0718e69352af3ac8b06753677c0",
-        "publicAddress": "f05152558308b505f6f6354ebf63c7153e6d56d18f960c030fce913f60e13eda",
-        "createdAt": null,
-        "scanningEnabled": true,
-        "proofAuthorizingKey": "52d635f7fcecd1d8aa1f3ddee510c124dc9a0c19ce126b597275f2cddbbd4907"
-      },
-      "head": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "4791D7AE9F97DF100EF1558E84772D6A09B43762388283F75C6F20A32A88AA86",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:gG+uD3IgsfpU1G5I031IQovkI6na2S19jtbdDIAsI2s="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:T6nBRFaAVNv6mZyGQIuwESeC/bmm6v9MjF175LUkMs8="
-        },
-        "target": "9282972777491357380673661573939192202192629606981189395159182914949423",
-        "randomness": "0",
-        "timestamp": 1717538789098,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAKBHy8tTB8r/FmK6POR7isIbm85v+JlhRIQXKYbshp6GNP5UkxuyHOfYZDcc0PnRypD5PJCdOVYvMfa2L0iAh7SMYv1T9o8JS3fMWwAQQ0WCYvijv/Bg6wnwTc3ochiQ5PIXcgLxQnmU2INXL89WL3FPq/Kr1FUJK681PgzVmIhQXllF/mExjHkZR02WngTqH3BftP60SBCeIYo1rF8ocAo/bf2Jy3H8+WWiJQ6Q1/MaLoqp1HarCOZ5ebPdn3LjGt1ZgZdKSaEMtaiv1l+GuAENWEc4CuDpqrR1LInPOwgSqiaGw/a4tJ90FmSupNPP3Dq7NkgiaV6bUz7HLU0YcVG/malnE1JAXZm3B2NXqhB3NhLJbshkTMNVcxXbswvhStxJCuy7ZKhmj5EfalZ4DCfu47/fBi/EbILCYDUF/TNS8SBq552Eg8p/1Aj42gmDWE4bHOTwsiIZ7iHhB8A0B671g3GFJ3KhSdk2uSfpo5sIkWFa65NiLP3E9jqoI9H+EEQiRAW89/8nXl48tZYQe9fLfMiQaBCti2HVfV5pMUDJmYGH3HcNSMtHQNJxLmAB9LMQ+p2TqZr0V3RzWxRC1dD9bywUfabZaL9BpTnXMrysj4gaGmUnO5klyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwmiAl46IHq/guQhxT4xJWKSPMchzCvBqUBuJ95nRoztO9zm3b8dnXUBnmXP6H1bAEINq6k4blgjbcXdQfC2jmBA=="
-        }
-      ]
-    }
-  ],
-  "Wallet connectBlock should not set account.createdAt if the account has no transaction on the block": [
-    {
-      "value": {
-        "version": 4,
-        "id": "f31d3fe2-b35f-49a7-8980-798854cf03eb",
-        "name": "accountA",
-        "spendingKey": "c279cf6007ca2fe2aa23c1d7051f806a9e0c5604f53c1b08a93d80b53a4e8974",
-        "viewKey": "7024a8ee339885cd32ebfd6378adc24eb20ab78cde7e87082aeb6591dd594970a8bfb7ba00b08d9d522f5dd9732edb92b93639763dc8ffa344079da16617ad6f",
-        "incomingViewKey": "2bd65c96b3906e5932db3a42febcba25d61a6953b65f523b53bcab7592578c07",
-        "outgoingViewKey": "fff51feb2faee0709c0dfcd8f3698408a908fadb9deeb69506cfaad625cdcac1",
-        "publicAddress": "388b72219f70f6da325062e5ad99e262d8a45137fca94db4de01056c8373f1b4",
-        "createdAt": null,
-        "scanningEnabled": true,
-        "proofAuthorizingKey": "e8977c2a73a734b44c202dd48c69a21f0031759eb4000d0ca2e25a5b85901502"
-      },
-      "head": null
-    },
-    {
-      "value": {
-        "version": 4,
-        "id": "85b515b5-8832-40bf-847b-8e550a097fbb",
-        "name": "accountB",
-        "spendingKey": "79725fd3fe93c52c61bfd98ae74097f1e4e483d5d7167ddaac60b9c7a5cd491e",
-        "viewKey": "dce8194d874c649b1f0abe5984b9ba60db41c6f07d2d39c7659821c5a54747476bca1f562de10898cc97ae1197b021878052f2059f1bd3bbef5106d9ecf6aa3b",
-        "incomingViewKey": "73bd776aa46e91e95ce5a3b720009ef9cd9e6b163bd19c70d8f5da95e675dd07",
-        "outgoingViewKey": "b19c83b5eb11068fe711e31942427bba2e641a03159df57e314898859c48426f",
-        "publicAddress": "c63c58186cc4a3c0fd3e3292fe0da1a6cc35bc463b8895da398674dab92484dc",
-        "createdAt": null,
-        "scanningEnabled": true,
-        "proofAuthorizingKey": "1498ae1f5c5e081d2e41309832439d8d91e2055f56caa501bdf6cbac6fbae904"
-      },
-      "head": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "4791D7AE9F97DF100EF1558E84772D6A09B43762388283F75C6F20A32A88AA86",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:acRHxw+cWP/ibepfjNXZc87XBzgJndGzJC2yprfOHWM="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:wVpWK8p9G1n8FePP7dQyvqf4ypNlp1q9etiV/WQco2Q="
-        },
-        "target": "9282972777491357380673661573939192202192629606981189395159182914949423",
-        "randomness": "0",
-        "timestamp": 1717538791945,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAXKdkkZWD1dm5lxaxZyEsqyEuQSgM01VH/LLz3GUZ6OuXvFVUStyE3XO1pOdoWE1vVU3ffduV03pQ1RvZ7DdlEoPgykadfjTyjCPE9NzPwROPNpxnG5ZROfmUTQsF03REpqno60QDwD6QSOBYeJQzeDbHGLZUqskHx2o/DhYXQRcJT4+5tOnNmZKHMzjOA0DGjp1z7HeL1hPSGv8Z8RTxH4pwE4Z053WnD13onZHufoyHVXT4zoBh0raTcRDEDoJ2JXoWvBzkCiq3qefIvWkNlHlJ/zxVvrwA/vEOnUWmDkiWSDtK1L64iGgHBaZOTK0pC3eqM6cMyRKriiJ2FVfeNBb8rOTA37uWvGnUBXP5YWrJ7p3NdcGdl7djHxSu3ooQ/07FtJTTY72T140KpBzDwOGplWx3Y9P+9E56YaC4/Kqt9Sne/KX67k12dnWybklD015yAz+3LqsifgagDl+wxJawQJw2us3STYHSHXvkWanRMwehkzknDf57pHHRmr+qgTY+6wMstxpJR31lkfCJunBjC7kCLZn6M8U6lBc1ew9+asJcpDo+RFQMs8/YKbfr0Gmo2LjAGPTF5xWnDdsL0glR0uT8TUUrHA8w4mwSDUAVdnazlEcSkklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAws2uAaFTsGEJtmdqVD++dkjMHns212MietZsizjoFcHJ7znoxEVUB1I64k4kGb8/O6MLCWU5nD2S2tHBCz4cuDg=="
-        }
-      ]
-    }
-  ],
-  "Wallet connectBlock should not set account.createdAt if it is not null": [
-    {
-      "value": {
-        "version": 4,
-        "id": "dd451e67-cfd3-4ac5-a488-b27beeff4c9c",
-        "name": "accountA",
-        "spendingKey": "39811f488f54d6e92d3f7f341cc5b76f574a24197bdaeeee6a05de53ddcce83c",
-        "viewKey": "e4b08d1947feaa48eb780fea468d7c493aa3a5cfe02d7cbe3119b76aa62dc358273e68609510a534841bd424f7c20e2444104bf04e4fc3706c1259c3725fba4c",
-        "incomingViewKey": "90a8f8f98471821e9df1412e1d950a2e6a5ac1489e433e79236be37293cfa807",
-        "outgoingViewKey": "801e2c3ebcf7916e410adceaaa7ed4acf98fa6b8119ffe11f3d11cbf45ae91fc",
-        "publicAddress": "f58e0e6b8457208f382488f030a45fe5415973c80c6929a2393c06c115f9a94f",
-        "createdAt": null,
-        "scanningEnabled": true,
-        "proofAuthorizingKey": "58652f234e80b7019de218000e350eaf0c711ee5dd4c66d72f1d611ca25ed302"
-      },
-      "head": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "4791D7AE9F97DF100EF1558E84772D6A09B43762388283F75C6F20A32A88AA86",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:elUGwi/sjfDIPJd0ErK88yK0AQSgPV4vYjDWsZFx+DA="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:Ddn3jbvQB5ORKUEEfn8s/xrMGYN7gpmqXNqVmOcwoxc="
-        },
-        "target": "9282972777491357380673661573939192202192629606981189395159182914949423",
-        "randomness": "0",
-        "timestamp": 1717538794458,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA1NqHxiJj54BQE17UDEPqVMbiCcMQ0nGmWz9At5DWA9+1xNMsFOEsMnZ54bNvm2I6ppVkewODOurdu7HnwtI5nmWO6REWA3K+feX2bUnyLa2EIBrTpMnt2XOJ98A1u6zVEgnTY32iAZ0dHpC8PGOlLFx9pOR97x6Z7Z6AsATZIxcJeWwgfsvMsNBWqEvoPonu8R3NQWG23Fe2TbCigyn+QqQldKjLuKxWlVhg1NuyFICWDBsx/7K4KKItSyJz7cj3F7TxT/9yW1/eb+wJkY2JjD5pzDeVvRpKvA+uZCAPeUY2Rwz9F0ddrKkwGVImQdy7ZUOb8e74pIwvfrJcPn2Qk/6vMJEJdAXHdrIN0SANx69VBPyTFk85jibeo79uYzdbGcJhFlPYIGvmQ618NJfPKEv2E3bc2c1eAYsjbvl2mtjprKllsNaxwnd8outXYfPFum/neQ+LaSzNQupTWcG0s7pvIULijYPZNE+dr8sWOKQkDJ5TYSS2m4mDgDmP6ZTmwyI2Jf7IT0HWiGWjT5vSy7IXBtGxRb3bEayCHn5PlkLF0f6J1U3flI3fzmNvya1dlD07qJn4SMCSxt1VmoxxH49bO+20XQe1llZS3LLBK8vFRyF31xgzpklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwQqQfM5NUTAIrURgLbUaJ0oIwwnOHaDjnI/hUQRPoKdsjmBO7l9v8F5f1EhXUe9wt3K68vq7WBtRg6ETHKQUtCQ=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "04D49503415F9C55A0D0757A7E6207923076EC745B05AAC727AB61E1B9C8BD0C",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:rrdnmsHXUQh+6XNX9knJnyOOKXHcQi4/3cmG13KpKD0="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:lE+nXnuSQZ8baWE1GYfBUo33F9o54ptpAAejyKhRaXg="
-        },
-        "target": "9255858786337818395603165512831024101510453493377417362192396248796027",
-        "randomness": "0",
-        "timestamp": 1717538795622,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 5,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAAN5H5ABA6oSm2IhIhHvcCR/kFPX9CPyzmK5Af8zgnyuVNtfT/Q0yZUc6YU5+aGFpz1hlZp8oKlKHdnAw5MpYwG25ZYTYT5MoRwczDnPKm0SuAkn/pRbcdQhu3lD36LjvKF22IhZNAVjrZoygkgf0yHYIjoPZc7NFTe4z36tytSoPKfPqkfWmCgV/jRn3C98EDuW/8ZDHtUdfjucRk36aBPxynQ4SIoyQ9pGSE2GNa4WXY7hk4L+nuf1bsCpUzy5Mt/cff29rgW5giGjrxCfltnJl7KCSe1ujCxXyfbCHBsoaSWZSVYMFGiK73oP7ApJ5GqjRNLXkqlqtOPw0VX9xOE1dnAJoWw/K/eKWl4a10xW2LDZ6pOgnRbA/oCocyx49UQyFGW0V4o+9PYA/H08QhtDo6HWMl0sPZsT2T/dT/jSo7kHVLuSgOJm8sEtYxiZrM26/hHsAiiCUHadqvIm5yRzA7+7uKWkfj5+YIRoedOcRPUQieqwlt1ZtyLEmxPN79vX5QrAqDDHmOJrTF+0C2xolH21pS12fDMclRK5qUSW71q54PSUYXSHWQ9y0Q0M2fUTeLZoGOkKNLosh0sen9dE5o7GKkFeNYSmaSRde83LoRV5FJDx/mklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw21ZN8hjtH82tG4OEQAEWDVGcXfmUbmHhAqnYZ72n+RdIFAKR1FzOiiAjuygEWxfSCjvra2TJ9DAApeMOkO5NCA=="
-        }
-      ]
-    }
-  ],
-  "Wallet connectBlock should skip decryption for accounts with createdAt later than the block header": [
-    {
-      "value": {
-        "version": 4,
-        "id": "b588dd36-a52f-43c8-ab8c-ed43a64b76d7",
-        "name": "a",
-        "spendingKey": "9058f54f590f4453d9044d8fd1dda16ef29608ec7c79c71ae754c452b5228b85",
-        "viewKey": "1dab86894e0b022cd1d2d547bc2c75524013006456bb0a9281c94dd38f866d4035c70a7bc98d4d2de2dd7e3d143e30790a0efdfa148c4bbe01515f441d08149b",
-        "incomingViewKey": "01ef479369c340c617803aaebe5749807fc5ba8f24a44f2f8efdff2f57e37203",
-        "outgoingViewKey": "2a16e7d2db5541a55d55bacd69f5a5077d3aca6d64482032a74405042dbe23c4",
-        "publicAddress": "002e67c1b367a11cfac003e4c6a22352676c6db67ee482a6cf425614a3903be5",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
-        "scanningEnabled": true,
-        "proofAuthorizingKey": "bce77800905da0e98d479dbd811ac2b941bc7fe0743093aab2d1c2d5548cfc09"
-      },
-      "head": {
-        "hash": {
-          "type": "Buffer",
-          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-        },
-        "sequence": 1
-      }
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "4791D7AE9F97DF100EF1558E84772D6A09B43762388283F75C6F20A32A88AA86",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:mNWDk2Q+ISdSRIMDHQ28QKill4FoO2jg1bPIFRNvtHE="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:KRr7EGRKjnQqKLwz7R3+n296Fz9F7B9+nY2OS6Ly6Ew="
-        },
-        "target": "9282972777491357380673661573939192202192629606981189395159182914949423",
-        "randomness": "0",
-        "timestamp": 1717538798786,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAowQEtMyAsMn+9DffGKM2ND2vf140nq3sLf6Xwdml0qup4saqCdK3HmsxhTlyEab4Ni7dYjth6MPPHyCN7tGxiWdvkdJ3Jnsb9tttqEancsuunx9wZRJbIQMkv5x7FXs54MG6Wiu4B0Dd+/lpw3oCC7VivZ/gLXJW8Yic6S3auxcEXFb0th1QIC320Ii/hGpSiT97UcgV4ypVilS6t/nSinKTYN5ZH8ynHsnFEY+45HikMnmu2OOC/E8TVWLOsI3bZI/fKkm7CWZ3wiMZtMGoXNbV5dywoLzWFah1q7xwusMRLA3k7/UiCk0xjdZJAcNZfa80OPyld5/qVep+tDkrmL92vFg/H7dupkTQbfcOB8Dz3gNOMwFgeuk/kQrG4MhNNuN1Qnrn/3Qi1TeemwBOkDTD0SQ5ZrOUvApZbBSImZ4Bovy4FiLQrJ3xsyQjaPqHOB1r+Ygi5UU2NBnVGU8S+w+BDa6AwKGy97fmNJ3Z+sfF+FczZc5C3s6KHUbNYxjWP5MasyiCokewZJ6diYGl6x5OAxxyD6MleaOfKjpYMyJgSM+HSmuqbGvsbBmVUK2fSIm5o+x6P9460RTd+vhPzQ+vwKrPHSug2gIl1acompD+BdJV7YQel0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwqFSGvY54V4N9zdzKv4B7rsVbhoZ0Mg9I0bDGgSuHJ2EltUbGq+ZvBmaiwnLwBKAi7uRxNyGzMwV3xPNmXmmQAA=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "7688B6A5D7E665E658526F7ADAF4FB5BF7CDD2BBD99341DBB6A6849CA3CAAEB1",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:46ARjbh7IqMrWxqcO8wX4d9GcBVw/R8/yLVycfMxwh4="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:ypsgJsKXpigzL8WH4wapmG1AzuyUFKLp4qRqjQsKEVk="
-        },
-        "target": "9255858786337818395603165512831024101510453493377417362192396248796027",
-        "randomness": "0",
-        "timestamp": 1717538800950,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 5,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAol+BoW5SFHzxc92P1NR4/Ybi1ogYtXhHsUi7UvxvOLCxVomyK0zQqi0y9mye0uNu84tmRuB2ggmRiwlEQ87m3zVx/shoQ4pWaMOJUx6h38qx2iqDkDMW6L1bflvSpDIfzQi8h1y+/WLFm9n8hQTA114oKJT8G0By3mLWsX9catsUt/FxnHFNKhZNXym8M6fdN7IVadXUi8kBe+C7HsDOZtipfcGM7wu5ropsxs3mswC3GeQEgtdBHqIxFkRiqqhthdZeKJZN4+biXFQ4Mc+qykbNkaXqtVnFuACAQjpse7vN2PWQuKjMxzMgTOuQ8Hg3JrRm2k9+mJidofvHvqZ9YJu9wRu8vZIotnl+HuYEnkSMSKt4ZlrawRHCuu4uz7Bo2H11Pf4xrDX0YmWhLIT6OQyWj40ZRrbuIuJoPB1Kl+eg1zRJHOo7FHoBzxl7G0LYzs9hNBhzbAG26vLjD/Jhfxkfm1ZbhTYzhPY4q4vD6ZRrUrOhoqNSkK4Oub6vo2jnvJl9wJ4UnN3aQkBjkEAAVQcYTDOk6tsEVSXYHvImmay0MXiLKzAf2ThI9NmpOLm6FMhR7R+MtnDRZceWYq4VnGfygFu6PHdzQv5RLpVL09ZUpur1qEJ/5klyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwrZHUl4EkptmplQte1OhdaHPtUfOkDqLxm8ucjAZ0htLU8eGoNDv7LOhtJqurc+u1plSWFvBvu1aQnGWAKQ9WBg=="
-        }
-      ]
-    },
-    {
-      "value": {
-        "version": 4,
-        "id": "99316e47-0acb-4513-bdff-26ea481ba956",
-        "name": "b",
-        "spendingKey": "23cfd3578bd734c519359510a4e314d6aee03779c8a4417027a1724bc2c12a75",
-        "viewKey": "e0045a5dfdec70240386b79b6c883175cb3e14993d9eb6a375fc4a88769028b9fce06cefd661d9be699283724f8b734313b2bad44e48432dac90fdfe251e05ee",
-        "incomingViewKey": "d93d88278fb58013b1ba30bfe8a00f4adc907274fe9f91c5a53e61acc4f5e003",
-        "outgoingViewKey": "4a6df989a0340102fef6a71b03df8cba0e0635bee1963791fb900b8dc705e383",
-        "publicAddress": "40140a86a5071c4985e1ed66c2b8a0682e9a60ff45cf51e464f8820db66dc701",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:zlABkHbPDQPcYhD7AzaIX5QOulfKN5eNG9QdRHEh3RU="
-          },
-          "sequence": 3
-        },
-        "scanningEnabled": true,
-        "proofAuthorizingKey": "22d94ff922e50cd7fe9ae0c514968f3e52badb3d1e835ab0975d66e80c398801"
-      },
-      "head": {
-        "hash": {
-          "type": "Buffer",
-          "data": "base64:zlABkHbPDQPcYhD7AzaIX5QOulfKN5eNG9QdRHEh3RU="
-        },
-        "sequence": 3
-      }
-    }
-  ],
-  "Wallet connectBlock should skip updating accounts with scanningEnabled set to false": [
-    {
-      "value": {
-        "version": 4,
-        "id": "55b5d5c0-c65a-4793-abe3-60db528f677e",
-        "name": "a",
-        "spendingKey": "7dc498a9da3700f32cccb798f96367bd43d5d8da827f13142a97da632b47398f",
-        "viewKey": "47ae04369220115e2936d54e0c900c8779b96b0e287f8de747cb383e9d53f3bc1a688b4c672e5f59d09447d964c2d659a87b9db6b3648f8728a68b8f52fc85ea",
-        "incomingViewKey": "3f80e3b0bf87fc10a7823f349b97858efc9c9ad62c3d5e3afe76f2eced7de002",
-        "outgoingViewKey": "4da65b8bd524c0f9e5b6e98998ab575d8cb912202f42e9ea73e1f4c1e2ff955b",
-        "publicAddress": "17eec804ae83239ae38c8849008c0864f2b4bf1ff70b341e71e7a2b126d079b8",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
-        "scanningEnabled": true,
-        "proofAuthorizingKey": "b0020a642ac5a40462d3d4cec61e1f2701d63385ec3980df5916e3fffee4940b"
-      },
-      "head": {
-        "hash": {
-          "type": "Buffer",
-          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-        },
-        "sequence": 1
-      }
-    },
-    {
-      "value": {
-        "version": 4,
-        "id": "68cbe0b7-4853-4798-b33e-718da60abcf4",
-        "name": "b",
-        "spendingKey": "c4f0d8703fb0adcba6556381d5ddbc90bcea828a07283f60829977296c141a93",
-        "viewKey": "707f8bc5c6e5982169e70c0f2c34c23f16d5b7d3423cfffc75d17b95850587b63d25ad7939e2ba0847207472de32edb348560aa86aeac2147be1474c7e51ba6d",
-        "incomingViewKey": "93050c8e56f3b603eb59f5f3185bfec01549efe873acfa463009954e3ad8aa04",
-        "outgoingViewKey": "8436e444dc23a2d8d5712f536a14ac56f0cc27e7aa691602d8c2e5fcf4ef4ff4",
-        "publicAddress": "a085e2b5c5beed24baf419e0d5d48d1c28acc6ff4aa941e6d75f509450fb888f",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
-        "scanningEnabled": true,
-        "proofAuthorizingKey": "252642d09a7431a7e0dd31bbd9324588f794a7ed55154a9a8a563d2e34be8407"
-      },
-      "head": {
-        "hash": {
-          "type": "Buffer",
-          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-        },
-        "sequence": 1
-      }
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "4791D7AE9F97DF100EF1558E84772D6A09B43762388283F75C6F20A32A88AA86",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:T26lr8PMOBcM5kYMOUt5cU1rtNnix147uTQVXz6+ExE="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:3mxMJXiCGdQwkhDJU9bwv2i6KA/ssRtV+Ly+NzXBGbo="
-        },
-        "target": "9282972777491357380673661573939192202192629606981189395159182914949423",
-        "randomness": "0",
-        "timestamp": 1717538804397,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAADnV1BhIJXegnwrktCtTYJf+B0PuPJseZ0kiIlvjWjiq5nTnsx3G7M4yBsFjRG8j5vNRq6xkQAuVUnKOIEV6EQNmfzgN1FXk6vCf3spJHiFOmXmWbwJJ78y/JgQ9XjrIty+gjb7gBqWqssrRUIv2tvgniiWDA8O5BYHrGAvuJ0ZMVD3hlYSu6t42UDBcy/gwbu1bBU8bv9nm+2UpxkozCFB4ePUoRwFeHpeGuGzsdKQuAJXj9gdoHAXJHId8q/883O4vd6oBfxsMWQdZx2nLW4QUtTUqbLr1tCZxqDK5ExVLAaB9pAvD+9QJcmE6b4mSD2x4QW2XSFxCLtDdGAlyDZkdU3RADN18ibp2y7B5+r5ZaV4EDGBCV/llNPgvpPb1rRTtR2kVZf11WWAnH+s4O41GPDNn+jKDk0mxSmShc1JHpgmAF70WBHoUdVshH6c2iGk9IaLG56bnq1LQKofHOKYfWNnVSwVqzBga+viUzFLXx1f2ViMJmudYDCH69W0veHCZSX08JiKbefZsPAfTc9HDP2dSY21WfFV2fRJU/fLRzD9lkGUei6kElqEiwW1oUHPlwIqhY8IcIEhI8dajAoeFEmGIzIfrWoTTeEqxdNN3533sYhCRieUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwA6QUF5JVn8fPQYfsu5ypg3+9oorQF3XZi8Rbe1ULH8kWP/WV76w108cpEF4n6KGuWv8iyHlAtOo26MQMk9p9Aw=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "FAFF4201484462C6EBA2A87EEDFEF3EAD15674945B9BB92F6821A6A8D82433C7",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:XZqMUKJKccQbWWfMk/OvUyo/srN6DS9FmWUVb5KxazA="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:RB+cuH59qMEU3YUPTGgRWNMOds4BdrEw6Y1D9Byuc+A="
-        },
-        "target": "9255858786337818395603165512831024101510453493377417362192396248796027",
-        "randomness": "0",
-        "timestamp": 1717538806590,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 5,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAARc3xGXqhfWxUC895dmLdMkdi7JOTAosTuTkwHgxfQ9WU1jtHmkxEswUmgx1nKxGiMvl3vkuUFBhpL3lRriNDylUsNyoXbNCdDEPsbIgQacez0wkI7ZlE2ii6kjwU66xgpYCawon59mpaHkSDght/i1vdTn1hqgZiptFPXztNdHwMG/EMEmvOzGlQ4uEDFMLVy5ah+6o4Ts0OkEuOoEJY9nQT4TqgX0ExaM4IytIU0g2E2JzQTBMx6sLbMUIJX7bpoqbf40YqXGTXgEmb2zQw5B37loviIbV36360CD7Ld8QeJavNc6Knlf82MzoivMAhjLcF6gGkpyaKwjM0/oUmxR4Or5SRFOcOmiPJq4TLdQu74xh4LwuvtkhW5O/PArthSFwrrCqZ/uR48bewoQ5e3k/hzwiisubBWMKxzcITzJbG2D9IOelK8jupaQ0curYUpWxwIeyeqDk0fE9K5ZkhJ/BrqrcWBfCs6g9hKmG1fb3TpUvl46hD7cp1rLt/lbOMS+uS5TfwivGbzRHkMHqB+XhSlsHKSXqEEIEtc3avxSpI+Vcu8XEv2JXRAGD81MLzhM4uNn+6DFnbfA+D9Fef1cXB+bpOv1SHTKHG2ZOSlGwngXCuYwQkBklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwjbNX4ht0TYLHYdEzOT6GmqBDanqfUBNoG4EQb1G7rzPoDl/pK9lyqSjAjVbi1y8NSD9dGSWj37vO7P9FB5x0Cg=="
-        }
-      ]
-    }
-  ],
   "Wallet getAssetStatus should return the correct status for assets": [
     {
       "value": {
@@ -5967,956 +4415,6 @@
         {
           "type": "Buffer",
           "data": "base64:AQAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAx1XG8nmZYHQ1lZDF28yrjNdwPtLmJXorkmHX9wpd2smEGUFH1c+R1x90Cx1/C++ZDaG0LZOzFoURhJxAgkQWtLaKuHgy4X/THyeEIRF2de+rikJf3pai7Sl1Rk5keZmyEGdca9g1R4j11EvorfIueXMu5tUkSxjXGQih7xj00BAEzGD//L2AFiegE3c7DNOXrcmry9GugoJLx0NtqS+rSFuQSJWJkifCzus9NzVT5DWDpPIC1IiQe5v6JhhNCAD3bawctCBU4KkpKbzeJTChU9EJ8Aexj6eRDpAlecHOsVGGCsJ0dz1bBRkJiQ9UnGQ2IaU1CRRecDT3y2tEEZh3DniqfyVpGJdU6HL5I793Vf4K9pDxdBYAzyBR5hkQ2qMrPC7D7dcJHAmBEEGkBPlB25ztk1sUmFJNHlIq/E3LJm3E61ASn2x8lz7VW0X+J1CrzBetBuTa8P1WyM34ygGinGtIbuixAvKTuBPD3D1WYHUL8AmCSLBd2MQVXQ4QXhkytGrV71vL0Y9TIQUUmsynj1zfwRDdhGwl0JEAQKEaydEm/MGpIgKMunwX17UIT1DcRHZs8QDL7V5ddIHkl+pamlvYOqTG/Uv2yY4gt7+/5P9cKsBew8hqBMnYroNLOiCPvcwZKFcQl7wbyc1xBSswaeLuNGt5TtT27T+9Dr/HzejTvH8KfCGfBD68uJnPQsK86SBZQilhh6ix2IGJIsMAh06kCZq+XQoBoFkdkqFZd+4RcgcjGpbRMA+YBC7PguW7foeHd0jEiouRNB9IcfndU8o3VUtdabdKkYsF5F0XvJ+V1+586fBd1gJ8P7HZaCfXlVbvyTh8vjC17V8G0LSxSdvnpKr7iOgvD4l2mFXwK2CnEwLRVNAVR0j2WiUUknP0PDm6N9u2sf3xctF4ldJ/EsaKRN6kDSpgooqKnc/d6JHoWKN5KJj/MI5L6FnZzO9BS9sesUewkJiNSpAYd3hvVuz4C2buMGj0v8wsB/aJcIEy9bxOBNlFd3CIWxg1FS3I1aeKEevjLq5hc3NldAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAG1ldGFkYXRhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEKAAAAAAAAAHegEyym/Ucg/MHeuws1hyy+jM+zhif831l7UTldqpaTNPaIs2r0vnhH5D+wIM5HCifg0OlnTjV7G2mcuziyfgc9gwv2Dr2csHNTeZsubKTYJwSSmUTRfzwujsxrJaaUv1RZoQ1ta5XLLCMBXq33YxSofd7+rr6rAi8TArKGCNUK"
-        }
-      ]
-    }
-  ],
-  "Wallet disconnectBlock should update transactions in the walletDb with blockHash and sequence null": [
-    {
-      "value": {
-        "version": 4,
-        "id": "4d36c81b-117a-422b-ac3b-a9313d02b5f3",
-        "name": "a",
-        "spendingKey": "6a6e0c3cc54799d623f7d9727eaad86529db7c76b1b676d1a2059ce3dfe4b793",
-        "viewKey": "d7476ab6c2b44fc2a86f9f2e3229465a156e8ec0545eab7351b585b1e26b7568c5f5793362cff416f7c9ae66a5d96fdd44562e634fa150c96e177c45163fa04e",
-        "incomingViewKey": "559be50c376636b333867940c56e5adf3bf14102891c12e2df915bde0148ed03",
-        "outgoingViewKey": "fda80687cb6b89197a2f474bc395557aaa78e8ee775375a65fb46fb9c8d4db8a",
-        "publicAddress": "77f8f0f146065f36329224ae5b3e3f12cab487ca04d4f589754f97872dd08e2e",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
-        "scanningEnabled": true,
-        "proofAuthorizingKey": "c12d8e4220df0aed7a6089a41f1b3f95198e22fb300fa9a81737065a9e235403"
-      },
-      "head": {
-        "hash": {
-          "type": "Buffer",
-          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-        },
-        "sequence": 1
-      }
-    },
-    {
-      "value": {
-        "version": 4,
-        "id": "2922b6cf-3662-4059-bf2e-0176957f82fa",
-        "name": "b",
-        "spendingKey": "03ef7aa84b14d78820cdfae07c7e46a5974b9b42f98d3ac1dd56d9cc77b625b3",
-        "viewKey": "5783005de68cf30674842c1348c4a770552bcd7f4ccdc95f90d45a35e9e9f61cdc5e03670f8ad85e438a9634b17ceacd8dbf8ba1bb062d6a2df943a556137114",
-        "incomingViewKey": "d4779702213d80c09cf32fcf339675fd42f7df41c5881aee93fb05a858c0db01",
-        "outgoingViewKey": "aab99e3522c644aa7a35fd99242b012530f7c92e5f7d09883345a3617711f332",
-        "publicAddress": "9b88b5a458a7f981f54b9ffdda6532677519dd0c71f71559207e4df60b5f2e6e",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
-        "scanningEnabled": true,
-        "proofAuthorizingKey": "4b7a55b3ca8d174f7858f62bd1704173147c2506e7e0110a43972abfb712bf0b"
-      },
-      "head": {
-        "hash": {
-          "type": "Buffer",
-          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-        },
-        "sequence": 1
-      }
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "4791D7AE9F97DF100EF1558E84772D6A09B43762388283F75C6F20A32A88AA86",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:2ywBgNNP8H0qbOMxslC54Alzx1npm8LN9PZkbmzxVms="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:iqNdPEjFbXj/df67x61DdErXQIUhWxLcDcpAzEaQXJY="
-        },
-        "target": "9282972777491357380673661573939192202192629606981189395159182914949423",
-        "randomness": "0",
-        "timestamp": 1717538817506,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAn+SgA5elA2Yw2XHJkGWcINS3NN3LYbM5gv208m6zZpWJndQl6wyYJK9WMOnOT8jdtkrmmbtcKLt9y3wwNeuh76dKefWQTYno9U7jBcwQa8WIBCD/P10fJo7pEEqoZLiutXHm6zKqDraXAZtmSpKFie0zzkQGy6eZMY5DEoJKTlUZT3HB9lhJ+Zl4nUdvAo+0tUJpE8j/+R5cZ/5AEzTgJcCgzbopLy2eNU1jkgUeO+6A3J60mFjtEcdaZ6P+HhvddNQGbnkICUhVGUB6J+bC4nMFrV4UIBYPcwSa9oS9appixHG/NgELn6EiVnwcmmq9PHr7JL2tdiLpM6/sdbyQnFeEeRQ8Gh6LaF1Wkck68SVzcpWQUBhAQZUs0PXXErxVVCQwjjNwk5mP1wBg3rqIYvHTG2HB6Ta1fugrloURYxAwFz683WK3CZCoJNbiFWQFPxoGkaTCA7qxrpiSc9s/f77t+lrrW5R5oJhMnvbjH4O56qM7uE9+7k1ZJSEV0qxZLU/BETrU/O2gBUdqSxLty60HLCIc5LnqtJSvUuGTMSGZXCTWigdHtH9SkqDU6g1l+wocnc3YYfN0DAWXDwjBD3ULmszz+n6bfFzxUB+us+A7WQ+VwD/6qklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwuN4KaJjKLCHOFw/cn2rhAF9bJCqHXgLuedmrK0xz401fRpsaz1WjPx7g7CWPUX5XgOSGU1ShMd2B4o3cdj7MBw=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "87F7E2DA3BDD6138E780C429171F7D03D4866EA7CA666787C71F372D73C0779F",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:4fux5iPMDcHRKhXYTfbyUtiI+Ny9akWMFl14jDuDJ2o="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:7Kmz5HPGmfr0IqxHToKMovYX7ViGL9wgOdwrE03CEbw="
-        },
-        "target": "9255858786337818395603165512831024101510453493377417362192396248796027",
-        "randomness": "0",
-        "timestamp": 1717538819526,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 5,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAUc3/rmPJEkcUH6FoJ67mpmB+ho6FGEvAVVJuPdX0x1qkQmJAa4Maxdw5tgOEL1JyGpz0x156c3JBkgAC5/enoJ6/kl23433GDl3pmmuxpIGCKW2ve2/rb6DLdbxwPiV6+gFaYCX8W3DmAxYAhpIkbMCamT+StVD0Zm8WGg0n2N0Fn0OS3HTPa6gsae35IGo97X1RcegTeH5BRa4bQ5r/gdoiJAbL6JzFJ5UJVLEv4jGIMiMEayJZ1uuy8mBagJR7DofUrMu0j2lj3nnAt8T23dlXCJmHItNJPvgTVfInfri2FYE8xJjmf0VRKWBF6KdZ/QiLBwmS0zVMQCd+koNel4UsK3UCK1pFIPudJi/QXCEB7jW17mI6PRcpSlx/E3oR12JxX5idF3xLs1y6eVwQ+caSWrN95nVGZ6DCroidBu3fLNX74bWqD0o0Xb+v9/F1CFJTmBhXERInb4qB67xbupkrtzlEOqjuqN3bGHgq4AHRYO5R67Uj7Hq7YRcHZVOr7C80OS3q4FBwoyeDusfU0ZhYi6TjGLcOz93hmqV0OsrerKsK82vz/z+rExXKiAA6TAboPUd6BYv3xhATyAVXAxhhusOyE3LnKqNE8yF26hOwzw1XTnW9l0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw9V6ltxaB0huwsyo12VcVbxswvvdoj7gsEmAmlvOLTZWto3nLzV2Vd0ufrnwaYf65hVAAZqcidYDOQS0naptpBg=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 4,
-        "previousBlockHash": "64BC4CAA0864E98EB217AD9718387D5EA97B1631D1DE556AB219C70D2A9FA9CA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:fEbtSjyxeX/k6mQSno4lRP8X0a7TxBi4ii1SJyQrBx0="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:Xm4OsaW1zo5hFTxslay3UKW7D9jgtEgN76jtg2Covyg="
-        },
-        "target": "9233318228143625020618577701423519925017621426082203201059080050516648",
-        "randomness": "0",
-        "timestamp": 1717538828217,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 8,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/2vKiP////8AAAAA7/BGXjBaoQcXdcKt7BLmtO72HDn6vL3yrvfyo62QmNep440nAfH6zOxZ2f3sEbMvVH0zyBx3jLYxrjMudbcXiqi1M/Jf+EFHwNZ/d45YDGeNbClOqQRpAbd0FRAkTQtwMuk8WNI1DX38Yv6TzOYQoPROvNilfyesqxAHC1QPmyINd7wdXGOiqPX+Z6gBqLlmiywSvmSpsOZRmTN6YDkfO4EicLxhmITOWsOOsavp7faqENyNEX8yXxWCqfj4O45J8t53jaki6hmqaqT/utiYr1klY9Oafw0JIY78qgGVQZh45LK4deKtPd9SEutqP2HRh/uUF90bcpu/5z95XIpXtzPf5iKkoYrqKaQLfcOfuw3rdC2JGOtdoTWa4UvoS7tTFYe4lhSzh9gpwVVgYG4LoDywirWcwK/a0tHKKUeng9ooB3+Dtx+DV5rfMjjKzadzC8TJQ7gpCAgeVRj5B3deagCmdBoTBU5MebLI/5LzyJF8kADk25h/hlafHP98JMN8G22/mGltDrTqHmG0O0kP21coZlGt4qZ75S7cHSKclQg8jLQ+XO+ONhe86vxozEqg+XezEgNrNFm+cKyyhk6yGKtDMrWq6LPxsNI5TzMhW/44ycbym9yrsUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwh1LckMrSdyMKCQf4nrXWxGzTJhaoB2oCXGv8ckMUJ+DdUy1OuVHww5mbN9mErDs+oWj4R4FAeFVNs5ekXfsOAg=="
-        },
-        {
-          "type": "Buffer",
-          "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAN1aMPhqNBjLikuXaTnrGJay+0RQWcuYK7vLqUlSq8YSNPYzN2q7SCaMZYA0o7TqT2CmMfKQ2h4NntZaKOyunnbwxSmWQsA+dRkPvGbOvl1Sw4HOa1ZbWSd8vEYepSc2uymGeUnTKRA6ixytamFERvJ8WhjxXIl2JWaMeaOU9qUYNUF5T1ma5v9oLLuHr/2bdyeHYOVwtw8DKJAPiXtlcs1Wn5/TrYrHBDkIzkW7/coOO5x70pOqXR8VzYxol7s7yfxl296esMiCn/lQ7F30mCljR0U68SIlTYghU7FgRWhICv8DvlDiPbPH0c/hdvp7c13DxxcThoz2BqpFfCKPqKOH7seYjzA3B0SoV2E328lLYiPjcvWpFjBZdeIw7gydqBQAAANXKct7eOCT9pozgY6hZ3h955onOuWs8teQw5kKgeZR9V4NmJZlYR5/Pp3uhCkDa/fMpWKwPddJv6AfCmjeZM5sJTxqAcnNrSpsTEEiKgh/OUy+ZWHcrjOAriivy7RKkCIWckvomu1lugL+KYyxGk65YhlnuxL3JpRbZMOuB98Bg35dJTxC/voIABDGvPbyrS7CyLiy/ofQ1yF5wvy+yc1kSBMVJyagnFK7KHILJYFTTfjJuZEOT5fMdZA9F74PRvRDEu3wXIzSs5OKhG/VK3+iLWuJVAD5czM/+kl4o0g4952mPUwydWRljCF17WkY6D5LrVowNQOS5hZ9ganagZO+kFWQlQ/fQI3tY4ENUA+O2lowSvDnH+JK6d2rqN34EIkLfOi4DWleUZ/1sgwDhx2ZKbZMjlbl5t5FYFIEV4MRSTr9WR1HVLQ28k3a3uH4JN/aapvCD+2itPxlEotV9xi7Io7Q1qG8x8FjHQ4NrkV9IjSnGkEoXYRRoO4mgPweShFYtPm07aF2SmkNX/SoqVSFNfTrQ8bWhxQixtHsNA/4hfxvCuiyWD110P0yOdn8+3Y8o+d/yIi58MX1NcU3Wsfrpla/nL0Uq7xVv81qt5+Hb9hY+L50QmuQPTLtPjGUKt0NRgiTtoNeQNdAgavriJoesNBk3Cl6EpqP7HeQIf9ZxY2gPYtJqWck+dkrqjg8xyRT8gTqLawsR6wJtd21lKF8gMaz0tByqwLIGPUEayzufec17RE6L3FK52YPbdAc/Yav2JSEFtHOv31G9um+v0sJDPJWR2XMNNVvCPl/oOWGT+a7YRe8iwBiqMklJtIcnxRThFTLCmzyzuOT1rno+0Wm5Vka4mbKebYT6y7Pn7IF+J5BfSIteIt+WHi8xQ+Y+/3hLYgmeCIifW6THPBj81/u4Dvg3Zo8Sna10bzOGJUvrhIwdjHrJH9AWCYubXgMr6ha50e5+3e5G6FJs+6Yb53ElZ6EQk2DCeU7t9AgQovhaNcpkJEEiJQGCtRaiftjtYbCJPu8/TZygIxMVoVDOlP9rv5rEsbm44hg5RI1OaBioHeK/9EfaBHuFkNK2Fx0OuvgaKL9b/LBbRVqdlkm1feJDFbO059Hil3orb+PU7TJQ0Fs37c10uRcWhpARRn0KKAsox8QP0acpbbUx/DvQl/iIFR8u+/De0TkZiDWg/EElwthJST6Cbwvclj4yQVjk3ddoGiWDtEHTmPUioyfVOfCcuvKVU6fEKpmxHcn1vlimrJAit1pIiVMkXNUZ0pjFOcv64hWSwL1PIfYyEWe/yJ9xeRODjMbPjeXYgjhiAe14Vcbf9g+C7/gBpu3RYRx5iYauB2VWqmtuHfewX/4K4QkzBdvGgZqz23r7q81Vj5RlPpQtQSfD0eaO4Dqm2f5whiER6OtfRXnlmGE31luYCWrpHJxQaWdfJYwnN2LzR24RDsH5yzLZ9X/Ui6hO2ZCqd0NfnH1LpOxHMJr9P/7iF3/M7PkOuDY4db69bFEqhQkkvOuMKGf2HATeMYHC5452kafY2yzsRSc6pYzes1lGoU/8/5Wm9r0qLOurj+hND446wcyKWicieAVV9Ps6GNchAQ=="
-        }
-      ]
-    }
-  ],
-  "Wallet disconnectBlock should update the account head hash to the previous block": [
-    {
-      "value": {
-        "version": 4,
-        "id": "23a13952-9ca1-4fc7-8b8b-ca7d54528a7f",
-        "name": "a",
-        "spendingKey": "43d0225b1300276945a95e014300ec96efbce8ad4350945138f974640dbeb8ae",
-        "viewKey": "a2e4d5ebcc416605a649cc105bbfbc1744674b87fe96ada78e0c25126ca7d3ec1c13945530ff3c86b9df7464db04f3c17036926053a127e94d0375de2c4ceb55",
-        "incomingViewKey": "85be2a194babc67ca480a7fad7fee31de1e22b1bf6a42c180b7957f804bb3b03",
-        "outgoingViewKey": "37dc14d6db97de98a5cb417b4878abee0da710aa9852b78509457db265a7bd9d",
-        "publicAddress": "a04b7f87ed8da22822fd6e12d8e4f1ff026e075d81170fa389619687fc09bba3",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
-        "scanningEnabled": true,
-        "proofAuthorizingKey": "82ad3b2281fed4dc1e6688d397fb8c821cd31958addf28d49bc8759fecaf4e00"
-      },
-      "head": {
-        "hash": {
-          "type": "Buffer",
-          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-        },
-        "sequence": 1
-      }
-    },
-    {
-      "value": {
-        "version": 4,
-        "id": "3db24702-4c00-45d7-8cf6-d3a39866dc8f",
-        "name": "b",
-        "spendingKey": "9fd21200e06e7eb043ab19cfb0baf610ce78a34cac2459a309bf83c235c6bb9f",
-        "viewKey": "af25a238a5b7571f4a04c68cbf0a3d2b439140bceb4089037e6002dfaa90e50b5c562f0c23f1293933808a008239d4804d7accb73bc9c949b0c3992b82307632",
-        "incomingViewKey": "24375314e92a44b3ffee23a1ede3db99417d78ed573557002190bcc6168a3604",
-        "outgoingViewKey": "0170cde824d36c7b73510632c2eceaead5abdcc3cfe0f3dea276c1fcd2784f4a",
-        "publicAddress": "4df7683042db7b5452447fec67f8705fb987eac27dbc7a90b3952631fc9eef14",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
-        "scanningEnabled": true,
-        "proofAuthorizingKey": "6f056d911f82921ee5b80b302cfb83be49c6a6d9f14ef3f0bd514733161b9d06"
-      },
-      "head": {
-        "hash": {
-          "type": "Buffer",
-          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-        },
-        "sequence": 1
-      }
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "4791D7AE9F97DF100EF1558E84772D6A09B43762388283F75C6F20A32A88AA86",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:XEQ3Bvjk6XhOZA3wHi2/0JYKEr5N4Q4zuCPfdqkoDGM="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:qJLnZKHMkfT5JWiHaS0n2oDYVnQQ8oWHiDAv8Kbp8JM="
-        },
-        "target": "9282972777491357380673661573939192202192629606981189395159182914949423",
-        "randomness": "0",
-        "timestamp": 1717538832024,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAHq/ooVgaEf52Ok/jN7FT4CBAAIoUWTyCp4GX7xpxAEWoLwVq85RgQ1GqhEmlBrZyP8WijWJCNdyRrveFKm9RnK3NkLjqGS7r8T3zvbVH6tqHGM0N1kd20pWEGX1fROAQqw+FPYnnSOPZUotHirCtHcEvwedqCErrhLaTs7LG9r8DUdqPhLpbem3nRaR6xG/F8xpNAvRLe65RL4iMR73saKVMsQcCLGlKC8KSGDFdzpGy3Hp7ZwDGyq/19koEvI/d+eOlp5jEiK7NEpD+IRrbuUTTLsgeaipz4kbZBDSk5kY1/nEFAyo4HQ82UOVt5G1nogvxHsePf+36qI3u4MPpRzs0loinoq4UcJJH8HOpxDIIhmxY/t3n/2Dkezkkyw08UlSx54/WGNoiDWmAySIdc/wNb9qbUXV43oj9yKhinCLaLXvXY+hfwk+lGSwViwqPYZkUY8O3BkYDJ+Y0vhbRWVbNRfVZghtuGDVwDynBwV10Uc3f2KBuZcVnf2Ctalnmz/fdCXVzxz3OzHH/RpLyfD/jyo9HDD/DK4/cdAuDcXfMXiUlmwaMQKyiQC3jXxCuecB9IJa06sS5hdMksBWR++KBY/f/Ht4IT0mmumuNX9m1xlH+t6CfBklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAweBrhDoyFhZhF9bbrEiyy+RQt3ft23/UUjRvKzv774N2HP4kI3CDV1p1c35pJMV2VNRmA6UFeacXu7uzbK7hFAQ=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "7F840778C2EE7BBCEE58345E540CCA24BA65274887151D50D7C51AE1BC1AD330",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:VLevhByK2cSaVFYaNWBo/yiiAz+38SIQFC4OTVQUvgg="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:weNpITr/hPtmw7dvQGSCoIp5dTXHrQ9rd01PbDsmNE0="
-        },
-        "target": "9255858786337818395603165512831024101510453493377417362192396248796027",
-        "randomness": "0",
-        "timestamp": 1717538833953,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 5,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAiBjSTrwG11TFrZKrBMkbozpK6BUV4ZV2a2L/D3xF9eiSTMp7Oydru8f4SdPcO3hT9r/zF73HAnFRouEIztu6QMJfHv5yBeKP+UQ9VlcxJcKPgKxjefh9oHxa4zf536/QIBwdYI13JxQdou0HRYTH4HwBdBjXeF3dOAO2Ah39JnoJnFxWUbpyyICeyHHoxREtoi6Q/RQgJ+qx+tXKkYvUX08cJYr8ymRMzKk0SoB4qZesp4PxHlhbDsYBtHraSFd2unPRQnNzh1x9a/C8tJPYE/J85OuZbDSJeTGzJlgRkPV+S/6N1SOZnb1kJdI7r2L03H9Jd3dd6p5EZY3jBvNpanyP8t50E/daoVkBWwzauTFq/N43PSMEAYYYtU72MTMwxHq4H2srfd45R0v36wKg0k25Xx77jsL/ZqGQb2Q5028+60FTnH3VdLQ6jn5iUqga2dxB6qB1jxJyXPsQLBI137TPB+hPrTBA4pUD2QQhRMbZZ05VbPEs9bT9vE3Ef+pCbxU5WXl4yavl7wPr0tH2bDskCrtA/YbDBWZqgIMolpXzgvw/QOc9xzhCToN7X+8eMQb9t9zk8Z3nD6C0OOIXxX++4mniCbJAzBml1hY/vedIuFx20s/COklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwz5bdLkzzcHD32CydUnSmIf07YTCqFmWgAdTrY4ywvL8uGIGp8qIg2pRYcChhep8AMh/dz7fvblEfwQ3arb8MCA=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 4,
-        "previousBlockHash": "7A51C70423B28FAA99D236FDB07C41896C626A3B0AEDE5F8F77EF748B335744B",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:1VFep3fDG3jQM7IXUgSIc5yayWx+kTt+pWNuuFrQMWg="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:HtbB9rZdaTtVHX6qR9rSngAvUmd+ptTTlSNlrEciW1E="
-        },
-        "target": "9233318228143625020618577701423519925017621426082203201059080050516648",
-        "randomness": "0",
-        "timestamp": 1717538843233,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 8,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/2vKiP////8AAAAAAH0GoT/7LrRguG0yKDNoy9ewEA4cl6FOB7BfWLne/Y+KPwu0Irz9uzUv49v8x87FJ+zAeEGJG5oP7xQynrTsACKlnYEfbgj5bJ4UWu1wE/2WqgRENm3eLMIzjgHaqtqavLzqUmHBTZvhtFLYAb8D/wqBdCSThiIRJKhQNbdX6gURCmWsjj6X9decFpaJgY3Yntcr3V7dWlYkwf5ZPZhJYOBvZOeq1ipMAPEXGO7DvQGPnO7StvBXHXNwv3yJp6Dq0k/W4bsF9H39jGKcYj2mHLjtdnI2ya5xOzhl5wHGlpFYjGovQceW5idwYxYkxesN1rmUFR8yNCyKzXcE4L7vWqUWOiTUjSMO31dx7vFGx41dImcUoLxjOH04z5N4CiNX6r+4sPmADN+fPBijO9G+DonljGDI+ZUkKM7D+uFSvj1LbfeWUHNjWY1Xl+bym4SH61AAhmnSlQrVG2yOSda06oqxhoblbixHTfplRfWTHBBiE7leiNR0LDpmKi8BDO2yp9yVSB63dwi1VtAujet2vb+4ei4rSu07tCr8aUQPguzmpUL5Q13YU74zJUvkPMRKVNfyFHEfjk6ygfaV8Y6lPkLAo1mqin5MUjW2g1dnX1AlC4ycEV6E+Ulyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwSU5gwUKD5ZDJfOoXXkRjRoaQRGUUt2a1nh5f5M6QXelciVGZ329dHr8qn18zI7i9AO8wFhj76fVFVE6IAxSXBA=="
-        },
-        {
-          "type": "Buffer",
-          "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAsVj1yV+P5iuV3DltoHMXbeBgTqhtWHYNHhsilaFhIqi1oP4hz5GGoYsQM9XWNq2BQ5lr5NxdmFRD+umqSuiyS2CFexBdNKl3ULWNR2jhD6ajEmB6GptEEh9XXRVfhb7Dpmxaukf8TNPAMQQljeemC7IqjXgttaXZH7kwQ7l4xkwLbTMhud2VYqfv3zl0ubJE3uoDGU7aWNu3Hj7kNqg63Q5Q1+4sD7XYYL0YHXdgGiuQhDvzlUYFPPpLLUa8tUe9CWD/QwJsVr5O4uSfYl8oDZp2qCkWZOYhWgnDO/HbQLJn6GAFouwyQLO3co7R3b+DDYAuK9uFFWQoMXJWkUF051S3r4QcitnEmlRWGjVgaP8oogM/t/EiEBQuDk1UFL4IBQAAAI4h66Vpc9z6JfEJUi32sYFCoi2sSXWv11Y4IQGmhvZMpGSO3tuzyNJlsPKB8e5Ct7dPSnelCeUmxeVD3vG7t9Bcx7TO5hP9nHof8Gsnl7wFEJLeRJjnv806K7NkCMe3CJdZ85lljwu3o7837OgZ3R2gOAcmfGEbRHqdBxJSuYUg71uXN1gq8FCoWGid7Bkl1pYKjBDzfO28nuCaPvQ9NTp/jTbf0mzrLQM3a0Ws0RwzLrUMmi8/JeiLneSjcNLHVRDFSXt2UssE0To+nH6hDU9HTJLhfPys+YVn7H6oo0QVD/1d9zJoGS1ozWnIsVqRDKvGtbLlqgK/zPu7qJi13Hh4VAWAfttaJlIZ0piST44SWorUNih2EGYJvQ8einQJ4A3HKsJeJLEOpI51G62ZhwpQQyDLBE/0crH2SKmLi0bbihabxnQi4sq3GpxANiMZgxumZaQ4400I178uZNejXT6P9fpAZ3ZwhTN8/P0GdBii4ygpLsQ3NqgDmhNWYJFn6aY6p4jEmCL5O51R630EIohL6kBQVr+JhyLiLUGspwydMa6gE2KKoGN9o8hx+8a75rLEOZbP2wgCilWhmxx7tg9g1v08stL+UPIYSUlOVAPn3Ln9A3Fy+oOVsirWqRFYdfNgnFyBLxF+Glkftjg14534UJv4RgrDbnhUuF6JEiYJTh22OD7vUtEh7indVRA41guq4G2N+1KVjSIEXzPL8ASZ4z+lD8QaZgxsDlgM1BEadtt7eKKsTSvTckiLKOIdXcHQBjoVwRmAyOcSDMPzZrq7nXDwbBygudgrFDr9TTf0gTlAFwbYJTiv1IVw0iJGEYunMnHI8RDc65zSiZ1b7tKluZHxTqaTF3sIgCoSsu+bqZu4OY+gwUimLUG6FubybEh/0Z7JSRKfYFGhm25/njTYjU/2ZefXlfG+V12lzt7lYjdmxIdAL1wVxFZ9Yg63chLO3pls9OHIYE56jL8OCzrZ/RCh/REW4e8f4CyfJCy+5ge05F4+6YKxMiUkCOCXXHjz/6CfkrtDDgMkwEhp9Zu9qR38HAKhBJCQ4bTdwQiRurrLQ9PAwc6BzLzASAZABxvebd6TtIEyWdRt18wy2hN3xk5Ek6OJDVsjO4Sywbl9yvvjLwaDxKvcSPAJvttMZtEKkOOH/MQFE/3zWFg/Xqw83Wi3uIHIT9LYxjig2N/ewyDWx7kpUOoJ/OUHogVdS8FWQJcdpPeVNJLgE3PMqpGecM52UFDHRK+SQhj1eaffxMzGoJfPJxkoSLyb18l4Kixdp3yrBbUexUeAvEPmWS7Vojtwzui3lxhsnDM32UggclhVfKxc+LSUF6pX3eut9skn0FkHvc68l6Auwpmh0ljoJCukuXs7VdsBCYJ6ltrTCiEgtIguxe34p6L5ih6XGpV3Lha5Uzs54cyr979mIVcJzYRNrmkdD8LwytZwzqplMh5fijS4FFflsfz+QXIg2jS7olebEzHTt+w4xaQA1SKdvAWdtOin2EHnyrjAAUXYOtSq6SEXErlLMORNt3yS1+k8jkNE0RBUYn8UFacASU2theizMQoBU5bM+ENEkbZ3ohdRKEMuIhSsH7ym1JprAg=="
-        }
-      ]
-    }
-  ],
-  "Wallet disconnectBlock should update the account unconfirmed balance": [
-    {
-      "value": {
-        "version": 4,
-        "id": "5c3b31ee-84ae-4e9f-8d32-3c758ca02176",
-        "name": "a",
-        "spendingKey": "14202ee215ed69b97c6c3317793af0558ece43bbb2ee3f0cb164df9d8eb16170",
-        "viewKey": "110d3c1105b91392ff60c0f2ec143ed75738346f6f3d6a939e6f5cfd0134f29258070c1c4a7f76ff3838956fa5541f9bd8e3f5127b6903fe25efb07359c9a4a4",
-        "incomingViewKey": "af17c73970552539f2392f4caff51cd13ca17b635e01e1957aef25a55650a506",
-        "outgoingViewKey": "e1844f59394714ab1dee5d294c06f4b05884c1cb4cd78e4a68d25ffa121421e0",
-        "publicAddress": "e76c858e25070012fcbf5126dfbd4318959d300f4e0bd9e659b0beb1bf771cde",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
-        "scanningEnabled": true,
-        "proofAuthorizingKey": "311edf69e8789151f2348e5705591d1511a2964e218061c450d24c9fa7951f08"
-      },
-      "head": {
-        "hash": {
-          "type": "Buffer",
-          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-        },
-        "sequence": 1
-      }
-    },
-    {
-      "value": {
-        "version": 4,
-        "id": "772a244d-93d0-402d-8c0d-556b3f67925d",
-        "name": "b",
-        "spendingKey": "bf5135531a77781c0c6740e1ee5f2c5c88aa96e4ccee9efc30199a8ab55664b0",
-        "viewKey": "fd1ff51a5fd1f024a47c8e214de1cdc8eecaf506bbfac1e923511077f3ee43899300d1e4ed347d4cff8b9ac1000734d99e828e34c20e277b6197738baa3d7d11",
-        "incomingViewKey": "c7f1775e88f82bc6fadfb27c3a443063aa22b9dd692f3a0ba8caa77fb2b78d02",
-        "outgoingViewKey": "7ac5c5eb4054140b70697ca4e896c329c5fb55ffd98e1c1b352692b6adc9710c",
-        "publicAddress": "7788a27f2d1b3376f6d36b386bacce08a33724fb0565d47c6a24a5d0472f945f",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
-        "scanningEnabled": true,
-        "proofAuthorizingKey": "e4407cadd714bbbda77c092f4b9409732dfcc15842945fb45b073d2793a8bb0c"
-      },
-      "head": {
-        "hash": {
-          "type": "Buffer",
-          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-        },
-        "sequence": 1
-      }
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "4791D7AE9F97DF100EF1558E84772D6A09B43762388283F75C6F20A32A88AA86",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:UVEq2PuNfdEoC5os2mTh/pGh+//KtVzV9OmjNE4u9A4="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:KMr6pfCHWpaCUHXO9ZY4pzLg/F+5HDmahXtMNExDzrs="
-        },
-        "target": "9282972777491357380673661573939192202192629606981189395159182914949423",
-        "randomness": "0",
-        "timestamp": 1717538846941,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAMHocbEKX/hFqteL3S6G/e3KMJAHNNmRRKfZVlnk9mD6wRc7YCXfS9W8uBzJK+P8xTdoTXNp59/yMVGDgBEQ3/M+PWGueOStYeTcPNaqW7LqgG1JlwwtvX73WEGPb3xq+bJXPnSuALtvt/hLTBpmNUKnm1hkzgCrfk6lc92bJp0sV6t+GGzIwX5FEYIa/98a/YJGLV+rhn9nl9WYXMpvu8ARL9pAZ0h8xdmvCpIZ79amnJ6V5KVGpyvI+rgNvFzb5YEMqfb3Hqtlbf4woIFdQEDU9y4u1lI+Z0TqpJd4m0ai1/DgpKZZY9LO1Y7kKmxA8a9EreYVxg5yCQxSPq0/GoTPacLy/TdOEgropoPrj+LG1ABME5Ywm0OwHHi2V6BZTH82Y0izewLUgvi40d6k2xvv52dbz9jhKBY81GXg1OqnTQ08jE/wypHRosTQQEegdxVrGuOHLU0HAnLvIbCxnIRgnHViHklbqaTU0y8jkepAjTdKsM8IOzsIr7aC/zDhNoRKjwdLZO3rmHJZHDZ5rqKdIBvQvoUjjBvpgyFXKb2+z9DyLDGYLLAUIO7+hu1dI/On9b42CcSEtGHc6QgUWY8D1dBlO0mGqA9NZ7EiEnThuYlSW1pdJGElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwyV+jz+8x2nGaHlf/UyODXXLpoue7fUuDmziRqa01zxsa7s6iH48m6i6opt/8hRYHCLwAt2trGPejvN0liJPyBA=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "47BE1B2BC6DC4E9124BB587396A9AB36A373166E8393DA3C22078A4EA29D86B2",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:ircI02WWlTMdDjJj9Ca0t6e5NN7vTiBxmQmi3WRAIV0="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:925HWtFRAfb3ctfSfvk9NYg9xQspfZWKVkx+W65mItE="
-        },
-        "target": "9260366780148527510972123832573278885902566341756516011968728852484845",
-        "randomness": "0",
-        "timestamp": 1717538855857,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 7,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/2vKiP////8AAAAAyUcbRn9SkBycLj8GjNnpdxJlegIdiiV5CiEBe0YQ/zOqMJiEGG4UvJ0Z/Zx817eRrxSXGi/AgCE0YJqBcmylwQYh9xe06QBCXY5SiEtnDzquMh3B4wkzgL6xJ+qHol5lsgmEJuv/Gj0oDdvm5Oe/AkoeGu+vJYVemvl3C2BCqpYWolxorcwum7RB+lfs3gGNlAGbytgmjh/HoM0aG988Lo3Bm3qvu50+Qg/7cBqgAZ+uAlbpCLwG7ZT2XB+GKQtI8F3KcmzovUeriiuqc1R2TfwmRmfGu4zJ4JiMJh83QQ7L3nMc5tBmZ3F1xGHAvV3Qpr3Y1no9pZ7ohrfg3dM7TtRs/olo7pJiCBOt7TdDGkBrXrte1/ojEuf5n09Q8QsMjGUmcKlyXHl64O9nc0a5VoJwjfRoVGeOPqs6pf2afGZMic74kYMuF5HI50TAwNwzYg3EMifD15/t/Lg/ychFI1hPLtHdHswV7nLG/4x61ia87dcFQGS0UO1ePKgYad+LtXlvX5hiDJlUA0DRnlUemkJCW0pyXtoQcYEgtD6bCU7xQ/S/4OnxuKZf0HFOYBiUWGR71+/vmC+l6Y8QYs1RDc2GhALw/juhwtDb0REBIwcdZEn7hM2E20lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwDVZm4rAZYBWbolDd4gzVsbi0PtZuxU/ccMWHr5ZkL2XIaJJ/mWZO1BLEUNpSwLyIzAekacg8TMNuQkAjGkwsAA=="
-        },
-        {
-          "type": "Buffer",
-          "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAcIbTSj5X5dwiPouHLXYI5QOajW2WwbB4tun+0Hz+Fr6oRpcakoIL6bEZQfx8AffMLLEqueiTk6r7dkUYnVs1LQ0z0Xy23g3WUx/5WJEPijGrdJ+avye65OZ1VWHuCPoQAOnn13YYhiaxLnWxjiW48YofBdDpkX/r5kvhT1EO6SQZJ9irTSn00O/nFq4CXxcnMRq/DhgItM9WCMIgiKP3VH+N6fnznBNtXVAZjyjfrKOvGE4qQrNdvv81Zsx9CTbR17OEa6+NAN25AJLzw/MiO00aufLiI74U/UyFOej6UcVjsPEeVxtN9GX0PbtpYCVG1mvF8QJjuiT8ufzsdjByJ1FRKtj7jX3RKAuaLNpk4f6Rofv/yrVc1fTpozROLvQOBAAAANpXX8ersxpuq1AKk7y0dOwLYjGJ2ZWT+s//0TfZkvGzW1tbnHYgRX/W+FCIjcOcG/7yJY4o1kJR09BMQ6bvD1CZN1MVKHtFAOHpcg9eP8lWDo5NmEz6SUKfHzAS9JieB6SZ/ieVeyT/dgP9FnG62ZuGFSeh5DJuT2cpk2d6y48fwMXJTRdsj4eNdHFtkGNT74U6InHGMAOU33NyXMVC8dRuOH3U4q1Pglr7EJRxJFqkoK3OdVOLb3Xia8eTTg7qORF9mIZpP1ZrsILlKcDl0lOkCymNLVyCSAbFDXM3JMOboEjr+x0HQ2L2APH5owfDn7dZpcYResuup2S5ZwDSXnjka0CzccXik5LQLMIENsjE4gyw/4qQNY/J0HOGzMb4NfFK2lkUWmahs2KCARVfYncdfoaaxiBDFb6AsmbrsA4AEXEhmUQFJOudAUvH525Ef+ymLd7A5sjTAQX+6GmqHCBan+bDjB04PRJwLzTgf4zILtKhYYJtLYWdl79pNCYCgIsvmnPoG//nZ5ueBd1LWODMb7nUdXgC40lQ+yxu/V6i1/OquA4OGJ0Ih+bltKK1qqB+4qPyLHUXwhKpoqQa1uVnomVxLdGA76RW2NRAJHaqfvhJHoRxmbYFd859/ikFXi+5dXQwEVQaeK8NbUFuVF3hKIAyhqYlvsV1ziBPqs+pj2RfDey3qIvmB4kFo+mLqi/cC0N586CkH64HiQo+vwkP1n6xSgc5FXLTk0Xta0Uw9oGSgvdqgx23bByfasjCm48oGwoVxkWH6uK+LcZUPeEqHKci3lQ7l65g9Mf2FpiS0FbcjIlt2Gyl3j6KK7yvgToJ6cM7zwz0QhJJho7Ua6XamJpS0sYMaRRcoM6IXKecVXDFjbhBzW6IRasvSmuG5quxculPDHm6S1cheGSZA3pNTz4gnT+F1yeW68vBPPzRUYkpMhLf8LkGrqxN8ctozcDJghuZefipRb2n8NDfrV+ez5npn9MH5asGJx3C9uHx3Iyv4qWSsL2GORZuTnSBmTNrHf7K3wyK3JusG1p4Eh8aqKYjqOyzkX2dwQJ4C41uwfCdwRsLXZbYKxpN9NX/SdpBsaiWUbQl1ocq1QYBT53rSc7Ngh2QkQWMMisdp8a3KIdxdPwKxJuhevcs4U4c4nXmtObcmJ8DKzSF7uASm3ytjYEiLp8KQvyxslRR4NqDokJcKLyCAB1rNzpGJeI6sASXZKWP2Wa8BVDGj5XcsTICrdAOTi02KRLWuUAIYdX1EQJ9k5hGkLSupIbM4iSO0cTpOEfeaHoH89NBUL2tqHcq3hfD7gNEBSYWjX471RFI1um6/EOeMWl5yyXHZgRQTzkAHjgrsHouSsmrtRwddNWYaI8/kFV6Z9W3fZ1zYKhs8ajcHA+GlqnFMF/jiErw1tl/5XJPDRBq0IZM4V3amDiC/BouZpwmQgFKzI0iGxl2qHIBjPFRrXDHaKCBURrH+876JQWdyWa2Qof2PNTa+5IhG1fW0fKW/7sszZUFSI36muDfed7nlnCCm9/EDI6oOVjXEmURVSoN/hOYp2Z+MuasGAFqDo/frtoh7sdelK+j/325JHVg7kGmb3g/FQ2bCA=="
-        }
-      ]
-    }
-  ],
-  "Wallet disconnectBlock should not disconnect blocks before the account head": [
-    {
-      "value": {
-        "version": 4,
-        "id": "06c2b10b-d498-470c-bc22-724c216023cf",
-        "name": "a",
-        "spendingKey": "fc8ddbcd9a14a83bb10605aa95d83327f72c3113f1e0c385c2142bfdf14ce5bc",
-        "viewKey": "fb1290c5fb54837d30953e67b8cc00facb268e284af9531716846f9ea0606b86f0b7241488e5aac31e9160371939c203410bc7fbd094fae09160bd0d911912ae",
-        "incomingViewKey": "8a7496e08240c340567d2689c03fda557d0fafef3af918b0cd23bb6d2f637004",
-        "outgoingViewKey": "4ee2db77355e1431706c7cce644bfcb43c102a7d4ebbfe5b5ea70685c17e3a5a",
-        "publicAddress": "cf135210deb44de9cff4bf804acbdb5ecb8afdebf15642b16b98c4283068d62b",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
-        "scanningEnabled": true,
-        "proofAuthorizingKey": "5116aad81f2c1c4cf7a0132eea2889d7541554b366731a448c9a656883718607"
-      },
-      "head": {
-        "hash": {
-          "type": "Buffer",
-          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-        },
-        "sequence": 1
-      }
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "4791D7AE9F97DF100EF1558E84772D6A09B43762388283F75C6F20A32A88AA86",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:oIISnC5yyLhTdHruf/8Hp5Hxe87Gpu1+5b/zg6HbHCs="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:zspW61o33712G2RTjQUZMzo6yzNBI0RZdWfZOz1jsM8="
-        },
-        "target": "9282972777491357380673661573939192202192629606981189395159182914949423",
-        "randomness": "0",
-        "timestamp": 1717538858455,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAR8+NW8/ifVihj/Yv9j6yald53BZyqmYv2igRjH9ljKi1o/U3BvFG1Iq8AuB3aVMHvyMp0MZ7qEEnON3bLbHKZgDiY+d/z5bkigCRNZnDjAezmDeaOcIOMHCRYUav4ppMzAcxr6HhE7zEiyDadJmgv0I3vkO4uaCbXNcHvFfY3hQRZkF+uOFkyqGjGwaNGu+KUyRvpc6fNmwAvPzZ/oQyCBR3zqihtGHmKUSgWojelVSuwDckcHDOdzorpeZ1o2Dk18xLQQyX+UB6g7+L8ivG1h7XoXzfH4rucoC1qXPzvOKdaqOyYjeqhSbsPjdjF9D59k+qyC3q9if6DNgO7dK+aubmU0r6cVaTnTgY5wi2zLUnPSCTRABQcRLi7PFv2sEWTcQeK4JfP2FooiLIUCb/KvzCjoxpxaNOFUAV8HBZkC2D0umxZ25FYMHlVT+eFB4q0iiPpIgDq+UlmzYdfO7XWLNM7eQJdHaeQBM77CHWJ85m9iwjedg/ZGIkch7dv8XqnbqnR9BwfXng2/FtWZvFFMusG8RGck9Ip8aEwIZDdfdszV1sXCugq0V86iK8vZrQXUs+Dbg0UHUitVkC+FZ1QorTp+pCun7lwE1ngQpoajc157Rcfnx9GElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw8WA2ieOlnP8TotfkvOs4SQ1gwScWSFnFjf9kqaDuvMTgKqJy4esCCZ2NezZ0r4P+sxeC4cNv2qmW5ZJ1UJjtCw=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "D5CB6968AF11661F9A7A785EDA2CD889F40F7111C3E8BCF954459BA888B9DBDF",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:TyeNFr8FNbUG0C2wCQe5jv+8jXWOmJVNSYIYkPiEmlk="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:QY2eAdcGiBIKWdRgqsEVtCVf2BWf7X//E2T080QyOuE="
-        },
-        "target": "9255858786337818395603165512831024101510453493377417362192396248796027",
-        "randomness": "0",
-        "timestamp": 1717538859907,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 5,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAATicJNlPBMAX96+ROTIYVSblPyu41TTNrolZycYj5bMuT3jVrwQ8X3JAFbQpoCd5yANzw3KejzYeeOb7De+SAi++JzIn8R4CJeN2U4OTPSS24pMv7EZM8E4Nzhsur9rYpV1Bw62SpBX+At7hR+Ywm9vvZr+VfnVzSkl/gphueVu8LrIK9U4OiK8YKZAzOLKBXrS16NnFQusF3A4O4s9VByv4oQUYk57nuYBctWCltcYyOwxROejWRPJRRCd4iEn4vPlhRFU2pJt0qs6JOL6seev+5w6NtuNzo/fCCu2KF3YS7OcXT1mqBwnRfE4rl7RZLYdemjR4vZXjtK0e+VJxm8tE1hT9WQpPrgnR0bTXX7VR+TmBal2ItKvpHfWgKdGReA4TYP4RgeXYvbsLlWOao9tn9jYjUMFvPPDSVTeWog5rcT4C0ZnJO5rrrr5XVB/MJNNBNxUiljLq/ouMdofpuUwTsvbNFNeB3spanQiolE0WPBpESEkjDZcAmyEi2h8Y9k6k0IzdiNO4JKUAPAfwH/UUlP9m6D7iju5UUpgT13KsVC1q/wEFrYBjOsXZVfN6ICc9mNv9LEdMhJt4QzaCk+4Nuzchtf07GuZW7ZMuRbDhfQtA6lPTd3klyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwYVlXXBZYDSff6CVvwOFkKAIMRuRTMW12CxDW0ZvMBoOlDKU7N0UAeUpqk/50o3qQlry0hDp7zR9ztF0BC2V5CA=="
-        }
-      ]
-    }
-  ],
-  "Wallet disconnectBlock should not disconnect blocks ahead of the account head": [
-    {
-      "value": {
-        "version": 4,
-        "id": "d985e9f3-f52b-4032-b73f-2749d94ad877",
-        "name": "a",
-        "spendingKey": "341da00743442551cfd2e4fd4b68f3b2a301e29b888cb1db28dc0a67b266f86f",
-        "viewKey": "ec6f5f4687cd114f2c7f8ad0094e23ef9490abc9690787b820ab7a09dc6c54590a8e84c158347b4f731992e730499294869b077f44d936e47f9403faa6be5098",
-        "incomingViewKey": "f636c40ba00c10270a2e4f47e935ad31ee0a5ecb382dbc184408aa0ab1402400",
-        "outgoingViewKey": "6bf7751d5aa48ea23c6ff551afc76814e1ca5da64e6f50506505c115cacd6272",
-        "publicAddress": "3ad02fc5efcbb82261f4e1ee206e30125ec84b708ca463f94cd0a8f60422b563",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
-        "scanningEnabled": true,
-        "proofAuthorizingKey": "f3291c52c0b33405b81cb6a60460c3678a169d5ff146e595794386980f77f308"
-      },
-      "head": {
-        "hash": {
-          "type": "Buffer",
-          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-        },
-        "sequence": 1
-      }
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "4791D7AE9F97DF100EF1558E84772D6A09B43762388283F75C6F20A32A88AA86",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:h3iHfNNoqk3ptWzTCvzNuUgKVkB5Ih+6h6qosgoCuWU="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:yNNo/jHUN0qcdfQ7tay/7TRILJjOnfBcPL6Am9fSrXA="
-        },
-        "target": "9282972777491357380673661573939192202192629606981189395159182914949423",
-        "randomness": "0",
-        "timestamp": 1717538862519,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA+kBBR3w2770Gg7r/fUAdw93keYoVlRD+i3dd0fpEl9quMMUyYja2ZtZkSKh0yDmbwYb0g1tF1SZDkMSHZqyIUGZyzHgzRZmo7MsuAFSMxWGVxq3HzE7gqa83E6QLdXc3CwDHV9FqO3uCuqUlPEbnntJeDeA8m3+ikD2K+e32iDAUncE64viikd4bxDXAFeedJEVKMGvdzHaL5LoLAbQpqHTE+g6DfP+HMNE+/QAtgpCJyV56kPfxB6WJNi6RxsQo+CJKwlRO5K9KPwKvgH3nUfH0J/+eVrAkMr4ZOdyqICkAlfCHfsIJYrznWgNYc4vROcLATnwu31XwP2opVrHYsGyRpIm35gpc6ZC1oXri4pxRkIXYVdmzlD8J3buEFhsQ8U5nDBo6G9a6PN4qbZaCXAIMXP1ZlnariHDjC8m/xgTZ7k3xeveOS6WIRQCnOk0Hnc3aKIRAhHoRy9WhvLmcxOcsDWKz611NnKdYakPHtSAn5I+8GFOc7ORl251FuNXU7TdO8mmYs8dRb/P6niwf9hri/xfX7a80CHpvcHkaSEe8OIIqw18vsrEkk6aio03y4HHqhW9R2nsz+EMz76r3jCvm1wikvRrDVOn96dRiLbvyrx72bJFX+0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwGs7nTOeoaOvIMJvM0DyeKLMeuJWVRIspaww4L73ZdwNfZ9Xu3XjdI93Yyn1yHWqGh23rPsoV5udQdjBUBJFPDg=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "E48E0FBA10278DAF09A70F9A42BB91111FD244BD9C1451BDEB6B84EC3284873C",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:85xP01XjV7CBMD+YPMiqLt5Ta1jsRI6avi4oScbg5Dw="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:bt4ip0u35BNrDx6veGbcrD5MBei91dNWMiZpQbge8go="
-        },
-        "target": "9255858786337818395603165512831024101510453493377417362192396248796027",
-        "randomness": "0",
-        "timestamp": 1717538864120,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 5,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAJm8DcH4rbB7Ll1Uod57AASBHE6oNjWuNK5imEIyNFGeho306OydbtbVn/yk3uhLlODCsxAticOKfipAUrH6ZIBMaHAE3hkSKwejHx+gOLI2vcoKZZu7r3wdQZEjRsJPtOdzlLFmkk+X05/BjXjmKUpBtLlmEKVDThqhe0wlmmlsNNf2qWxwQ+gaelJbS7E/7HaAQ107V3eZsEntJoLErgzYNsocwAvRNXloDTsJXf5KyxVMU6Z8pIF0TaTLvldZkjeDIwzVWAzhphPOOoGNjmL/QlgogcMn4fMxQFSHUII1+4ykj1DNBeroMvCva7eQdX93LspbrLbMXpqU63TPOWiFYPjH/2Igk6PzIuFMIZevnw8nMgGLKJTrUvPVAm3gOXIXHWXo2J/4m2mwyfhp9pT44e2IHIObjRlhLLsf9PtEo18iPIFg1ZsD44q699Gs+4nefmMlOm1XGUOOED7jmKweY8zbsWCkov3jAtbnbRNcL69eLHZ6Gws4f3ZXY4NvKmuoqBHz7G24JP3CopSgPamgUgIsyh4votvRRdl3ypIwE8qvNYvjPsbFVtA8yWU2FRq9iINZW28YKsM7N2xJR5GxBpgJYFC7sqrbSPJ6vWIQ0O7LwND4RBklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwYOzxfJdc6cI7qAXgjadd9STVhj4CUYgo4+deMLXXyZdfpcL7LSGzvxy0r9XdFJgBtFCYKTr7vrzATmpeh7K3Bw=="
-        }
-      ]
-    }
-  ],
-  "Wallet disconnectBlock should remove minersFee transactions": [
-    {
-      "value": {
-        "version": 4,
-        "id": "9fcf3b16-1c4f-4a39-8b86-2f3fa8072833",
-        "name": "a",
-        "spendingKey": "9ace62028db6bc54d16c3773f6d42834e008b24078d7bb5401354afd15e70040",
-        "viewKey": "eb66405a64ad09358f93e9a38c3467b4bfa0a7d945ce89b09a53682049024803baa1a59434dfd01f668da5572e6fe80dc40f0df4fe0acdb6de36fb1e16c09eea",
-        "incomingViewKey": "0c6d858f2365bf1de92b145432f2e938cdfce1fa2e0e9168196b603b84645e00",
-        "outgoingViewKey": "9ed004a9bd5c88b0cab75aa01c29916a40f67a07d3c0bacfaac041a5e06d7cb5",
-        "publicAddress": "9a8787574625ba72f6bb0707dc3d055bf29b9810910f0e75ab20d64a1b0e2610",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
-        "scanningEnabled": true,
-        "proofAuthorizingKey": "c2c64c5284b54d248abe1bb97082323ceae5448b78f1b647d24095a882453906"
-      },
-      "head": {
-        "hash": {
-          "type": "Buffer",
-          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-        },
-        "sequence": 1
-      }
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "4791D7AE9F97DF100EF1558E84772D6A09B43762388283F75C6F20A32A88AA86",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:BK09Iduh+yZA9TBEQBvakLm/dVaT+lyl0St9px8BgUs="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:xLnOApyO6msCHA0mKFC6QfObZRJcZoqWL8OQNfrQo0w="
-        },
-        "target": "9282972777491357380673661573939192202192629606981189395159182914949423",
-        "randomness": "0",
-        "timestamp": 1717538867634,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAArBIIeopY9Le/A5S2FpsUqFDMU2FQuoIDG7SJVsnKfDaAzymoWjz2esM9yxhJedrKeku53CULpASR1jDhQTsnHf13h4ZkUlFC7wJ1BSygRsCZv6NCdwnc1dNb5EZKymY2kj4sBTmS82T4xnyydkfhCaNaWKZJz/9agL0WkUlq+JcAURDoGQ8Wua57z3XKuUqTEMXYe4AsXvfbVVhO60YRIM7tGC5DPiDkLDun1qoksBaKYMxmo+LplRYE1NYiuSb80RZEdadBeBmRgLVyEx3LxljFCLYHW7xUpYOr+qYRoVsl+RCa0HSXrn0mhQKUYB06yGlduKN//o3gYio+wW/tcaH3/rMIa8ZkrkTQ+nzfDAm6a0J12VDrSAdestI1LTVxMjl3hLpXzvtl+IfFVFfEqgI9sDYq72/bDF8mIF2xUoWBllYhuq8i+YXxrLrtcOkzJ3G0lfEKpwxfB+kHS96bValK1CsTYXHr+jbI2DTcQFvE2rp7fj2rhDNymgPCO5m7mkP9bwNR4xvjGThuaR6K0eLXdc41MCsSjp/S7nGN/ae+LRisyADv6N15SkcqIHa6aJYTHHT6Xlt1j8XHOMhtkhFkCYr1RUpIhCicQk1DTmK7TSrkfeC4ZElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwRgirMlKyM3DQ1advz1sstRkruHRrxEtjQrNQxq4/uy2RWCPXbcHPlunyCO63S3hTvmqQFtSjyHRspyQhJGdkBQ=="
-        }
-      ]
-    }
-  ],
-  "Wallet disconnectBlock should update balance hash and sequence for each block": [
-    {
-      "value": {
-        "version": 4,
-        "id": "6a5c48e9-63b0-4fee-ba88-1547466299cb",
-        "name": "a",
-        "spendingKey": "c0ae2e6716930fc6837ff659953d4416cdd0999add33c4a6bfb7b748c5d5f96d",
-        "viewKey": "a7c10ef904c8865218ade06e4d57697d6aa04ddc6a7bce052c14a559ac8ed8425e14852afa6c3ec155f082c50fa05f35c6b679a3b827e8d6f3e537c0affc39ef",
-        "incomingViewKey": "42594ce61502059464feb01764689c46fafcabdc62d178e0888b1f4fde333505",
-        "outgoingViewKey": "e250f39b02cb196bbbe57e381ab199ea21ae82e9dfaabd95f82aa6dcad713e5f",
-        "publicAddress": "135e42de661dbade17189fb1b52ebe7b73af3f00b0a22236468c3fcd5a60cc09",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
-        "scanningEnabled": true,
-        "proofAuthorizingKey": "7fb4be33957e2929393f676c52a61da3fd30f7d07cc9e324c63ff7beeeaf5f08"
-      },
-      "head": {
-        "hash": {
-          "type": "Buffer",
-          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-        },
-        "sequence": 1
-      }
-    },
-    {
-      "value": {
-        "version": 4,
-        "id": "e55bd8cf-aba0-40e4-927e-40be6949497c",
-        "name": "b",
-        "spendingKey": "bb3ba1a4e7c3bc528aaeab2633d92a8eca762d943aab5cbfb7b0d4caf2a6e517",
-        "viewKey": "894854302b48846111ee21d32cf2b84959586ac66f782f0ff907173145deca737982c369eb28891ecd91c2a11e319d4db020cc7091e6e715ef4b9dc6721d2723",
-        "incomingViewKey": "a986bd3bca479e5ec9a5a8f26a0b234b49d1ff9c5327b9917d57913d4bfcc503",
-        "outgoingViewKey": "eb4440e0bd5787b009ae6a71d0b2d7b493fdfe0d95d33be05e6e6dcd0da49eb2",
-        "publicAddress": "92056c5da34c774e45c9192f4d54cdc7b4e5bfc068897e49cffe47f797f0a543",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
-        "scanningEnabled": true,
-        "proofAuthorizingKey": "7fcdfc565d9816e4c386cdb82217885c7ae2e603033177bd4c91d7a9d85b860c"
-      },
-      "head": {
-        "hash": {
-          "type": "Buffer",
-          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-        },
-        "sequence": 1
-      }
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "4791D7AE9F97DF100EF1558E84772D6A09B43762388283F75C6F20A32A88AA86",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:ckxG76qAzR/l+BL7Es+E/PfyYSHovhqtZl/Xcqcq9Vs="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:vFQG9StojtP6rZwpVrufvNhCI7L3mJfz/dAOEqJTNdA="
-        },
-        "target": "9282972777491357380673661573939192202192629606981189395159182914949423",
-        "randomness": "0",
-        "timestamp": 1717538871563,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAb8ykFyFvqfsUq5qJSKhinnnhZq4RywzYBhvcwieC1MqDi7DmhWd5H06hln+Z9x37G5qrE7HJJNdid63HeOpGE+L6ZjotHVchkR0QHFoGl9igHFTFe5ubwCRjUBpT6QdFjIbUAWiCjx9SQaCHRokXhAEsE4s7f3T2xgu6U3EjZ/YCKgmdKUaMz7bkFopaUwMOIHXu6jo2Tf5DLHOP6DUYobrfLg6fRgmREwmaf/y01fWMFbWgixOBQkcheY9ZKNnSH3e+DekFb7hdKnwSkLQV1LeD4rEbtjPww+00fMU3csea8gqD7AycNObbUWKbpMKcD45cPvBUrIhOizW40wyll54QQSu3fDveTEng8CQ5vsOjBnxNN67sqWUaxVr5U8BXNvkijakskyhefQ7peFtjO+EXyUimd5xrxzmgzbf0bTYUyTO3rUmGgNXhkGvv5XQvm3NvSNhm8aqr50WPpzX/2770ebg0wuu8w5pBKoktB+stJy/3oJotk5WIlVQIR5ubKiyOsjBsIR74OCVSvAkvEtGbnb6G/IhCxwkPL2kmG47pKzlSl8aw+YKFFBAa019Q7pbznPz65qNAYw5RsGHdcSutjdHGrhl8Amrja5ciRAo+Uzo8N1d7uUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwOBCNIrHuv4VUgVjwKUZ22sRoe5B72Fhasp5jT2x07bLykW6rw+kRPGjThAfGucAB53oNPylWoSd08f2prZVPAg=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "26B5A48FD98F6C8DC5FDD8FAEEF8142AE63AA8EE4FFBCDE6E0818F7692A848C8",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:ARTqhia4P+mIapFqlSO2WMNTE9+TqldyOE0EdSNSXxM="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:+Z1XAIlRfVvNS5Q4nVfMakJsXu8ibAGUluggK9h1W4E="
-        },
-        "target": "9255858786337818395603165512831024101510453493377417362192396248796027",
-        "randomness": "0",
-        "timestamp": 1717538873930,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 5,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAADeTqEiiS6zAtcGIUeFyXJ24W4aKQuMDbRhXeJ1s2GMSOtgmwruJLzr82q9bADT2qD5V3tPNngpeyqzdmB2ofbtbBIvg8ienVGrWidUBUrlCFSS6TCrspbpwJ2hIneojYKyq7Y24ZKe+YlmQAYNQoSy6Mw7kVNMgoR84/vEWJoMABKq/QKMgN8dyJJA22E62jGp52BeS7DBHNNl1Ap4Ppom1kN0QNNoA4rsJQbSbW/LuBFMHGHsX3LOgDa2qww5/arCXIe6b6wD14My6H1YjEFx0WwEElaEm+0u1U2vhI7OJbFKf7/uyG4aIn+g5LA7I4kMf72oG7gyewwAaAMEyCxKH/KLDafAn97PnEJ0xI9yBjr09pTXGMrB8tXzM9F0FQglhEhPOQtzNYiAcElPkDWG4zpeQpQIVAmClnzDjWw5Yh3D8r3TB4wZ9BiuYH3YrSPuA1pedV9QhUUYE8QMJSU842TSmRUkOJ7JJR1iNoDb1efTnjsaEjTcHYwWw5cm5SKmFkv77A1FGdvwuc8w9B/z08kLOblZERs4zMvVhFoJ6QwK6rj+/mvcnXFVpcmXxe5HKXzjZeJdl8hX09ghI8TfP4emeXFD1Zxi3hA90ubmiCpuEF2j5xEUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwbhDlC542gvg5F15aWnw2PLKX6mVnFxbkCDHEQg/l2KbveB57nBCFLBQgwOsXUksRdzEORk7GdY7AVJq+CbgeAQ=="
-        }
-      ]
-    }
-  ],
-  "Wallet disconnectBlock should update balance hash and sequence for each asset in each block": [
-    {
-      "value": {
-        "version": 4,
-        "id": "049ba4f6-931a-44ea-aa5f-ef433ec90753",
-        "name": "a",
-        "spendingKey": "20e380868cfc0b2756eadff9402b3916341731118b077552cd9eec97c9c1c00a",
-        "viewKey": "7a4da4fbd1efa4d0afb8739778f43f690a1b310a49fb1c33f70d85ed443594602a00b0cc239cadebdc9c7860ba96a344c5b2911b01efe18ea9d75123fdc4d0a2",
-        "incomingViewKey": "082730efefa0ab9c386a1ed5bd0a064f42240aeca8e9a3fd5a5311d06750b204",
-        "outgoingViewKey": "26c142151e6a3c3c88f0e6c863722b32b76ae10f2e39d4bb13060e7baacdc5b9",
-        "publicAddress": "518cdb40b18edcc515f251ab82e56b1b33850a5a9ec837c81973bb2274f85654",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
-        "scanningEnabled": true,
-        "proofAuthorizingKey": "9f3a339fbf57675eda822fe6434f13822ce64a5d2d5d6884fc98c77615195402"
-      },
-      "head": {
-        "hash": {
-          "type": "Buffer",
-          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-        },
-        "sequence": 1
-      }
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "4791D7AE9F97DF100EF1558E84772D6A09B43762388283F75C6F20A32A88AA86",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:s4Yi/MuKDM4qGHH1j/dzHXG6aXnE+fcZx7w72b1w8Do="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:2ce5E7c03qw6ZPD37elDhbyzxZXSrNyCJsQ9Mmnezfs="
-        },
-        "target": "9282972777491357380673661573939192202192629606981189395159182914949423",
-        "randomness": "0",
-        "timestamp": 1717538878477,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA+d6Bh3rNKCxPVVCuAf4ZKLZvmtE6tF//46sa4FYpxEWSOpzBFpq4UcwpHkLEC2GFWY5VC0hY6dSnG3/yPD/O7AeYeL/oxRBMcTIB4v2uuEO1cMebwoVpdAW8uDEkgTSC4rpTG2esj7qRv+ZLdc3whdcsGbSgzvAO5eFoeuosPQwWX+7Rbk3boL/Lo6qPpFBn78j9aI9rNI5YxNu7ZO0VFYQO1IDDcpKzMn8Lcrfi4uGR8Y/RsIF8DGO8sIG6SqKbMCM1ovrdR7BieNuUPeVpLJZb9ahRA/F32rrZXEuHoCy+fxZZYJqcs8JOXGwD31gCn0+g+yq8kBvjAtmzomY1u9UjxFBkddY0RY64QGJKexS5H6AGPuYUfYZOXZFdbc9ShHAqrcboyYvUr2+pbCCMrmpOuZd5lIEktGhTNfO5/7FrB9RBTMhrFopQkmCKNSg0YQ3bpRPLml+8ZE2YThLyrUtn4949dcqPA5O6oy7m7lZAUXCED8xvd/fUruPrmTWXh/Nnck1s0aebuj+jNt+qIHnCv2RuHNxVE4UhuGNgdzQD6AhrLMBQiZ6avbdswENIiyHcYP2q5jSjFzN/hhJch7U+zI2vxdiUmnta6pSUwkdnRIvU+IYzaElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwk5w+JVKihJUmq/7Uc27qM/oIgGSA6aZGBLLJXd2qyW+z3jjAjBlf+IrovzqLwsB423tlhOIGos/MXtR95IkbDA=="
-        }
-      ]
-    },
-    {
-      "type": "Buffer",
-      "data": "base64:AQAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGy967/fBpCLW9sv0oCvwmbsaQuFPDohRKI8di80SzN2zW5wURMHQj1vAeztAf1NKT4clMEFh1t6ecQfm4hWGn/rF4zn3Xt4m55JEkDjrnKuyh8UZQrhABH71w7i2B25nshb0bg+E62Omo+O0wFRaOy05griKdK3lETKCnGUQ5WANjKOvVRcbIu62Fk3AB+GwdhRuhCr4hvnzEmx/c0j/Hrtd3hX7pdZiJoMp4zyvOQOxp/XEaWLt5ZsELzOUyEvgVPEG252Kxrs4z6m1Y4yIl8GvDoeT0gLwIv3Uw60S8Sr9P6cb7Bi6+5Uy1IOdCIphOuQ8/kodbKzvelPDQAMbYJc3iPDOj6rxaN6rTjzZJZxXC+tGHFsuze66x6t6/+UyIIrLG0zWTgIfaEktINGshdWpxssVJZu58h57l/xOahzMil5OxpLfyD2OuFiHqPomiuuNbBL5AAQZPyJuQyJ7YLZkfJcuJ5j5SLlqQk6w2jeCBWcieBphWUFPSXpyML8coUyj3T/6AY970+VFx4gfXIzy55v6DFkUhZw0pSQeLbGw56IM1miMUaOWcZPER7NO/PwtEjJbvFhGMrDboLe3RMviTz1pHG9HvhqrJm8SQWoLzL6G4BOnT7kIpyfULZcUrqMYNhwWPk7fsDUkqU7b+BsQOBGJFlRKnE1ZkNodwSfJZdTKUoCM8gxCJlepOXmzPQxkozWqTK6kCg5JHEg1WAOi53M8sTtIgRAKVWxY+k6SHXaGzeEZm7l2VgwfrzJiLfKep1F6ZtoKpSN+dG2oTE1Zwfacyy8VmIzjlkVln955e4wNsJ7vaQ37i2gpB2QTGgpGu13A1NaThreUi7STsOWFIN5BmB95DQQfwpUL98uaWYhSqW/25iJ1+ew/TKM+vgP0MUvBGsJs7lmeFiHzznKQAxFqgN2fqkMXH/B9KisbRlnlpeUGe64G6u5tAHXo/8O05f+TUSHjtvEzu4NTcp7OlhQ3MDekUYzbQLGO3MUV8lGrguVrGzOFClqeyDfIGXO7InT4VlRmYWtlYXNzZXQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAG1ldGFkYXRhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKAAAAAAAAAF8utaQNXTxJwjztt8ATwGNp6cVIG3oVpIzivdvv9L8PEu4gOAPAzhitVZqKE1Q61g9hly65kMvGTYp2sqjpZQrBPJCYPyxhXSG9gcEohagom2FmbDIcV27bgO/KY2X5a4wraxrmKzIYFi3J1DqDLkX1RSdQcG6bSvp3IsKjqwsE"
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "B2570284AC115B3A9CFAA38EF8F03F6B8997B59655DBE0EF2CAA9DC2F05B0BB4",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:Xz5s56uEpF5d/BpUbB+6qmZ5+7a6G3UXQpPKyQBslmY="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:L61kuPw1B5sAoRz1Y0bWK4YU1WwvfrtKSynuFbuRiE0="
-        },
-        "target": "9260366780148527510972123832573278885902566341756516011968728852484845",
-        "randomness": "0",
-        "timestamp": 1717538884282,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 6,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAGzkoYW2EUxZoYAo7xCqsuB45+79IKlj8x1uQ6PQmrsSFhk1yaPVI1H5LtK6tkJ4EDKFVHoyELL+ZBtQsE8SBWU05MCihwSV7f3DWaS0ticeZzDRjCWm+6MsOcCba0V31lDiiv3J5HBAYqlSqlclJAxLIoGtwROS8bBRMcidfVvwY+XEnIeZCNmjWGGb2zVwJrLUCa11Uk7EKXPxEver8UOVGb8qY7wO6oNWnQwFdCl648kqWmeXCmXYAp2zbpstLpUzA+oCRyaJe0ROeAbTYzTNkzkgZ/5A0YZNkbQm9tf3my+uHgUA6DC9GF4eZT8UZcSCnNrkc+IBc8Nq084AzNT7NkGl3X2aW/4CrVxzFZXvk8xSamzehf5QL6B/mdfMU9FlzZ7hsi12RBaCUjyxX7MMSnPhcTIZvfUVpiHdAFp46qzJMeQXoAuokH+M+hwPntAxirLePWVaTZ+zFYTWaSjwdQf937+PFjPlLA+E+ZlprknN4va68G9Uzh0h5/iUyjZdK0AcFrLMAJxnIv5JxF3BdJSAVwS1cV9w9mh2RMk98xB/PCiEDonVdvsKdolPAHvhokpwRpVkktAQzJh93wfIf3oUT6xx88+3a4ku1L+d+x4PK1h5v10lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw8utdH0ZHQwkpSjjtvVFWCz9fx7VrMp2Ely4hmsA5ZkP1u6qkyThgMmwDXGbuOY+HA7lszscsamAm/Pnp6Yv1CA=="
-        },
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGy967/fBpCLW9sv0oCvwmbsaQuFPDohRKI8di80SzN2zW5wURMHQj1vAeztAf1NKT4clMEFh1t6ecQfm4hWGn/rF4zn3Xt4m55JEkDjrnKuyh8UZQrhABH71w7i2B25nshb0bg+E62Omo+O0wFRaOy05griKdK3lETKCnGUQ5WANjKOvVRcbIu62Fk3AB+GwdhRuhCr4hvnzEmx/c0j/Hrtd3hX7pdZiJoMp4zyvOQOxp/XEaWLt5ZsELzOUyEvgVPEG252Kxrs4z6m1Y4yIl8GvDoeT0gLwIv3Uw60S8Sr9P6cb7Bi6+5Uy1IOdCIphOuQ8/kodbKzvelPDQAMbYJc3iPDOj6rxaN6rTjzZJZxXC+tGHFsuze66x6t6/+UyIIrLG0zWTgIfaEktINGshdWpxssVJZu58h57l/xOahzMil5OxpLfyD2OuFiHqPomiuuNbBL5AAQZPyJuQyJ7YLZkfJcuJ5j5SLlqQk6w2jeCBWcieBphWUFPSXpyML8coUyj3T/6AY970+VFx4gfXIzy55v6DFkUhZw0pSQeLbGw56IM1miMUaOWcZPER7NO/PwtEjJbvFhGMrDboLe3RMviTz1pHG9HvhqrJm8SQWoLzL6G4BOnT7kIpyfULZcUrqMYNhwWPk7fsDUkqU7b+BsQOBGJFlRKnE1ZkNodwSfJZdTKUoCM8gxCJlepOXmzPQxkozWqTK6kCg5JHEg1WAOi53M8sTtIgRAKVWxY+k6SHXaGzeEZm7l2VgwfrzJiLfKep1F6ZtoKpSN+dG2oTE1Zwfacyy8VmIzjlkVln955e4wNsJ7vaQ37i2gpB2QTGgpGu13A1NaThreUi7STsOWFIN5BmB95DQQfwpUL98uaWYhSqW/25iJ1+ew/TKM+vgP0MUvBGsJs7lmeFiHzznKQAxFqgN2fqkMXH/B9KisbRlnlpeUGe64G6u5tAHXo/8O05f+TUSHjtvEzu4NTcp7OlhQ3MDekUYzbQLGO3MUV8lGrguVrGzOFClqeyDfIGXO7InT4VlRmYWtlYXNzZXQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAG1ldGFkYXRhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKAAAAAAAAAF8utaQNXTxJwjztt8ATwGNp6cVIG3oVpIzivdvv9L8PEu4gOAPAzhitVZqKE1Q61g9hly65kMvGTYp2sqjpZQrBPJCYPyxhXSG9gcEohagom2FmbDIcV27bgO/KY2X5a4wraxrmKzIYFi3J1DqDLkX1RSdQcG6bSvp3IsKjqwsE"
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 4,
-        "previousBlockHash": "C0BDF738AD62CDCF238CC8CA39B8BCEF0FEC0B0ED663C7A48C34A0F7C3D4398C",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:sivJwFVBBCDl41P4R3jX9tvWsP5y6f3y6lPa56RzWms="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:x7Xae19m0YrW0vFyKxOPS5E6H133rkrVIqc6ldiUnl0="
-        },
-        "target": "9233318228143625020618577701423519925017621426082203201059080050516648",
-        "randomness": "0",
-        "timestamp": 1717538886454,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 7,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAt9ZAf2K52BMpV6vLbiOPzv4vQATwf3NbDNIGK/tqW7OGX2Yupt4uTqg4hkIEXVAnRvjgTrMVA1jiQtN1lndRD1GlHBgdbW3Fi+hPsiDiutiJa4jNNqW52gFG3kOaEMQ9Vg7blTAmC7QAE2at7FOodSNwOntfZK90MICARSJEdyUSzu1Ux6Q1W53yT2S1jElaFM2dZsK27XfzyqEvVOFIVXOSNUtRH3VkYD5mNV/1ZImKoNK1WOXPOdIGz2JMGOW/U95dF+vLwP/ER86oKepca4A8wHoCdulq4QON4IJ5VotUmiGqASRhr+3DT0eoEtnfJXEQLf8OPeFvObkHFdDMwb4MiNmLlWLiGofkaRSzOI+MY40d0/DWJDTI2Vi9IF4OD/avim1M61x2G9x8OgWn7x+K/yGrojF64oNSYV+sFFKDBiVWPZC9z/hSBW1/XBkLqlACtTUeYr1qEjMduaKSKVbXa4T/W6ImVnPpmxmcpXgZFBMHFGy80wgBun0REor05tDCDunbBYWQqObBNfUga5lM9IPyfZGHY2iybo5YHtErrpkyrZT/VI2IfnsSUf6kXK9Hb8P3LCiqYS9PsD2/VsRN2xYYOc8p47oPWo4F5HT05r5TyfAD7Ulyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwQHLFya9LuojFQffCrOPp02iOHhG9Y5aW2uaFx0Gm04Yzm8H0uC9YBzK/SF4+JAVsnY8d7zR0bLPzGoahh6saCw=="
-        }
-      ]
-    }
-  ],
-  "Wallet disconnectBlock should skip disconnecting for accounts with scanningEnabled set to false": [
-    {
-      "value": {
-        "version": 4,
-        "id": "cea4db72-3c0e-4490-ba85-0a19f1b2af42",
-        "name": "a",
-        "spendingKey": "d0ec738764e95ace955f1d7b432b4f130efcf2049b0c2354bcb852cd8e226d6c",
-        "viewKey": "ed77109abffb7d9e35de05a3d4d4a8958f639943c3e487871ab4e7b41c5c9911aa7269bc46ab31c43f036a9f6198fa86d59b4bd21022319f1975da8ee6d32a22",
-        "incomingViewKey": "46eab4105e43d0021db1fd1fe3140e7e23e951efae0c6c13d130282b1e3ec000",
-        "outgoingViewKey": "b788c45b68200423b608cf34888daeb2f56938e76c8d0297a572e43c989655f5",
-        "publicAddress": "95205789be04b75526c4c33241dc8a94add1e0ac4455a66786bf53c84952cc3e",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
-        "scanningEnabled": true,
-        "proofAuthorizingKey": "6ae14be9b436bfecba83f6fa2bb91a9de744591bb43f41746e5aa965690c8605"
-      },
-      "head": {
-        "hash": {
-          "type": "Buffer",
-          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-        },
-        "sequence": 1
-      }
-    },
-    {
-      "value": {
-        "version": 4,
-        "id": "72031132-15e3-436b-bc2c-ee915c5b454b",
-        "name": "b",
-        "spendingKey": "5261a189da5e08d5797137e520abbec9b401603e58a597263ceae9b5c3a0b042",
-        "viewKey": "773d68c98f3e4197c379b784213098c0dc5eeba9cd2396d884c37176826d73221a504ade9945c0b6e03ee0e65f77b05447085e713a434e3a23f46bf415995b0d",
-        "incomingViewKey": "c8933e4fc82fb3d0b145ad385e9db66ac6e6fcbf5ae274991eb5c11226ae0f07",
-        "outgoingViewKey": "92af0cd3d4f015a0c6bfb0caa6ebf667a2851436b7445fece8766cca68a0bd78",
-        "publicAddress": "c703444078753dffeba8416cd0b152f9317bd190474ee6206328d166ba79cc9b",
-        "createdAt": {
-          "hash": {
-            "type": "Buffer",
-            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-          },
-          "sequence": 1
-        },
-        "scanningEnabled": true,
-        "proofAuthorizingKey": "2700d803eb6def99a93347f9b798e663c4420ca874a559582c24d868bfa4fa00"
-      },
-      "head": {
-        "hash": {
-          "type": "Buffer",
-          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
-        },
-        "sequence": 1
-      }
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "4791D7AE9F97DF100EF1558E84772D6A09B43762388283F75C6F20A32A88AA86",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:4Pm7/rxUpCE6r1IMblGXJTOhuJmrjwRA9OOv+r1faSk="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:D5TmiDwxrHVWaxxwPp0bOs88tEbBbkYASoGLXC5d7Ac="
-        },
-        "target": "9282972777491357380673661573939192202192629606981189395159182914949423",
-        "randomness": "0",
-        "timestamp": 1717538908054,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAlUK4uq++YpXh5AxTydB7Y4bEJe/mmVapHPB4BAL0CoK21Q7MpGTPBCm0U5jAbHFCPB7ADfLgaV34rqKCefaqfbT9UBSAr7uyfcVz5k78CvSwNSAG061Wi0r6J77dA8jfk85O94SKd/AEpB3xoPSWxuEkM4qLbh6Prfg4e8d+haUTeroaP1Lb4XiIJxugJl0qBDpiBZFJp8FcPW8hMlm6l2S4plniz93UhmYkdrATyWuS3kOwxB80J/zIqgKMCYnGRSuE6LSzc+UN8+F/8DoMiRLECFZodh688aKUDa911YitHlfGWwzNP7euvSZQLIdtfH+tqCMf+dUO6Lnk2m846fQ1kRDMKAVTz0TT9BLbaIbWVT9Io6cEwn26Q2Yy8u0nkIXcYFTZSvP9SN02gT7b2Vb1A1hkNXfOGozjASmway5O6zznsxk8CVUqQGVfH5HwOREl+RqCrcduephTUIwupXPkwcIC31qKGYIa8sqBTnc9GbDA3yocaOdSYRcuDBFBYr/ofZ4MWJiJJXIMEMZNVPx4l/aoZ8rVX4zDcia1Z6hOej60KYeKsc407IwCt6NZcp2FROpIEtVVOn6G5Af4Esb+KW8x4PsJcGh1dt/L3RjQ8tEB1J40hklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwmvC5vkg8ztfVFGvQ4mtMVsoIy70lGzD54s2+0kEzUrUJBFBvjx3tlk4XyyvGPkXqbwwi8wkbMGkPkSBAKZYaBw=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "18CBE685174195063E79E28674202485FFB63ED6F47B3388F9566FFDE5CA1EFD",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:ogJoHxeBjrLVpdDXTwUon7gP/v5ODhfYI5vOQceOJUc="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:1ZVDi5SxN4jhWm5e9/YnuNkCiGqr/ySypdNkzmwolHU="
-        },
-        "target": "9255858786337818395603165512831024101510453493377417362192396248796027",
-        "randomness": "0",
-        "timestamp": 1717538910047,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 5,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAgJAYr7G9B4yiJ80g1Sg0aghZxGcyDMMzKqmulsKZd5usbNt59K48GDCfhYgR3doj+5WcPF2n5Zoa/73oScN0lmDLsuz4eTPKNdUDepU9TgGP/dDI2UpeGODBeRii3mfHhdVOsMTRwfE0pzk3Bnx5ICtIFcBwhQNT9RRJbILfwEsCdx4Jfwyd3eEoWE9YLHcJtcFIqwbMnvJAgKhbRmug0kEiHdt1IRJ6byv8teGpxHexpEagw+8GraJAxbHqGgzCSmEOlKEZCyrFg7OZQpUO1+DDyTQXqoqrXyTLn1yhZeyYYLz7kgSB2YX2h/PKMCmI3P3R/ffQ1byeFitRVSU40d3vLElWt/ewXfibIL31u6pvN4MEdW4hvLTwMfU/QHAdLTh4ZN2idnLiukKIfC3CySgL4xK5TVcd8ftyfJGC9dAdAXkYYhNQuwFrvUoB6tS4+/rBnpqFnAZ/kEk77iorm7jEY/ibvUiUqCxAkfr+D+jqCA8Pvbk6JQc/9O5AoUc9EG4+bgnccCZcdHkBgXI9viPNqbBtu8lEm7YQUDgxtzQvanTBsIpR4xG2VQQCZ+2H6CY1Xzvh2etJ4v4jRvZnnM09DHChD/TbpFXFvBYc3utRl3SWbFCHjUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw2AM7OHElJs2qtKyQmxYHsmSd4JQBOoKKV/nhIFVH6cb7Is/6Kxuq3xUgg8ZJznXGc7+jMM2krHDSm74GQRfqBQ=="
         }
       ]
     }
@@ -8117,6 +5615,1286 @@
         {
           "type": "Buffer",
           "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAeRsNEYt3ZwfhpUmTnlAoxMI6+BpLof6oRfHanFWaLQqWZCetZjOwdBadG2PWNRfhOYCj5kCz/FYXyqKDMKkTU/gS5tSiLixEqeVWt+LwUneKKoyXAeZ1OKNH/obHr4wFzvBwbPZ1/NhhgsGvbcBmENXpKynPgC4At7PCqBjLn6MS+xh8L8JI2YI25c2Jzac7boKEO4SUJWqQjnhT/PVNx2NJkd+ET9pPxDPxVJ9qaEGN5lmieKU0h91OfnpxUPWoHvbHt0fyfrEXLJOH2IMF1P6q8YPzmBNIPE9uWSh1Khrcv2cKbkul0cpw3Nt32rShV5kTakqHe/LipBTzKGmRSyfMk3R1qvkdot4OrlSGrgB9MMJKLf9yjvMe2Mq3p0tRzViHcNTZm4LWDwbaG6MdKaHz94M4iDqzrLa4lxGQaNoV6qLzRvvUtvliIlUh6ZRyXS37gNlD7Q7BNWuGEMsDmjy4xt0/fNsbO14ZaTKnn+EPbGECCOoDKX1yDFBlhzCAOEd41+Mi1AT641saSnvO5sMHoLy2r4x+lrDE7qyCL/3SClcmj0PFbi+CjPhSJn40hErDnV3//Q+X5tw+NcSBzwydSpdZgwwRm38Y+h3u+IsG281wffNTR0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw2eSVCgULZgJi31KzK3GdX62J/O4YGGwndBTL55y1Qd0m4Jq3ikdnPKJCLa67MczlYI9hwYzENBQbt3O3NOeRBw=="
+        }
+      ]
+    }
+  ],
+  "Wallet scan should update balance hash and sequence for each block": [
+    {
+      "value": {
+        "version": 4,
+        "id": "825e4a80-f3fc-4244-a3e1-dce2193fcd55",
+        "name": "a",
+        "spendingKey": "58eb718331c282d7fd759fee0a3ebd0196ae918bb2bc2085da041f41aed207a2",
+        "viewKey": "ab85cfb9a1ee4922b24d909d6c0e495d4f2d742c3a0afc872c488a836d551371a29325b2f86e28a87c0f425c44eeaacd2acbbb4e88f3ef3a35b47567e4b6388f",
+        "incomingViewKey": "7d8dd3ea50047ad4447a9916de0f34bc03927712d8a617ba2c3012b33989e906",
+        "outgoingViewKey": "b20629e4e0a199ad01436d5ed504b0e912a3b7dfe64f21bd2ba5b0b099cdd220",
+        "publicAddress": "14e8a4486b79f64937f8dd84d23afa5980728d1a9f63d546c55d96b3755d605c",
+        "createdAt": {
+          "hash": {
+            "type": "Buffer",
+            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+          },
+          "sequence": 1
+        },
+        "scanningEnabled": true,
+        "proofAuthorizingKey": "b3b33adb285f558e666e66d61d70f04c1440f1de96692d8edc8b4e564b9a0805"
+      },
+      "head": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "value": {
+        "version": 4,
+        "id": "ae195ec3-2434-499a-ba5e-1e7525fc67cc",
+        "name": "b",
+        "spendingKey": "81465f82a3e863de768db3f3df447c88fd66a9fcd74d7b832080a81b8dfebf29",
+        "viewKey": "27f155cd9d320b59881f4ec9101e10f3ea45ac361ae12213d3f92cfe2fb13e6fa40f057a9d1059c1fc20fd16bc34ae3571aecb36bd70fb762296e83143931c8e",
+        "incomingViewKey": "f03820937c6de19e91747b494159535ec3385451436faccfd8dfd9f8c7859401",
+        "outgoingViewKey": "ed0fde53f1dbf38d1b40e983ebde9b8ee6536153885e772b055d4bba7f3accba",
+        "publicAddress": "671f81804898b2f7002bb07a27b76b73fba95f0b0bc134a5ae4325f8bf8fb633",
+        "createdAt": {
+          "hash": {
+            "type": "Buffer",
+            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+          },
+          "sequence": 1
+        },
+        "scanningEnabled": true,
+        "proofAuthorizingKey": "cf173acbf8aaa3e24f6ebc7c15cf0f9d59c6048e503083bfa1b8ce232f44c50a"
+      },
+      "head": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "4791D7AE9F97DF100EF1558E84772D6A09B43762388283F75C6F20A32A88AA86",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:EPBO4Pb0coY6KJ9Vv+xO1izVPFOemeKI6im+oqxOr1s="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:SruRXSo5H/JY9OIhb23x420ryCwvMoBRZ/5VkHgTkt4="
+        },
+        "target": "9282972777491357380673661573939192202192629606981189395159182914949423",
+        "randomness": "0",
+        "timestamp": 1718998708731,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAeEasFfctBRZ04NSNOOpYZNWtKYKZ4w61b3ESf47GUfOxEgHgijAycu3lld2Z9tLc8Z6RIzUjJQG/AjAWtWHI9AFXiSkviCNrH5TKGDvEhJuS8aUTDPlUfytEmGkdl8yhOcchAoKpA/hlZg9Vl3f4+QPcnON7rSX3lkpVhtpnzJsDoj1fxFThkleGQ73DQdkB/oPA6lSP3iGJGh8regrjiIz7FwWDyxjkODuDE5MRiMu2SUoAcpjZcJ2Eo8wBqWL2l38PcMhKOpbvD4xD1aZbJbCX4x7/SHeWLkFbshdetUU5Xo3p4e7eNbCS20poGMVzN2GH3oj0y4+1DWSq7VvMLQr2LKMWkPWjPs0o+dzN28EOhywyytVOsvfnYhsp8mduf4EdUUhpQSBPVAOCr13yyidRhmWevoPIkTKr3KqrdtGZ8F1DGE/5A164rk41rMH8uT9CuwnL6LAdPHLBjAuwKzeaqY10y23clN7uCKvzWx+UsxsR+aGWbT+R856WE8y2eWCAbz7Jh4jO/qAXpgpLtLIdRrTt46ZkRjwt3ALDpMQbINh9Sv+vRBNOb/rJVSBBE938xSp3coMV2JLEO6Ll44C1EEaBPFrFusU5CoY9jguyj8igwleSfklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwJi14SmKiVWsrsTo7VD5PJ2mj7WFP15n2jV916tGxx9MA7Y8mLVaOhWbSuoygEy97RUlNgGX97py2OndJs2DFDQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "B5539191CBF67B06B628EE57C0E75FBDF89950E9610558B37C34BDE4C3A7B433",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:TKfwwMYhHPL86FtdOkBeKPx2G9uct6rI2VZfSOw4WyI="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:83FGXGFrEJmYij5di0lZO/429lDYKHNl98YT4d7lp38="
+        },
+        "target": "9255858786337818395603165512831024101510453493377417362192396248796027",
+        "randomness": "0",
+        "timestamp": 1718998709182,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA72ClAMJ9fcgPPhZOTzW+gBJUYlDxpH7FdOWkAB9Rj76pQvLwaK2yX3NO8RYmdwE33xJoL0rbuJ/ElbaXOTbDVdXzCThjcnKUs0L+1Ks3YCW3SoMdNGZ/2g+18hH16nDA2uCVu2gnSWeNNT06FdxxkNgUjY+JqAPE2KX8obpHYpgQ95+tFdX4qJ1Xsa5q2v0DATHgfqEWZAuv73BX5jXlPK0z+fARRXxUlvEhnSwEuBKruu8JNrW1qSozJO6j/ZnAxzpFhW9AaH2EFD3J9McN6X39H+KS097+CjzLA8qzy5YsKNBokORChRI6byvo3kc3hEx9HhIx5a2fdMfdGWs3jbzOi+1O4WiBLMUyq//BPlqv8YCyG7ZJGVaB2FTR6A83LJ4wacpsIKdmY0ZJkFrrFIhKdznDNaMFSUvR6aNzA1Twonhw8YhNq0U3RbMMbVEYnXPCVyU9DfA980b/KHFkGtjorxdZSpfkjMvPzmWpVXHEHMPTrWT0CdP32QVxdjU1pd9FUYYQnufXVtpzH3kF9qP5lIa//v4Xa+d+tlDBv1ZJIkP2JfhCSF4obHuq4IArE1gqRH23t50XiseJNx99IJtacP/KHY+oF2uOrngJGuGMIzmG3W/v3Elyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwor/BSgv1V4DhZv1kjV+3mBf6+i4HSOSrj6blyhHQO7JoN83/EBbj+/U1RKM/TmPJsyn4yWu6saUfo8Kc0kukAA=="
+        }
+      ]
+    }
+  ],
+  "Wallet scan should update balance hash and sequence for each asset in each block": [
+    {
+      "value": {
+        "version": 4,
+        "id": "65e0e2a3-b6f7-4244-b081-4dc218c09a68",
+        "name": "a",
+        "spendingKey": "4d79a56e084d8a0d2cea281dd016a5778188e6261777d680c75d61193678e45c",
+        "viewKey": "3d958c1c0fa717d3f7aab984994430f65567c758572a91447c74b1e119b1c3e00163509e747a47e11b9235b611502bea61adf296f7ddd2a70d60f4fb90937732",
+        "incomingViewKey": "f68ef0ae034a1d451e3b0865297008c2ab42ba3935efc844c6ae45c87c542505",
+        "outgoingViewKey": "661cb216ea8f7e48fe14352cc795c1e6ace047a0c96cd0ce45ab9116d9812657",
+        "publicAddress": "e508e5c2ffe1c3b175047408199665151183cea699d68e00780ce4a30a023214",
+        "createdAt": {
+          "hash": {
+            "type": "Buffer",
+            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+          },
+          "sequence": 1
+        },
+        "scanningEnabled": true,
+        "proofAuthorizingKey": "d5f3cb5409dfce37fb857e9c039826a0520b398f755558d5e5645d2b03830203"
+      },
+      "head": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "4791D7AE9F97DF100EF1558E84772D6A09B43762388283F75C6F20A32A88AA86",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:4NS7yLFXJ7lejwrSwGvf2GWI3+1I4aqq8ZpDbytqvl8="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:le3k1kL/1Ikpp38S/WYk6ma7da/Ia/c25RjBV7vmcyE="
+        },
+        "target": "9282972777491357380673661573939192202192629606981189395159182914949423",
+        "randomness": "0",
+        "timestamp": 1718998710216,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAuxQW7dJNUZQiCBlTjmyYaI7bhlo50XhgS7BW36kT/7WkA5dSrsBHZXtVfvAh9yW8gh0SPe4OVZeelHSG+vgRwC3B1EzqlcFJ/wg69h/jtoqAIf0oGubE/TtCliw6aeQV06LXBdavxkIEGTnns7gArKSwB5c6eDXrJz5bSmNQp6sLA0RnkNz9QjRON20LUkCjo3EVi6/9DmQaDpVofip1tl/Kb1UgUWnLfbHu100KFa+GITlCwzoeKJCR5B4g84g4bDN9Z7PZurX+HbvqLJgNncJtpsgzuU6x7zcyqgwJvkm6Qn5pjz7IOu2txRkrzKY0IgOFzbFqHqa16jStcP7bPP9WU01bl/JMdqIeeGM8PRCaIOrvGS/PPd3pNsLzrqVi0CRu75T1I1kpAhskMXM6TV8LJ9OSjIJ8ZSsWZGqRz41UJlRJCjNpO7hJKvWSatYZf1pRMZPo4IXAZpc0X3dGFqyQJnDL1crRjeZPRKfeLnegTz4HwaY2Zd7ewKLfJ9T3us7P5ZUE4YiI8cfZrTPhePfDTQUWtmhGUHchXbsJMDuZ5HZKaCOlYr/4qWH1vEAG9/By3TggQB8UDuKRHyilW9UDy7dMGqiOwEUUIp6To012ir24eBudiUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwyRjJG/EXJ5fUz1Cs4gZS1EAN4MSIWrYkR7VlWBLEDGcpHW5tcFRgftSvFl3VSHdRm2CsdKdy2wbYbMFulQYdCA=="
+        }
+      ]
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AQAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAsSkluerLUWvC5zECd9H09NAGcrk72CjBgCVe6mHWU5OQnohpcUVmSSrXizsbx4UGJIHBmWQhNNisr+Fj2isdMMZrLsSckU8H0ZRXFuZJSW6Zx6zbF9a3M9QPeQiqkSPRdXJgEtjNNyrqZshYTlhsAYHd+vQryTQemDmvX4B6qjQTu495Qn9OyZkVv1Tx1YvygkDcO1xWjZvQp8RtFskMOLcfcwtnO6455RjcoHJPCXSlfqks2A1bXvzurDUQb6er+HdBomaeEJWQ3SALOeiFVOdjcU2KGonw3/bBIG9QhCBGNuwtfOMCpbqoaE0vdGX56WvuBfO9TUgadZsGQuuFQlT7RTYkIuUyHGoAew3cLBu41Xj4vgQQumOdewasZ38ezI280bPh3ySbGJxlW6sQeAiZYrN/OdQtjwoG186EWmcebNhlyNRyXCm3St+914OfruZsO44jU4ODdog3QGShdI1c+ZkYph/xXxOQGvUHm5yTD6T7mkm7YUpmnL8yLsVjpZi7MWlrvgPiP5T8TqZRedEa5EFw4zb8uYx3Az5QoWhaNH+SdlGhduayYeohi6M5Hn9l+KNWWb3yzC2yvDsrGp1A8j4W/jqfcLRdBIj7Fnsemhm/1nqhsqgLFfeGgHC1H7MVOvw+EFjBLYpwJ51vSbSAj6e1rSGIMLCOWNZkAPrGAvBRp6UWpfwTqQY0af2eWbZxMTCrncyaaZizys3Ef73yfggzpjLvltLEPfcbFXQAJG/1G0BCzX6xK0ZJsk6nK33Oc6T5We5dy1ODLnqpYo9ROPdpFuSosxnFFu5UEsby6CnpSOCqHSKSnyH9MfUYR8VQ/hvM2G9RqA46ugWELPovEfJS74aHDyQqfz4CPJsEuh9RBlMBLhuWX5ODVpO5g9f+/YfIQWQ/Bq7fg0FocA7WHotA2GgajPoMWuoYLp61URHOwn+cwyOgtbNz7RdzXAnCHrvIjuQRQurSkafvLwnR8zXeoqJr5Qjlwv/hw7F1BHQIGZZlFRGDzqaZ1o4AeAzkowoCMhRmYWtlYXNzZXQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAG1ldGFkYXRhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMKAAAAAAAAAHsPTkV4veuMKoWfqTn4c40zztpYF2Ld0MxjnYcvp//rktg3o/nfF6Xzl+mY5MG9OvlbcNHHTu4vIY+TJChUFwB1SxZ1/fsleNYb7n8UXIYSwdFyz9o2C3VdVvMp+fUbYn1P1Uz+TS9uTm5Uyu8RRvPEz40Ez53X0awGvBp6uUAC"
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "272FB9B5AAB050F9784343C1FE626C0F666E5A7418C06FE76D6E1166CEA75E1B",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:R+qEOUj5s/kM3zyG7IlcXqeaUi1E09iK4bgC/82opgg="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:zQTJ9s7FJAAJmeU/gcdiOYHWpf7ororQ7fWEMOrwPvk="
+        },
+        "target": "9255858786337818395603165512831024101510453493377417362192396248796027",
+        "randomness": "0",
+        "timestamp": 1718998711370,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 6,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAlHkmFjj+49T6eBDK+xP0DK8MOchyOu6SPtFQsLqPPQ+qIlz5nFS/B566IT7doYmiq9nRR09JcFnONh/BuoAF0Bs+uBzwA0Fp4OXUUvAvTciyHavRyYHy3D2Htd69GwnAIAFwq6HnvIbmajV5Xf7QcgvSL7ozSpNPTCdWoIRGkaAVnkXsqi18QGCJl+3fLtrqLOIGzf0W40g25EpfXTsT32JLu4dYaCWhXtXxnvXqiK+CBGSxQiOqAMs9Dm45VFfn2NS6mj+EX4vsKEgtrajseDHpOiI/aFsqQTbQNUCT87YNJeW7jPk310pg0kU6oHrYdnyjwcmQLm7jGAoCCaBWzmXats9rAYNtunXfxG26bS7ruz6HQvkSKmmMi5aWxcNHSdb3BDrM1Z4Slav4TdcmVHVkxl0cJObA4cghRFmQys18CQKKi5AxCMso/puqGUtIET4FcFqsN9Fw+seV+8jVbqhcqSSgtYkehyU/qjJj0vm6C3UnAnZus/ViabS+PIxH53ogLBLqtUeLdV1SFiy0A3QJgoAzyLdG2Xm1UxnV8hn67lQmRQS6ahd7LFlzNC3tEYvao1sIN5+ac7c2syoOqoot7L3XcOQtJ35Dz0EVOfnmIprc+0SFWklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwkqGM4g5fA4H/ZjvQBZvYEFHTo/KKyT8JwgK1AJ7SUlHFhjgk8tMpgUqgLb/y1lSewRzpUZU1lINhcL6HWsGXBQ=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAsSkluerLUWvC5zECd9H09NAGcrk72CjBgCVe6mHWU5OQnohpcUVmSSrXizsbx4UGJIHBmWQhNNisr+Fj2isdMMZrLsSckU8H0ZRXFuZJSW6Zx6zbF9a3M9QPeQiqkSPRdXJgEtjNNyrqZshYTlhsAYHd+vQryTQemDmvX4B6qjQTu495Qn9OyZkVv1Tx1YvygkDcO1xWjZvQp8RtFskMOLcfcwtnO6455RjcoHJPCXSlfqks2A1bXvzurDUQb6er+HdBomaeEJWQ3SALOeiFVOdjcU2KGonw3/bBIG9QhCBGNuwtfOMCpbqoaE0vdGX56WvuBfO9TUgadZsGQuuFQlT7RTYkIuUyHGoAew3cLBu41Xj4vgQQumOdewasZ38ezI280bPh3ySbGJxlW6sQeAiZYrN/OdQtjwoG186EWmcebNhlyNRyXCm3St+914OfruZsO44jU4ODdog3QGShdI1c+ZkYph/xXxOQGvUHm5yTD6T7mkm7YUpmnL8yLsVjpZi7MWlrvgPiP5T8TqZRedEa5EFw4zb8uYx3Az5QoWhaNH+SdlGhduayYeohi6M5Hn9l+KNWWb3yzC2yvDsrGp1A8j4W/jqfcLRdBIj7Fnsemhm/1nqhsqgLFfeGgHC1H7MVOvw+EFjBLYpwJ51vSbSAj6e1rSGIMLCOWNZkAPrGAvBRp6UWpfwTqQY0af2eWbZxMTCrncyaaZizys3Ef73yfggzpjLvltLEPfcbFXQAJG/1G0BCzX6xK0ZJsk6nK33Oc6T5We5dy1ODLnqpYo9ROPdpFuSosxnFFu5UEsby6CnpSOCqHSKSnyH9MfUYR8VQ/hvM2G9RqA46ugWELPovEfJS74aHDyQqfz4CPJsEuh9RBlMBLhuWX5ODVpO5g9f+/YfIQWQ/Bq7fg0FocA7WHotA2GgajPoMWuoYLp61URHOwn+cwyOgtbNz7RdzXAnCHrvIjuQRQurSkafvLwnR8zXeoqJr5Qjlwv/hw7F1BHQIGZZlFRGDzqaZ1o4AeAzkowoCMhRmYWtlYXNzZXQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAG1ldGFkYXRhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMKAAAAAAAAAHsPTkV4veuMKoWfqTn4c40zztpYF2Ld0MxjnYcvp//rktg3o/nfF6Xzl+mY5MG9OvlbcNHHTu4vIY+TJChUFwB1SxZ1/fsleNYb7n8UXIYSwdFyz9o2C3VdVvMp+fUbYn1P1Uz+TS9uTm5Uyu8RRvPEz40Ez53X0awGvBp6uUAC"
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "93DC731FEC65C2E24E97378DEDD55D439FCBE79E56CC5C6944161F44FB109E40",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:kBHF3YNxOL8IilNDokogvegDjm/I9lyfjlDm6JvSNGQ="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:Bv2NFa1AlF5PoTAOmrvgJMKq9fJl13iSdftNIS4tdZ0="
+        },
+        "target": "9228823284279306817296266184515742822248210830185427859262273659833347",
+        "randomness": "0",
+        "timestamp": 1718998711826,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 7,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAAPFFBmW8j/PyVUgfNGgfykCVdiLfUUWcO6tUmbAUbFmvENyjwQlIydjPxm/dxavuyPCiYqLtRVgKVBRBaN3MCGxAqHeqmTHDgdUrBhYFW0CSzgOw+p1ptuixYO7OF3vt6HEuHsDNhlMEPnwVNaOUfPDJYgtf8S5dMHz8AIGYNCgOZmhaRhK1yjEAzyORc+cafbEOyD4jPlFLffaN6wCOjyVj+egevkeWjFwnpXqzyp2CwNdwfvPXvWsDgfRiOioMLkSOuIwjVWTdkFzVDVP3T2CyP2II2ShS9HNYSeTsI/YBU4zSDLGdNM+x2EVGYD0NghsodJCwEz3sxVt83eNTjNKvg40G2+h2rN+U382OvyKN9/ZP4xAWELu/XOmzf39zgR0J0dOxnV8XX2JlH6tQt1Pyuen9V7wPoqIsGIoD9JPb19PIIFluJOg7t47oxHopHpWiTLHhm3jZfz0WdurvZIptXU35MkXWEemxGbOMLqUwxt/SPhU47JbYLWBpNyyUHfBl/GlXoAJ5fYLKZDxnnz+UGyGGFSRq3/q+kYHWgbNMD7VLSdr78x+jDiaIBNucfeDsXV+Z/j5ZTudoWEZn+hsfnFDxvHDOfJ7kd5alq8NXHJIr2gbOnklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwZ86XEuVDtOd4ACDILit2J+sMsZUUNrNCfU8To3kNidcl297v8EvP6TcPpGnCAYlekcuysdQy/Gy70aaou0KmBg=="
+        }
+      ]
+    }
+  ],
+  "Wallet scan should save assets from the chain the account does not own": [
+    {
+      "value": {
+        "version": 4,
+        "id": "bdc181a6-6b55-49dc-9e59-c0902bf5b8ec",
+        "name": "a",
+        "spendingKey": "7d48d21dad81529168478dd42c385abad164a8b745b2313dc767ddb76d994948",
+        "viewKey": "fdae9c1c296edfb134e49d1aa46c64d05417a7c940a8436ebed2a2b761701edc0f8d0bbe124ad2d7f6a6232dbe403b48505378f18f66ebf428378304a443966c",
+        "incomingViewKey": "1b5f8e55cc7fe97298fb0c30ed94d2a639fcd79c4c174fcd5051f490ebf8a605",
+        "outgoingViewKey": "bdfc222fbcd687066795224ccc27d04fb698c9caa56d7c87bba012ab7c907cd6",
+        "publicAddress": "c253b29c18945be96e99e6787635cb8111d144fad1e4bf06f4224dd4deb0b54e",
+        "createdAt": {
+          "hash": {
+            "type": "Buffer",
+            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+          },
+          "sequence": 1
+        },
+        "scanningEnabled": true,
+        "proofAuthorizingKey": "cbc742cb6fdb5dabd8e1c61e202845fd518dcdf371dc9d97911c86ad60b88a07"
+      },
+      "head": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "value": {
+        "version": 4,
+        "id": "e4a46dd4-2963-4a3f-8f8e-21743f7e36ca",
+        "name": "b",
+        "spendingKey": "f3dc9f070a757849476e8b6a7c81e5877641de307db7c78f71ee4d4c22f24844",
+        "viewKey": "35dcdd6a8a7862e03ef133e1b1f028864644d41a57963b5698c6ce3d6f842d6e8e099be4cc1e5dba687563ff94cd1c7bbdab80f6d4c96b598ea694992d6b796d",
+        "incomingViewKey": "4fa528a002b17148e058ac6853e546e1a8c5fcc36d1dfee7d226bb3e14aa8204",
+        "outgoingViewKey": "8363fa72f466c437fa86902e36b035c63505128eee67b0626fd9ef95374d647e",
+        "publicAddress": "b0ce6cca74144339b1a1f4e75569d937a51e00cbc1487857564ddf40d4082f07",
+        "createdAt": {
+          "hash": {
+            "type": "Buffer",
+            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+          },
+          "sequence": 1
+        },
+        "scanningEnabled": true,
+        "proofAuthorizingKey": "1edf1b1ef2e6d68c9d6f79a7aebef28a66023ae210d609d5019588289a5d0b0a"
+      },
+      "head": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "4791D7AE9F97DF100EF1558E84772D6A09B43762388283F75C6F20A32A88AA86",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:0oCyhTiqAZnyKvyvwDkJ1fXFKQ/UwC+XSWLFvm7B208="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:dfExbCGnuMJybrBuH6nRpd4+oXyRPDJyDmpnrla812M="
+        },
+        "target": "9282972777491357380673661573939192202192629606981189395159182914949423",
+        "randomness": "0",
+        "timestamp": 1718998712927,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAuT/alo07JnoPN5dRhQh+6/w06bPgI5p4PHdHqUm1fPON32EEVBtLg70eV25lfx6f94FMf0sZfh65dC87WqwbxeFw2BThu93vb7Qm28V5UMawD5iCI0u5PyuFasE2A0R8yBaPWKk8vhGwO9DPZRZ3qsZq9d5M+9/5/o/iXlSpK80X+rZsRmGTrZrX3cu8FZlIjpwg3oW4dWMEyyMjNPcjEOrLkX1d2E1wPFszJhp8vIekEEsB/xb14OFfZ5GYUHha2wBGHedlbM0e3goFlM+o4ixqjR2zYb+2gWNS7H2EvTez5t5DMvqaBBKsR1iv4tHqDohyk2roorG2Egqn2twwZglAvpdbWxviA0XCCW4WXACCYHKyWwjo59DR1h81KaNbkONqxfD0+EIUZAJFOQmUjdbWdBP3ncjVbIDlTnfJsYQSUwJBGXiPmAA8cj7oJ8c0hXRKEn9REWOiXvhrsW7BMeM7T8mO+MY31aY6LNrty8r35+7pwOnHrmjEgxqnYErMZUgWIsRTzuQlmd4tmyIMAzw6wfQ6ySXM5gztmAiHqHswZb49KYOlLP8PK2cGbnBWC5L8M+F4vikKLab9o0WLuIj6aweCVT4Mj3dGoOh+StT7sDDQd8imlElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw5ao6b2Po5V/WyZJsLpEEy/MMw5pvWW9Zan47u1OtIGr++SK2gVFrJ27EDS3kM015GsavU7sjg6oFk4TojxG3BA=="
+        }
+      ]
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AQAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAr3z206a5rUhzKJ1PC9ZwCsJnyl3xxi+OL6vd8grPLEmpgTz8GQna5Xx/xRnmVgE3FGd2BtpUiQfwzYp945ryzkeztzFZQAWlRdKyrqsUsqanHd55LDnZEPf7mKJkTRSsgQd1xmqd+ZZ0XZUowFaoXj0hQsqXaDOD8mjxsa++ex8LKVT6frtt02xtFbtr2qJ/olVS1OpwpqyLlcgRTlUP1/T/0eDOVAUyQAMrLBC/8dKOxfQ345n00/bC4W+EZfqnp+9OumCTjFyjuq9WN88vuXlI9AUA+z5T64MDGPcs2eRb98zQTS3k0AfxvRocHeOQ5ddTMnn57y+9v9/MPoEZx/QDwSAdkas7/Qcf2DdHhjrGhTjmSgpbSmbg4obPfDYmvzWaNQL/QZ/3P1XL5bU7Cvv0k3JSr/1w4s6fvUAA84Rlnz6Yn1jS1iqe87CxIUtJQ1wwcxR1Sg/RmmrRWvObgKZmCE88eqtQCbhvU1FKUU4TwkctlbOnEG+MbN9CeC2Z4i0epyIw96oUhkclo1CocjKlemvpIIoLvVlMN/k31hPzO/9gxkW1HxUeuQQVwSZqEx0GjUCMRL91JtDiwMjJWsIDk7ys3z3/uVmpXxiUQ3hxDLjTmOKYiqaOcGd+e+40tYKrbuKpC9eg4tPR0mWXR75bcRFL2WIx++sXvm0RFZPgLxGirUqCB8VmQJ9OsKRvk07fB11aZkRkutNkV1fYZHJi9zd/nmyrrjWVRxQa5NMY65ZqrVPBow8u81PRrreRhVQR6Js9ci2A7hWkp3t1v8P+FIsBKF+ct7OFHEuMXJgN65m2gzJ8P0xbHtTu6yTmfS5V4YfVUX1uR2VCVVKONQEjf8EcKeZDD7ga1NeUbaoMuXBn200Cc+DranuFsGeVR5Ht6eKnLC3gzlGjuX/XnfOlp12X8b4pjefe3neg01A4RsuaqqlmO4of5rTKLaT9tOG0yZ86tiv+R6EhuCeky/hq2DgSiZoKwlOynBiUW+lumeZ4djXLgRHRRPrR5L8G9CJN1N6wtU5mYWtlYXNzZXQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAG1ldGFkYXRhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAoKAAAAAAAAACEmPOiEeDtHhHphVmloBA6u+Vqp3QdND7mmOCfuem9MLaQJtzH5bGRy0xAJlk92F0pSjwBj/Lz/IOvISnV/PwlcO2Sq3MirhgCNadmJeWO5gABO/gDELQX1DfIyemNgby79UkS8swG68VnulnCMAQewcKbHLPbuhOPKlbfFv80C"
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "A1DFD858C000115E3B6DD56D93625B25E839A4416DC12A53C0D46C9B627398B9",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:28uBqeZXKceWrBSOAt3/AosjWSybUxDbN2DivVo1/00="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:eTSIjSVeiLWU6KZ4TYOaoeashqqY6Grbml/nvZBuOfI="
+        },
+        "target": "9255858786337818395603165512831024101510453493377417362192396248796027",
+        "randomness": "0",
+        "timestamp": 1718998714070,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 6,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA/NJnmbh919a25sPLqkCkNxs+97nPuRPu54dBxfk+pV+vYZO48n2zfdtPqwsBBR3zd8d6USGF152cERr7hBwryUM5JbRCm3CJ0Rw2ohacwAqNnm7CuRly7T5PSxUreOXsTuDZOC0dv2Lz9wrnpCxkjBc/XffUV9EkT9QVoo0lfgENz3kih+rZeC/BvqIflJ0N4G839gmsVvonA6jzxChoNl705MkhyKZlQFTs4mNSF5ahwJMUKwj0EJRZWU3PQwJX8VKeHo+ZLyzPuhVd8H5PmJnSnJnsU92L+x12wRrU/yNd1oWOkOoYlC4Jvd4MUgK3K7tUI1VSM7LaNzB7XAvEgFMm8guqltnaVEQRizkv54Gr6l6xcUs1kg//VlhWKgxPJgpgAnwmA/7LDAr+zbZp3nupMUXKUuH7oR4b9SSao1n/WgzM7hbGBvcMxKSOceKZi02tPWRVcrjQ5APtFeF14P1/U9qeZKEk3MMaU0v2RC1Cp61oWidypjxxy2hWuHj2xiECFsVj3hG8gzSuVqU6K3WNEPt4C3fvazy1JAW13BCBdyBMQg6l48mix6joQJ2HwJNgTcg6c7dpkoSaMkqwzXpSTJRVFQKDjl8OHf0k9r6pq9bBXdp3HElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwR0LObUeOt1vE1Miyq610+3dTq9KFagXjt3ieQZG9uu5cHAvDvl+DfkSchQ18KQVNcnvF6i0SCgkd2rH/eGVLAQ=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAr3z206a5rUhzKJ1PC9ZwCsJnyl3xxi+OL6vd8grPLEmpgTz8GQna5Xx/xRnmVgE3FGd2BtpUiQfwzYp945ryzkeztzFZQAWlRdKyrqsUsqanHd55LDnZEPf7mKJkTRSsgQd1xmqd+ZZ0XZUowFaoXj0hQsqXaDOD8mjxsa++ex8LKVT6frtt02xtFbtr2qJ/olVS1OpwpqyLlcgRTlUP1/T/0eDOVAUyQAMrLBC/8dKOxfQ345n00/bC4W+EZfqnp+9OumCTjFyjuq9WN88vuXlI9AUA+z5T64MDGPcs2eRb98zQTS3k0AfxvRocHeOQ5ddTMnn57y+9v9/MPoEZx/QDwSAdkas7/Qcf2DdHhjrGhTjmSgpbSmbg4obPfDYmvzWaNQL/QZ/3P1XL5bU7Cvv0k3JSr/1w4s6fvUAA84Rlnz6Yn1jS1iqe87CxIUtJQ1wwcxR1Sg/RmmrRWvObgKZmCE88eqtQCbhvU1FKUU4TwkctlbOnEG+MbN9CeC2Z4i0epyIw96oUhkclo1CocjKlemvpIIoLvVlMN/k31hPzO/9gxkW1HxUeuQQVwSZqEx0GjUCMRL91JtDiwMjJWsIDk7ys3z3/uVmpXxiUQ3hxDLjTmOKYiqaOcGd+e+40tYKrbuKpC9eg4tPR0mWXR75bcRFL2WIx++sXvm0RFZPgLxGirUqCB8VmQJ9OsKRvk07fB11aZkRkutNkV1fYZHJi9zd/nmyrrjWVRxQa5NMY65ZqrVPBow8u81PRrreRhVQR6Js9ci2A7hWkp3t1v8P+FIsBKF+ct7OFHEuMXJgN65m2gzJ8P0xbHtTu6yTmfS5V4YfVUX1uR2VCVVKONQEjf8EcKeZDD7ga1NeUbaoMuXBn200Cc+DranuFsGeVR5Ht6eKnLC3gzlGjuX/XnfOlp12X8b4pjefe3neg01A4RsuaqqlmO4of5rTKLaT9tOG0yZ86tiv+R6EhuCeky/hq2DgSiZoKwlOynBiUW+lumeZ4djXLgRHRRPrR5L8G9CJN1N6wtU5mYWtlYXNzZXQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAG1ldGFkYXRhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAoKAAAAAAAAACEmPOiEeDtHhHphVmloBA6u+Vqp3QdND7mmOCfuem9MLaQJtzH5bGRy0xAJlk92F0pSjwBj/Lz/IOvISnV/PwlcO2Sq3MirhgCNadmJeWO5gABO/gDELQX1DfIyemNgby79UkS8swG68VnulnCMAQewcKbHLPbuhOPKlbfFv80C"
+        }
+      ]
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAsf46DKX34ev/n8SRi3cxGBCmV2/IZhZ7XFSVuadJmoyH+dz/UEq8ZAOggG2ih6PggKl1waEF6bmeDVt9HmA99K3mpNftYD/U9HeO4ZluPimmFn/JS0m6rNMy9Da7eQf8QrGUET+zkkcDxl+kLX2s/IC8qgG/k3GriLSSw7Hy22wAqroYfAyiiB/QBHyKIoeceRxO8o6UU27c5iq9qB+Z3aFylmal4o7aMLsgA1D5tGmqTK7NBUzy9le+QozrTcrq2VyROuYMPxDKgO6hsR8QmYLSGsz1QaEZQ4IBis7Bbv4WG+LohLJgy00cTfmcaRMQw5+ygwn6dwyvY/8XhKAU0tvLganmVynHlqwUjgLd/wKLI1ksm1MQ2zdg4r1aNf9NBgAAAHGMXWlmiez+Bt1uJnIJLiYxY75a4tnUcqQ7anXQpUo15bN0ZEAMRZOSTTBZjIEEoPovmmDVoNT2i17iXRdml9qR9cdNtaghFFWApvDNVbVTHzjCiekU/wSVIvn5/1WpDJlT465OqqW2d7607ZaByNbsGKoIWL7H+GWT9C9bAk6jWzK9Y23HvEEpUlDR04tCg4qiNmyZ5NPr/ww58X+hR32NukYgjUdONxFIYFpqcJlnia8adu07ERfdoG17V9hqghj6zr5MlRUbD0skMFr5JDgy/Sv0GaXpSXC1619uBtmUqhyW7ulf7SKrN8VDAIn6UajiIF26Jl1uJxVLfVoVxwg5k8VnYVCaR8P2Cm11a2dhyYvSXLANoc3Crui4xCI+8HFV4eB6KXQp01hpJ6dNA628zct/6pFP5tS2EphjGZPcgW9WVM1xesV3lkFDebI055w5f/tQZjRhRtDkqFezDErDRBIXuUCDsivEah+l6ccwrgO51y46NxBgWYrC7A3GOP1p25WpZkMEEnV/GZ2LSeQGyPy/8FKzgHo+gLVDyvpKO7uePvbWs3vcc2xzlO7qzrzOWokNe8VSHYFvGiFLKkN0bVtg92lpeWuhWNjiPSMczkGKzwd3/6XdP0WPczanQlJbKNOeoEV5ZRP+SPXv+cx7jz0u73OoLroaGs1ndFPgQCfzRfUf62FUxFVd0U0aFMnSRQtu3K+W1QmIh08LfdPWABakAm2AiUA9uzYat6O7E6UqnzFX6uwGesCiUnTUCV1TdJrrS7fE57DlExcy80P3KXaU7k/tZSA6Elgx5hd+bXlcZRunI1Kn8xb0d+oPUTX7dOYj4xE6j9MishxxPBzIHD7C170tiBEvKDobGSZHOsPcAho8uvqUXcvAN22xJXc6pyfWH1+HMvoRJHtA6mEg9T2ORyBlILJEdoIBgyTPE3E/yqd27lYAY0PJHg8JqLPiL15ZihxhXfvBcn3Pa2TPXD09vEawKjxgVSb8TcNUjPgUcdIcxnCHnsLf2aVdwErvutecZ/gwXEJqI5ubkXCDDTRDRX+rK8+HQVptrtdffzrGCFftztxGrDK4IiWSaOVWjOC9hRJfDBZQ7TP/VDstweDNPMTzEkfgfNIyrmDRUxA93G8NGcxOf/8GdaVYRJ87aZYZKSsEG2YuxbtwJPz3fb8nkQ+BKf+x4Knfo2TjLP5Xz4EOyCoWEWiNyv0MaTYGBQByNQzdDkPRAPDFuSw4vrGHLRunbYkTF3o4b1NLIn5/uK7GUHE1o4ENf4/bgZAzCEzMwI1yMEDexp4s15BzPWGwuJG5o6c//vSC90DjKUKFE6caTEGn7IWLTFmpkV2RzSPJQuV46rMLTQmh9J0RKTqikl1zS+DAixGec371JUy0cxvEGPVYfIAgCZEWtIRkcyJZHMjph/3mtzuLfkatu1YyMYwiO9M7EOgEy/QPt1j6wL6VN84zEG61bOpNGoxe/kxnp3GCneESt6rnKZ5v+GGGLORd9pZAjr6XCXgL7y+OhyEq8ns4zUyPsSl0384S25HGgJ5zHfmBO3aNrgBvtMnIFNMFXE1ybHGup4SNsQQHe7YSdoBbbD6QwSHxDQ=="
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "7785D93CF60D2D01E7438966BCB020416F6FCD85CE6598C7AAEA3DB91D11ED36",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:SvlE/JLGCc3Dc9aof+eSJoAXgQaRjYTRwnaar87sFBA="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:2/p55iiSZWuGQrCipruiSF4TzxZR843SFsl5A/gIvEk="
+        },
+        "target": "9228823284279306817296266184515742822248210830185427859262273659833347",
+        "randomness": "0",
+        "timestamp": 1718998716388,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 9,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAjPFV3XQn55MP/1zlKrJa2F7ArSZpTb63+NrkKiV0OGeTl0Ky1k01lcAqaz+ZRo7RTSSjyUXDWy442D6UclW3Wuv+yK2fwVesLnt+GsFrO6ugw4+E8KnnC94ltRT76ocN1nOY5w/is5bzQv4F+M0QY/ECeD0/9ih67wTSkn97agUERNxwE6b46wWXoRJxSB1JhnvSAIaVJv9h/cKe9D/+NSK8k6mjhoF0QxLDH9h6fS6gcDNFr55dV58kMOLdfothrRYMz0csZgsFRD+LQd9cvBUz1NORynwqtS8RWOOwwpwI3KYEO7YAX4JSgHVsapDyr87Oe0ojhSj1XfYpEzelFmcYNoeb2J18oOGWTtpHy9QiJrkyN+O9mNr88ihBkEUhoFfKLSwNHMBK/+d49VDDuCtnyKcVsMt2Grw/ZEqLYt2Xlweo/zzaHiVfjwPQh98lSLledVi99a39jKO0jOCdMYe3glvmnazaATAZzzhUhX0Ky7VDpn7V6NGtg9zSZiEUz7n0rYldNKiLA2Yk+1Coi/J0cyI1BpHRM9HyCAesO6XC/15xpyAhJT+AlXGZPcyWPpl5XuQWZet7liFIpmkvmT4KQ5QycA7ghZdUE74faShfVaUqeRicNklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwvmIZviEQ49o3CTCqj9KCyEpeYfFmGPWHuRj+en5mO2E7hvOnf2vGFI3F6IQg1oIEg3k8r8oS+kKTZXdt/6enCQ=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAsf46DKX34ev/n8SRi3cxGBCmV2/IZhZ7XFSVuadJmoyH+dz/UEq8ZAOggG2ih6PggKl1waEF6bmeDVt9HmA99K3mpNftYD/U9HeO4ZluPimmFn/JS0m6rNMy9Da7eQf8QrGUET+zkkcDxl+kLX2s/IC8qgG/k3GriLSSw7Hy22wAqroYfAyiiB/QBHyKIoeceRxO8o6UU27c5iq9qB+Z3aFylmal4o7aMLsgA1D5tGmqTK7NBUzy9le+QozrTcrq2VyROuYMPxDKgO6hsR8QmYLSGsz1QaEZQ4IBis7Bbv4WG+LohLJgy00cTfmcaRMQw5+ygwn6dwyvY/8XhKAU0tvLganmVynHlqwUjgLd/wKLI1ksm1MQ2zdg4r1aNf9NBgAAAHGMXWlmiez+Bt1uJnIJLiYxY75a4tnUcqQ7anXQpUo15bN0ZEAMRZOSTTBZjIEEoPovmmDVoNT2i17iXRdml9qR9cdNtaghFFWApvDNVbVTHzjCiekU/wSVIvn5/1WpDJlT465OqqW2d7607ZaByNbsGKoIWL7H+GWT9C9bAk6jWzK9Y23HvEEpUlDR04tCg4qiNmyZ5NPr/ww58X+hR32NukYgjUdONxFIYFpqcJlnia8adu07ERfdoG17V9hqghj6zr5MlRUbD0skMFr5JDgy/Sv0GaXpSXC1619uBtmUqhyW7ulf7SKrN8VDAIn6UajiIF26Jl1uJxVLfVoVxwg5k8VnYVCaR8P2Cm11a2dhyYvSXLANoc3Crui4xCI+8HFV4eB6KXQp01hpJ6dNA628zct/6pFP5tS2EphjGZPcgW9WVM1xesV3lkFDebI055w5f/tQZjRhRtDkqFezDErDRBIXuUCDsivEah+l6ccwrgO51y46NxBgWYrC7A3GOP1p25WpZkMEEnV/GZ2LSeQGyPy/8FKzgHo+gLVDyvpKO7uePvbWs3vcc2xzlO7qzrzOWokNe8VSHYFvGiFLKkN0bVtg92lpeWuhWNjiPSMczkGKzwd3/6XdP0WPczanQlJbKNOeoEV5ZRP+SPXv+cx7jz0u73OoLroaGs1ndFPgQCfzRfUf62FUxFVd0U0aFMnSRQtu3K+W1QmIh08LfdPWABakAm2AiUA9uzYat6O7E6UqnzFX6uwGesCiUnTUCV1TdJrrS7fE57DlExcy80P3KXaU7k/tZSA6Elgx5hd+bXlcZRunI1Kn8xb0d+oPUTX7dOYj4xE6j9MishxxPBzIHD7C170tiBEvKDobGSZHOsPcAho8uvqUXcvAN22xJXc6pyfWH1+HMvoRJHtA6mEg9T2ORyBlILJEdoIBgyTPE3E/yqd27lYAY0PJHg8JqLPiL15ZihxhXfvBcn3Pa2TPXD09vEawKjxgVSb8TcNUjPgUcdIcxnCHnsLf2aVdwErvutecZ/gwXEJqI5ubkXCDDTRDRX+rK8+HQVptrtdffzrGCFftztxGrDK4IiWSaOVWjOC9hRJfDBZQ7TP/VDstweDNPMTzEkfgfNIyrmDRUxA93G8NGcxOf/8GdaVYRJ87aZYZKSsEG2YuxbtwJPz3fb8nkQ+BKf+x4Knfo2TjLP5Xz4EOyCoWEWiNyv0MaTYGBQByNQzdDkPRAPDFuSw4vrGHLRunbYkTF3o4b1NLIn5/uK7GUHE1o4ENf4/bgZAzCEzMwI1yMEDexp4s15BzPWGwuJG5o6c//vSC90DjKUKFE6caTEGn7IWLTFmpkV2RzSPJQuV46rMLTQmh9J0RKTqikl1zS+DAixGec371JUy0cxvEGPVYfIAgCZEWtIRkcyJZHMjph/3mtzuLfkatu1YyMYwiO9M7EOgEy/QPt1j6wL6VN84zEG61bOpNGoxe/kxnp3GCneESt6rnKZ5v+GGGLORd9pZAjr6XCXgL7y+OhyEq8ns4zUyPsSl0384S25HGgJ5zHfmBO3aNrgBvtMnIFNMFXE1ybHGup4SNsQQHe7YSdoBbbD6QwSHxDQ=="
+        }
+      ]
+    }
+  ],
+  "Wallet scan should add transactions to accounts if the account spends, but does not receive notes": [
+    {
+      "value": {
+        "version": 4,
+        "id": "50376cb0-c18c-4a9f-b2d8-48130a3b36f8",
+        "name": "a",
+        "spendingKey": "0fbe0f47e68c6ae12f774705faf73f426c3b82687d9f6c436835b405555479e9",
+        "viewKey": "6fccd442bad1509317a3483da3e1065b5c5f968904c6e64cbbb23b89f275a6a3a42004ed5cfde6716878f66d504ae3787322dd024906ca4942bcfa163fcbd5d3",
+        "incomingViewKey": "cc9f96ea76668ecca95562334d936d0deec92e4f851b201941480a73cf58c207",
+        "outgoingViewKey": "392d5baa236ace5670483c774b1d89f105ec83d2c878e08f4985300ed2a09145",
+        "publicAddress": "a0fe3b97b976c443140e07deeb5fe308bbaa2001b9ff49b4ad86df9c8d272f96",
+        "createdAt": {
+          "hash": {
+            "type": "Buffer",
+            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+          },
+          "sequence": 1
+        },
+        "scanningEnabled": true,
+        "proofAuthorizingKey": "769f765514f867ef878297cc07f437344893ac7f82a85762d39d95eeea470906"
+      },
+      "head": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "value": {
+        "version": 4,
+        "id": "d37ffaf0-847d-4284-942b-c83d69031d48",
+        "name": "b",
+        "spendingKey": "6f3ea4580e54053f905b710dcca5b09ccbf0cda779fb4edffc18dcb9225be680",
+        "viewKey": "2f963c00eafac58da9fb02ee32d2d57112a57f6d84827a817844452300b2450ced5ae3a4753c0904327ce7e680150388f840daffa414be9530f45b3d57da51e5",
+        "incomingViewKey": "4bda4aecbc3ae34e47d40ae5849e5348dfc59f2364ab6b1130f85d7ea2500304",
+        "outgoingViewKey": "7c9eeab937c4849bf319e38559a73e654ce1ce067e8f68d2516483661747d615",
+        "publicAddress": "d7b74f04612a48ba0add85013e3df5fff7e4e9ad71d928da534eb9550d6d67dc",
+        "createdAt": {
+          "hash": {
+            "type": "Buffer",
+            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+          },
+          "sequence": 1
+        },
+        "scanningEnabled": true,
+        "proofAuthorizingKey": "e2419be2dfdbe1ecafb99d0e09d27ca845d0ca4745323e77b2a576d46d9ab207"
+      },
+      "head": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "4791D7AE9F97DF100EF1558E84772D6A09B43762388283F75C6F20A32A88AA86",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:ZVsuuTLt4XhvcZnBSSV6uaOWDkjBTAmYHoL+zv08BkQ="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:/vA3ZYYNHb17hemzV6AksqInp+MGQwTtFaD41tZmpv8="
+        },
+        "target": "9282972777491357380673661573939192202192629606981189395159182914949423",
+        "randomness": "0",
+        "timestamp": 1718998717727,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAjefRxfyJ8okVx86BcEIDpaa2kstW1lXDQm8IZH9IY3KTdjy0tgtVjdpcbOGB3csSu1v81gI0ykaJVqCF2Umltnx0n0MqrSAmJwCPKgd2AX+iIVWDK4hCma3etSmtNlMfnvGWGCA54YhqDI7omkG/pSWCKbARQhCSJv8SmQaQjhsA82bhUKiLsfHpQu6Ztqnfz7OCWvWwItFJHJa0Ll3De1J3+rut+nm666F66y7jRG20WCzFyVBBLAZgGc2JiNgOJcwo4Xa9yLwVIGt7OJzMNsGRE190MtcykPUMb5CJQJNTi117Q56luVOHZ9hwhoj7NLswBz5DKoEmJ/u9oBhbscky2pJNiJbbmuCcFRKXmoBfYU5cewVoys5hddOqcPAWBZkVre7mez9bwX/Y3HHtrlt6RFvfQAUuOBaNYAnA30nDDE01JuqqnRlo/uRpCa0XmCEfpfsmHUbyQy2IgZcdGUQAu1keFRbqJPEINmnza1MG3iVt35CDEWC5rp3os07qU4DussT/m2T81QnJQJS51adCg4sU6OXujBDSSn6VTFxzKzg0l0wZmfFqynAfgmkrFjDf6B+RgNPxR0plYkDU8Qyf7P7RHiq6OTClqgn48739Xmq7NSBeyUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwcXPRTd7YL+fhiiZj1zkQA8oXhFBArzNDklDUIBmoUZYq8e7ot2HkenZ1gMeu1aLnZBLODeiQP5c2FZmLVDsxCg=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "DF97E204760D5DEB4EB34DD842375E408DED59D23EB68EE93EB7A576FD62B48D",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:tN2/rx1uS9oklsWNiQHT4Pujqkn2H5rxhsVzcazDmGs="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:K+Rq7lGlObLNMuI2//UwZ/ehCYQyh+z1w/TfqEy8ZZA="
+        },
+        "target": "9255858786337818395603165512831024101510453493377417362192396248796027",
+        "randomness": "0",
+        "timestamp": 1718998719572,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 6,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAdiUEf////8AAAAAjn4SqHnpJxr3xEfdcSrwlvWIoEWaDasAuZ5vUfgiCoKuSkc3jW1T7dlGW41k0jiaBeOJRc+zUBj+gSGzzjRG2ENvggcoXgJyjEwgFt8Bh2SyxpnA2Z3vzHqOJiULG11euI7YPgcDOTTWgefBjhvh3020lK1NvnPW1NJ9fey5iUwT1NUaEnBYHDKPP3KUVBeSSLprn010P9vrFaZJMP28T3lsiDeAubaG0xOU/Os3pTazewIQOeq2iB7m/ne2WmhxxGdQBYgYBcIPmE+A/K6mTTRxLNJmpfBB9il71o3FvJJBOFC3RRlIXIZL81HGOAhUjNckpIePL129h2SBzMgPZWo9pfFcRTQIMgUq09L3mx2Ya9UdBUJDD4Itm22Szbket0TZyVoELvKdeYIvbMc1NAKwZ81K4dO9GdC94TtUOJK6zv7SABfxXdFqFTY7PcgiqX+BsFCMhCavExwQra8hFUkHxjL8K+AgYTXv6Ne2Uswimjd03oK2NEAwq4Z5Dsf5NRfbo03H6a/m9jGtaXsikR/42TT3naFRrrdLNsJxkk51jOGg3yi8sx9X3w39+HhgOH0I+EnSnJzmf/f+fhXv6BE6kDV+kdRWJByTLQDHN3BqSesV6JQSj0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw3YCfbUGhIenmguozd1lj8ctMn8wXOl+ZLuVbZlC8Awj8kucMYJ3n5OCT6Fct7V8+99kJEKif90l/ob8RcMEbBg=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQEAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/5M1dwAAAAAAAAAAM2xsqx3frTSOWm+6ENKY9y756KtJ3CDwyvveW6xlwNOr/LdsdENo3unQFw7FLWUjvp6jekw3VXe0gRXbRManpQp7NcK3odB6NwKT+SXcM1ewVt9hw2a+meFS4sHMeFA09uM1CJMLCzL7jcciT6A9SeS9vcOa2UHFAN2L0jKtRaAXREMBVslN/KRIEP5Epqbdy26a2M0xLo18diUy0nb/6iwM5aClDKiqyQRc9Afvw3SGWAqibRVcKnK/95b8zL4GCNypMZGg0j0KZuZ+tSoadSvnXf2Fh6uNlXQM8X/xGyACMyLOAB151BuEhI7RaXYwnc4fITADa4+K5gPso7FuAWVbLrky7eF4b3GZwUklermjlg5IwUwJmB6C/s79PAZEBAAAAJ5TiFx0SaOjKaHCJUmLmAiKir+xFMtYsM/z/yTkJx4U72zhychk6tWtCaq2RWuU+wmwjtHhPAFbpuZCCbJIlZO/ZXmgvXLITzAI+16T4h5fedRbdjcsHC6sRpvidV8AB4MAu0k1AwXvXna6hHEWTnLjcoEQc5rk8iMhF9dTjuuXsan2PIDQeap5VZk5xmCYaoygBpklFBg5lXFWEbK6FW595U5sv1CPxhibEviQS4W/naqk4RKBKbERtVroScJmNRFy+pITLt56oXVO/jSd4IqB0vs50h5y7cMtGzG6h2Ia7Bnsq2pcYwpB/eWuIbB+gY2iB4Zs3eaRrbpgEGfpIcUKIAZzlCJV0qnmYXyJ1IdF7HE+Y2N7uiNDVoDke4SA8LTKknDmTb7sRopOEd5/+6rKwxYfMxd8HmdRAK232aPIg/qxOjxPCdQ43eRZ2CwQnuAKXY0sJRQ1L+nA+hjiLUIhf52DvxtFp5lDoCZwCUQn7dtDMXjm3FPqYaRFnNMHZQMA9WyApCGlbe8HDjmRJQhrzciXwUWPjgzUIu6VzAjumTAOWilggYPrScPtRGiwC4gn1feS/4u0Rf3S2EtEJzbtbsEi0zIXpiK3GfSwas4MzBVKqm9ZjAAgadV7kDKfVPUSXxFSA+xsWNHmXwKGig4+TFywvt9kpAmGAFluAhouGxeJea+Bi6JAgspVKi6OH9dfyLy+zHmw1J+xRs/cNEET8cht9gT2l0pPTaEpOqeiNI+dkQFzp8GwJq/Z+cOkTuN1oYJwXiGKLodSDaPoXXye3/0B6uSU6nugo+dunCgfTcc2UJrHGYPKRASwzIf9My17sjhnLMuZNy+wmNS6ruKgrLSI753bEL+EgVjeL6+uGlijAJm6uQSfdPgtF4y/lPGSWNDkNooF"
+        }
+      ]
+    }
+  ],
+  "Wallet scan should set null account.createdAt for the first on-chain transaction of an account": [
+    {
+      "value": {
+        "version": 4,
+        "id": "98991cea-da6a-4bbf-8cc5-4fdd27f81271",
+        "name": "accountA",
+        "spendingKey": "6c5a641a371df373dd39dfc3ecc0d984999ad3a7d0a0786ab13d0e15e1ade682",
+        "viewKey": "09fc30937fd87b9910cbd75580559afb6825c020d589d66ab3daa550be6a0a9bb0c6ea88d93cecdfe7cc675c523c6a2bf7cf2f04f8f2e1f2953bd9be95a49539",
+        "incomingViewKey": "5db14e89c345663d5f066d7ce62e2d22f98a3c8f038c068bc8d48bab84b6f307",
+        "outgoingViewKey": "85de8a992117c4880fac395536df58f1eb2ff4c06634e30ee9393ac90ebd457f",
+        "publicAddress": "e9c1fb3d3841e52e96d6cff8eac4e8f5cc0f1bd0a07a5bfac5bd5ec99cb997c7",
+        "createdAt": null,
+        "scanningEnabled": true,
+        "proofAuthorizingKey": "d71357283f7d946802c5893f6bf994c6faf8097caf27adba4f04b87ea6724904"
+      },
+      "head": null
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "4791D7AE9F97DF100EF1558E84772D6A09B43762388283F75C6F20A32A88AA86",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:TQXdLry7EgfukF8ipqsKdRTM+FJcOnnnVczBUoke7iU="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:6oPCNz+EGoWrITI2NYnEYeGjbiOcwv/JAvMLq8dTqKU="
+        },
+        "target": "9282972777491357380673661573939192202192629606981189395159182914949423",
+        "randomness": "0",
+        "timestamp": 1718998720696,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAm3cSdXbX7cKHnSCrfA+gGBUvoBPRkrzbSOKHj6Jj/musrgqgsGRLp6MtrA4KrDN1sc8KjM8UpwGNwKUqz9+gXA8EGlp+V4I7tELelqBbg/uQkK/LUqq0uzEoRdOswE5dyA44piCvU1cbbteME37SzwX5e0bBmDyavD22IuivygACQtkSLdjtH/rjU+U5+8ID3xPRAx94raBT9GZMzws5Rmgkh/5cOiKi5UnlY3B2CS6lckx8r02PYALueYyHBq9BHqFdjIAx+ZSX214tP+T5SMnlBhG6NSOEojSu4JQ6O7HUGUnIf2xhwLsg0ftP1CdHKB9GfFHnDnfNOEDOGKA7AfJ8qQWlzTjymKxWVcmsd4UjUC1MSKlo3igCU2/x3ZZedQfUp/yiH0A8tW5lhwvZckrGBQ4mWtLAk21QYd7A8AQprr4wwaQ10mRe7s00L3e2sH3g07d59mAalpVYqLm0sKrKzF6KqW0Z9OVtApvMjxIat6TW3dVNHucaLvDQCFRE7c1M/F7n/Jf7fv0/2Q7k7tD15AGuRCoL5bWfS3fSJKg6YFvnJOLHZngbGyTq8LOoFuUYDRu8aeRliMaPZdv7Ln3CMwqa2JPSpdC5wiOJ1SJZNoiQw+fs00lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwJ84t4RTp8dTjF6gNHcHGuMgql9+jfMDOV1AEHjHQkqpp+qAzf3chVdnOqj2Hh9CwA8kwKnpcIrsh1grpcnk4BA=="
+        }
+      ]
+    }
+  ],
+  "Wallet scan should not set account.createdAt if the account has no transaction on the block": [
+    {
+      "value": {
+        "version": 4,
+        "id": "a31335b0-59a0-4544-8168-d812ed76e603",
+        "name": "accountA",
+        "spendingKey": "87b2bd40fd9bb27d8cb5553cd63f162ede5d5b95b988a09f93bb0373afca66e7",
+        "viewKey": "112d5ed92dd70bae4cf2f11d74d93ab643ee0953294cb9974c135faeaccdcd4009444fd2ab596ec499a47d599770a9e2cc4460afdaaafa354bb1ca449bdfb206",
+        "incomingViewKey": "2b96bca15ecb9cb436ca4d770d3d8a4b9545cd353c666c4dcc4fe77601a50806",
+        "outgoingViewKey": "357c78b412cc8fd39cd0ca4d6387cc5efcd7e3101465607734923b39d463da3a",
+        "publicAddress": "e7ef66ff93467d483d1f8b42e4d569501cfc567448ec7b302bac008da172f4be",
+        "createdAt": null,
+        "scanningEnabled": true,
+        "proofAuthorizingKey": "6c50131848a61ce5f7d26de20ddd6286864f022ab88c78704f9b858ee540210e"
+      },
+      "head": null
+    },
+    {
+      "value": {
+        "version": 4,
+        "id": "a009f9c2-b16b-4500-b246-2e94506ebcb9",
+        "name": "accountB",
+        "spendingKey": "21aaf945865c7910e0cbbf02aa1aa9990907451c0bdd35d71a74d2e007cdec03",
+        "viewKey": "0f7035d736159ca841c02b6df564491448a45fd054a3d4cb2bd33f5a236f57942e93ab131eb4a97e06e2e3671f99d9052f7f63f2309e8435e0137a9bcc027616",
+        "incomingViewKey": "bab6b41768380ff997078c8305b688fe92358b181d7244c1929bbb7c1f8b8d02",
+        "outgoingViewKey": "d300ab9a2c9e0237d9555fda97832feff2bdbcb73e58fa87ab67031609694ec9",
+        "publicAddress": "368de5243f8a31b2979a7b9ab6234e6d0d4e391e393a894a3e4febb77e323687",
+        "createdAt": null,
+        "scanningEnabled": true,
+        "proofAuthorizingKey": "d37cdf6fef4c6dadf450d22d8695ac754930a7b110e7fe48d2bc0d7daaf53e00"
+      },
+      "head": null
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "4791D7AE9F97DF100EF1558E84772D6A09B43762388283F75C6F20A32A88AA86",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:rno/E0mfHjie+7Kc3aS30qPrnU4yZFtw1DlqCfdLExQ="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:nHkAiwD89LJtKTABXYEM8jZDg4LqcgvyM3nVaorULCk="
+        },
+        "target": "9282972777491357380673661573939192202192629606981189395159182914949423",
+        "randomness": "0",
+        "timestamp": 1718998721727,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAc2P9rmGqlrHZ/ADOkq/2N8hhuWHb9hcqIngJz6OSyeW0sYPMCbG3ngxXoj1hvRpoNQWfoTP3MUFEAwdV520XHN/nQsGZqkjzEzC9opAjd0SmIsjqAsoeL1b/6XgpzHp/M0RhEEAq/B1XUcG1jqMwsKjHpjeX831joS7aW2kyBY8SuHCVlbbBh7fp9lWIa/fi3IYN6DSsyGEJYlPdvP8Hq9Pthe+OnTjRfmiFoqa3DwSUCuVzGT96b8LXdANDvI3NqjpY4WU0kmfPjKm47nXPL5x/NwD2MJVpC3BbOWuAz5l7baRoAzMtnkXII1lZ4s3mipJVG4ztLCAnJDSAhrg4Kh2uKZUL8IcX+1E1oJEuUK95C++C3idzEJlNnc1YGdFZKBC95GPPz0c9VmViQu2a95iSh6Kox0KvdJnJUtHwR/G16Mqp0no7V3DHdqBQQQFAfrWKlFS/wlUY6+6C7o3p5s+P2lsoEwnsAdXMPOSAEbrcz7T1I5ldjZI4akSmoK1nSWylneCVDOTwQgfyN8d5WEDEUyrOBhY9JOIMpGzc6PQKZ5YJ0VZbai5RmTif8Bxxl7R9hZdlXV/PxrQX7ABixov3NL0E/f2GG1v3Nyk3Dla6a/tZPoZBCklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw+cugJ+ZCekWQXEr/BamcuY0rk+UejCo407FMBBxjKQ6/HMcCUJWq2u0ZwRDSVrYhjWCmDox/ZUzkKdJop0O8Bw=="
+        }
+      ]
+    }
+  ],
+  "Wallet scan should not set account.createdAt if it is not null": [
+    {
+      "value": {
+        "version": 4,
+        "id": "b51a2177-7bf9-49d5-b3c8-7020567c2f78",
+        "name": "accountA",
+        "spendingKey": "641c1bdfcfb9c53b5fa91b612d083e66f03cb3d18e7a733b9e6b12062baa8b4f",
+        "viewKey": "d3b69546923d9ae28bc804f2236e10e8a9209ea8327792bb5810f18079185642765e95bf26c434cda64e5a3e899c6f9cbe8270dd163b8cbbe87b7b3e6e8b2d11",
+        "incomingViewKey": "e10aae9a56527576cc9fc13320972cb64795c4e09b2a49033c80bbafd275fa00",
+        "outgoingViewKey": "24e88559218318ed0d30fb12626f7ebd5d1eae39c7c648f3344925c2e4f8513a",
+        "publicAddress": "0951bd228d8b1d4d0b374478d0358ff586c4372f1bedd7eaaac4c5672c2f2819",
+        "createdAt": null,
+        "scanningEnabled": true,
+        "proofAuthorizingKey": "6bcffffdd490ffba451aded0449ea15d42f27df3b8e7be94e658d309e8563807"
+      },
+      "head": null
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "4791D7AE9F97DF100EF1558E84772D6A09B43762388283F75C6F20A32A88AA86",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:CeM7ZiqpJ94aF3xuvweO8TbeF37XmbC7kmG8B8pDATc="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:hsNOgWGdqZ5Kqzhnm/t36IqzIC7khF2HYAXQL2+olNY="
+        },
+        "target": "9282972777491357380673661573939192202192629606981189395159182914949423",
+        "randomness": "0",
+        "timestamp": 1718998722800,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAn5mKakjLbopC8b5ZMYWuYrmA8HMrzaVfHwpxYS7BNdaAP3OobriYPDls/HjhK+2EimlsSX68i+cRJPzZkYnBQRlqt1VkURq5lcA++FaCYfGpN6tbBWzY6JyxFJvivYuE/Q/boYalvm4J3J/aYNN4MNp2q7Fp6wyxiuipBInyXXsCpSbWXbkJxOieX//N3ZIpbh2BmNkJzNWC3dYbbLxfiRrBeIBsxbe1KgwswZ+qfwKyh5LdabL4R+42odr25+AtYb0Yzwirq8dKt+/uiKc7MYrKUmgidhypu8kNK48owiK1osx7aOJsxKWnLIl86rz2uBni01HShu1utmLrYJDhhY6L8X0bsEH5hvUhwklnDEeEeQV/g27GnFrdE9CZ0QtonFxbIysdXgyb8RA6cBhpfdyAAwb9Eref/FvUx4wxm4P24VEBtEuHwbaXAam1/s5IbzpAKChX9t8tlc2Hs1pongPsa76/t1X0N7BxBlhYfSeGVIw9mEUFvTpryibIf1IysgU2r53gnr9pj9TO/Yy3usn1SF72mda/zCRVcTO1YhwfGkTyMEm3WNByI7zqlLeshvDHHyQHYVUhfLssbRdDIZ1OHd3etfOqtLJoMFvI79PmNOwQlV3JzElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwnYMsLZBmmyxiPmVnZO5txPHfqPHzz03HI6s3tO+QftPoBniGe05y117jKTLztGOKR4Whtx+BqmSSv0oKQDkBAg=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "F68930008A6CEE0775619E6B57CE0E00E23B8B3D46DDA0AEABFE278208A5C932",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:J2DN23oTrpIte4AeFhXEQbTMzX1UTOeZQI7CAnw/4Eg="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:wLuMntvBDYmme1IFV1r3M1J3eO0bTWoMaClwFcxAclE="
+        },
+        "target": "9255858786337818395603165512831024101510453493377417362192396248796027",
+        "randomness": "0",
+        "timestamp": 1718998723311,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAOT4hp3kzfrJQfa/A0mGj7voP84AvUQajpSsBdj97I3CvILgRKetnGcnBe8ffBA2aUf8gdbAFW4TdU+NDHL28tA0AacTubqNK5sdrTxiHfxGl5C9JqPAs3ATFmeElsHaOWSaqHS7mV0cCBuH1M0JEuzGsaKNTL2jRvC9rTWApsmAV1yKqiAspfwMN166BvOxrskd7uPDN8lWPnwjdQI29aZD4ZU/ihjM1W4A/ppIOhKaEY0mIXpeiOzgWA3EAIE1APAPsJR+7z+CHAvdHWFe+IMBzHsOsWz+vuMbtDU98c2WsDjRG9R8G2kqVanpwyloy7SZg686AQ5p2wDbMeMDfA+fww+zD+p87VoNL3zxP4Nzw+QnDst1tM3zpaQouHa4T0rt5OB3AFBrZMAcOEZ9RbT/Ucq+hGa12HR2WWrugM+KpgEfJkcYXZ18iLAWKiJACUH7DUPmrszPtpcESfarxluXhjOQHHOVWLCI4xIEZqRwsfAdOvoMIXRi40K0xB+UJpHANOE9eo8Ss54gfXmIbhLDpRkfCeTw/ms++0vyPt0j/DM7wEF2XaFccF4l7FuK/cgR/RYWC6HwIHmKlQ/FiP7dV7/eY4ChEzvpbNPVnED6+Wuk7VE9Dhklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwV+gJr6dA7B2IZy8lSR8WsYLaRBzYXKisGusQfhGTjINnFFWXdvx3VgP0qYv3c09MlLd2r+fcRBlPyDC0Z5DQBw=="
+        }
+      ]
+    }
+  ],
+  "Wallet scan should skip updating accounts with scanningEnabled set to false": [
+    {
+      "value": {
+        "version": 4,
+        "id": "1e4922c6-aad6-4092-91a5-2f338fcd26d4",
+        "name": "a",
+        "spendingKey": "50defddc864b45ae3d92b0663d1ed98ade1d7f4cfc7da5609b73122abae7862c",
+        "viewKey": "bb5ca714f08db91372f4ac368253bb91675cab092b2a443227f85d30498aacbf12d3c65d86b6c8342760ba3d9f5789959ab875c70b3d77b93ffb582dbe6ee8a0",
+        "incomingViewKey": "d4f4638e9621a02550df9c0e7aa46bbd556a6cbd5469a860801cfbb85682ef05",
+        "outgoingViewKey": "654d1cecc91700d92d4f1e0d6381ad6f27e593fe587f509b45dd337cbde0aa1d",
+        "publicAddress": "4106a42311ec85d37716faec49be530a90885dbb5ed126bb0f67d69ac3839ef3",
+        "createdAt": {
+          "hash": {
+            "type": "Buffer",
+            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+          },
+          "sequence": 1
+        },
+        "scanningEnabled": true,
+        "proofAuthorizingKey": "fb887f4f928541aa4ff3d1a93d527dcfa29778255ad7dd6cfbe24e1725ab6804"
+      },
+      "head": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "value": {
+        "version": 4,
+        "id": "878e5aae-8a5b-4a0b-8b81-cfe176fcaabd",
+        "name": "b",
+        "spendingKey": "17bc6df6fe6cd3500b85aebbb86a9626c62c57098b63d2ce18ff125b9bd89185",
+        "viewKey": "ffc8e1787c9bbbcb75f3ba139943747f3cc3914f3c4e87e6531bbf3cdeb7da6f9f750bc2a14677d316aeda30f0c6919ffdb45c3166255a05652ebcc7c6893cde",
+        "incomingViewKey": "bd582662218864859210d8a719129a19dcf7a879e4d05a13597abf7023199f00",
+        "outgoingViewKey": "d7be5cd02680db56a1eae3d0dbbc4d8e88743d21ef2581dd40c07be295f5c584",
+        "publicAddress": "5af1ab5b21b972f6cd638eeb7165b67d1b3db81164f4d0f17ca5ed0e9713d1d2",
+        "createdAt": {
+          "hash": {
+            "type": "Buffer",
+            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+          },
+          "sequence": 1
+        },
+        "scanningEnabled": true,
+        "proofAuthorizingKey": "ac3815e4928d9f9eee9faf47f3cf37b389c6d439699e5486df2c14449560630e"
+      },
+      "head": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "4791D7AE9F97DF100EF1558E84772D6A09B43762388283F75C6F20A32A88AA86",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:R+jWuC0JYf0T7xNmD6XGJgIcuA5oePRNISk3RICRaQs="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:JsO3m4JXINrXPB6EI20vO0aFSyjip9mhInzjDrLW/Kc="
+        },
+        "target": "9282972777491357380673661573939192202192629606981189395159182914949423",
+        "randomness": "0",
+        "timestamp": 1718998724419,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAABcSOR4fMrH91YBEfpzjRHFiGoXDVJNK8ysZAKcvxf0anR3ylnovmFXuUbPhhtuiLLbCbaa3ptq1msDsQ5wR9y8HtL9ucYNgfA9sEIp8PGIyolMqmhlhnH+vSVbe/n6ui25mTa4oMKmwlBtvY9zkpoKrTA704CiXKQ87wSqYtp/oE+Q0yDWSDxNg8FW1a4JfO7aOVoOQNEZlDvku8JUCc7tfeAB2kyO4KIZrw6uFyN46F2jaoVvrlx7+MYUtthgTutjsnVw1nIOo0ugOuIYGgBAEoN1+AEaaVSiupeMc4m+vEX+4WvW4F4jvsSxTgSMbWX0ooN05QjbqSJwAYhO0ZYixW8AJuEiJM0UEKXFGTmOfemL5IMCNP3aCNUCQuER0KHqi7Zo+R/hX1HK5yKya5mT9kDuCIHwtmlKsNCZXdIsdBgVyS41L7wRNx94YHNeVefzbxfue69hcPuR9uAU2fAaJDSifKrAvoTAF2kql6fuvNL7DzuLXYdUfy/MDYXbhvsJE+Gt9m5j2fl7pVxhQaygdOUHykt96gJp8KEIO7nr/tOHsH4iV1qzBiEHYSu0Z5JN1cYTGCvDJLQXmPBXq9AQqg3jF1dQ5c7Y13HZW4+Sx5ikMUQKMlq0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwIlCkMe8MTJOaB+rlORtldvZZB3Hm0AaQCl/r9Ms/p1vvlNtgSQSE9hk5vCcFRBuvI0hHL0DgMjzyB4ATD+QRBA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "A3202B2AA6172D4DC91676FA64361471F0358A92D5EF98B74E15DBBD43B36208",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:ocIRbw4Uovz4bkldejTirUObQWEIwYsZhJ+8OXKfvSE="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:OkCsn3smkIs07W+07rjSCr7ocka+/jAEEJ0b0wRWPCI="
+        },
+        "target": "9255858786337818395603165512831024101510453493377417362192396248796027",
+        "randomness": "0",
+        "timestamp": 1718998724870,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA8Sewl9kPhrjCT6DVMfsB/rMJBKnw4Zoa9ZJvwoZzedWFfWg7lB3XtZhQgTy0GnaZQ6D7YgrdGmqQRwc6vcsTJEUL40Kxb/ZovEVB0tHyxaixZngyKSqCvmvrqWfJJtWgBneH1hBSgcIb3GO9iHCLpLLvKNFmeyZusuK9RnCuX54U3Zugm1nE7PDt6UF67gR4hHaiN8WRp/hnKSyQfRoOQUS91+6D5aCYCqacSWIgPgWkP9s6oAUvB5RbpYF7OK/uGwb7wZdLCVl/9zgh8O/VycsPYs0vVJPkC7Sue0JVIjrEh3w/MIMnxVGoBaVtj5Iow5/1YUvAl7a/JxSYuq1vLOoJJ0uhF6OJXoFJjZDI2RbXPLRc3zAqEXdZUUu1EvEID22SkKpwJmgW/TaYzy9G7OecPHJh2w5k1lhkEO7/CM3km6/MbrpFWCViX0RDRBVoYIJ9kX4tUOA5ZXUGSxkpVjnDZp6hhnHHFeeUMpFGRHiI5zGk0xPx6BC5sp4Co81KVhYQwcnPq/kfUHL9r36GHMIBc4k+oMU7WnPIdVDGlhQXxPCG6MO7ff6euBjJBgAv8WeSsE+Jf4KgOdxlRChD1awCZqe9G9yTl4rxXNkvUfez09hW+dde7Ulyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw3rmmGw6WUA70k+ltmyiVsBsG504wgWV9kCr9GDQrAi972Ha1IpaiTyR8A0yj5ylqLBnf3+p8kBoyGhWbAaH4BQ=="
+        }
+      ]
+    }
+  ],
+  "Wallet scan should update transactions in the walletDb with blockHash and sequence null": [
+    {
+      "value": {
+        "version": 4,
+        "id": "aa597976-6ade-4d4e-87b5-8113e3f2da93",
+        "name": "a",
+        "spendingKey": "32f81470c56f97f4c52cd402f93f3d92839ae6433f682320ea895a7249d19226",
+        "viewKey": "2982ac68b5ede7dbb8eed2644df70e082adff97e6b68ffd4636d7704826a06038f7061c45cd2df510bcecec3b381f45a4588fa2841dc39d215304b1505f1980d",
+        "incomingViewKey": "d9b0d9e337cd2063abf908919b180e6ff2f9a86a0856ce449cf05ad0b3de3903",
+        "outgoingViewKey": "e7c1b9a80c8928a1c520625ceddaef379f9bed16bb994ea0d9a2ca8b42724af2",
+        "publicAddress": "52dc14a8935ec7e6bac79e73da8f145ebc1ddaf36cf02a61ff9ee408ff59c134",
+        "createdAt": {
+          "hash": {
+            "type": "Buffer",
+            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+          },
+          "sequence": 1
+        },
+        "scanningEnabled": true,
+        "proofAuthorizingKey": "b7f018120431d77811103d474ad0ce7885a0f93bf7e5b542f9738d9f0a5a870a"
+      },
+      "head": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "value": {
+        "version": 4,
+        "id": "aa99f6b1-bc95-4570-aad5-9d7350d021b6",
+        "name": "b",
+        "spendingKey": "02bc7fab396c8ffeffa7049c6954748ce9efe8e3d80f403407461ab86f115859",
+        "viewKey": "9f394e59eb9d01bded00ecd56092494d52ef401b33b4f0a6264d48ade1ccf5ced01bded720763c6ca99f93f6318d3c55d1463f206de35e3d5b4e431b91dc370e",
+        "incomingViewKey": "013d3e467fd07dbc3d362994855e1e3f760b33f5ee1f3fa4c9ca2eeb6595b102",
+        "outgoingViewKey": "2c2261868d1c92906c7fc63067916e0e9de04d842d99596743b41085d77af779",
+        "publicAddress": "52cc478f846e52c5736fd12fb3dc1bf5d34185f77cf20539492bd36cdf6054f3",
+        "createdAt": {
+          "hash": {
+            "type": "Buffer",
+            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+          },
+          "sequence": 1
+        },
+        "scanningEnabled": true,
+        "proofAuthorizingKey": "ab27a089182c52ec712e77d2ee9b3a980c895cfd75e357f3f7947a07186c8809"
+      },
+      "head": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "4791D7AE9F97DF100EF1558E84772D6A09B43762388283F75C6F20A32A88AA86",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:QTtGxhAGyL1j0nNoBVSltclqiCQrsibApaMtyQbf/Wc="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:RWDv0e1VGnDos0ZWR4MZYI7AE2mK55ibduV+nIyLX0A="
+        },
+        "target": "9282972777491357380673661573939192202192629606981189395159182914949423",
+        "randomness": "0",
+        "timestamp": 1718998725908,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA3J1ZzKogOU3C47WORiXCSkQ8m70xzpUIc/9wXSvGEIOYDlRDN61GD699/0ZGCjtSwNajcStquhjLNR5yMfExUCPpxD3qEiFJ4CTefEHwrDSK8Gg+zOjuui38mVx+4JdUAGiwNRp4IBsaRGy+gbP2CGXU8TWQYlwFtZDraWAxp0YPNeFh7woEklOSLWHdQD165Iz2xyVPa3NrWCDGtBDYO6yUZIOy/d1NPXvvY7+WrEKFtBIU1PK0CoupmXCBoW0Ou/c7HEydHhe1kjqm1TxTr9ZHJ/S086t65w+jZnHzilpytmW4lW0175fdEG5ONqPP23vK/zAgu1hbmixz0XPPOCfLQVXq2HggXSzCA96b9129Wcg4upyNsA/b+RzEbm5FWXbzU4uxfy6WXt/yJE6So+lJ5c3gKTXuJdT4S3/wikLSUB4bWENKz4nwHmr2rCjIFRerSXGGg0JjCqn6nCJRR3mIY9tU1jgrhuo3fVUVf41BmEDuPzvy4lx41NU7jtw3LI0eS9Vq72/hnrKPWF2JVhUodkbWdgoDm9xvjm8mg3nSfBaMUC6IbiSj84KSB6nztz65IQJN4RcvV7vWold5PUrxO6ZE8wBkX21oUhHP4T8rUGF0M69EM0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwtXnZ/VzfzcL3ri5t0USzXR2/DwdG5f4YzhJftD99QF9+Yzck2MV5XpK1jBbxiPeFTY8ldLO45l7gOCKXSbnIAQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "D766E02BFF74FA6273774954B60CABF52D665E050FB58631E30E7F4EA4BBC6A4",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:O9eQaFpLD66t7aBv0GozR8/lPcH9VRfM97FZqsBBRgY="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:HHwO7qVISPZmBlU29haBBjYP3krd2JywcL8jfI+2miQ="
+        },
+        "target": "9255858786337818395603165512831024101510453493377417362192396248796027",
+        "randomness": "0",
+        "timestamp": 1718998726349,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAfGjm0Z1/yMIHLjaWKRGexawHI9fz5MYrXMp4iZ8iD/Oo+a4liZGIqPe0slCHfEF3DNcq1/7xVj+BZG4fVph9NagvNKeG1/Egr7IiuRRk3xO0bRznmOvcBxk7lGWTURU3FiaSC+VU/2f9Hbm4Jv+kPpx7yC9v+539wgp25fNIH7gWKgCfE9e1YsvYFICT1G/qjebaCWg3sJ2J01xM0dRaWaxV7XAtpBJHRhk0ba3mtXurNaDstCPeTZSuR/71x7kIKp4TS43A7gRNPxjNlCQngvF4bYbNyTae2+xOWfxG7ozlqbPmL5Q1LelRdrvG3meU1PKM5UWG8r8TElLrvvRMGyjRLDnPYhwWy1A4rNoNQuHiKBhMt5sWZNHrh03zntJA1Kb7g3HE2aHStoLFqhWTk/5IsDGJuDLL7/eSWWyNuwy0HvgQk9gUngVRdlxnSrtT32gcBeDxZdlDlJreZAp9wz0x9SHnASc5gBQko7zLA7tUsHvOHg73UQc7iFlLidaB5ph240US7hFgv4XC5RaVWlrtEJJbaCkDGGbD90QnRxzHtSZQhmzdubmCEFZQpcASYroU+rNbURkllhI07QZfM0Jt3leO67XfU5F0O/rT6BppbfPVeMJdJElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwZGpVs31XVgcXJyT4T+MGSb3Gs+mmU5bqriJE5kEZa+buYF2Tl9xKApsFOP2+PSAZXbL8dkUq3TgvAlqsuz2cDA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "9F0C15CE5430B84B7FDE1B61E0400D4B4292E64060312DF36EFF68BD8FBC9803",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:KbDDm1t0aOo0yYessRIxW3MTgQ7sarNwShrNHJ33CnA="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:PO9wVkBUUO63nIu6lRt1Kz51iUnisv+M+fsqFIJMXh4="
+        },
+        "target": "9228823284279306817296266184515742822248210830185427859262273659833347",
+        "randomness": "0",
+        "timestamp": 1718998728632,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 8,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/2vKiP////8AAAAAtiOSV3p9zp6O+X+5e9vCduAlLw9LX2wTc/YfxtY2yqqguRCDzRStLxl6xKrK1X76/yFLtvk2+ACEJCcTY26TU9gw9WMeLwHX9d5+BNRQSxyRhADz33+zgTf3FUtBWnQT4DSksHsyR0GAiUK82oNOW/MGJJCsCWsGEBsyzUl7NOEB9zu1PQrkqrFL+4bD6SM/2BOaQFVZhJCyaXUWpmjhBUjOUpJfdFNfN7cjnGbnfrCURSiFumfCVJHzY0VluShuJ/TZuLYn3YHnt5P8OokXojuNXFXWYY9dhWooC7bPb+7bsrQfcbWrPsxMg8+OgQL/JhJHrQxBoHr72zBsB78mvTRlZ8H10OX13kl1/6BmS+i+3aeNLuX7C0JqaMKamQ8HyxpATaaX8GYgz3qPHKc+O3z4VVnzHaHdCKuCw7dVsF9+oHjzhnVGL1y3ZXCrchv8BabH69+D2/RtqihaNu+mnYuHOTmVIYZVGlblK2iDSrl8TcdhsAzAmyCCkBhB1xsap5h4Bh09HB99uxZVoqOTy9qikuQKam3cf7xUtnBcVOsYtehVdGcmgoANsMOKIqYH450xm2/9u1sVCOxcLP/cnFa/YsV4Qbxhn2ASOu9z5rx7OhS4t8TrVUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwdVaf8Lf+/mpO3lXd8f/l4wpF6ejFqSW0ZIu+mQ5EXkZLj+iOwnowVDqgMnpYjZneQp2Bu/o4snPFfaOrm2nNBA=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAhaDaJtsn/DQIALcjOtUSProfA8O7Q6T1g1JjAHiTTeKNJtZZb6/YCp4dpznozj5m90+83gGtjZQIoOO8LhkqEZV6zGixOWAJ03ZoiDuVH6GzJAq8WTGXLgkBg/iPNbNxsC8vblH68YvgqojbFgUqY84A3ueP0/5KhZ7My94honMIT9LdkuyjAxear2R6XUoBPEWKab4NQmXe0z9RuxRoKSUhNCeDD6PE5ER/+anQD6qD6EKqSMfoncijyDxz3vsnGfgdZRuMRCOVg5RoLOaCmWf78cTFqgCOzVH7wGh+4ws55m174WZaPKdyMLf/v6iyibg+XP8e39LWadmpQoZi2zvXkGhaSw+ure2gb9BqM0fP5T3B/VUXzPexWarAQUYGBQAAAMKDF7Dblp5wSMp02Tdk9NnT2Y+I2YqK1FTGlaEo3TdzZwwuo1fDePbgEEBeh3cHhpLt0ECPZfAO277UVyqJ/enLHU7h1eUXqSWamWC6u/Ngg0V/KaLgusJHOB7MAtTpA4VMBtjw4JbtSfFY6qfflt9SXas7uMP5xo2WeRd5UuOZUh8bzD0fM3bzEicZMdUGnLn9pGKHoYyDDKhPRdSrhDFHXhvlHWfckZ6fwaU4YvlaJInbC82S/BVHdjj8doGHYBdCrA9RKP1okFNTCresl39xdbO/ST+R5kVK6GdKnA0fW8/CP7Dmago0EAOLAppqaoTUp2zQXfdWF71OfnvF0pBR24y3Le5vICEuQq0OkdSiD4fcWxbTgY3XlZcM744pHn3GOs4HIlYyF2bVMJ05EhbCgcXTXmj+RQDgATmJ6JK2Xhf80rnM9FC7zUcjdGeNCUig8ago2apajmjBShhOICetkQxVNgb9iwqqblLay/yNI/W04fdkyn5HjvgnLXXxA04DxddgKJX3eaQHVKfXyglHjsZn7zorUsVeuxYwtzEVVxn44T39ufsi1i1syyVqF/mNmJ93qOMxONZ2MK0543DXjBap5+2Gzez/9I3h8D3jnoXHc+N3ulilL6XCpr8X9XGtZV3quIGa0hrr9GsCm96/lroTjmw4FdyW7oHp3ypEn/3EgzCHh8AL9wVytRtHuUzbdZU8n80Lo/WtP+OB0lPSFz26orHR+x89r6FSiLjJ1+nukAVrZ7SD5G33uXdPRj9ftdrIsAhaGE7fLxPHV3aV0pLvG2qqMgGm9CF7du43RiWDIsSMFWmxkOXaY1MsT3BreYi8q/M4OF4QiWV+ppXg/+tIPRWk7ZAu/UI5bBJLlDycxb9bOBWOL3UIuA7GaniNK9LLCcgGqwYUOzelTNM8FVZ4dlD5tZTi4VUNFK1+6/G7jY2hAbQPLCW82G8ne8D1ZAYWcjwpYUYBPkvUZP6WfBptBInQbf1+UM+kL9AhXetUIzM9uWSY86qhkoqILytOBytqTjDjmNKdTtAAW/RDks3NiNSqQ7DCioAvzqOBL3vKcy7e0TR1PsrHpbgPDA1h157VB0RVzFekmYWb5+qVuZ4lU82hatkS7g0ln/kSzdRPLjqfEXiYOkOLfc0ggT1K+wlQgMIiUrwHCgdu9K46LdUzNlpatXBd2Bkou77Py1FB2AMtG4Rv6yUOkoc18EsyzoHH7lHxWWmBT/n4gU4ll/H1zQgJSBDjFqpC8vurgcxXBUIBLnsfvxeRkil/CvFhbPQKkzigA3CkpM1BByQFElugudeEW+OxXc9m54bWOL2QkSWcHO0MVSqN7EjjPTwj6imloNMYW64QVd6PArloWRBGTYN+Acj0NmdACpfFQ+w9HVSiUk3sWIV88XtjBhuMHlDI15KkhA2UjnugQrIPFC8r6wjNQiXK2xT+SMvFEL60Fhi+D6w/H605/ozA6gVO1c18MXw5DiYVtLZcQf0f6f7SFBjizt2NMp/1RhsKRdSyosV7TzHL+MgIFRQWa+KRGIGZh7s5hCdT0LKoKE43mSqxkhPXcRGH9rbr1k2VJ9/QH+if3JoKTKqKlS6+DQ=="
+        }
+      ]
+    }
+  ],
+  "Wallet scan should update the account head hash to the previous block": [
+    {
+      "value": {
+        "version": 4,
+        "id": "63220a32-4403-4509-af43-7d3bd0f2dac3",
+        "name": "a",
+        "spendingKey": "c330e22814fad3116109025186b5dfb43024c56abd6265eba92b1aeb375106a3",
+        "viewKey": "ed1e0690b0d522b6d875ac45a1781ed269c85fa12e06d6c7b30bf9bcaae9ba269b5a6135b8e04f2f22ed949f7831e6b68a6a3985e518b2eb7151faeb4d2d156b",
+        "incomingViewKey": "0724670f39a3cbb2ff425f30aeba7b2aa2a923d0e693c92559dbde859c5e9704",
+        "outgoingViewKey": "0fe5cb9227cc49ba6385988f093e750a9d509cd9e4f3c5e090d4411327b2d06b",
+        "publicAddress": "ca61fe0a1e39bf3887ade3b530c8829f549b44fb8c84f5b5180eb20ba1140969",
+        "createdAt": {
+          "hash": {
+            "type": "Buffer",
+            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+          },
+          "sequence": 1
+        },
+        "scanningEnabled": true,
+        "proofAuthorizingKey": "e0bf1c29b5aecc238f68aaec9f7f640c8820c4a5fd1389c20bf3422cd40d4706"
+      },
+      "head": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "value": {
+        "version": 4,
+        "id": "edeba17d-ddd3-4b62-a8f6-415bb61a8567",
+        "name": "b",
+        "spendingKey": "892fec6b956a1f4fe033efc2ee4c150d198b2aaa2a38a2578891d3f33e825ce5",
+        "viewKey": "dd03fcd010aafbf08ec089bce39ac5a5268cbe1298b44512c20dcef279af4bcbe7326c3cf6ae1456336249057896bf0368cd54118697a8b877dbcc565138374b",
+        "incomingViewKey": "27c2edc9e1452c416a8fa8a111041eb7c799fb3809945375e00ff72d5b20f503",
+        "outgoingViewKey": "1110a22e0daf369fae6a371d8a6ceb5ff2a94a529a83ce92efb2fb789a5819ba",
+        "publicAddress": "b764ef63638d4b4e41678d678f165f7421ae529483cf8dcc93cc2b2e6a7fdbd9",
+        "createdAt": {
+          "hash": {
+            "type": "Buffer",
+            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+          },
+          "sequence": 1
+        },
+        "scanningEnabled": true,
+        "proofAuthorizingKey": "4300937bd2f0c2d6e192b0943009980478a0b956b8d015862188bf1b4ff80e0e"
+      },
+      "head": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "4791D7AE9F97DF100EF1558E84772D6A09B43762388283F75C6F20A32A88AA86",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:d2LF3PDsPRhfgw4pk92GNhjzxFLj7EHvRa1ZMk9n/04="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:C7zJP6liRkuYSNRLCQNzCjxt6JnF/IaQfBqoEotnONI="
+        },
+        "target": "9282972777491357380673661573939192202192629606981189395159182914949423",
+        "randomness": "0",
+        "timestamp": 1718998729703,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAANVl/XAxlKVm+Wiwz8REf6J69AiIlCz7H4Ad+OOBV752S+UaCzexMix+6s/AGZAz8j3o54DgtxE0PJY4RDO/QEvQCjmn9YRn4UB8k9R61+seihlTOQUmj4Ns65GwDNHJGe9YH6gKHBV7qdbhs0awIVKzPL1tumDJFuFEq2w/axiET0PUcySpClQB5/YaLtIe2S3Kj2O1T5zs+jh1lV3wY317cs0qWTx7RsEyJacl/fm2Yc4b+7MeKg6xqtgnRQ+6CWrsdnmEHgzczICUFQAKqWEIx2J32ax6aH+b4aEsUw+jeHgRoHhgt80m8cwdvxBJdfTap7Lqt7UNfe1G+0DRzb1LkgL958DcVzvyWokZV7OP0NoZsZlfnWHM+cPHDPSdN1DRNd5cyDgFyhU603ATIxVIUqYDDPn4YSUVjW5R/eV5huLBVTrCnLJuCdjb4BLiAdchECdfeYpZjS4pdb9BLba4iNX9l1Y0unT2PQoyy+JHwKKQ09Tk49zLBEsTwoAb90ZLNyCwHl3/hLbWTo82mpKcJyFGc4A9n6EDBYxJqxuwLB4CLfcuhLPf8s68LyusxDM7+XKmxAQqsClcG4HUnZI3BYBwUdsec7LjeE253EtZeWaAZulCiKUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwoEL4AQU3Gt96xS5iy2fQiL6tjZ149m5BPQTHdKV1F9jEi2Cf81MC2qrKfnftjQeqTSY36NVK03Kx4s6UROtsCw=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "275222D3A20E9183D3589D087629D1B42A08E0045E2458E0CCF168E36A45E832",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:Kic4MpK22UVhbzQ1TFQjGvHy6UQFcn/UOH4etRS+Zig="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:LxSuzQfsGrSXBMhxKO9TeWtDNuM1DXwap2bfvFYZe10="
+        },
+        "target": "9255858786337818395603165512831024101510453493377417362192396248796027",
+        "randomness": "0",
+        "timestamp": 1718998730163,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA+5Z3w4OeTJZKCQa6r33v8CF8cJh9PnY0WAW+cZeQqBOZqvw8cpGCoQYRP4qgcdmezBk/Sk5SlR3vZagEi3wDPAFeg539olCZWUq6MHFXJVyFzVq0eJ3DehjSTmiWZC3eXEpEzZQYksp+vnI113atPMmF07AjgaSjHI/JXjPwNPUXXwylSTAD6NP1NHuZl9vhcS5XFx0CPh9A2nosh6ZncRkI6Qce50Aa5W4MB/fLGYiiMcogoaLIno9lx1OlzzfT4BdEzMfsc61xJCYcpLSIMKjRMd4jf48jjz4enw5SYVbjMkBKXmvYHFZqnePQH8pYa/Y/Ig56ymmLXQSQ6r/FcHdhnqzUj6U0GP9Ng8RkUkZCQJXcNLqkv5Z6t6WJBoAd7M/kKo0Mjm1GSXJeZtkzvW0XtVyUNX03ppjeyAGf9AQ70CN3Z5WqH55J50wEYAvgDjFpOSmfhZAKDomOB+AYYa9Vg+idjMArvUgyDbgY94retXDxXa/qklt5tbFG2iI10iIH/huEhit2tIJanr6nKDe8ep+gngZOmeNR9c5yr3k1P33peAP5wfJt0DznjuPBXaLUjnlE6Hz7R9adaZh8rX6FNjb21/WY0cpoOmtjAhqLlcxvCBSqEklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAweBE+qXELXjPpXxgjOvQbeH2si8wyiXBk14rdaFRiHCPQZDFokcwwKTS8tILc6pR9U1Bt/0vMXxSHjj6gOUPZBw=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "A8DA1388883F1124C6C93B6E8190361DA577A134FB8BA066DE906D22A0B4D3D6",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:Eid7GfqN3PnQq7+9G1LjRGQ21NdwxpmeEx3Bdhe+ugU="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:9QOVLzJMhQU5G8zrzhLcmf+P3vHPd+uEkOnRenm2+g4="
+        },
+        "target": "9228823284279306817296266184515742822248210830185427859262273659833347",
+        "randomness": "0",
+        "timestamp": 1718998732418,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 8,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/2vKiP////8AAAAAt+cn3qJcRwVyEOKWXOMqawRL5Ttlk9enBHO49M0mmY6Izd+CBftG7BpsHRCWT6ff7djnzwE/OaDsavpsDG30CPYq4JpARM6WeOd8pEx4LMSGETDlHAHQH6f5ZjwQ/0c0bfjdBlAO/TjZgz2NMc4Ndgam7iSqro4dVDlx9WMEBRENVp2SfZALgPST1PN7xpBVdeK2qD8p/1LHkoxmnbbKo/14BSU9RXc0a5qYMZPanomhABqHckJuS/rMPDgtMQDLODIm35/p9aWv3j+SbVe+uCfmisdQoNaXP2oP/McxVh004Rabdr12pRgHfQSIWGs0BN+ImvAXB6slhCy/X9Ghv8Ff/W51Ugvjh2Bh5D2iOM2qN+fxUUhhpP90ROP9UZoGFGPgW0/ubCxPcIhaX33YDt5DtI00RWHCfuUIJFIpzhkne13sx4yXKErSIcQDjKQEbXoSZVg3siRUYx2xQM8FgltJW/k5l2VplSvhJ/xJ+r8rexWx7qmjm4SBeyg3/TBAH7givJIwP2/PRCw18Vaaq6/9g700XjQEvyAxFZJ41kXsJvkNjVZmxuMPnVasAfHy0zAW5yomA61xlAEp41JQdToQ+NwI9fr/9Tvy9EQVV/EvJPXmpyIsiUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw/EZca1Sac0WEAqFsXKvj5uB1v0QXOb+qET6fTEI4wCgkPFvEL2uNyBOfhLBKW4Reg/MwHilwcWHUiFEYkAanCQ=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAA7tp/JQGkCLvuRBrvr2P/0/shks3UYAMZ3sQBH+vgt2WCf9E0VXB9XAWBa2DbECphBYxQZl7vK2JFpTUiNVf91aESOZsUHj6wMn5gFwvNQ8unXIagP96Ws+vvDFAHtI9nz3zQDB3we77E2GAwuxHKCfedtl4MrY9rE+Tj4pgvsfkIPsXWE4DRftXjO/PpcKeCjPHqXtwlP4Qv3YK+8HFBBA2cUxwoKPCgwRULCgtYYMKCsAKVrsflmOw0U/zxvm8ch804VnFmvX+pS4jS1ajzj2Fx0Z8ZmYuk5ZXztk3Sj8KJivkzdg/jaipUrD7keOX15pOky8cQHJoTcgcawA3E8SonODKSttlFYW80NUxUIxrx8ulEBXJ/1Dh+HrUUvmYoBQAAAO3Lwnk0qZ52dlBxi6YP9mVik3pQNnJPhvqOvWlCLmOEdqyfwjFW3pQGxNRMek3YD9afRndo/I+yPaJP77/G14VBMsjhDkd/FGdV8YcoxyEd4H70QZDQBNlLGZCwNc32A5Hn4YRUZGPjklMAM7rH46VFd9cTzJvpWAtkfoXCaR+cngx2U7G5iuzkNc91gRw5m4XI8CAQydYtCLlQ6hWVZ0KhLGy0g8BagybsLjeT8M7HL1uDL1RuRA4F0inkUOI/1wxwgYjHx/TABO/u0YEGDVP2xRlSBGIs23GfhaNdKZ6udN0GZEwrl1dBQ8dGY/pJsq7loRp6N7blWPFsieZk/x8ELGWF74dpSW2WfnovnKP1WvljNLIupLqZACg8BAedkR3bidZzzNw34u1td2W1Z7Ab7+QRO9ikUK5zGH0uXjpXB7cJhbz0OA+hsoTKKxwDmQdt/W8iDni9ONKAqmblcjpAgE+mU9XBgHwMRZ0pnt/Ua9OWBI8j9/JMUJk39/P1K2qEfKux1brHEjifROZCeKrPrn7orjbAuSV/qjzO2gQTed3B9g071I6ppk7nzYEB/mhlqxvEojPLRNWY5tezFRMkZ6cz2F3hlwY6mZ6TNxBksvSkcpj1esKHlLok7hjKiQdsj+5RBBbNIiKC2ytTL+g44S9zliIDvFroJYIp5AGeN42orbfej+0iuH+/T1wl4/i8CvqCLqvwT95jeRK9NuIjWZ5+OII8GgZZvhYei50AvVj08ueV1u1vv2wUYy4qPwQmaoIEi+BtPkU3wZT937SFz90Vr4JjJo8J2id0SbXoDtXxnqa7qLOMhampNiBYrSEoHOpqKXlIww38vkIP2Cr+/aglHYBAS1H6sxvImro8IL1eO2h9UDC1X4tu42iER+E4oiLpaYVnnHmeG0A8wY5iX+0bmqmbDL0ldnMg3ojQ61pqWi29ClYMhDnfjn90juYsEAmvHW4cwUDggpRLPuhs7zD1F05nu/ykZiSftxQBKxe+G89rlQ6W1fACeMFrQ6ql6KduInuxiKhTdLrIU6i9zW6IKFufCgrNXJH1TFHOEMzNXhNLMyIdP5U9b5tzHj9UoPDL9XwhTpdMZiDaCySoiSaekaqmcE3YBduOev/ZiaaK8VlC/kKko6ZdhXRNsKygc8QY0qhtZc/4enVn6FBUQEv7NSdefLt0eEuUk5QMEX1favkBCjItGsUXFgoMXyYEF2KEpySj6TCBQAmCVYTNB0Nz2U98ElMGZuYSJj2XwTqmBheeDUihUgsZgWy59ikDY/MDGYrojsvS8C+FWOOkBjTX5PmDniXt8twrMJwPMC9wlKYd1p6zRxM8wQGK49hwVAcFuoGjtIUnEIzNfFGTsPPywGhJvIg980HgYwA0mVl79U1onk2NtrlVpWbqzRHdwTxkQ/pGkSJfo2n59PH7uV3hkI9xUmuyLv7wGaEUHoHu2/oztfGJSYlQc+i6MeXh2753uhaq4TeCalVdVDulM16dY3TCiwSTIVTvLIoGGTJk6C+ycweal6x/NvfrLanTyE/5miDHVpta6dc3NRncxezyGXsZ2Uc9Qd9m8atO1vgzBfV4agGp6cKHPXt6Cw=="
+        }
+      ]
+    }
+  ],
+  "Wallet scan should update the account unconfirmed balance": [
+    {
+      "value": {
+        "version": 4,
+        "id": "443cbfa0-dc5f-4a55-abd7-188b9989ca51",
+        "name": "a",
+        "spendingKey": "f77400ae038d4abcc3ad56c5656736e00a5705e92727b0bc0336d9adbaad4c64",
+        "viewKey": "1a7549089d44ed91832f8c04a5a2251c9c39382dc2bab1e97ff411f6e07e57347306079f43ab37c1f0b3d6f3b8ceae98096bee94a7f30aceb43ef2d8268b9cab",
+        "incomingViewKey": "cba672f8f62be3a6063a5ed589a699690899f458ab51fc5f6f56994a23126f00",
+        "outgoingViewKey": "5a30ff3926020d28cfcd71f654c9a60a0de2802143ac931eb507d09a6714039c",
+        "publicAddress": "0b1ed1b1bba0c28586e1cd5676452941716045048536a7e172861aa6ef2e99e8",
+        "createdAt": {
+          "hash": {
+            "type": "Buffer",
+            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+          },
+          "sequence": 1
+        },
+        "scanningEnabled": true,
+        "proofAuthorizingKey": "ba62929ac5412d6e59e72a2047916f3e4bd2332c4f20de1a9c17c1dabe79600e"
+      },
+      "head": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "value": {
+        "version": 4,
+        "id": "e1f17f03-19ee-4855-a041-7c20c3163504",
+        "name": "b",
+        "spendingKey": "e1a1fca44e6fb879b0ed333e17655940b0bd0ea76d29c7471395987574ac4200",
+        "viewKey": "eb24c844e8cd929092d85ec5b8aec0ab5ac0f1e98e8387a2710e5c62d06f9a44d1d2271d657c5a11b6efe8a7977b919c3acfc0d52b5083a4826d93718f40382a",
+        "incomingViewKey": "a090e822c984a1e0242eecb707f95a44c0a6e451fdf71b46118367b0ccae0e03",
+        "outgoingViewKey": "14b7d822c079bb399a090253e1acb60d7fb34afa929b5fdb07b675b4d8142b29",
+        "publicAddress": "98157d7ae91fa6b63134ab69de8b2b846e46f7244584421186a60db6d707ff27",
+        "createdAt": {
+          "hash": {
+            "type": "Buffer",
+            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+          },
+          "sequence": 1
+        },
+        "scanningEnabled": true,
+        "proofAuthorizingKey": "c44b0f397080feeb29e812bda53ac2329a176f0904cf6c15cd68ece8215f280b"
+      },
+      "head": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "4791D7AE9F97DF100EF1558E84772D6A09B43762388283F75C6F20A32A88AA86",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:JAOuWmBu/5e/8/RiCwKZWAF/U5Ax4X/kpb9MJZRh5wI="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:3TdAabY4irz2YH3Y9erSn7R0uoEZvf8HriiPOT6H//0="
+        },
+        "target": "9282972777491357380673661573939192202192629606981189395159182914949423",
+        "randomness": "0",
+        "timestamp": 1718998733489,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAANJgWLJuWiGs1umanMHj1+nIfhsODke6cO7kFZb/Ys7GBwbgJ+mA706Y2OsRUHD0ir13Ewe+vE6jD+Bn0xZsbNrR2fj1mTBZ1v66Mf6WnKhGjW/dGQr1a0Z+pdp3ZkZMDs9ltPB/NGQTivkB1dP/BZ5yiKQvtrgwsQW2xNhzCq9gCkdalu7CDFX5l9FeJZT/OATXmXE6y+9yFlxxCgtGqIAFgsii9n9VMwUIQotsL+UWrATdSfXEpRASrEANGCzfOPXAeRP+q+yXpVWhrPtOYSgTGYrTx/BdMlXfZVTyBgh2x0JWIQ6b92NO9w0K10LbM8ukfCYZApkKMXv3dCfZz2b4WQtpsU+xsaT4fameg1JGFbhC4DGryDJerTcdli0sD/xIBNKiWj25hsrRN6r7uAEjfJEreSBx36QWWWg0E1WZ1Lr7pfEN65m03PNOgTdvulYzOVwshMIRmpxRIj85QxFg3QKAmiYCstq6b51MHhmvtBrnEMdyCO6xceQpqM5SbaN8CCwYn+GANpJT4UpDThK1ywk5ScMmIRU5wR+kiMtNFc6SYTMzqdFfgfe2+VUZ9Ndnkw8FyI35CFNoM1Gqpm2zaL8BDcrE+JWy03dEku+bQp4qXq5oExUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwEirJVXAhrO/3zGPMr2Bq8cDxcXIIG81dg2J6xSS3qFYXXquSRWYL3pthOXm9H33iASoggKbPsj2tLHZFEm/HBw=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "86B25C4958CEBDE15BC9CD38D25DE3A9487F08DBEB8F7057B885D31E51FE9ABE",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:2UkxK9N8+IJzC7/AFAF1+lHXNakTzXfVG+i9iRr2BDg="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:yMOSFF+Pmzh+4AGWUj8UXhnXrk1ldk8xAO6Gh9iLbw8="
+        },
+        "target": "9255858786337818395603165512831024101510453493377417362192396248796027",
+        "randomness": "0",
+        "timestamp": 1718998735748,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 7,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/2vKiP////8AAAAA+y4bbBfJu5rxeGt8f4v2JdCYoEQwuO9i5ncX3YN9PeavmpTnsGlqdmdPYi1GAnVSuwu3of+lz82jlIGlAMzXln4aYnGa9nzGVtcEVY89VMe2syy3nY6jc2RbTluOPAnWFjPqwnmEF2SK9mXQPe/RI4xQKz12rxbYjLMJECkS9jwMBxjtxwWZamlEOR0fD3wvYNN9dZSSAywxsVuorYhFx+pw0sQSiTSKUrENDr/ysia2hSGJu6QCo/OIqQc7tw2bCcR3ukhPp/IKDJXy0qkPpRvDPjhzL3qKQh6CJTP4twVA/T3px1ERow8pPt1mh0kWb7usEDdTNuYmVUqjqryG3++MfhdG2wkTuvWCH2AEmzf+W9hOpnI10T+IkP0EZoQBtg3l7GyQ/hgadXKMPTvfkfeyGP0SjQX7B+Q8z6kRWMefoLCfGJogfZ9EQR0mEA1xsDgLbQ3i8Q5JqP6BD6FS4eVKi/vi/qtJjfXbIn2t29pF8nGt1PI7WZDVs+aC9IXjF3ueUJONVm8KOD9bmgZkBRsB5ekI31dPsx80t1FeCePpEkL5QYJbUX34+r/MBDFe8ODwwtIx+/VOcXncsUXZz0os/gzApgqcyby9X1kab6gmoRX5XlEq80lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw3fD2hzP8yNJGC1ql1ANxzu9H5/UpQY0fQ8+9O6OFxrtDIkzuZbBCyvE5FFSg/ZnQrX6FYA9SbAFMxmSyaRUVAw=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAqWZmNvRWwun5hB2oWP8cbPik5Gujgnh+skmTGFMPl4u4UGj1JBY8uDsVOzYgKgO/KRoNy6RzudW+2/RZeQz8Z7/UD1S66YRbTK66ca1fTcyEjwxZuseoaMJGfivTnNTaBtcoiWkYUn/vNpWii76sG4o95pPhlxEZ1L1OvJl4A1gEEq7OLKy3xf6OBnMUJlN8OZC/aqrsV6BCq6UZa3SFEOqa3v9fLSLklarZM/CqM5OVDX6MWU/QAIASRwG/AWMDea/iEAnHEC+WzshCL4LhHAXg7PdCnnC9chJYzcEvNeYld9aXGVQBJvbSHbhx2cvBPgbpsfib9p8m0uFJs+9YyCQDrlpgbv+Xv/P0YgsCmVgBf1OQMeF/5KW/TCWUYecCBAAAAJ4acn5O9z7n7PyXoFg1IcXYHJR04zc6JzR2s9hPYkHRWrC5Dv5uDDlrJyheqnFnGYf7kK/qMh03+p0I2XDUA6pv90LaptdIoTMRjgqFYBWw9Fzh1QUhGkttX4qnM19TBoGyjSkqyEeO2D7byk/LpvwUaOYXqXZf2LtgsYAZTXnadjba0NvB8hTDjDMBWEl+v4WANXX8pD1r0TPhc7jLs1dFLqio1qcgDfDtc3Mdb/5MCc5BKdhrfXTv5tsbFgKTmgJ0WBwpnGLxO+DZS9k14l+F16PfVdXfES1QqdgRFhg71FtZ1GFA4Lav9nVr2o7B6ImaQYBxa2mKTQUiPizxpVDiaaPsUq/9IrskpLG1lKWvETSrKc9oNV8BQrCw8EdCutFDRRmw3QWOAigwVe31QNoEY5LolXY07bjiLklhJyC9tELzY/EjVywoPrYHAkQo5eAI/9hFaZIPOSYYb5nOUltGCFHK7sq7a4KjdKSWRSde6N3HgZ+ATWtx9ZGvLCNeyApwhbobJhPDAhil5Vb7080pm5yfJ6eYpmxrRBy2wBtswxVjmpt7Ly0A+QFzAnwntF/ocyqq+lF521bnukBSstULxJtpGENAVr69h9ICeDFrwCVbwXW9G6Vf6/qUZdx+reWtACIz2Ii7+pkDOG1iKZg5Y3Ux+sKesLJvLKLqMl3+hAkpe/PhYd4A7572P2768CG6RpolNhDUy2H1T8Z7/F2p8x2Kw/dnAsgu1BfCvARfdZYZVhHHp1hBLuICHpi2Izb1I2CBtFlAfmAmREZDB1emCfyOdra0Wzn1sH1MgJAyTuzrChSNFu+AJO8WuDuyNsMnMVRPTQi6rx7smsiqbmgyXjEMjNd2oFLU+1niQqCZcXxX5JzZsy6FvQy0e1vEzaIaYjTOijyFNw0jjd6drdLGtHa7PdWePXYeeWJyJij4i0bE5f0ke5MCrIdus0Hfn+iPhHsDmVcRLtynfcLnmOAtPSI7DZuB/3g2eIlfmcxKSZRYFrpYse+kyIE6sjsYyx7SRlZm6pakIqHwIufXU1mKmeXEjHHyfA0/EomcP5TaVtmtf6jJEpjVuA9+8KzfvSqupJIiDXCGs+nahT5/CbYTQnhZLsmQiq6mHlvWGb9hfyLimT5HsEd5kcXV4FCNeqsZCnT9sbJdBb9zNqpS1rv3RQ/fotNKBTwwisK1UqjzjB2LnewSYeaAVCGDMYjzA80qrc72Si/5OYXu9hUzj1JRCOuOGpKJsZe0eJwUTzlGyJllbuRZaJKC5mjCXTzl6ihQ+/iKg4LLc6jC/ewkMUoWgYWgIQBahy18Nn+2rOWZA7ciABWpD0iYQn7Qia9qI7MCJAChYZOsjTPKnmwFli0ESdh74ABfKO4t5GHTmbroysAH5SUL+B8rZAzWofgQCeFwo1sSqeg4D33OeifUDPQBdS4LjchfmYoxSxl9/Eidu8yoFuGbAWOcH8cwiGGtH85P0dSXaTYXT+wjZrQhA5psNg542svtU754sGUkJRR+UJwkSFg2HS61SHounGQ7niB6EgrGmiLtzpyQ93EmLhFlfG+c08K814r9QAZ04m9TCrAN46e7tvFVomOEmP21Cw=="
+        }
+      ]
+    }
+  ],
+  "Wallet scan should skip disconnecting for accounts with scanningEnabled set to false": [
+    {
+      "value": {
+        "version": 4,
+        "id": "d01c45d9-1c27-441e-b784-ff8af537c9e0",
+        "name": "a",
+        "spendingKey": "8f9f64a1eaff9f7feed5244b5356aa61c8edab7d83227136ce701e69c1d0a2fa",
+        "viewKey": "9ca7f43bc49a93232132fb6eff5762dbe7ce62cdff57a3e276a3f3fc1d68fbed02965c2a565c2e807f24fe62cdf6ece4a44c55f542f43285f2cec5a92e3bb7bc",
+        "incomingViewKey": "ca7688753ac80b4babd412c1ac2b39148856a7ca306a54f361782ec9fca2e604",
+        "outgoingViewKey": "16fe0cacedf66074cc835585b159b984784685a157c2511394c2ff5cb1893f3c",
+        "publicAddress": "9075283923f7eb216acc138b4412e2b78ddc99f48c9867d516beeddf84e0d872",
+        "createdAt": {
+          "hash": {
+            "type": "Buffer",
+            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+          },
+          "sequence": 1
+        },
+        "scanningEnabled": true,
+        "proofAuthorizingKey": "8b709ee47be8e24d64970d6ac14fe5e14552af8acec8c486b3cc69f0313bb802"
+      },
+      "head": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "value": {
+        "version": 4,
+        "id": "66ac2ad9-775f-4674-b49d-7277abed0d18",
+        "name": "b",
+        "spendingKey": "7c524fdba59b45ca4c01b65be6aa1c4edf287788bcd7529f2da08cd786ea56e1",
+        "viewKey": "e76d6d8128c44b4bda9bb58f2b663641342fefd79f98dca8429046653aa2ba44f36c4af64d07a47d38ab353022697331e19b8016c850ea7157b640680e9ec0ee",
+        "incomingViewKey": "de480528573e53b2139f742f194cb99984f10df212edb1e6590c9dbe8127dc02",
+        "outgoingViewKey": "bfa120aa34568cbfd328b9d6da5057dfa6308a09ab338f0c1b7e348265bfa8f1",
+        "publicAddress": "6e05c6c0a4eb2a30a09dc8806240d36a766c2fc3b672857a9f465749cbad3bbe",
+        "createdAt": {
+          "hash": {
+            "type": "Buffer",
+            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+          },
+          "sequence": 1
+        },
+        "scanningEnabled": true,
+        "proofAuthorizingKey": "8091bea3e0c5c249a43ba005b99fce709dfe1505bcab213233f8e09fe2e3b005"
+      },
+      "head": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "4791D7AE9F97DF100EF1558E84772D6A09B43762388283F75C6F20A32A88AA86",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:MTg/aR9gMZCMIXUUkINNLEVV+pZz1Je97ekm9yvSsXM="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:6bRyH7X/5l6rOOtDOqQh+aqq5M34RnhIQ1dtomZx/FY="
+        },
+        "target": "9282972777491357380673661573939192202192629606981189395159182914949423",
+        "randomness": "0",
+        "timestamp": 1718998736844,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAojYc9cW5YD6f/aC9RGr7cMD5+abPX0cvDTjbIYQ70Bmi8U277G26BgwbJrhL67BBLx52FXA4vIrElodtFoXpUNtM3jE8clfPTgpjZ3mbzZWWfiRWi1pRlsleMs9GH03VMPltTl43JPVR7nZPskdUTWXSwQL8etZHzGYdXA7bwagD4At1E5cZknuDV0+TO2o1dbvwHUG/hLnTc/jughmpIbMJkstaIL96XajYJ+w/sBuDujSehZIus3hGf/kWHlsUz97iCSfHoU/VFe/VyHyH/0nQe0sZnKwQY6M5onFLOqupQukswdz86Cn6uzVK5xJIn1AqMSwIlHebVe5w8bCEOhtd2QhhwcLP/s+tTS31vJjXofak69IziudGgUf00GFN7sxVLPlMV6tzj7bkVV55fAOijqmYT4ojcGQbGr9LdI4lwNvr6yq9xeqZj+4Ok6ZitG12MStvsxZo49ObhkXGh+EVd05+eL6uMpOK/MsnQ7PSQVEYfEA4RFNY+ROCjNgkFyFuS3Wgt76netqrrgFzuvsuW+bRtlMS0xpALhvtJnMyLVruXQ4Lb3/NAiSao21ch4IDNGkRmLwmxeXqyG4FCGmOeq38eQYFwElymIKkbNw35mineXu2wElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwLQADJ0kFUwvmaZChkqEgsM2amGHvPB+NHgy1y2uVuJ0Qb5C23ATbXfWgvKvy/Zz1XEck4fBw5N/vBpI3UJ01AA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "5A1DFE92484FB9E71E8A586CC2382906E260D9077C20C1300942A9409F020952",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:nCNnG+aGfdXDWeaYKsjwyu9ucIDwL/+HKQ6PV4Gf2GM="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:ayPbzwWzU73tXogX3NQtyxd6PqidvHJnHOnEjEn12O0="
+        },
+        "target": "9255858786337818395603165512831024101510453493377417362192396248796027",
+        "randomness": "0",
+        "timestamp": 1718998737312,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA4q5cDD3EIrK9jOzo3PTC5uyeeHAVhKl+DEjb+FwJzjqIllvMNzG29ysYAQGkeN6Qo9SfgtWUbEItsWGmIBdg3bjgKP5hS6iz9gKzkziLaOKPSn61Ins3rPBJgvdZO8YMKnPNqTor47YDW2xTnN09+SAWW5paLU2ruhY8Iz3VBigH1Ayqt9c00F9u57jGqrRkgBd0ADzFW677S//uXe6JWzMV47CV7TJAA/uR0zgK1e65FV2I1oFBmNXLWAQEcOKlP4rSA1rk4y2gi7y2IJLIb9IboomSB8w/k7q7i6DUSuX7NCGLpNt+nLJP5zoTtftGvDxLiVXypzELKdYQ5s3XqJ8DsRlQM2BnNYFRfVsl/fpoqvAMoVNWuiv5Z4Sm2mVi8W9oSGy0p3xfa2BGpALMOjyGynNVRbzGCbDs0HryROqLxEMBx0YtgzDIurk8cnGM0LnGhOkr6zmf0GvkxuipCeDbaMGcL1oBoZMnfd+J34EHIEkHDiYlyg9basmgETPkp9oRtQn9OBtic8UZmYcKBwBL4s1s/sugVBCb9k/cyUVY8PUi1Mfld3Y1xmYub0ozh/qB9VAUiIBJJbc4SuE6YytRlhD4tb9FFCqUADMBjOS7gqrPTgnnzklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw+x1olFr+T/SNNAY+6xlsbb3HAc5jNQUfPi2EzjciwJqkati98bg7bw0CCEJrkhy/TgNv7MCMyLO+nBimjO9GAQ=="
         }
       ]
     }

--- a/ironfish/src/wallet/scanner/__fixtures__/noteDecryptor.test.ts.fixture
+++ b/ironfish/src/wallet/scanner/__fixtures__/noteDecryptor.test.ts.fixture
@@ -1,0 +1,372 @@
+{
+  "BackgroundNoteDecryptor decrypts notes belonging to different accounts": [
+    {
+      "value": {
+        "version": 4,
+        "id": "7c2f8d96-d106-4a28-881d-0575c83fc525",
+        "name": "a",
+        "spendingKey": "f66c365bf79c2dd79c4020d5bc1035a11801381ac4629cffdfa005416249d5fd",
+        "viewKey": "486d222400ee1d48bd41e283c35d2bd40db403d5b0672b5172d4cfd96ac9aa69a48c884a14fdc0f9028bb54997a9e310bc92af843f6d62619ad9845347825b4c",
+        "incomingViewKey": "f7ce154974e2e67d0f0527f1654849ba381db5114607729ee7a607b9e0dbe500",
+        "outgoingViewKey": "d572ef776cff8911609bbf1d17b0f99cf7d7b7106ca22e00fa23f4a356598f2a",
+        "publicAddress": "45e654e5369ac6542c7b58f0f75cd33c438b0e2c3e37a7a4d49fa240b9b30670",
+        "createdAt": {
+          "hash": {
+            "type": "Buffer",
+            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+          },
+          "sequence": 1
+        },
+        "scanningEnabled": true,
+        "proofAuthorizingKey": "8047e668c477f7dce2814d832cf6b7f990db8951cc62a56693969fade5054900"
+      },
+      "head": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "value": {
+        "version": 4,
+        "id": "4b4c7ca5-fd2b-4206-a961-308db8ce37e5",
+        "name": "b",
+        "spendingKey": "0b4d99be40fc3749e078258919ac9ad72034a726a200013a07100ed8a286125c",
+        "viewKey": "82cd94e815cb70ce2a4b6662ce8a08dfbfd161f95848edb7e7f52774c99809996ef81b670e345dae038a8ff1bbf9c49b5747dc5a590bf9aeae6551b712e2bc55",
+        "incomingViewKey": "466ba7009f92c950750d20749d905fece3006fa34e25add7884db8de417b2102",
+        "outgoingViewKey": "6e620f74dd727ea99416dcd5d72ab047970b142d80ad68d5f0a17511ad9f3b08",
+        "publicAddress": "ea4d3578d46302ab6445616cd13a74bcf7de9fb20019ebb5a0b0e2312558b114",
+        "createdAt": {
+          "hash": {
+            "type": "Buffer",
+            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+          },
+          "sequence": 1
+        },
+        "scanningEnabled": true,
+        "proofAuthorizingKey": "add170181082155557e9ff7286b63b63d5217924574dad4a8f4765a550035f08"
+      },
+      "head": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "4791D7AE9F97DF100EF1558E84772D6A09B43762388283F75C6F20A32A88AA86",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:zfcr+TmDxhEwAhBQ/zi4z0MNzxv242jhJ4ucXIlPFzI="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:SUuYRMd5Qz0Ciet3ll6faNPap5vv9b0psomXeZokN70="
+        },
+        "target": "9282972777491357380673661573939192202192629606981189395159182914949423",
+        "randomness": "0",
+        "timestamp": 1719013983104,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAQAq8G7wyJyJ0lbGbSN0FjqU50rhwY8Ryio8RZEi010+k8gLmU0Ql9OoeLqakhwhV/orlG+D9yYPAf/o1y8oslnckAdP24c5kEt1gJXACPZmFHEn77TFYhRkY/cA+zOOSp7XCMjvJZVKFv/xfxQlWmv2D+Sz00+GErhwXga1/WXMFjqm2Ejhs7RneoIeo3VmnBEPiiOKYK8g5ZpnEqDrhonxbyPTUpLzVOSf1FG8hdWCxk+TAv6qyWVqwae+5te3fjdRrSDosdGakBVQhHnRJvJFozLGMb2nZZbrgJX4XEV08w7rBG2D+gKG+6PnwejPr8JjJzI8tcgbE8f7crO0AnR1eWXyrt/t6XC/72YTz7x9uA233fNnVfCJa5gmIx0oYtgTlRGya1cT3dVYfHr6/JadS2IUh/vPfOKifhN8Lb+QbmFiXU0T1Iut1UygpTgYlbTk6Gl3FVEb9gsUMPyBiLDVto5f4wUa17QGKnYreZ5OodaL060Hwiu1eqm9d1NAOFSoSS1rkqQinRuV2pb2hx+lS/tzC13viR0Mn4hfxI0ixrYkm2PCu9vZCjsjOlx9194GdRcr09QdWDcvE5sGTNUrdrGh3Uh1UpqlgHGl2y+/8xlk+8ES1ZUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwY8CLN3dtklbk+71Z3ZBasuh+e7H3gNrrY3feBdbEf4qepCuIcTsr96KrImOmoncBy1xLZ6OE+v3p17MqTbSgDQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "9AEF6C533357CADE4EBA52F9BDCDB30438040F1A45C016790431844C500B3922",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:6LzdpRPQw5UEiyYLfq+gNCYUUmtuXvFxHYjnYpTXXlI="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:bu5PcDPnz0TRVNVxZgu5SL4dzMMqPxK4gNc7zSt38Jw="
+        },
+        "target": "9255858786337818395603165512831024101510453493377417362192396248796027",
+        "randomness": "0",
+        "timestamp": 1719013983570,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAZNxfcOB5YKDBOvla+GNPw2DLu3Gm0ACWELT7kUEgchizubqY95Wi84gd/5GDThRPc2cJOxb2I78dnj8h08UZWoDHpOAoTbBCdrrjjVnP1GKgI9OIAa3laTQBiubuHQGL5+B5saW2+r+mS8fZ9+k8trMHhOoaGEYe9CTVrzOW2zwFYCo6CSffGx87oWy/dcnLZbTb7LpoJVoZt2J1Aaw8rhe50WiNCs+zXeKQlhR51UK2QeV89b1fL7m6tlDa9k6/57jdOab8R6TI7W3ytKnvBTDeh4IShPCV7W2FNgmfyWVl9NKobJkqKbT6I7isH8ISJMrzAzMAxhjD+VhexiZ6RD9DLxKYBZ6Npt1CHtb9n4H7qiSrk7x0E8KXWOmwayg3wtCVbdYJROxjtvD8rBsuQ19l4FHWwB6CvC6Ym9APDa6WLL24nnYJMWKGu25QM+uFccS8LneKtZd/TtyashnCkEq9O1m0G0QwklU9EtrDj3ER3kYCiyq5mcgKVEyi6Mukyg8iH+nPJfkLb+yP/31OQKmGF1GoK0zGHvBWKPT2kiprBs73Zvc0Z17o3q+JdrHUjKgZlTr7964+13ZLxpe5+KMABIiazK0to5p8z4KO/v02t07aS/eXh0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwllbQhfxkZEA21dRZH0vXYKiLYIthVFgfMkCZHguQ6bGcJIphOvNXP6I+MPLwCTS6QVfF1gJrVOObmQYO23cTAA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "1B5F9F573B52E43AD92585AF9DD1A874E8937B7122ABAC70ACE36CBA06B25331",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:ZUFgR526J0OKlmRQS/CAroqhfGg2G1xtWGsHuUea6hc="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:GepXK1fb8/C9smsskZsjKNoioqiTjx8C9Qz4AuIdwd4="
+        },
+        "target": "9228823284279306817296266184515742822248210830185427859262273659833347",
+        "randomness": "0",
+        "timestamp": 1719013984028,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 6,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAKJusIm4uyCbXLeFzOHmM24RcR6HrFoTl0GeA4jb4xXOvfFkpf7q4oxpJFQPEAu7QjlIzKUGAUM4sMGtGjmcIPKNlu5HhpiXxgNTUijiFwXWkRQ5aTM0l+lsA2N+5QCn/hutfipLICJCPAeVOME8uqZlQGRB0JtjZRuEVDXJcYQcSLf76Z+e5Kezt90MeDC4Bx8Xq7xtY+nSl9y7GmCYV3yctcYZkGPyCl0c43arBFxCQRvYKXM0VAtoifDLu53a5q54etzSu18AhPrs/3U+l9YzlvUysOv575Tvt0MEHdxl5p9AdjWNF7+DqGzhspj8A9TdCG0lX92+o9fZi4BEK73Jg11sln+bGL55rU7DLG0KQ52gbNzwBp3MIlkxb0IFYjUMmdomQnhHFX3ggdTXNTyqiT9+v9FRkdiaZXQ8Lgq3lb/J+8YK7u9GtBYlhWI1JWt9g3gwaY211NAmnfdSeE2GY7fK28h0yRaPGQHKDIcQAO1eJb7RE5x4q8siTER4Qt1MqhUNLNMAMQ2Zw5XwTuRKsxMSmKa7MmCUfICir8LxYf6fV8aRux1Ky1Ql3+Dx8cXjoYxtcoQDOjjlHnX5ppbqcjfQHqX/3K+C4TFDFNYmmKJBusrFct0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwRXXta8pMisoYkCOUozZOpBRR7/g1hSlJ9ld8HQD0Wik58roilhIQ2RetZLgctMVp+4mNV1jCksj2cEdz60kIBA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 5,
+        "previousBlockHash": "7C790FAF96B3CBE01175DAFF6701F00A05FCC8A5895848244D2B306095FC62E2",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:zEuM9e2y5xNNUEEQYz3H/ojBpYY5fYUx86aqwOITUis="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:jds30z/+5CO/wYdxVkmfC8ojAAUdiIG8cg8J1bUUdFc="
+        },
+        "target": "9201866281654531936596795386791503876274441021197252859723586932895305",
+        "randomness": "0",
+        "timestamp": 1719013984487,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 7,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAo31EbF9w6iJEtStNy5UF5HeE3hCdr4rQs8juSHbFlVeGBStzUm9uvdQswl2VbiuEsikkAmSYpJ2lVAALfSiZXvdZiWCXTpcBUYsG8HRUzamxoLklvfsgHwSy6+jR4z268ViDl2NnxuqGWNlbcSQWqzCPmm7UNCWn5ocDeGAW0wQYJGKt337ygAdkUxHPXgRszAOAYVARhSXcWr4shiik+ccDHJkvQbUy0sIuRySQmSWs8/hBbekusUCQmriSJSds2d/juoZ8uZpF4EbcX4Xhm6KpmRJE6AdwgHKg/WRhneTTMIcY6Ms1dDETHS5f4HES2q68waF5shIiSdkM6DR+W+q/NnS4FhKok0fQs1/ckKz5BpbQLh3TgkchA92IHd4eAyjr+8Rcw8XmuPZP9UBMIznhjPwgHOVre3QXdud1Vgl0b5vP+YFOxQa9SlyYR6FT0H3BxR4rYR3U0ELCG2F0CrREqMJR1vRvrjgoS8yIxWZlxeCnFI8QsyGQnZKgtqq8WpeJ2FaV/Pz2/XugVsGrp8Gv+QFSCuhLIHYC+p42Rau9POk+7V37oEljyK6ORGA6DvyuyqyD2rhu9gl28vuo/e/Wkge1UVDsVpWPck02op1jPQF+zCn7mklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwXusFrGBzhSSnLHx/FMWedk17JjjT+ZH9tbyXQqW9bSKYuQwkJyJg9z8VH5iwPw0D1PfyMK1LsdvKYqO8RZM2DA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 6,
+        "previousBlockHash": "C673C584B178FC9B3A7BDE769B4EEF7A51EA9D929C1ED2EA5A4B44249DEC9648",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:vt5teZZqKbnfAHGKZbeOyhQQehfMlh/aufipw5zLYmg="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:E4KPQTuECSzAvG4GUVp8+1Q8r2WAnS7Xq7inHoS2RZ4="
+        },
+        "target": "9174987784651351638043000274530578397566067964335270621952759689537226",
+        "randomness": "0",
+        "timestamp": 1719013984938,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 8,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAKpkPS4Hj9c9ixRHHxEjRXdXiV7A+hx1XUOSmK8cJFiuoO4nrqdvev+AVFvpcR4pjQOhgQ0IYvsFfha1XjblrmYOYuCM/Wweyjr/n0TyWQPSHurdlFtvYemF/kATVwwheRxAsDfUN73CI4A28dGvxdiEk0um4acmweQiXPoN1Va4ZiEIYn3a+58vNNlI521SNiJVGj3WEnNIb2pTu7ok8sqQFgICIWyvqmoWI2e6Hl5qpl935x5CZ3JPoyPNvfn22Lt42yqWMm4OZshGr60hyJmaS2pRvO1J+aEfyWelKreeoyATKi+mYtHMibVHWI5YtjMm1hQVI12xflZr5XoIJ8xx9y9QRdfSLRnETJ/w7ulQUshB0JeQQ+SvZK+x4dFcXgksWXlw6convFzyLzefr1zDCF7jcozFRI4WZd/hxKYQiuliHl6cM/Ds03nxkRcHZKcsSmhs2p0Bczx7tA2CvQtivwjzAYTH6ZJMSmuwYikDGStmWwYDFOlr62Mv+ldtno/4sPYbfpeOuiXQ7DD/mW/kxEqmxvEz9OnZJ54/3VjVJsc62oufIuZlZnRCk9qfx046wMPERKnzQNlKSsyy+nOajFwqAIvXTn+nBCsank84d0Z79tlVViElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwZopsGf7sdqk8u/NJ9MPZ7YFqPPXX9jlaDJw5qtltuW9m74JVkY4do391FYpEnLVUutxvAX76GnU2fOe86/i9Cw=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 7,
+        "previousBlockHash": "952A76040CB63CFF045161F69659B67A637045CE326B9126783AE9420A126B84",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:XowEcJ2nvlme3vb9TCWJOp2hG5JgYmzeZcMtX7xttSw="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:U15nmA2QKt/vY0DpOmNu62eilnZgJ7afFAg/iZoPMfc="
+        },
+        "target": "9148187795366513087508709149025146424715856256637674150531751753357577",
+        "randomness": "0",
+        "timestamp": 1719013985385,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 9,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAVaAhcF+a4ploA1H9QP92QhV4lCYh5PrmxunwZHE9ooKLpaY6axzOBPyVdeLg5BT3jbr0cOzHnoqHefoaPo0IkhPmhJZzQIbM164/Ndthqb6ZZTewyWeOu/LWIqY/d3E6iE0htcn2goPo890hX1tZzBFiDTv9AJ9/tPNCfu3CVgEAgjzafD2J+QCSqhqG0LpknJe7iwuEuwY2DlN/MnDJH9JLjMhl1/3BIlFvH9YYpNayEdNHeQ5+bRaEt+3xliDVDlLj6qSwnkai1hyN7NjFZQCgW9PALi+WldskVESIROFQXKxTZoiC3Lg2mv/c1/c0JxZO2s3fsBKC5EgIVOXMJpQB5ZSmenngk1atop7hWaPW5h4ENmlD8YtQevoridU8dMimhPfxr85uCoGhaHqxAtDPCh2rUMUgMIU/1o0Cokz1W8v0m0wb94pK3DZyW01qbSiX/wpaE5O+mi3t2VH789JvRXVDfMNPp45C5VMgnyKvTdwG1koaGzUqu8qRd8Db9b372iHXBaNHJTO7BXZr9jhoY+ZMVSFKQ6FAUAu2GHARBNqiTPSghk8cD+CcUFVVFnGUsEIMLA76i2G6Hw736DPs/Od32tk6tLLy3L/ZIp3I8htZtzZqOklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwmjrNuynol5WyiDDUhbMWOzJ6t5Ege0Rv6RTMllKRQiqENrQkAEcrRb9LF+CgR6IlngJ8OTnNZxkSTZZD/90DAA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 8,
+        "previousBlockHash": "B3DEDD5D8C85C37BCCFDF449114E6DE67397003A405BBFEB50BD2BD21E8B4B27",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:zSBTZjhUjSW2wQS7w/yFg3BuUj8igHc8REsCXYCRgU0="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:mkiBdnLtYJN2lug0zNW245DPmmAFKExG53giOOEQYmU="
+        },
+        "target": "9121466311864876128923245652724724632104869735746188813030060672759072",
+        "randomness": "0",
+        "timestamp": 1719013985850,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 10,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAe/iqmEOwcKZ1RHevgjbadRohwDQqN77ozsyQeFJot6aKqrIQqvh1iGQpkNYExElCm+TjedkNHGyKhV1FuBRrnZanfh6dTT+NpR9NyA5Cw8uFUsCVqyndQi7b2Z+aRcqDZaCKofLSWnW7Ip0IfTaZgp78v2HtznDB0kFpt1QWe0cCJfLnzvBDY1EEi6/JEKgRHTVw+GLA4n0AnC2pUq25LlCrTw8OZCjyH9jV+7tfFWqsQuakW5YxRh8xmfwc8X/db92kxlV1+APBd2k5NnNoEx6qmhZeCRVBV/fvyGOUKQDjJXTeZuLrZoYiBDdn4QUq0oP3wZq4P3vhwf5xQNRQidtWCCEZDkunygFu5qBd/9L6LEw6XJA3giPElz2oj+ZzGv2N1a7WLJaElLZ4SHuseHTYPJmC/znlf0EJXIUAr1ZqaRnSIx3NTWaqlelaMnJKb3QsO91txLPEKlY84pEjTqBL/OUiRvqJiAHhy9k3OuSo+0CpVlIILYSCod72ddgL1cKwTQo/Emr++UBp3l9CoR0lOym4QqOwZxUdESOBVfvYjvkpSsIVwCQ+cRmTZ80N3CSqDczEq6L/h72yMRkNdnDzz4kAwsOscJg4MRKRh5R4YXx2zEY57klyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw+BhqUywJBzVApbpJNc+CNoUVtT1tJKDOaoFHdPYAHlHOCWpUcfYWeXY1Yc3Q9D13o33FsXhMLKBMRXZsovB8Bg=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 9,
+        "previousBlockHash": "6832C7361633BF97D10F3FFAA6BD1C8634BB33274C5B89938B487A1433E19863",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:XgO5QrXMKhjdE2HvXo4aFzLmlB3S8jZ45l9ok890mC8="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:XpOB9/4QyyJp5Z2xm9HEvBdd2z9tdEsWm/iBS6dUL8M="
+        },
+        "target": "9094823328238119324660168503613036415495463326164889575918026009508991",
+        "randomness": "0",
+        "timestamp": 1719013986328,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 11,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAnYD2TvWi5cr0GeFdDSkpF1ySC28asDLBqJQNURctoDSHd7eaNiMSAk8VMyonnGnc3gv9/VZP60Uz9LPrGwrg2tOJgbXF5lVy02IFwnhccAmsCChQ46AiZAwSu2BQ/BUgs8zptmZmv0VByJfT6Lnmq5J03GUlbBYpzUTwR65Zo3EITPHA4nH7mvZXcCskqMx3WR5L4U173iYz/bfFeEw3h322NyvqFqp0Du3otzILyY6CD+X52ZRsUSBHKoaF+F8/fmgBwPR0IE7EduabjqlC6Mdm+2Cmmih+QopyHIsry32Ey+QjGQyyWz9M2zWrL85GzWxRQRLzjWZDjtqM9IWZHp8o3R/FU0SXJS90XrXedgMFAk4L6Ixu413Sskk3FoYfG52pBmJqbVVxREt8p5dMFQEjr2/qW6fkZmaqHQYuoJ/vPmMItlXtJSSNDkjNnxeGZa9ok2CzSZ4M+RYIBhPRWQk+NFo8AjDZyYyAIjlC72QujwPSC4++dmDXZF/1PwG9eCctK/nqdeLZINXxE9rDTKv4CgZHwe2Zkqr6+2omPgtzuVnJWlBJybJC/WjyxbR8n2/QHlpTU7j5qvEE96ZvXqUokjvCLmofV6qW5nlAw90vYS3hJQga4Ulyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwLFsK5tlrIkpat7cVN46dfaL70TluCu639PCk5yYotx/LRPD1kZOfRd4Gz+VU/bHEbmwL/Jq6BEWaOIkGkSGsCQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 10,
+        "previousBlockHash": "58A0523684A584E001C874EFADC62F1E460EDF2697B8D9F511E18642E5F725D4",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:i4N5y96CuXjhqSFostekgl7/bhDtPAJFZ6HmO1++yys="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:bWKBnZxozSWU/k9Z4+Smbev7L8FCAoceXwrF/MRbeNY="
+        },
+        "target": "9068258834662928698220540790897658244352076778286486653826470223999191",
+        "randomness": "0",
+        "timestamp": 1719013986791,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 12,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAxBnmx8YmVy4Uba/bf0FZsUaXaevReHvPPTwzEcnAEUKvNBqOJTopDOa3ge/F8fij6EGE7yoFexmwpFirko1WH2NHgCSPGO8PrLwcg35BNe+WyBCvo8wdJrGgGOFfvEsRl/iTGYlqXEFeUpj4j1suW2zEFb/umx0UHBSDdkHtaGIZyTC+G17B5hnAbfBtNpG+Wkww23OB8LEZjdCN8ALT/sKBnJDI7Q6iInf0qH0aQh2wngF8LgL7b5DziBnE9l7sVclXo+SQQxixNn+P4CUS98SYVM/HFaUT6CPpsJeJu/j/pqT6ekkbDhdmss934GvP94wQLa0eVHxlwAl6pkrxiXBbtR5G98Sr4z9rXX9c3eIl0CoBN8Icoovbziuj9whuwvhyGbl2Vgb5v/3JCSO2xuglGtiRGdqstZlJnafN410nX8dmOtDZ4uKYbX+91ElnO2H/zQk4BnHCIuKYWO0pnlw0qrQID7s46ajoubh246fTaRrN/1ZUhdCzWEnkMmFy5tqjG7NbzEiJrK2S12ap5WsSi+QaHxCILZnmRIR1UP2lv/iAB2dtS0N/t2aMV6Vx3V2WF8VzLknEeve6jkYaOONf8Vq8d/yHjGKZbqBrRThD3hsMGTH5eklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwVlgb3VAxYA4/quGjTO2DnRUhwBax0oH45Alvd5CHvUUKdFvrCkSP4PoUr0ARmkKwZ87ZCdwDRDmmdp0hVL8WDA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 11,
+        "previousBlockHash": "EE1E11960354D5C94848038886BE22CBF0660BACD52A44E69A8C94ECAD783D61",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:DqLRDXMZ92KgoBoHoEEvBul0Qa9NKA1GIxOCZuwWqnM="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:PRosVo1ZTB77kalVWa9c15z/6GsYCKd97N4IJU2sXPQ="
+        },
+        "target": "9041772817458669358631436925553476123971485443441062513642264290171806",
+        "randomness": "0",
+        "timestamp": 1719013987272,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 13,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA8v2KH1eaCGWjnmjsTf8l4CS4qrP7QtikWedpfGFIjZeTY0pFCd4LUpChinhP9zHbbIvKxHf4EFZfra1pG6lWj0ChaoJnExsHC6OwUH3v2yO58kxa4muyzv0+RvUM2+ufyLHNWRcD5DIoBSTaORxGR39LiFO/3d8V776E2EhxbScJXyBY7kN+RP57eoCvfiBVaB0F92NZS/oQAdwJGqJBQpfMOQkXycx1jnd5aB5hsByJ3Pe61FucFx7hE26aLknQSqGhozj9Wlb573FIcJZ5qV1s9JcIZCnoVMw1YZOTnGndFvgPcBbXCkeQ61DMnrRf2/OpjLluEdzKB+z9L/q7WfPYAR5oIHUYKEOGHIPPBlc5WIu9Uvhm6W18XqWjmdkgETEmCjnvzYviapfgW1/eQRqIc9llgIMvgFPQG9hueZMyoZdaZVKlUgsOWfgxNbfGKdXbNTqPQdd0w7nV1ddPwqn0ct+eEtbTnF9JuoQNTQGys7SvUx3B6FiN6GPXCk3TuqIAk1WqY31A8ZAGXgw2IjYVWVaxfbVbsSvoox0OhnqwIKKv9ARshpF8jOk98MaGbARGRDu1G08d/38CoLblGp0rc0xUt0GpMOamD2bVWYvCvNlnAXiU6klyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwoaqz/TkttWazh30GCjZi05aD0ExFz97kO6rq+RU6+ZnULmanCEfTiIk5yX+RaXVX1FCz6ygL/iCCkJFzaeE5Ag=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 12,
+        "previousBlockHash": "CB4DB234446AEFBEBC3111BF2861682D233AEBB9899A0776D1B230CDDB7AAD50",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:MXyx0nQL1BKvC52C7mi+es1dDeReLAAp0hidjFU0ayw="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:lbUUxQRyI685D5d8NCxSs77BBV288Vls/6szjg4lwqo="
+        },
+        "target": "9015361047625083866771187507615534750461425295595622380322060663659456",
+        "randomness": "0",
+        "timestamp": 1719013987740,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 14,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAPrfs2jjx/bvllkzfBQxXgFv6RZv8Fa7mN2koSRMrgTCZq8oXgOrPCvT8NpuIfZ5lM+Ui4HqR00HWa84Z/BleqS0Q5jdT+vIw5ne5lNqUc4SXSkh8u+kXnXtEm2werA1xGlz6Mg31m1T/0id3DK1PhqVLMyyt1/QLtEpLxAzoOCEY8LswOKvdlBePclwVuHm9miQqDTrFRumOXVjvz75eJPQIF2WNugKXcPqhtHHKeuKByHPrtnWoVDYbP9qlS2PHJF7skRWTxkh0nwiVjZXLVlPHe3vrs3npIF7IMXb6UkAxLKcEoLjSf8gWAuJ9kz80sC9456UlL8LddQlafDhqoVO8SD2v22iUqhStGUOqqfuav9jYpPTJtKTsxyMbvyEe8gJJtoJeDyJZl5PWW4IKuUfU0JQuJqw0/WW5VzWPeRSsBv5uVOasQGX43r99wkX55APEa+uu13jXJFrNoRVMguMssjzLuS0rNthoFM7yaLJ7O43ruRCJ3fFehJ98bCUb/fnRG8YjMTac0mNt1oUYqyENk+u+qFOYqrzRAYZI5zip4cYa6gWYd2tFrs4Xhk/ZK72cnTp9ygyyeHPtKxPw8NezsIkcrOtsGIBTY6OVR9X0rF/ThNr+9klyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwLGUCF/Z+XiDH2AgVuK+HpcZsvlpJ31H6ecDPjnNG90ECqN30w/xRMC/p4chq0bM1ZCq+zKySY0ns4HQV4jt2Bg=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 13,
+        "previousBlockHash": "985678547DEFBDB3E3875327CA873EE69A3616E9DEEA2893F4E617A0469FFD4C",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:4+CqnqYonOwdj1ImVbCCN1MzdSbtT3rpmmuqhMkPzjA="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:t9Dh0IBHhXIjkc8pS9gbvggzcy1tplXV0UsKJsjSvfE="
+        },
+        "target": "8989027764587843972078000359639078132662736945816568766992021111212360",
+        "randomness": "0",
+        "timestamp": 1719013988207,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 15,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAm/YVZ+H4eL6lQXt1cRWkNAAJ97Xo8fX55KT0+/Z0JJuR6MMRsvCgk1P0L7DfVCbHlFqSHyeylSXnVgyc/3YGlkM1lxohBzHA833kIWzeVHq4K0KYoTmHsD1zLaMY4qlc1BZSwSgXJwzwmijlM0+aHCSXwfIaIzQMvKYwB9KFPcgERtWjSaAzFm/2xLyGB0k97EeGjgCj4GVXIHeNTL48eMJbKkqQdNFdZWfh8ZxoVeqzcB5et7A07p0HUPuJcXfqqqW5/HhucZp7++27dKT2V+UHriHNSf9jkkpBEGs6r2gMkSFw9RSoF/NM7hRCEsPBceUOcmxGDwia9oMVXK6IS5RhomnxrmJf+doryU0xsKXq3Y76pQTMSawwT9LzoG9LMKJSZPPfx8fzXUYQDLwFHUFljA0dxoFXyxWFk4M5WjK5hDFcjVRzqKnJEPnEGBpxuiVNwdWcq5kuUCf3A21L/SD3nzbqLIK6aNi0RaZNV4rVHk7CIIzNYtho4OcgPtjA3dE4ltM0RUfhNC+AHIRGQbjgFHlV/kKc5AGEf1c+I804dP/L2EjLOPUq9J7eM4DWt2GhhfDRIH6EBdM3Z2bgT/nB0oGKuVHCSXM6dxV7jsfZZ1nrvQlC/Elyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw84uTMTAkYg86x/oEy8JUbwEE+zFrZUJ6PutlyD78PLEdNlgTbfLTyilb/z/pseY5W4Te5EJPPHwaj6ezR1agBg=="
+        }
+      ]
+    }
+  ]
+}

--- a/ironfish/src/wallet/scanner/__fixtures__/walletScanner.test.ts.fixture
+++ b/ironfish/src/wallet/scanner/__fixtures__/walletScanner.test.ts.fixture
@@ -1,0 +1,1764 @@
+{
+  "WalletScanner adds transactions to the wallet db with decrypted notes": [
+    {
+      "value": {
+        "version": 4,
+        "id": "d1cf4a73-26ba-463e-84dd-db70931caaef",
+        "name": "a",
+        "spendingKey": "dec96500a1803c548afc31244b1c3c2af1dd2e656a6f5cce4eae23b40b8f245a",
+        "viewKey": "c2b12faf677f79b93f770adb4ffc7c2e3cba20a277645a676a58724782ffe861d1d88fcd45ed80e5e16a1320ff875250eb0f614a34d368db9b7f2b59efa5f93b",
+        "incomingViewKey": "d2d98c9c0cfb2051ea4dea5948bdfa35a18db6b244706a48fec8fd9c0eab4e05",
+        "outgoingViewKey": "ebc96689717ae1fb810465e5b827b03c849b4e17c9caa336190159db3c212b05",
+        "publicAddress": "cf2deda03dfb466f832c25aee99f6aae5e65d87ccf89120c2168eb9a15e39000",
+        "createdAt": {
+          "hash": {
+            "type": "Buffer",
+            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+          },
+          "sequence": 1
+        },
+        "scanningEnabled": true,
+        "proofAuthorizingKey": "d8e8073254aae15fe24704d590fa37ca0c396026ef5bdb2c6012bf044d5d5408"
+      },
+      "head": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "4791D7AE9F97DF100EF1558E84772D6A09B43762388283F75C6F20A32A88AA86",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:itEBRkuh+NpQRbD6hs9/4O9Vv7mfl2/pQ8ntJJLn7Qw="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:il3l3FuDvwOhXk7L4snmAUPdAMnJZYQ6UotnfP178Fc="
+        },
+        "target": "9282972777491357380673661573939192202192629606981189395159182914949423",
+        "randomness": "0",
+        "timestamp": 1719441703087,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAWnEuHSSveUq4ZoQoRPTTrnZ/6EFMa5OBfv9Fzk2gsDaRTm15GIdSlbIVvScNfI5gCG/SelzULkElM04+cnrE1j594IpBErw7xWf2mxkNOsKZ48P0tYyyTEPlXp98g/C9EAY/4pPIEC+eOuCzboW6SvPJMzecOgYBuDhpMhaG//oRDuNHvYug7JoFbJH6wObIWhJM6oixok3tsFKlT8Qs1CJd9ZBrtfKwZ6TpEC/0gbGY5Dmy1nmgVG03ge/WzGTRPuYrPHVbxR2qD9PXwrJhKrs9x6aGbwG9uAPKounEJ5wxuEhw5MTscaUknt38YpdhcKLgcAniLt3Jw/QWeKeiCvkOTLSBNf/dSDw79YFEvFKfzi6dRV7v+myr+M297MIRzmcUX11BzPP/2IHji37MC3OWJf7Xrj7qu2OS1qU9+MnPOdKRIb+YCrrTu22xR0ya3dpryD0/5IuHYDFTQAMYqBXDGBK2ZHhsz8TV29T9Li2ggPKSqIN5M3zD3wG5Sw4JLtl2/g4ulpCpskMwGGd+ft2Q0bMTC5rko60WNf34aSJHCSl415N6yJK4vJFQK2e+qGsbrcLTb8UGgIaWIOssGAyH0z89DMthYiP8O80uoq6nvoS8rpLhiUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwYRGel8eDPjscFom3Ss+KyCvF2mZ6ITTaAE3CaNd/pQsH7kbKfzN3/4PetOD614d/IyZar3jqwioeDgp2o97VCQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "BD771382B6F51DBAD16BBF20828E397304360B8F4C41EA4AAE4F899DCA091348",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:GI9hJ67TDZtvgeaDQWMz5v8BU3x4KLOebmx6LX3IDBk="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:apcufvG/5MYo2BuJxXgf/0XKvpyWF1PUUVfMbOT7kB4="
+        },
+        "target": "9255858786337818395603165512831024101510453493377417362192396248796027",
+        "randomness": "0",
+        "timestamp": 1719441703553,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAev/XVrZBMN/+tj4cnb5nDkkOKHeMS1Oo/udw+KFj8MSjevA2febVCbQWbtdVF622fZilPU6egNmyuBKSRHrqFCjB5dDFINgwyBP5NBqmsYeIrfnb/2K4YkHN6aWl7D+PH/p1n2DsVyyX6LyQtinl7inmIXtUu5G5zHKTJ/3aljoMSaXrtUuvyeZhXiT2vNEZ/aju1zsFZU5WFryRBrPoxdE23WjhNUfz4xHwxPdLBfivYp1O2jdNUlG6INpxNWxxy+s2pH3ct7Eby6eBHrEzDR7npfVjQnpWdMFbFnTQ29aGAxg4fsGM+H6QdCvvUg1QkUwnPfNC2UwnCg8QlhX3y0b/PdkiF/0hDetDv2bMlBWU9fwnfzftnUlX76pA6UFbJp6IdKhRM8Yu+Pbs5JkdO1lXDusx4Czv1kzhWqS9psGjHMboT/pCtLhZaeMmBI1LTaHSgpfq/PhcdQ7I2wzLmnztZQz1eRbf2uKmycLqiWUt0zvqt8ODu74BWzMVD21Yj3BM9CthY32ikWAUzUnI+AAIf1+eeUD/rxcI583dl5cmGhN/fYP2OlwF1rZBk7soFrOT5bvma+w3+RoqhjzJP6lT5UHwrY9vRSd3BipYWvytSdUVcI+X2Ulyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwK+0oMAXwcI6ruO8mM0tz6ivDuImpFkTRswicw6hYfgtKM1uycguZow8m4QYbnrU1xyRBWrqAbeHelR9cJfedBQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "C3C3D2CA169A13FEDEECC66178A2A186F405B60CC5B7E66C795464614A752CAF",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:zWgjVHbnPw8JQmC9NL5vMtrb9ReTUjqCBvHUS9DBFEU="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:X8E0ZOL8NQZcDOubQBJRvGi7wg4cdEQllw7D1Yivv0I="
+        },
+        "target": "9228823284279306817296266184515742822248210830185427859262273659833347",
+        "randomness": "0",
+        "timestamp": 1719441704027,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 6,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAd/4AdJJdsAtp5NFcJ31d5YC26X8zbPWS3V3AFRedjoyG6S0abi+QVAEL9+R7+dgh3rIVUjfLS93XTdRNZI8HS4fHoCcMs3qy/1DGARr6enW0nSZk/AwN8Hdjs68ykYfzTuxQDMJrlhWn6h/XctyymTjlqIHGA6kuRP7X2lB04F0EPOei4YZGCsry42zXXQUmwxJIPEdZk1DCYmoaVxKKv+0ww1L7Hj7Xs5o69Qt95h2gogpZKKaepMbteFB1Rn3Kfz0xSpkx79A61Q6BrtEDfRbEF/Dp9EDzMyrNPfM4nLiW/MnMLReIiOU8JcnkxcGrQPu4r1mfW3ptu1mVA7CIQxHimKAmHmdt2Y9khCpJQKpyKQ46JqIwD/bxCqcfJ7odhYPzBMrNc8AerIs08aN9odE9A+KTskRo0jchZJuEaaf+2NvgRRA9w2qYQ709d5jhf+gIlWxFghhonu4kKvF8qJcZeyQY4wvzhufeYL46bx7w8L/0FdZDLfXY/POIgm6/3//GSAmx5k16Rgsi3BrkT7wv+BaChtxRuKV3sji86HxlpQOW88Dlid+g5dRj2wsJyfH8QjkbcoIrq4VIMqfX7RqtlRFTsVoBCQx4jOhN0R62umnKztgN2Ulyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwWkIKQufSaYEC5DGaLxzHP5Kx7SDL66mZgY9ZyJnhQ1mhH+V1bMV/aoBrG9mVSkmG/sy8vlXN4WU6jk7Eb7qgDA=="
+        }
+      ]
+    }
+  ],
+  "WalletScanner updates the account head hash": [
+    {
+      "value": {
+        "version": 4,
+        "id": "4845feb1-b76b-4675-a4a0-0386104197b3",
+        "name": "a",
+        "spendingKey": "8864a332b9ffe6ac4f9ebcb5756086285e3799f30a432cdd7ffb9d1a6d39b000",
+        "viewKey": "09d115a480a1d2b1b8a149a68542a7ed251d573af7c807b17e98bb529892d8b1e74605cacb2e2473a9f83ec96d8acd3e435254dd63b6b50bf4cb1f67febc8980",
+        "incomingViewKey": "958e5c34a309ccd6faad896122a1ea549803d423e78c002a3fcba6cc7db95704",
+        "outgoingViewKey": "cb7ad68454680fc415010dbb0cea2e18dac420cc34566fda8047bfb4e5d74ba9",
+        "publicAddress": "012d22c53dd3aa7cc986bd8755f8a7af024c3154bc170c8a588d4dbd55bcc416",
+        "createdAt": {
+          "hash": {
+            "type": "Buffer",
+            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+          },
+          "sequence": 1
+        },
+        "scanningEnabled": true,
+        "proofAuthorizingKey": "faa1fc9d7137e3cb50ecd6e02dadfd30af82a1ec5c2ea9a8e482fc20ed60ae08"
+      },
+      "head": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "4791D7AE9F97DF100EF1558E84772D6A09B43762388283F75C6F20A32A88AA86",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:0yP53NgcgapmcTlawnhFEADpOt3D8bPEZTqA2OopGSE="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:4xqaNuh/b3OqHXC5adH+PM9V9G7195kNile9LCOumDc="
+        },
+        "target": "9282972777491357380673661573939192202192629606981189395159182914949423",
+        "randomness": "0",
+        "timestamp": 1719441704807,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAADkyAZx9VeNdAbJwLTnTKAe8+xo/bb7LVT/oTP/wHjQyGaAdsW7NUXP+Wy+l6oRrvR38y+gqpM4ArMNb5bqAHtUyI66srXud4dvDQL8wEkD65l5HzkTr6ez8bD9EKpvQXluSPu31cn6JsmYVPxzfdi8JAXsAohW2jehBOx2bqMKsHpcp9mDatVtBs7hwtJ9nD1mCOfk+bLJqs+kxscHxtJj+4SsQ37KoV2Wk6O7XL+5CV97iBFhfUtrh/M6GJjSvvdjyaoM/FBPe6/8DmFV+d0iToMW6H3UiJda6CoJ8kKJpYi7Y0lz4v/M0tFI3EiMPrDADlwOGpJYZ0S20TFDemROedpEs7IOkjfHhw+CL4DurUfT31gW8fBXklb6VdbaspTAu/jwoUUXCmQ29l55PHrJz05RJJuEOe61hdbPabisWisiUIk6eeR0ijQCWzUTOFMK0ml+fqdPQlS/Dd1/MlUOpp0ApM5zyrSbHw1EHihWmQu5k/NjScIemsKPYItfqHCCiIlwvE/sCYEB9J4UF385h0Cue1iHIW6hBrSUMREKuTcVB2crFrAaZc6Drx4/foy8b74IjnYFolJnj/5BWj0b+5ty2NG67fUroo3+P5E/sySN2oekhOoElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw8K31x/ZrfevKhpGEccgYy+TZ5zIc2kodOYlG+rY/DEZdgfxlxpUL0dbUine/x0KBZDnqPBOqxadikP+veqDCAQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "84E024B89F913F167200B32F0C043FEAC806E0FE96B2B2CC0D49FF9D6ED413F6",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:eGT2PrD9wxP0pCoqeqOdHuCEOmoCa8Pp+c6NLtxdmzo="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:RDvoWjRIxsSVM5ctsU417Zwa6H3H9HicqiHES5dGZI8="
+        },
+        "target": "9255858786337818395603165512831024101510453493377417362192396248796027",
+        "randomness": "0",
+        "timestamp": 1719441705285,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAALOJRFX+2wNDH/UBKelg3Vvh5g5AfkdivpDMA7lMhty+UBHCJXFrlkQRKV/kNlakvAklq6iYHZYplbLlvvAbLvjG23E675POU+CeZR92crOmvaEMUV+SDo+U8fuJzyg0zkwaTi/oUBWs6A7q+5tYOib/mgKHekf3/3MjixeMCGpwOUHeBjJIiNmtGXBQHlSJhLWb3VJ+UvdRNcQAEGDpB2iWfqkgv3HRSehYlhxtvNBGGM4m/y4z05O55DbIBua+fZKWvn7ONZwJix0xyGt2ZWYT4t974cGFmvK2qgwMGf66A1b8D4g0Wlsox/7k2ZeYwLegvXVDoY3aff2pPvKVfuvCGCqSEcgX5mmGpLHSL5SDPrD/Rgv0HYJiPe4sShiEkYjjiynfHdyqz0wII1m2OQt1OZC8Q//smh/Wi9uuEmo9Ukd9Qd2+X4sEB2Pa5H/QCVlXh1N1muRXpH8feELQKYw0UyL0MK8XpeulcFHa9QLUoLS0tVuiJ02of2dqPpYQsoS+EV/Csj1YGqxO+JfjondVhNhwoLyl+4dinOpb+7SIc5dgHaCVFll6MQpH+mkc0figt7Bn8MOXPCq75BwhGvcJsVHNQeDDr3Rhg1lm/yDOcg6h0gHXLoElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwZ+aYeJt37LklpZxHcMExSuceAui6llbkPXNt5Nva+PAka8Q6LPw98mcjbodVcxjgmri3iFAKfa3cWehZoNzkAA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "92C047025D6E0D505BB553F35E15A608FAAC31A096EA5B1B80310CD04FC1AAB6",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:4vrfGlMPz/rVKYTJk9cR5DiFvvltdENwkp3iBQWASyo="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:yuz27wPlERZ9zvnUtE9m+9aJGfzQaueZdRXrAjFpd2w="
+        },
+        "target": "9228823284279306817296266184515742822248210830185427859262273659833347",
+        "randomness": "0",
+        "timestamp": 1719441705753,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 6,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAVV72G2AbMfeY4iqe9DUR3dNwVBULTM8anEaHxKuOmWKHz0JYmYQ+7Dvg3eyhLvqNzM3WWPCLVmr7EaCoEU1Hb5r97OJzHx46HW+JUGKB1uOWg0Y8IXU8YFZfQTkO4HRMqS9Ga/rTUYOjUKWYNaz98f9fK/cdd7Zt2A+cgxXj35AA0ij4aP3c+CSOCtNGMlXRpwckTO4kWXij4eelqzO957265yJlk5w3IkNwsakjNmioVHFoSnADKvLNmdP9T4OOGkP3FBzGIwsLAXstXm0CdZE6QcJA2r1nfrysym6fi0l84vRCgCKr3UrAsdgjsyB8L7RNY28qM6rGdBe68JWFWR7qGh/aJ82u2e6+OXb7QAgq1O1FtzGvP7PpT0r0+p9tQP30ZC1oRTAxVokTBKL4Zi+sRkIFmC6nhuDoKrhaBGLqlK7TsMdcQ8eSpGrn53HZmBdXPpt/xnrrNwC3YoHPAR4f1RQ1J56aYvJi/75omAs0ePBdaafeXK+MU2rX12Yj4KOARd1RT49zdcm5XUoS+Y3XLXoYEYDfsKhK6Z5RFZfkpo51su7LYAu1N3pJhxpDdpsZ0T1wtK1qQEPr+TonfTKBhFs4iakIftqgR7KraXRTMPCTevaGb0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwZzTk55BdcsixSDHZtS9Ucqx38nIr4P+IUUNk5b5y2rLmh3yM1GCuspaNQb5nKQGa8FoTjLa4/w70QmDO3LjRCA=="
+        }
+      ]
+    }
+  ],
+  "WalletScanner ignores accounts that have scanning disabled": [
+    {
+      "value": {
+        "version": 4,
+        "id": "065b1469-8875-4ee1-bbe7-6d36561d8de1",
+        "name": "a",
+        "spendingKey": "fd0a9e9f4d537a70c486eb2da068df45f231b6aeab564cdcdddc4064fd4eb9dc",
+        "viewKey": "25fb041e50363538fa6f9657e7c8224ff63a1954c55f61c130d1b1157dabc0adad00669610f7247e238f22f0dc359d4844932fbc86d99057d4e82f66534de65f",
+        "incomingViewKey": "b53fe8b6b6d13b89bf030ef7764855ca4bf8d9f24e1033e942c2038ca1d9d807",
+        "outgoingViewKey": "210eed54a39f09e7c97ed4114d69d1ee265d0c724da681451dd461ce353d895c",
+        "publicAddress": "9fced945add6d7beeca3bfc0bc951f3cb758463a3845487b96f2187c086b40c4",
+        "createdAt": {
+          "hash": {
+            "type": "Buffer",
+            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+          },
+          "sequence": 1
+        },
+        "scanningEnabled": true,
+        "proofAuthorizingKey": "5ef2b62c3676bdf5da4d6915f0fbca870a1852c605521caff0399e0b9b1e4005"
+      },
+      "head": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "value": {
+        "version": 4,
+        "id": "c986f231-7f91-452f-a91a-2cf792fb8b5f",
+        "name": "b",
+        "spendingKey": "506cc73cf1bef79d4d4d367b47e84c3a13d238cc61dcc558579ccfe453a504b9",
+        "viewKey": "c1a3951064fba9f691d3273c47c5be0d45fdc4143798a43b918f613e87dd0a0224001643acfa030d51ff991eb925563045444e8183869f1282663ce5adceb384",
+        "incomingViewKey": "0ce9869ce32bb9b8363ca02519cb37b7121a987005fd3ebc7ad4bb803fc49c02",
+        "outgoingViewKey": "ae150ab59040f0ac65c451cd68122b37e75aba445673d1dd5fe0d4f77b4f4386",
+        "publicAddress": "fdc8750b5b06467ca88a2351b01fe1c04c22374cebc4910e167532428d0f4dc6",
+        "createdAt": {
+          "hash": {
+            "type": "Buffer",
+            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+          },
+          "sequence": 1
+        },
+        "scanningEnabled": true,
+        "proofAuthorizingKey": "9dbe4ceefa60801569a907266c225bb491b1b9f7fe77c6338faab50395051300"
+      },
+      "head": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "value": {
+        "version": 4,
+        "id": "3247103c-f0f6-44be-aab9-3caebdeeed97",
+        "name": "c",
+        "spendingKey": "0a20db55d442b982b7ec8e472d4de751253656e7a8c9d8a7c4a2bca178fd4a0d",
+        "viewKey": "e12f8440a0d53301d668fc283f7a8a8ecde21d3c0c61fa219416bc17e48d8535ffc49c82da7f38b40bbdf08623075f097227e9c7ce136b95bc3465501c5a395e",
+        "incomingViewKey": "9d17222d43f5d3810d5c8c315ec56981d62bd449949e97ff15084f683f442d00",
+        "outgoingViewKey": "61604829e709df68364562002bce307167489162682dd783612dedbf467b2d7f",
+        "publicAddress": "7657b2be336b7f421204d3f77d6ef6987987c0ff26d2eb126d16df76377b6102",
+        "createdAt": {
+          "hash": {
+            "type": "Buffer",
+            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+          },
+          "sequence": 1
+        },
+        "scanningEnabled": true,
+        "proofAuthorizingKey": "065b39b91094875391065c11b4537a87c56354a4ac5d328cc030a870dde6060a"
+      },
+      "head": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "value": {
+        "version": 4,
+        "id": "14622193-0462-478e-a64b-1052fe31b17e",
+        "name": "d",
+        "spendingKey": "9a5484f82aeb1c23964d85390b1c4e003e4c640652d1617638454ac0cd5ea1a2",
+        "viewKey": "c6ee78b3c8ab7d29a5946163254036ef01ee62d6579bcbd7a4877a5910f6bec6ad767a68541e702565c185d83b79b5a34bb546dd0f2051f2833bb865e8a1fd9f",
+        "incomingViewKey": "9204a43c2e699d4d1c1ee89a37e8125c11de657653462a1130e76e6e34983800",
+        "outgoingViewKey": "ab6bf9dd3118cfd00564519429a1d4a81819bcd5a7b7f7cc82317c72ba610da4",
+        "publicAddress": "58d0e4790b30940363a48dc576826307f71ccbb8258d79fc47f20337269ebf50",
+        "createdAt": {
+          "hash": {
+            "type": "Buffer",
+            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+          },
+          "sequence": 1
+        },
+        "scanningEnabled": true,
+        "proofAuthorizingKey": "7909244afc59a8a93f67ed1e6dfb5a424d981aea2aaeaca2c97e25cae6403a0e"
+      },
+      "head": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "4791D7AE9F97DF100EF1558E84772D6A09B43762388283F75C6F20A32A88AA86",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:6jaJJl61oR/k59FxFDFByNwVYS+CwucrEoluoYlFXGQ="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:6sKQ4yRZDjKOT5nvXwWg5LZniN+7sfyD0AikFfmgqxY="
+        },
+        "target": "9282972777491357380673661573939192202192629606981189395159182914949423",
+        "randomness": "0",
+        "timestamp": 1719441706482,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAqMbKPDNR2Yts4XeNiR3HUxI3t09nM/0J9tUHZ5hCFA6xy1hGlqQJqCnwU8ZWqhdxRQmFio+Z8zkts/vig1T1QXcot3t4tGfzlNt+yUxOORGgrCjxHDMI2dWLRlE+SJWX/OvjoA4gjmcXwXXxRPaPVXGJ20itMr7qNQtZb07GSnEMyE5OjS4CetFJyvbyBw6/eEta4ygjzFeqKcU2Iv5QoOoSE405rF/ZdUsajTjF0GKCG0jtR9wAX4dUKnjTDa0ZLh56cWQ2DZQdJ/oRuRRC1FRpi+btePyLfTnN8XjqwMULyQJybCMhGuCM9OTyhZDgohAAJbHMhe9RGQYRxPdwsx5fPwV+nLoW6KeQhgAcsGTo3bp3+Q8PtVVbVs2T4GhsjbUk5oco0ZNK5+BW8ljdEgPfXBmOb1PPv9NOeHFzRj/aK0ViaBhYC5Iuy4oGyHMXscxwVdhPdKpd5+7rGHeAXIkF+Sp7glkvhBj5yhJk1xqDZYZsLmRYbor8/n+SVMNqxO/5Px1QIOriMA5yP04KdhBvgeNEqWi6ivYRfUnwvOKTOKA693DkoRJ/A36fSk+GKDlm4X+94yUpvyGYr9XSGyW7N9AFi16wBqBWGQqMP/q78l75fojYUElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw1z+InxdLdAscu0OPEqQwCDIahWk+CCvOgRcfuc+JwuFM8ctzXOkXW/Znf/cDYKz0ONx/fDUNYnLeX/pI0P8QAQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "01FBE0D832AF2D36749432271E8E02FFEB76F377410E73C66C59BAABE4274D37",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:wyhr9qpeBSVCzDqyyxvbDVG1+8LQ5Q6pbIVtuHrOJFI="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:/RoQcHHeRE1iEnYSvmRc1tA90LB6kQahXFECIx2uy7c="
+        },
+        "target": "9255858786337818395603165512831024101510453493377417362192396248796027",
+        "randomness": "0",
+        "timestamp": 1719441706961,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAKsDfnw1z8D5WxMUkzL1jM2oa/32D+JvMnwvl7GiYA26XfVg8AC+TYl8TC1SYiGJaY74jDGrVp9szDWKTraM0CIifnJI1JLqewZipjMm/C2yJzyZiAH0cqMmCkO2uDkl3eO/jiHnO+QksXcQE2ZWlsu9/OhQlD0m2snk65d7mmNYHgOXpsASBTc9HqTyFsNdjIfmRnro9pc+5GGw95EuTiNHzoEzDQs5sbzOfVeEFo6WrL92hiXQ6Pz+nZpOtUmT3KorezFva0Nm4pa1GOipFMAc2zOWI1LNSxQuAd4r1RUN86/o8kZxugBsBUF8edT4uQyWvkj5Nm3TFOPlb+Ek/m53nDCDh4mBqZdEZfFYl0uxmQ1BViA6SfNzW2WPf9FwEikZYpTUEE9x0yRnOcF4w5L/vXyKRIUrs9mU60poJW4ZZ3kGOIofurPE9O/p9yRDfoqkoNpJKBI+Yb2EGW+KWk5JG7KNyufZ1rSWckFhFtWHd/DoFHayM/Dc5iH/z7GnZyVU8R4Cz9IAR/v8MEjSkc+M3+By9INB5pOK36jNzBg7RBvbQX2CilHw/ohT7c8Frmf6IZ2zNyMMCyAi4oXj7zsypMEvv9v+NSwehxPn8zeMB3MoSXnfzwElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwlAXuvSVA6UI2UOLCrtB8B+NXJCZuh8egx1aFSrSNtkAKHrIgXSBpZ99n2tRE1z9rphTlbxWbdATbiJpW8VrFCA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "4C25AD18B5FD890D7151EF9F12CBBC5DC49B7CF79BE2A5437FE15BA660F7D11A",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:7Q/OPCaCRx+rkjjgRo3mirLyPr/NRnDjFKz5uIwdukg="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:QtmrusnKO2T3Ay4C2b02NKppz2dMwSnDtM+LdnwEq9c="
+        },
+        "target": "9228823284279306817296266184515742822248210830185427859262273659833347",
+        "randomness": "0",
+        "timestamp": 1719441707431,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 6,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAyukXH/ZnanqTAxDwpA8M112/riPdGFT5eMgYNPGrnVWG3KTVTvGkgdVi4ax6eUulFJDnd1xoq07fl2NPEk+URLBeAotFQxEt26PpVh6b/jy0k5tfE0rJIOhncgVJMwf29DFnAjMEIAvIOLPT9qVbLNQEMY6pFyiDQKt8OyKgVRgPjgBZeZaWzzA0Yir78n3iPQ4sDzYdWY26CN6pe3Rf6kHh+HuVD5Seb+FsIggpE1mBhYABy9oK6GXq4qI65NDsLwsGoVH5Qz2VUMHlNZbZL8OC7ViGtasy6EbCOneuI+7kCGyB5T0J+kxEzfRmJvdZL1yag1RSx9FxWFRPmnXggMZPpSAGYKAi9gWItsWcv/pUgMK09I0KED7q1WxckTQ4AbcOnyV5mF6AzxDnon/05TU5bLVgcEVjQtcI2V91yefkRAsjKgsv7gKZTeX/cWhv2wIYzbUSsv31ZY2n6rbnb3FxJitBuFD5Fi2KRlsiLBQ5qhOiuGG+Vs0UPmdIWDvKUIOzJzcjb0I5ZUs3xcKE87z5KpBsvqIfM3h6c+BszNHDtHoUzJ73j6B8eLVgPTJ+dpdEJkaZZtRRI13wdZoJZft3Lg1LvTqmVRgbjig0Nww3z6DFAh8VHklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwOtDS2Qw2/8ZrRoPibD3/w6c4TUZuXVe7uVlcVxBtaGPLE6xfuW7jcWf654NM/oUAshVSibAfIoMA5XuFJxa4AQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 5,
+        "previousBlockHash": "6C0FFCCB541112535C9D3F7FACA59206E97D7F8C03819F76DF5D3BDB16C37EB7",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:l1cZSZAZP+Xa3HOzuU/VQ2EEGfXgciHvljUkalQmZHA="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:Xn5b79Q4VamUTW4LCp0dFs5Amcs4q7wQ6GCp+KzijaY="
+        },
+        "target": "9201866281654531936596795386791503876274441021197252859723586932895305",
+        "randomness": "0",
+        "timestamp": 1719441707902,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 7,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA+HDDRgCSqtfU+unIAQmlR7lr+Vl15xGMpiJE97r6lA+xA+ePuQHVUR1+GV4Ipdc5hMz88i71DeQj7sF4jpZmhovomQuSnV/4+up8smfdzU+C5RhT6YEFTvp5z5bWxTIl+9wNboZpmNIGLUxLFbiFe/Unzh0V03ffsI3vIAikUQsLEsN2eHzXixufZEM/6U2Cr2LLIgwb/zzILagG432iByw5PVtwXD+9E6ye4q+8OXCvrZwCe1Sm/rrpTYcIEFrlH9ujolXdynOpfl2W1m79V85xv7myyedadpdgBf98hYIBfS13BeDgRxmUhIvxayp+HmQ6tnl8mAYvC23hWU4/Ep+Ox301S6rAhsv7bCIXZYGuVwxpWV/DZovCh8NCe5FmqBfa6BxaA2p+qnCAEqkvO/pB9NjaE2DJB2GfVt+6OGlPEYc5+UOpWxMFQw8DFB1DyJxpvHNxbVQ+VBic7cjQl/QeBKE5fxidJdXnGYfGSuuHZghBFkIZCJfrhMbcnNJuaGFvnNaJxfd0L8P+jND5R+SjEgjvJPh4IrqPKbMXG5v3ubYidIC48Md01wBQKOdYmdlLtkq7vcI9rcUdWUr2GbFvksNza9SmE1yGimVvZ79j6ksLp+3WP0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwcsoJNdbrQJXDZlew3/ExS2Fo5DGeXnf99Mqrl6vRFFYbkJUuoHbR7Q835Da8c/lJIh0JTNV7kRdqCBsCSdqhAQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 6,
+        "previousBlockHash": "D18C0BD715B3742DE3EE603FA5464013713CD3EC47516601CEB2F1C92636A1E5",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:z8pNfaYp9hR0Vdfjvcxw1dNpnVLFozRRKdUNvIZdhFc="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:ACdINcnUrHT649NvK9h/Ueb9HjNPli5Iedp3Nv9LkAw="
+        },
+        "target": "9174987784651351638043000274530578397566067964335270621952759689537226",
+        "randomness": "0",
+        "timestamp": 1719441708372,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 8,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAPqmLs3kEtsp6RDX27GEwYjJ/swB+dCIticFhUkR5PFKRpqDK0qtlfAz05kPvCEMeXTiuG4Ej/a+Bq4gWGIFc2oKT2nErneqA9qEfiESkRzyVEi/cjWAoGaWC0sHhhYQoJDKNCEwQ7CwqLnkjtFm5kdd5J2/5/wOt+KtPD7B/NvEOMAM0Z7vsc9SX8wcI0sJiHCMVeemCTG1+KEOJSrhI+L9gtdbWbGl8MyL6gpBkLpmM5YXEPgGlOliSUFUbwq7aGQch2ITMSK81YsTTf+7dn3up8FIROe7OVQIXcd3gaFO886h0aL/+z9Ef5/GGqkipIDJgzVZOHhRivXi7ZCSBEsqyk7QL9D723uYGFWDfht5tBDsGse2QVssYTOwctr0ThSDur6eFui9IV0qbm06ksd3DvwxGryg4UEwJEL+xBqp/WYhMAlW2wwSSqXHqqo0DjOQirJyvVE0b6xFWiDQk6TzgE6+EcAAgltmqMGcf/NSiuXWBk5EEAxTljgdivN2d7Z4R/G1PtOMUFrM1l3CdcfDmFPqQuLZ3vSFxqY9/PguHIP0qW9POjrk93IgKsq6GN9oHuq+/zynvjvp4VXQHEkZzPZn7c32mbzMiMBhbklAt3XD2DIIzhElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwcwRDzsXh5cxHX35HkJ1kQdotmhaWO6ytlzJpO2q51d5Wopic26jC3z+8ZHtDu6ot5FKg+d6JvTL6gtXFuyhWBg=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 7,
+        "previousBlockHash": "0BB4B6B6E56E8C9A863EA4266D2D75D79E23E28779483EE7337EE4F757B5F049",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:k3BDdZVJODTWmPWsUvVNBH54zyAJBTGcYegReQeHhyM="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:cWMk8WHQB6zLDM7ilPcWI09ki2ensf/wyXSMFjhf2x4="
+        },
+        "target": "9148187795366513087508709149025146424715856256637674150531751753357577",
+        "randomness": "0",
+        "timestamp": 1719441708837,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 9,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAbnLEHaOgEnj+BuzPXF/0zlnW7ZxZytlIqi2EsXbAkBCqmHLASf7uaDoyOH5QcbjMY3qwjgHuoTaKdCvKSKFG4Ak0A5M4NnC+PNDyc/mj2ku2IVrA1E8BmQNs5wgFWlOW3sy1OcnkE69b4ln1n9He/uen3q/EsmhkJNZKe/OftXkJB2j+N+3OBGWSUaUEbBh2gaH2JmXIKHdBEUFngu/JEPXNOF2iyQaaCIEFNkoe2uyxrwsULYDIYnFVR1ZMWrQ7MG3Po04muutSIXMtaky7S+AdCk2efHNJqzxFQRJaA668/pnQVHqkr7z9PLdRt32mqRS9baFtsfBJ71UZgOWgI8Jb81Lb5k0BNfWLrg/PvOLrAs9VhKqQxgffmAL3bY8T06DrAcIbM2L+ac9k10XKsRjejBq46jcbB6Jnzk22AI4/2+pqZSzltRAddtOFkZUmQvL9EMSEsy5vG/dqomndgeFpFNA3F47LXtmFn2vXaraiZbovuFFRGCBFx4GwQCXo5IPXEkRDU8REmx+pC4vuym3p7wZzBII8TkN+fqiCwSSt3xaemYD6GdKuO+LuzPInqFjhNK0/OLOKk6V3SIVVhpswyrk0UW9hQ2RbjsR9h+yXibUB4woaKElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwjUHz9KZjRvDfUpZtLjkDOjuDQ5op+Z0l9unsXY1Uc7O4Nv2qgAa2IDLfi52UMd8O80h1yzGqc5b07P+sKRtTCg=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 8,
+        "previousBlockHash": "DD2E10F6A5EEE09B16680D21855369F2271D9FA73BDBC300FBBB891049F3D7A5",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:ml8D5iykqwVr05+UxsQ5DRamCVvVfGN3SswiLeCHW1o="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:2qqjRiEepseDBj20XRTF6iHPuR5wfZgMQy9TzmVtcqI="
+        },
+        "target": "9121466311864876128923245652724724632104869735746188813030060672759072",
+        "randomness": "0",
+        "timestamp": 1719441709303,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 10,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA21ilbjArKP+C4LpwOnmDLX7uf0OckijaP3ilua55UYS5eFH8tRd05pWBm0VwtWA7TsTogKdGp3v9tVXUWCj5H0Vss+53PruNDYmqcnsulY6hbk+2JT3SKLD2dZIPfwvPe6nAHcrhYQFGhVd3nHlayfjUvxRGYG+vpVIKBK5K9koNNCH/63L7QoVc7k90yH76rk2eTnAINO9qMTG1cxOePap/c2CTEOKUJCTrhzoixBC0U2NkODHHwJZaf8Z9kgGf/Tdwc/V6Uw+OillwSQ8P7g1BJLZQz+IQOyntED2VpEBoq71z1ntz9xhq+L/59b1OV0ZQiuPbBfJMLRfvlbQjmmOeYIv1XJibBHLUV+odU/bGuaZiYed5UQ/EeC4BZGJWgw/GJ/g6M2t5wujBVJdWZHdeBVkLi3PHr9RoRw+6OGANyuIGZAs9YEkrnUt7weViRmO14GLnbgJzlKnuTTRxEJd6scs6+LQJwjxKqTH2Z/kcnZ++uy0h8ZmfhHE/AqGaDc3roqWsI5KnEVa3l6hrdvfakZrIlqBlHVG3A5bJQSpLLgISA5TEKfvOXLCZgSeV+dFjGlK+/tONsneaph1AzzGEZWfcNP1NYsYmlo/8F68Du4tMTzIRzUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwzrU/k7Joho9/q9tte08Zb2lMIVC+Z+N9zu9NVNUgOw6Rrix1XS5hhpZMJg8Bpgstix4y5KecXbg8kBQZUI9kAA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 9,
+        "previousBlockHash": "68A8E7E164F55EAE6C472227972BC9F36715D3334BA410E856D0B716FE454354",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:A0EePpa2R8oKPAW/9QsU4IsShV/gXumNWosUa+SwjE0="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:lqyBehni47RhZPoC+o+W5yLgAxSsKeOSX1GGUEJD/Xo="
+        },
+        "target": "9094823328238119324660168503613036415495463326164889575918026009508991",
+        "randomness": "0",
+        "timestamp": 1719441709765,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 11,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAuWwvugJs406ahfgO6OdzFvIgr3h+590GcwHZfAL0wq2PgfQiAFCyU5/HKtALDLNgeAAs5M+M4QOIS1DMbbCTWvMOh1XKjRslqiADR2HzOCqjiSyK94jYw9HvhcIZF5njDk2chAyxaMoqwuHKDsEAGHcyTLTeVmfQBebnAe6NtsYKS5V+Q8O2w+FR8d/noKKHP3zht7ZARE7WcA0VU+0++mcPIW5BnNrfI3jl1uQCyzyLNAvXSe0oWmxPAzy2lo59hy2mJ//I4iTu5kfqhWZj1AVgQhRNGDe55g5Ypsr4o3ivyOZoZExuQd+azZiVtwVrbYzrWVj39Wo/W4ug1SxrQhKY3yCxXfT2C7q9rZbx/VqVwX9Z/ua6nCbvpQYw8NM3I1ty8CO7CoWyMpB8TH8zcZB78vqapSGfnsIXcv09fgXbpuV1Rqpp5qkYOi8wsYECiGS4TWYDr+xOPxEorBddzCGDRbvu2dwBdsX/RV4SjfizP97+uEP3OYelDL0Vo7j2ffS+EzRg/JdSuAGzbeYr3OgC+uBp7mil31v6KyqIXi3mJZPSyOhmqcPRCQ+/h0lDcU6vaFVV+fR5Ojlw0xIrKZBr01ILydtb4sx3gMxg6Dpb5ueEnMfoTklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwaoEq8vrFIXGk/vwRx65L89NP65JXnguMH14mcNj9aZjXLVFIcD8kvDnaGLO2yzsbFpvztR/MhA+RVc8Ux09bCg=="
+        }
+      ]
+    }
+  ],
+  "WalletScanner skips decryption for accounts with createdAt later than the block header": [
+    {
+      "value": {
+        "version": 4,
+        "id": "d9a15ffb-857b-4b35-9cdd-f6aebd6fafb4",
+        "name": "a",
+        "spendingKey": "22b1818679e09c97ffd67ae0860ccaa55b2647bdc4e9c7124f7d1bda0f56afcf",
+        "viewKey": "2c0c02c7affbd92a2e0ebe4e92c26a40e2a75648edd6a3120e7847f3d8b022dc72611332c4649d178fd1146cfda95188fbd84c78476d617163b071a2115b00cf",
+        "incomingViewKey": "8725edfa3900dc75bd03d9b3d5cfa0660343b51184180e58325f78ea726a9305",
+        "outgoingViewKey": "b451d2f3e6f74f91db3ee30066d9da1bfe910ea92b96a8bcd894d4f08b6b82d6",
+        "publicAddress": "3caf65b0e6927c83b65dd4a4665ad94374bed54388eb75b7891d24ec52cef4d3",
+        "createdAt": {
+          "hash": {
+            "type": "Buffer",
+            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+          },
+          "sequence": 1
+        },
+        "scanningEnabled": true,
+        "proofAuthorizingKey": "d6fa34fa12847f56e656c4053b6ab91ee02ccf0ac38390cbb0fa82361ca86d0a"
+      },
+      "head": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "4791D7AE9F97DF100EF1558E84772D6A09B43762388283F75C6F20A32A88AA86",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:t/nGRBfEM41bTDxqlaX709f32cBhvjnkDBuhenxUZFE="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:U/40oB03yqTvyY7aSV79yLUPad/shYB6WTv9jd5Kxak="
+        },
+        "target": "9282972777491357380673661573939192202192629606981189395159182914949423",
+        "randomness": "0",
+        "timestamp": 1719441710613,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA/esP+kmF8bkJ1NxWAyk2dmoqjlCOs4l2wFfu1/iCzO+p5NndvXVSnThaEUKtr2Rq8aq4Kq1mShyptH74ToK0O0SIyUN631Fcf6XOjVuyCb65EvVqj/8RvBA87I+m+2aLSyhl0ktuZMl3pQzPATdp8cML2HsUWiZCiTS/CUco79wTflqXlBsFEZSsjT1kilmVxwquvQt9qESHLb29Y9XWJnHSbrlwWNfiefTSvHrqVaKEaeys3SrVzyNSkvJOvHNPnpZdvTBLumnJfcViYjA0gahA1CPKODcRzPv820Zskp8hsauw3byb+xVfCZQGA5melUg9x348Eatp/5WmM3ZTRZ+61GOXhfiJVSeS+JluL7zkzgNkxG8qKxc/pmtGRsBrloy5KKtN1jY7BB9r7qqqvD0WAdXknZkqpsBFtJ5qeup68B7TAfbTBHdUh5vAbdtCbxoANOLQNrdKM7fGEc9f37KkJk9KucJdfAY6BYA3bK41jVZgBLzaA0tEAXx9N9MAVUW8Pftt+xowV3XrWzjO2G6UHvS8Y6lpNR9rc687O5ogLrKyvqE6pYXdWFesdm1VvE7E/ALgQxYPJMZRyVQaU9RXkNrUixVyo7/1dKNjlBgCg3GC9OyqaElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwrRTjhXSQIwdA/IwpRPE92hipHCD86Bd8uVV7UY700aWK5JcRmYYUTCBHlr3EaAP0tNqY6uH4T3xUxi2hMUzwBw=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "B69F5673E6D012B151A6E7F1EF4A49BF8982BDFFF46F5E15116E4D52163D641A",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:O5Ti0VZzOH2K5836j7oYVkvXnRyaO3ftHWYowlVy/1I="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:DIlzKFLoKriJ60ZF5Z9nW+RMbEBDl9nsXK2m+xubzxk="
+        },
+        "target": "9255858786337818395603165512831024101510453493377417362192396248796027",
+        "randomness": "0",
+        "timestamp": 1719441711079,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAtNXI4O2D3UHH3OTDo/uka34tATF91q0lEAriziW4/jqpVdJKRQaod2TfnAR2SsYWJsiMNTv4xXatHuCP9xSDvKuKDLe53JDUBatP4wsRLAW3kBcHTNrc91Jh4Ixjc3VATU65ok079ONqvsYhQEOKEDW5FRosPEhnxo4edvpdxFgO+ScfLYdofprgR9Tca4lWQmrHCdt8qibqLTeK4MwEfTPAbn3Lz1nP0xU1PCoIIIOT0jBeAe6nhuh+GTSr9xxxezvMWC/XiS3SKHvOKKrQVUvZT1TcwWA1cBJdMBQQir8itqTArADqCF/U401oxKu/9SfNqM0stq2BW5IrReKKXtkIpsv3ZLCy22Ytuw14nzWxPUeSN4Z1VfRYVRjmpepDho5JxB/UCFL7e+P/oSZkygTfZ+0uKlPIyzRc47SGP0kgTFszyFeURXpbzzfkY+nukmjhk6t+TCbKjksYaSM1cR7ZQ7PL0Yx0bRrVoYVYTZlKGD+J6u07CzyUvWlbMhh1+EtH5nmi8zUtdUUVqNrpuY52jCucc8BqOwdUp62GL8UM8eCJxiUvJEnZSMDGndFP1kbLxCdhybgMwcu9An20LGOL20ahOeyD2/7uqrUKDW9tKEcVOr5VwUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwqaZ3rvg2P6S4roBKdX7YfKVaLgQxWauz1mqT6E7e2pQmDQhrLq2KOmLtGAL2UDIXyzMuaTnXwwUMgkd+xonyAQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "F8C3A577B51F46225FAE20DD8B4A69882C775183A262032F8B7739EF067C4BB1",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:eRIDTZE+Z87/uElJHpqUwrNlHDuCezdU3SN+XaAzfTU="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:5H/Mr/pypUmRoTmGXiaWRVkeYmFJveBYv/8DvQxh+KU="
+        },
+        "target": "9228823284279306817296266184515742822248210830185427859262273659833347",
+        "randomness": "0",
+        "timestamp": 1719441711542,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 6,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAK2c0dfSgQKwQDHZWhi98pAEQKTri9HeXcVAST303romkp/rz0+oDYCPVrCPg3HciREuiW3d6upXvQSI2uCRLUx/l3vD7t2UtkxrRU/9cI1iw6QhKMi82kbQzwVVV8Br2Cpn2n+u7Vi7238UuH66I1nDnNtMBodKhsu1zoMrbzbsGIUwgHRwBUbGAT+e9RUGM0kMBr6VXCUgD/XCYpYJN6A/BIflVu0DRocgqqFyZbp6S/j+joJqsxRl5cYt1PQ1E3X0htjCBE4XtD2m8RKkpknRFVs09l/5WxoKRl2CuG2xfR1SroDKEk38Y8m1SQCPkpIkiVrjEgrdPSwMFz0mH8rYJ2iKoFSG1soeAT2U6svW81enpg2OVuya9iqmHKAEuXWlnruzI2W7ZXOc8/5SlIDUkbFIoiSongTOGsSi/LhL2xPVgLJkc97cHNJpSsv/qID+FBKN0skuHduZ7pMghl0ZA/tGx0dfjuwn7PVZwdhZVW2tP85o9WZl0LdP5PsBJtJTmR+J+A4Q/XXC9JOwodtqMZefQTXjPOyuhs+7a1Byw2oIYGwSe983ASM02a0OxH0IbKT0NpLtWmUvjMDrHPROaANJTybw0I+RQ3FXeF0sFTuyDxGoxB0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwoiMgzBfo7rCtYWvJwbmHLpmTA9hSjXqLmOblA/ojpWnmL98ZGsDxzfQGJmhhyK86xANnS9T5CHfUwFsGoUFKAw=="
+        }
+      ]
+    },
+    {
+      "value": {
+        "version": 4,
+        "id": "c1f6dd22-e561-4f82-8e6a-9c971f15b29f",
+        "name": "b",
+        "spendingKey": "bf4b4f8c66d092df8a26a7011821f031f8ad5afe8b1fdc4acda68f555dc16752",
+        "viewKey": "589dee75144a22afbd2a397ee9607f5ddc375ff63b3b9fdf49c0ce73b6789f65ffbac13dfb77c2b254f6f1e87f426359609280253dce6867d59dd99d1c8faf0e",
+        "incomingViewKey": "469135ad8fa89d4673d6d1338e19e2e6fc8a6c15d63084957315b72229451b06",
+        "outgoingViewKey": "270b99007c639c03e1eef6cf30afcba910f9105461590e6500f7f9339cac28ba",
+        "publicAddress": "7f64a69fdbcb9360ef620bdb024b781c162c7319bb5a107a087dd13abdc09466",
+        "createdAt": {
+          "hash": {
+            "type": "Buffer",
+            "data": "base64:/ipYiaG2PnsWFJVFjVpEDDjM5lxOzAzZ4d8hkQR/kU4="
+          },
+          "sequence": 4
+        },
+        "scanningEnabled": true,
+        "proofAuthorizingKey": "f23a343fffb68241b5fc6e287a79c2e65647d1179a3429f14caeb0062d2f2802"
+      },
+      "head": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:/ipYiaG2PnsWFJVFjVpEDDjM5lxOzAzZ4d8hkQR/kU4="
+        },
+        "sequence": 4
+      }
+    },
+    {
+      "header": {
+        "sequence": 5,
+        "previousBlockHash": "FE2A5889A1B63E7B161495458D5A440C38CCE65C4ECC0CD9E1DF2191047F914E",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:p3+mAe7ZXnQg0WEvnZ+ueOASbdoQy9rq1uT1ZCCWDyU="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:jIxPONrZpSh6C1zCW4eGEYHV73i1iEwB0NDY0q+JH8Q="
+        },
+        "target": "9201866281654531936596795386791503876274441021197252859723586932895305",
+        "randomness": "0",
+        "timestamp": 1719441712010,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 7,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA0PREpfnx1UrnX+G4RxRIE3vdgJodv+Gx6c8Wj5Hl3vCB/F0eRwdvjmvzJXUoAb0vH5hiOyE38jRlTvXTy9Djy/yAu6aZsSD8uMDmDYz0JPW13VFFV+uXEhI+BAr0yWlYLT309wTlGuZYTRERzlaAfJivK9J0HWmlRYI//tLbKXURurGgQg0ydm/y9dr+yy9SbSr7UfF4vjzRzH34PwK6kldpt2mjcXvkimOuQkkpmJ+xzWUHhP+vBtd4xZeFn9jII0kmSjOgHkMa7W6krvRwoE08HS2YdzycTbtNAQL0UgXrgjzr1gMcdPQJMsQ0tpNdOoOq4ES/RVmxBFGoU2v/nz9kEwuUGZitKQRwgE0cKUzx+cJ+vinOSQHCjX7EW+BvWy96VqbH2nEdFbQv3fIEcxEWTFl2JWZxL6YnQI31el6sZ/p0hhmLWnBTRI27xe2v/qKCr3FYWYf93idp5eUWvX5f7xVGt02YTDnOguReTs/NccxhA6ngIfo2BNeHr1xqtqYuqByks2Er5cnEjZoHYtI6+bDd/ubH2BFZtYei3YPbAFV5ek0utWHr9lg6xAdZrNMOzrlH0rZtQgN/4w8a34Pau20xBcFcSkXZKEzXx3N6AsKH7qFZiUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwIdhdPRFQi2+z4y4df/EZISDxdU6TiHEdm47T18UKlGsrTwPVFjtibl3l4GX6er/2jc2MmRVhY86YxBYnKLOLAA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 6,
+        "previousBlockHash": "689314CE4EE1C3BBE6EFBA25F64A8596EB38F70F25BFDF6F1D71448D82409B9C",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:EUSZDapvMTqNwZ/wIVqbZ27l520PL5mcDpFjqO4J0Dc="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:wYTT4nOnC08v1j4QD2y7+y7Ltj/sLzRMAo0DG+H7fMU="
+        },
+        "target": "9174987784651351638043000274530578397566067964335270621952759689537226",
+        "randomness": "0",
+        "timestamp": 1719441712468,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 8,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAwB9MZEdyIee95Jkofyz0wz8rvOnpqd4WcrhQhDMGyuWurYlBXBftPylZZTDIpw3DWvRNKJ1kiaJ+fFs0pjlJCImf/meYPcbg+F4iQa/rtJCIYwaRgPppCPTQ4cDYvU63n8wANuR/TUXtp0xqO+RD7ugTe/+nO18p5zeQD2K6rzYJyefXm3/IA8oy8RlVhZhuF/CsgdhO4jlLwKn7xJI6uVrhsRmrYgZ+cZWAffK170ao0EtQaUbImLdhMpApQuwcYalLPvSuhZsmmXVVxw7kLELWZjY4QZgL6RoxR3A+MV7qpc9CluvOH4VKsT4kO1js9mAKyVKMFsaGDnxRRu8+LGacuXJT8CKTsT5huUtjTpOHy3YSDiIfW05QcVRWgCwFLQGrqOFpa/N3Tm4PUBAH5eOlA8r/JGQa+7wuB2yfGxVv9XwegM5aVWVvpua9u5mghvP22wmWHmMeHoIiP2afwtXtzn2VZyWqYcRidwjwGcMyqtGlEO3GefgFdjJ7FhtJMEeppUmk2EnjX6efHuSOMbzrWNCamS/qq0zXeQq5MHZkL4pEwMdYpe0/uGlZuZF4Dc/ES5cNM3M3SRrGQhFNLJ7aWgJzKthI2mobBBG0/n5y6vOY6lIe0klyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwd+jPU9f18mMXt3vsQOcw7J+kn3dhQCpscxHOFR/KeC81K5IG2VuVSbddtR8u282W3qB4+Zd34WAD5renxxe1AQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 7,
+        "previousBlockHash": "18ECF56F6B123864351D989605EC8FAB4C24BFD4393BB6FCDDDE54E42C8E47A5",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:VOICD+MfsxjYm5nKiJ5i26H8B5ij7LYE67TfmvIGnCM="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:hcYO831nU2O+SraZYl9+P1G2gPzqzcRE4xMWIBJq5gY="
+        },
+        "target": "9148187795366513087508709149025146424715856256637674150531751753357577",
+        "randomness": "0",
+        "timestamp": 1719441712938,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 9,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAzXqmfHoGn3bU85f/Ho32mrrGpf+a1i8zalQyF5dqFQCNJBER8uHVNIJB06fECw20Os742eM/qSXRTTx6Fb8ndjPuu7D2sB/SROe0yod2db6QtpMqpJ+hroCaWb0GW7bS7Za30ZOLkJ5guJESPduOn4l7qa0H5EHxnB0GqyG/lJkXRwFGQPSd6sFqXC/86GVvtVIaZ1b/8w9iD7svVmtHsGMe49XFeXGwzik4a57E1Ja3BIMtYhOQgwWxi1kgmHJdZ+RVUJnMpdG/OkxvuOsSfXYkV9U29+IOKL5RpzYdGzELq6npjoo4lnRIZIYuE8xs9u4go7wSJ2XRB0C1XchAEQfGb4BA4oOjLskIRhnzqjLGTORjhVDnwozg13QV3Y1z6moVGKH15E26ZWuicVI6iKBHWsUoy1Wdyfkl8SBAC7ABhWy3gQ8YsO2aW5rL67GqlSIzjfhuTFBkHbJjGsv0Q7lNGkAIUmoNNZ5HvuZ6B/bF14Yrh57kVIaJ3QofdLu39g3r1CwHy6Nciw1fOf/3fKggvJDAvQPMPnLVIMmnDce9vq3ur24qX+JIwAQYTTuWpwbDf9vOKBfvMqDxNXGkeuamS55yVeoVmpjiQAl6jK2HrW8nkbsaKElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw0eqROTMQ4tkbiKk4O0z+Hp1nYZIoviQc9R4HXTa/JNiUsJbdb45S5i/tUQWr1fot/1SHcn1z7LVtS5dNj3xEBw=="
+        }
+      ]
+    }
+  ],
+  "WalletScanner skips blocks preceeding the lowest createdAt": [
+    {
+      "value": {
+        "version": 4,
+        "id": "0f3912c7-d0dd-494e-8b8d-f0fb45510f22",
+        "name": "a",
+        "spendingKey": "1616f3fddfd2ccccf7fc1ba6d43ca07ebaaa7da1cfed5b4df8a05aafeb5ea0c6",
+        "viewKey": "c2d1aa0928bd76503b0b02affb8ee9b3efc1238aa34f595da93d24acf0b1b03274ea6a1474eaed8f1b451eabe3223a82a013a07373ce23e060b13b489d6bbd61",
+        "incomingViewKey": "d92c1aaca2cfc6d8d2191b38cd371ff05113e8a881cb8fc7a5f780276d83ff03",
+        "outgoingViewKey": "75bf194d2ed96fc414dd7731be658d53eb695481a043955bdce568a5034e6826",
+        "publicAddress": "669c07cc167c86b1b6cbb66dd3ae7a6a4487764d134defa5ff05c8aaeb15f1ce",
+        "createdAt": {
+          "hash": {
+            "type": "Buffer",
+            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+          },
+          "sequence": 1
+        },
+        "scanningEnabled": true,
+        "proofAuthorizingKey": "1a08001b02f599ef90837fe444719105d73e8fdcc0f0c986a5e27a14b8524505"
+      },
+      "head": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "4791D7AE9F97DF100EF1558E84772D6A09B43762388283F75C6F20A32A88AA86",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:n+sWWQKt9PbwH7itYIFkNooevniZOIfYBzKE0+xGoSI="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:xTnWIr3ftgauGO15C55qB/rZQSdUmk9t0gFa/WD0xds="
+        },
+        "target": "9282972777491357380673661573939192202192629606981189395159182914949423",
+        "randomness": "0",
+        "timestamp": 1719441713706,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAaSjZbAIdjtuTTaVpUn0OR4V8vg5kicC0o1hrMufop6Kho3YexaBPGIarOwPBk2F1PRukFnGDRV0wNtoSYkGSo85WND5oQCDoLzUlvBd1mzaXs8lSAOU//4uait4ov45uDToS2tldx5nEymYIOss6fimjQ/cdlqsJ78sOOTZ3brIJwIxU4lGLNbyiFpH4u9GKxD783SV+YZHVajGXdYNngvYqlxKJOvF5io+6McKWZoyka4LlUFtIK5aanCVYzAJShZdBvajRZXeVHkHAa+tqyafcdDnNx5Q6indRxTuQJnl4zla5xh2fNuc2tp5IHpeYr3bApMGEGOZ1G11S+W7w7vWJ1ZkUwP3I8ME/UA2sIgkmK5tIuwPM3QT4yhvdY0840nVFs5XE63/a672GXHa1OQMirduB/ajEpfwnL6LV1lj/YLt6ooe2x/AIp8wsvuzdrRvy2M+fUlCnq1tJuXRfD3fl4yx6iZIG3LwWE8A/zr6C/RUWO6hwTAON5+dSzSSi/hBOcDA6XqOnQ/e5I8lwFhklECpZqdfR9bOuo/zdM13wnEmayBU/yuQfQkGr/ynFCAQtcSzW9z1ujtnC5y0hUGKcH+xpV09IgKEpCH/nSbCqvB6g6wwNUElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwjk62f8n+8CMYl8g8kq6FzMdsckL2QLK7rUji+URQMm3FoOMmFjiB/s+r2h4wJ+45M7LgYOKsrhudonvGuTujDA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "0E8FEBC9A909790C9187E134B4A60AF90DB372D207886A2232FFDF775E43227F",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:s3Z9V1u6TfkPU6X485a3RY/cnkStRIntVC6kx9pmr2I="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:npxn/zG7ccyTfS/RVk6NqFxXNTAiBmDp9uh+4KyoZZs="
+        },
+        "target": "9255858786337818395603165512831024101510453493377417362192396248796027",
+        "randomness": "0",
+        "timestamp": 1719441714178,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAMKtT3oq1JfB+hNdK3rhdddiav6Gjul0r6/uhW2xqWG+oLDDwd1mtek0+3VH3pmV4IeauHL2+A6B+iZd0kEYzcZTkv0NyR2i/nFwR4GwgUu2ywL1s2r2BdLgoM16l12Ihys7IZMDZbfgZCGWBXzWPfvZXPyXw7Q8BrFwukeE29bUOKBlfTSYgaQtbmNpDP9obaj5by+Ld4Wo9fuJlBbawRK/13rI696XGxV1XvTdj3vWVYQQ2OmN+8qRHSpo2xiCg1fW3N73VpM2UorqhwVSAT0kigxxXpoRtXrl+FvmHwjLECmIZQXZ78D41fdn7kO6iyAkyjKwh705kmVCLbDqXH40JMwzCdxqbHnPsXLFELLGcVKCR9sY/JH+/kX5444sVl5d4CMkfOSlVwWXanBFRBPlNgQ9lZSaiQmXr8Gcm4RrziQQU4Iqj7piTxULqrxiTZZQBXrQAIh+W0In4QaGmhnT4efW7Zj6ri8Pliccvh8aicXuwULB1KUUmpYVvZ0286q8chbb4+7npLGwkrdxf8J1ZVill8+YTEKjkujMOAjY62F/9ahe2tw52+Hb8ZG+oAe0SULRoHtHBNN3efdygB1qetUNJLf1/I8ccWzGz3GmBeHrBHMKHIUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwUiK0RaSNlbAhO4HW4JAEMFCOektB/wIZcp1LCmsiEgpGLT/xfgZ2J3Jl/8WkcQ1JPg2QlDWsXVTVffCysfekCg=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "050ADA5533F338F1BA0C69A22373CC1C1720034401038699C5FC087FA41F8458",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:jFaBsVq1mcjZ2booxT9RGj8YlxLixkSETDInn5a/dHI="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:IcQgSI+5kTae2zkZc+OKhqL/U9tdCz9ljq2w0p1Cw18="
+        },
+        "target": "9228823284279306817296266184515742822248210830185427859262273659833347",
+        "randomness": "0",
+        "timestamp": 1719441714662,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 6,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAwpgPAEyajkka4eeMl1Tk7vzRxWDNfzQ80jLD+sl94z6BTuM0npeeAz1butHPEloBEStOgU9GLY+Yz7RZL6Tw1uapHzy0v9zgAWJ1fraC2zqZglZN1owevbu4xrj+mPawJnxHifmDmANPtNaZmeFqJP8gMzJ4Aq/eNPK8tbr00scXoqunHXbYvUdOX58xFRGa26FkoUguSVYf9Vv3WI00ycBpeNB7xrSmG7L0aqgHswy1DcCrgQN/6f376sfgWvGOn030p0T4U8BsjDkts5LnOnAmDpyKhDSUzEuGW0d4oC0Ds2mP69qH5VZeUSBv7nTg188EL/IP76k+MuviK+exc+WIboGykNdBnFzXfC+4bp7FetmJGcwYHpxjEZbCJ6wohCysB7WcUEdB1keMTtlLi1nLRZRhiydnL4B29nWvCQ9/erdiNdV813a9MDxHJ/b7BGLLY6WA54A94eIiUuZACDFWX5oBCooplTRo99JCf5Zxz7Kz8LSWN6EqqNd8BiVuvyk0pe/v9VbDR4cPjJT2hToWAcD5eBdczRbe5wEjTBc5ZAccKncWAUCh4nRMVKORg27mdx2AXJq7ugkuodJ5bYr7ntBDgnIGsUitIcIB76yKP93XaU5D5Ulyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwh+p9VR4u5B/UFJ6w8Mocg0H/QdLwjnL8ZafcCM/Mg/NcOn83fK5gKEKkMDEjClA1eclNc+T6v52xmbcIZlHLAw=="
+        }
+      ]
+    },
+    {
+      "value": {
+        "version": 4,
+        "id": "2ab7a678-7f34-4cb1-8a0a-bec779f935d4",
+        "name": "b",
+        "spendingKey": "7ae31eef18f3a40596fce5062202676e5dfbd3d015a674ff76857fd97b9ad623",
+        "viewKey": "75e1defc921bb4d6a2487cb79748674ee91a2977f93779871280a6b37e9072a581595f2e115fd38dd1d994600fb8fb412771ae1672a62056462b4072d95a756c",
+        "incomingViewKey": "effdc9b669b507c5c5c6ff4a024adb3a067c0c7a983cfee72d3863289cae0105",
+        "outgoingViewKey": "d2a463ef226bd1a539ae966e4486b4d73b545ea427cdd57a3c36332fb745ef84",
+        "publicAddress": "6cdb2bfcb2befcf5dba27e11dce86bc37e8c0f8d028c816d462bf580014ce92c",
+        "createdAt": {
+          "hash": {
+            "type": "Buffer",
+            "data": "base64:AjZ0RgBBNBs4qIs7/5Po/PuL/08a3K8UkG5w6p6VNmA="
+          },
+          "sequence": 4
+        },
+        "scanningEnabled": true,
+        "proofAuthorizingKey": "b3ec5c5ecd614b5ca21e5b1d19e2967d3e4d9b46a2f7a596b3973a5df932d709"
+      },
+      "head": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:AjZ0RgBBNBs4qIs7/5Po/PuL/08a3K8UkG5w6p6VNmA="
+        },
+        "sequence": 4
+      }
+    },
+    {
+      "header": {
+        "sequence": 5,
+        "previousBlockHash": "023674460041341B38A88B3BFF93E8FCFB8BFF4F1ADCAF14906E70EA9E953660",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:rhCy5v+aagBLTFzuRQLjb3qxjOObCYAxsLPBlf/++T4="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:P1UY1e3sVBtSfeNG0CIizxZi2crCe8Lo+30reKwJCxA="
+        },
+        "target": "9201866281654531936596795386791503876274441021197252859723586932895305",
+        "randomness": "0",
+        "timestamp": 1719441715146,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 7,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAs54E9HWNTTiXFcBvkNzmyp562MuJF9Dsose2yAlsx5S531ki6xZ7opTMKPUADdiIgrw30h5xiDdZQK5r5XaJjqK+HUYia5Rtd/HTCTbxwvSyV1zl6S1iMLP1kJQHmhg42Y372K2XQsJy5wk8fDj0gCLMqZ8DvM8FvipBRMLzwg4ACkc0iKce6VRCzPr021BFY8hbrqDCzcyODl9KXkNe7Nb8f7KaN+RPF778eFiUNkCNti4ing6qS4v/Z4QLiwdrm5h1JWh+RCCPOws9pf5BRNgLYKpv1ZxREHNbKVWKCpyFMGDa4Zqg3MaKz4mb2tKtoLVyQcHL7Me7ja1gJW+k11zTvdmAAzUWJIU2Dybu9n11HajhFh9MxW+magWkp30tOitFdzA4WlT2h0HRdWNph6iGRjgZrtfdRIZudjnosTB4pAe0Vujx+U9VDAB1VliMtFRYAqO2E7RTzSs+1IqxNNEvfxTV6zqro6MfOl5YbZOcWSxBMW/o3kS+B0xE7R2cSamOG0bskTY2fMFZZl4uwE6sCs6PkwNjI7Ta8jAFT9YWoaOBJAX7a+PYZjxuXPSN6nXMJX4BXzo5AwS1+jhHLkqY/C5sQwiUkmaIxO5RwKLDpE309V1dl0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwOKaw1frd5RHcG7TER8VH5D8xxpsm7HMr0AwyENLbFpmpxiwIF0Fg1/G49EfilNsX/SlAvDgB2rlaRb9maiJmBg=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 6,
+        "previousBlockHash": "C9669A682E4EE5610FB8750FA51020662AF29F6811ECE62785088AD27700B8EE",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:n75LmFooqdVeYYip4h/WFM6VFxCZ9OES4nfZUv7a52s="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:93lLj1s7YLC+TooYjqFjGmn6zgoVpIF/bmdX8RgTfIc="
+        },
+        "target": "9174987784651351638043000274530578397566067964335270621952759689537226",
+        "randomness": "0",
+        "timestamp": 1719441715604,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 8,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAj4CiLhs2IHU1PkFZKltmxULim5udHt8s2bh+Uv/UU4uou3DVVEiH4lQdvRw9yA5zqnAOWmOl6oBsRVgrKn8fLcwmOiZsXl1bgrlUkqGPOEChrHJVTlt/qAF6xa9PuxvIhgoLBMFxEtORRDkC+5RckP8M3dvIBF3+3cxTSSdqUBUKg/CUNxXaMgVi3S0xU9y1nTOYEu4sFtVzNYNjAY5MmoICcWngxxnQzSkwqTVurbC4CxW/42UbMFCR/LlgzELYFJpLhxgz6jR7Fu2QrAxu81860jWVOs4OeeWiCCU3p2++jyB0Hcweu/3IP7/eP+aUm0ecVRxaiFXo9cpNGoCoSsbV+/zKv/MLnUd9QKIuNDBb8/n9tAEeOZUt/e8VfpIMBo8+eSTUbXmybS0T8slHq8ORVO1TmFDcN7wsT0ED35vWaUzIk9Otn1vpnAJibvmbGlFUp7BpLz3J6KH54ImmLqqb95aJohKJmqeZFuTkLy6N5DRhtN5Q88cQhMz3R5+Li2PZy8NpYLlk4mJypfyGYhiky0LqEPUfI91Bm1Zx3NACD1VBlItLYBoI7LjFrinEHs1xxSm1AVVJxd4Ckktjsl9ILly9yH6rZplmiqBFbvGKpLgkxIMU8Ulyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwO4LoCRuzeFt+cisoqjfFzzGZ3yDmDtGicWz35r3oF6UCZbUR1RIHLxN8Ja9on7VzfEm7Fn0nwdTRYW1HfqRRCQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 7,
+        "previousBlockHash": "A562DF2A70F3C895A03FB74102E9659F9900F8B54E9DAEA04CD087ED24E44755",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:Z77o6+kbFLouSQoNIerXjL23qy5nbYjBRfHsVMiDvz0="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:hfRtvGkUUTRcbaf1+ETs7yEs8cp0C2feg0RtAFwtqD0="
+        },
+        "target": "9148187795366513087508709149025146424715856256637674150531751753357577",
+        "randomness": "0",
+        "timestamp": 1719441716107,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 9,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA4FcrJ0yOAGHyKR/q+WLSBtoBXhWAVIJn9kUe7zTPpeyBUB2CsG2Ikrd80KVFy3V50rocDc6Vh+Sv0KNNquREpsOeYmarnlUTf5HGL/Vvt/O4G1vj49j9N36GgGwCptsB8KqEYYS8W9mxsPVZGU5hn3IpCLi+7U4rkpcJFPDtgsAXoWBkHKatWfiYm73gYHtIIG4mtLJPGz1WxLOiDO5JMvhl7LeqJxoomCPwn2ZkCPWw6uxZ1WEIiXu8IOHupCzKehp3wJ8NjegQch73s6UVmxLiyBuH5cutxC7XsHxmJtbVfdDUrL4sF1x1o3O6CSTgs4JQE9h4IK8IbJyofpRZYm2f/HyYDdFrwEGgy7Ey42kP91mAOAykEiyf/YaUrxg7gJawArtUqeX7BJEWxITpvv86uClQNHTlyv66TgAi5jYrZltV6ETHXoLgvUK+KNC+ifR7iXkOoUEjtSVurff0OmAf2nixpYA+4MVXbBKS4oxgfn5U6rBgFxLAm3dqLbUMPHI5b17NOEMfhGBfaUfVEzQjNvs0g1N/2Xamlsv+V9RTkqPqUVQaUlnuIourCuMrwHpAE5nHkfKNbKbMNZSeNKjcPT6lpPI9m9C8tQXSMLMVAh7d/yAD+0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwCT2TGuANbPq8HuWQmlT2a8TnepbB3DCQAZ6zLH+x1CaFcRCSt6NxlfLDzrrMKMBGHgYp1SmO2fhIBnf/sQNtBQ=="
+        }
+      ]
+    }
+  ],
+  "WalletScanner restarts scanning when accounts are imported": [
+    {
+      "value": {
+        "version": 4,
+        "id": "fe28d0e8-833d-4a92-9e3d-ed6208fe7667",
+        "name": "a",
+        "spendingKey": "c9d732595166f6b8a4f285f4df0ee76adb106b0c39615895422a633a08035d24",
+        "viewKey": "9518d298441f85255980a09aa07d8280d159e77b892b39c88d8cb8d5854f58219775f94ffb45bfb9046868cf82683acb24995d7f1f3d2216323c9403ffc80c04",
+        "incomingViewKey": "ea7dc790dafb32a077078d0590313d0f1ceea22cbe9c0145fb7a6481c1693603",
+        "outgoingViewKey": "c702677769d9853277836e270ea232f1e81b4f804074eeec27a1da371e534379",
+        "publicAddress": "bbd37319139d42a222151a92f482b48e4381f48ae1cc1b83f92f7b278c57d3d8",
+        "createdAt": {
+          "hash": {
+            "type": "Buffer",
+            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+          },
+          "sequence": 1
+        },
+        "scanningEnabled": true,
+        "proofAuthorizingKey": "513fd18713e16aa52ff01fe6f9b9a651b28088e229c8e1e050e0507978839306"
+      },
+      "head": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "4791D7AE9F97DF100EF1558E84772D6A09B43762388283F75C6F20A32A88AA86",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:zesnAHOaaPkl0/TO9DoQ0ZLtdUyoy+Gm2q3p/pSWmnA="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:kOw3BW+L/nRPNpJDVjsqXkF5IH10JZSCpi1bFUfxsHk="
+        },
+        "target": "9282972777491357380673661573939192202192629606981189395159182914949423",
+        "randomness": "0",
+        "timestamp": 1719441717120,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAMihdYOG31F9KdpljKhP1NL0cUntNX7RhcDH+BUxV0+WxJwyG9GtxEcw+kEvnHUl2q6wntoA3jgQFnlNmeClscGdiFtM0VxUvqI4uwlVvJz6zO3OPengore7jvSZujc5CKRgS6NH5BLodY+6wxL1+ZyXx63H/n3y9rXSAWrbfXmgIbYzwhdzulg7ePDE6xAl+Zwtcy4lAIas9i4bSM6rnkqks5e71WWqRHbIwXvZeRRWqAmZlomEp67dM1u9bAXcgSQOQQU9KCC2Rw+tLuGiniATTfmo6pSoMV2ICfyxBU84/VEnUuKuvIyMMXpN16Y2T7hZ9xyspOgBprgwQ4jpiazeYo5vk2pSB1MSm/VADqLTUI1Sr0wjbcqDRdAlc74RmQ1QFbtVesTtY2pINnj5UXJjTU+8SIC68r6JkHCYAPVNWihG2KUYzE5IGRuOLe60oi/ZzLtB+kaR4eVWWWXB1Y9cPFO4i1J0EJdYQb5JYeYWmQEUhuQ2xhiSTb8XhilF+rQBk+brdNRau0xUhDJz0ScfQreNt+C5pVnwST4n2chz3IWt797PkmanYGNmKR/9F4+B738nfzbdRCKfUS95Gm+lVO+UB0LWosQCbRiNiEcF1a61D/ChqyElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwKIcU6uhqwIsl+OCYnKU+YJ7ziYvkYXpF/R4xr3hKJCHzZ2MaSsenna91kR0alVNOeQ7ujnmUXbZjMqZz5poAAA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "C8CA8E6A876D5878FAD70AF8B1FEC153FBB8A7EE0BEB8FD1F734C2B938ABF1A3",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:1Rn0AErDH/BbtTxnDaBwFo60NbkEGgyXjs1d1aWy8i0="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:uWKhSe/jmCtM1SuBEktGCP+AE/nY34LoRQN1t/FgiVo="
+        },
+        "target": "9255858786337818395603165512831024101510453493377417362192396248796027",
+        "randomness": "0",
+        "timestamp": 1719441717605,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAUkStbxnJv14xGa4ZJcqzts5BPy8iqSUhz4hx/IbvP5+vA059uEDC9nIl/AusFM1TsAcqGkE15a6pLTGKgdMRzeUhXOpuA/Qp5hOXymRz0RupSSU3RNFtlpZ88VdnjkTe9PxAanWEnja4cESktVTOtdcShFtSNU8YRbVwHH5uI0sEEDSwpUKirB5rM0nlfFZNPyKuklJ05YCKpWAUmNPUq0DYmVRfOBfcy7omRFjzCIyJiVFs1CmK2FRsFAFtdCD4ikJwTumlgloqThMRFamNjn70hh9HgoCDpT+BhWUVB0AFZothSQpRoSjJXyD18s88M2xYpFRZjYfT4g0pHxYwRq4vT8UYnEPoU2yBDXPkLj9b92fALPMl1U5aQCDxd8tf3aVIQWAMlQMWuQi13EY9NVh9YV3NaBKaemoUmfOBNQCZsQcNuNCAdgwR/xCAPuEr4HaE/oR6wQZpBhDLIEOcx0UcAaDKU1InbGq98r//iWsklMgFaAWsIxQXF0FSWTN1WkcvgHDCxhjJS2mcxjXwRJ5a0d1moYW6n29MQIjXehiZpPJePrE7xnK6jxqfI7HGPcTesBLgUAxxeztAyEXOdG/R7VenvRp52s0MFn7/PiAje7GlC0RGVklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwsPgtteMzJa4nKsHJfHj/MWEdvBeejIxX4C+ppoUraAN0PwnujqDeIKppcl+de6Ht1FdYzwh6RJK1kkXfxZ1EAA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "17D18CBE275C4EA79045FBB9A0152C81C5BDAA792D9412BE14E00E12B5550FCF",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:0BqcEKChkWcfXhBfKdW6MhM6MQRy0FoFf1erPAVQ3FU="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:Y19EIjCOwps4v9oLCvj50uAqdtqFSeKa8Xj63zIpyIk="
+        },
+        "target": "9228823284279306817296266184515742822248210830185427859262273659833347",
+        "randomness": "0",
+        "timestamp": 1719441718073,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 6,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAm1c920uLO3/jJmQCI47v9aMbzLLCyH8K+QA2e51OIWa489yxqWBZlY1ftJv4e6rq+kjzI1Ku3pYAHj4pzE6H/Xunvvp2CoGYJA1OSsOYFlKzGpNIf7Roy26zLwp+jevTRc9ZTy3N8+1KvpqWui4Qbuns0KLBsj64bKGaS2qtTUMIJ/VuCkpmftHkTzAYVrGmYArEASuOjnOvLlwThgW7O/gGItUJV07lkjQrm71w0lKtOnOJsnN5xEfwoVFs8OahIp4NATJFEyvUaybmrF9FRJColZ/xHS7q0Y6aI8wQKbLEuuFrcXEtwriK2IjUMbTgMFXJak0HS2t4CQu3vke1t2CI5edDd1lq1jMgal5/K/l4Yu2LSeijdUc2rV+Kd9ZXjod5YnlejZIEP+3vkix1A3JHruU38pvZSct1guQZWymBdi3eqHvh+/gCGgQdlNZhbA00teKkiDDVPAS72y+pwnJP5XasbMdol1YKLkjK1xDtl6IJc2cDBrmoqiruC0kNIhyp4qFRLC9pvJtk9I0n7FWYBYwYBfEU958bpO3avxxZ8Qqju4bXmjy5r8prYpPAdmWixHqpwo3+i7kVPh6IqEmlMNo47fkqLc8N9Df7uqtDQ5qFYze6VUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw8WS+j73JJrv0TpdwwzTbigj27kjmsDVuLwjhWJxG0ut0MPLWf4Ihcme7ZLdzipDDuh1eRmeBXx3h/RuPmvH0DQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 5,
+        "previousBlockHash": "5B39752EBABBDA851444F03E035BC0B6E04612C13C50B82A8CCB145361AAC51B",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:fR9+wSJRKfKxT/12apfk0tNAgy+zDinHornWgrFSFQ4="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:3DhppDVoL/8nVjdNcxebZOU+iEQrpY7LDZs4Z9HeN04="
+        },
+        "target": "9201866281654531936596795386791503876274441021197252859723586932895305",
+        "randomness": "0",
+        "timestamp": 1719441718552,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 7,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA84sgWcXoPfqmoR7nHjM155OIkQqj8zxt0TOatCy+KAmYlhquVcZjNKiSWHH9Sqrg2RAcL6Fv764HTdxRq9eTG9ofRyrR5B0jCEAgKruELDK4fbgw/w7WihKUtmVeoi/7kA5trExOzUONhHqC6DlihZOeyyXaSZsxTWOlMGP7t2QK8WplmnZ4mHfrIhDFyn0QJfgKM9MUD+sDESpBLVE1lhXYf6EnrACz5oDAgQ+EX0er+4pugnFW9vyZWwIR0a+8qF9pYz+Hkk2zWvZNfkYjMMrIa4hDgDTOlEdlMiRmry3U3gsKGk8fMoSmKW5Hqdip8RkzSpQLpjHdtxZLOj9scrPnNQ7oly43dPx94FWQ4fL7MwHAZcI5dz7Jf9xnF6Ru0J9D2Eeh2z099QMVQugUd9ps7oUz+LOMcLMu1cdcC2U15hywzkJnyDb8M1q+DIXTdOqvV78MxJwf3FZb0uu8FxMCHYkCLD+n5mES4+lXzARVKuPGJ+EKnfITmeoKqylaCuQ2Bx/Xtg6QscKwSCDhgAn8aEQJQU6/GuwBvJ7vl9cukJ7JAqg/IoLkbRyLfq29s/0BTT+4yRDVY7JEoZfNsBQWL0aHh3XQB6BOHNA3XrkLJY9Ow4EaUElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwHKzxAbQx5rHwq9DRAumevsJceAwH6j0INM2nyXE0l5k9vMWzIiA+QRxWb/vEbg0zUFCL4tmtZmKEpueHOUPrDQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 6,
+        "previousBlockHash": "2E9D77A3CD1594D60F226EE0ABC1C3D71DE2E5F37EC4F768B438CDD865378B52",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:AZ9SRuU38eL+Y3fG5n+4ojeU30otj/iQZL6ToiPEHi8="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:3+eSpl6evErbkDzWw2g1cwEsVwpHL073Kl6lwvRjMJA="
+        },
+        "target": "9174987784651351638043000274530578397566067964335270621952759689537226",
+        "randomness": "0",
+        "timestamp": 1719441719027,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 8,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAXuppMbOuX1P9Nb+QEj3LUtC20xc1z4Y7hGdhOXteKuaECo5jbIGFOGQd12ubGWqlkFf4kFHszm9u4I3ICVKIvpPqND5YmkXij5qqeNEgwgKC55tSykuv9eHIM3fHaQMgzQVhlnrd6ifhYCit3V6JFa0FrxXcviSZ19uuiVufFO0Q+Rsp7nBYSc3nVIDTq0PQmxaNrwrWOkLGwFBmvknqC2LzLKIs75Zbqo98HymeGPKQ5mIAwPzhoqf4/oqNS2hwozrOrFayLiM9YJrxnsCII44iKi1RSfYWa7kiYxqnpDREyP/uwaX35Q9bnu5gkzac3d7EUHgJjhZPCTux0uRrRbY3eT7cJny9NzSvMK4mx2r5L/2ViuzKme9cdogZrScaMhHrM18mpNu642M+DM2wM+hmB1X3gk5zOhabQoyYg9MKgWTIydyq1BWvqooeqEQUcNt2UDR0oYdmE8ta4bn1MUTuB5B+bBHckDe8jDRdlxHuWlPccw77A8mjFuDHoT2+u/KKZd4vpGnxqIKs3vv+kDvN9zp2dRQhJIFbCssld1jIhFVS1cQEt7W1+TbkPsGlcjg8X/b0PSz+KCuNEHoQ2sYyxXOkdTOwJqIlO3quegpu3Ds0+UcM8Elyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwh9ZL5A3gdeb0gUiDRfzGnIXygpFPj/BBlRsTuIa+9DLHVZ9C7ckg76VIIDsdewZHWypZOnKirTJyVTeDoclnCg=="
+        }
+      ]
+    },
+    {
+      "value": {
+        "version": 4,
+        "id": "e456bae9-7fa6-4bc8-a07a-df3134b43499",
+        "name": "b",
+        "spendingKey": "3255f21950748d71ebbf2c076fc83b9ce7d0a36bf20f65434f59dff5710640f5",
+        "viewKey": "c42287b519e46eafbbb030babe8f51ce959098806661a3ed1835f8bcbd726ab78414c529999900bae72e13d829c6ec915982445df1fcaa7efd7c393fa88d0357",
+        "incomingViewKey": "5ba98e55e02563842dbe144f53295a69befdc21a9295e606f66a068dd0063a04",
+        "outgoingViewKey": "3e8256d8194cad6296eeb0efc3b4069b3eb6bae6e433923a65d677d077596224",
+        "publicAddress": "77b8690e1d2306024d5c2d715a61e959d357799a81ebfd109f12257515eb9d73",
+        "createdAt": {
+          "hash": {
+            "type": "Buffer",
+            "data": "base64:+pRJwuyUK5S49lKeCQlMuoe6W9+noGtRD7+S/PseErY="
+          },
+          "sequence": 6
+        },
+        "scanningEnabled": true,
+        "proofAuthorizingKey": "0362ef3d9cf083545988a4229b6021f77b9874795e6142b1f01c21cc1a61e90b"
+      },
+      "head": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:+pRJwuyUK5S49lKeCQlMuoe6W9+noGtRD7+S/PseErY="
+        },
+        "sequence": 6
+      }
+    },
+    {
+      "header": {
+        "sequence": 7,
+        "previousBlockHash": "FA9449C2EC942B94B8F6529E09094CBA87BA5BDFA7A06B510FBF92FCFB1E12B6",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:wJvBtKKtiM3i7C+pOQw3tOjSwKpAJ0B1fLQ29S08N1w="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:wpt/AHXDmcSysIT52HZwG3R5Fb6qXd+A38RDFLVT904="
+        },
+        "target": "9148187795366513087508709149025146424715856256637674150531751753357577",
+        "randomness": "0",
+        "timestamp": 1719441719496,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 9,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA1aD62FhUOYX08jpTsSGet3Xw+/WPICIfF97I0ENKeWGHIqANRp/qcVvJ3HfYCWWvdNXrDdM9GU+oISWfuGXsqDwZz5ZkeGXyJV+9jX8nn1+rJ3wqzVmpdFXPArMCvIkA8b2wWIzG2Gtp/h7oBTkF2c3XBV0TFp0JXmdSfsl6L2MMqCOy5A6vIAPTIyvlpqSRN05wM1d5iz8yJfvvT2mpSD4syggBvH3PizIlJARWw8ezd0h/PabLS6mgNSdy0JGGNe8eI+ViDJNbpaCJBU3BO9FIF7zLTrbrpUslXdIOj0qnJGd+mjV5NzufnpsCcJ1TyitG3RzvoQnucWEriCHq2Btz5vuX1KuZjDowe1LIMRqtMyYO0tH8+Iy0Hg6YXgtIspIDSjkGAloto55Z+CVgVuQJEjiMU8DGERB4bf3h4kuC/da+JzPCPfcTh9W2Qphm+1C43A1lkIJlTScjAuFvcaRfVuragRIpWssDL6xkgoyT1VjHTMs7+ushaLGAqz4pq1DntKQvASh77UZVQH2N4keJhYmuIXdwkf7Fxe/Eou8uqs32Gmf7Qmg6PDIDNKptEeh70cwOkKrUPFU6ephodisM2mBnQLTo3YSAqByeP8gDfVXTPUTcnUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwe/hyyBzA4hnSsCXpBnk09GP6mRkhhBpOtANmUldRXJ7iotke/xgANc19FA+lTyojHHduyzv72chwzzplWjgJBg=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 8,
+        "previousBlockHash": "310A4EA8214CC2537225A980D0DEC08BC9A8A9831D63CE2B928B06903F8A7B59",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:o1UlnyKvu2N77NW8IkjtH0dH8lr0nZnqhA+cGwkurxw="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:qaQSGOM2f+O+IQnwWwTephTeKSA1/CCrrQmdtuil5SY="
+        },
+        "target": "9121466311864876128923245652724724632104869735746188813030060672759072",
+        "randomness": "0",
+        "timestamp": 1719441719966,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 10,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAoOwj0D3ax9FG+clbD7etJj5uTK5MiID03p2Na1JC07SDCYd/EVLeRkW4EqnedD77jWZNt7VvtGPi4vnTP8vcy0G7aPA5RL0A91qIZdrqKhuSyu5wVdx84XSAB8hcm2cLLfu9650q2aQZNxXlx3uheRwxOENo3oGW40ZBvvREWrkGjyIdUL7qUYC2QkN6u/bR7f8IMg8rKz8EpAUF2clTrbLI/FTR+ADe7B2V1nD4gKeYcv2nrjjxzdW/nkJxJGfD9S76UsCjSiQB2Oy7w2BB+mQVEHozdf3kC0SSVQ9xDYgI8/OV7oYj3nf/WEqWZzjQhk0aDSPcZJmHc15pesL1NJ0e/9l78g7MiE40rsHc1bCtzTLUCmUn60NO/tlxiu0eIWpBme266FomnDGC1JEArdyw7LCBmLKbKbBvYm7MW44xGPtqOUQ5kK37ny6ZVNt1SIEq9KZAhmqKtWGzP1a5mu210axjLiP4ley3/qDrWI/sHYJfWYQiar2yH55agQ77agxqhGXDF86Tpqu0SJ93srH32DGEsaex+ocTS9wmRcmEoIvGaiamKqEiBRpEH3T9C5b2UxKYpwbqutHJRhgXM7uZ4QUiUXdVlMn/EQGwp5sISQAUR4rgwUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwvCow5y3rRpVL2N1EBcSDL9A/Iqg9/ChqFM2OGwgCAXJ/GHA93wZdyhahefLwTobpHAUjIcvx8bjtlUh0X/0/Bw=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 9,
+        "previousBlockHash": "D3F62D4AA18D107C962B87B0334AE09C65879473148623CFB3AED58BC7E207F5",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:cYtqOqKYIXJxWqNDoAe97uJzPq9y246RZlCat3WrZh8="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:BF2xeNj2jEpOOggwo1ZnL0GqUYJM3G2hV8oDN0/+Znk="
+        },
+        "target": "9094823328238119324660168503613036415495463326164889575918026009508991",
+        "randomness": "0",
+        "timestamp": 1719441720458,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 11,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAtIiNhGQHI592BD+2jwj1Hux4xU/1MQRUZgJuYVztJIODD8v556Mk/6/4S9ukVaexxVrIfvAYTROVMcb/drdmU/wul3zeHT3ixNN0lqzEABiEcpTRZRhVNjDmlSmE1F6RB8Xmdjz/afkGR5UB9nnzHxxguJUyM+2PF80dmuiAdmgTEyYhesAfl4o7nkKPABmE90st1gOs7+zIGyxc4/fQ2H0w9iq/GWicrdiCOcFJ+V2qzkEQRbqPPUnZnBHjINDeVUCAnzhGxseYJwbdDMytR+s58eI44qC9to/8FhreTWmsB+VQWHblCbOsMHHGQ99V2dBPilX0rqswdPB28KE5Z5gGXGltQ+PJeferK86c/s7EvJY+IF1CrPXTzrHsfaktE8D8+Ol0twKjQUE+Jk9MDggfQBJ1MMq50O6OIAt4dtXVGtc0HaFZ6TQBSnbmpzHzMeIslDuL1XWw/QmRzvzTb0WL2Bl6bpu1yx4MG0DKfKFEs529HOfZqYPaeG6VNkwFwPOKIkjo3czg9fn5SddOhr9kgtSfK9jw8j8o8NUZcKyyh151a8t9UjNBQVwSQacHFvc0mMdSOJrrvaDPFTIW+8kGBxCCNbFcfaqyvO+10ktxMTq3HOFp7Elyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwao5gAd6MisvctVeYZ03+D5IQh3WLQo0a/iDliETlqxzeHMVgoT6BuA2WpoF3kSXFs3hT6Qva6OhyawvDl3DlCw=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 10,
+        "previousBlockHash": "53EB267C5DF1F5B5072C3159B66F8D1B50CD168B375B59E3FD6E6A7BC565D490",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:ev3+y7hDnHIyE6if3ebI3ghqYLww3T5bXm8n7eA9uDw="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:t4ybCJL2S4+VF6crnGawfekJPE87oU1+DODUqlvdRPQ="
+        },
+        "target": "9068258834662928698220540790897658244352076778286486653826470223999191",
+        "randomness": "0",
+        "timestamp": 1719441720930,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 12,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAE6GygXOf4j5BWdT54nOCh1LUxINfXl078ml5S+oGhU2wx7vinzi0qjBA5rNzwjLbTqA+76y6A9p0kiC015v8f9GmodXeBtIYgbvgoHVJH2W3s4FYdZvB1EOSuJ/tAmcLQPFR+0+yTwVPntIqRdcP0aeeWYDYYJQU5BeXQCdS15gOsREn6rTQBE/s4SN71KqX6/kfBXB6dDOpxDiyEQa5BSkEn6gBIsXUKiYgNd+IO42twxIGxhtYyhe6RpK768kEij7hzkdxLX5iCVNPieBoduZWDlj8S+L5ti/04TRdvFCP235VW7NhrNvptyi0sl5IQnQPi1po0gkIBg/HqBspWzFnzs0YPCrUYeny/jbSetdvBgW0adGw2yneLxD5STRvtcilpInmVp/r4pdn4k+dRckUPcyPgMiLx4xoGdr+88IvghXNortlt+4VspSNgWdLjI0cevUfkXTfaJABcXZnlZOTwiDyk1+H7IJOHJumfaYGYULKGG2TAVbdUi+nedQMEMJS6Z4SSsiwdsiapeGPQ3WbIgUe7DWPxXEw22mnkAYRqaXt4nzvc2IaEXLTcJLYqSjMHRCE0Z6qewZ1jbzwxxTdQ9DHcOXyPezWm+Cfe2iPYDs0bjEaBElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwSIDJaB3bHEHS7BP8+JxkwqnH3yDLXK1NCBN6pT1RP0MRIlqm82jKO0lN5VOuSv8ikxtE5Fj5fS82EBnvrPDpBg=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 11,
+        "previousBlockHash": "4A82EA2E6B86275150FEC2C6AC1FDB1A2262462DEDFCE722ED151E2A5D974A76",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:6FzMIVYGtIqhuJo1jE5SdOhYSqPvEoYdiFtHCNei3D4="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:wmh124Szjs67KYcdnrL53mz6/+x3QXeiEqTSs8MxNYI="
+        },
+        "target": "9041772817458669358631436925553476123971485443441062513642264290171806",
+        "randomness": "0",
+        "timestamp": 1719441721391,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 13,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAGo2d4Xh7XjUHD+Z5PP/YK1fMNt2Rm54fo4Ur6DRViteRWqVhbLy+3PbLLA2r3GuBThxhgcK7rv4plClp0NJndKoYWCq6fMzOo/Jp+W/YGVmk1q9591gptLOXoO1dpBYtJGHDwvNEkiEBxB47pYYRfINPfql94z0W1M2Sro3R410P9+pOwQ9JYdWmWSnCl3txn1eEmYPNVPFcGbsd8ZzhOhkIDV7qSTCAxdoWSAKYiNawFC/sRCxGYWHArMbTJ9aqCnNAy+OKd7xokz+4XWNEVuncZFUSuEJjrtiLsbq8qUS1PFCeak6KBWeMo1ncjTNLQ2RCQXnqlQOud4BjRIsN7nMyOQXr/R5LUf7OQ+wfWmiVsQbHBfAsss8KIxN3lUZny2voX9xVxStOadO6ETC9KbMVOdmVKpVwlmSd0c9bEGVaRBGaXNLTeLHxLdpqgwput5rgqgwMiFQnprT3snD5e7tBJ/yrWpo8lPuSjjvJJOace6d+Q/1q8vkcVFDDzlLTIDnb5h1qygCxfZyZW7RmM3l5HcLn6vXBUG4JaKC2GW1LYAHdCAMfhIIdEsQgRCl3jz0s6g8r9Ao+CriifmqaWuy2hWwmTHL2Ajgb6CTT4spj74tEHUf34Elyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwu3yIJiuBIErbZCJyytdbtIVAotG6Ri8FaPKaopuUp+8PlMMYf5C1CGqJ7jYnM1XEGf2Zap6VhPbpSsA9sa+LBg=="
+        }
+      ]
+    }
+  ],
+  "WalletScanner restarts scanning when accounts are deleted": [
+    {
+      "value": {
+        "version": 4,
+        "id": "5608f677-7560-4083-b0e1-c0a3bc57925d",
+        "name": "a",
+        "spendingKey": "dcac9d1a7fd7dbfadd9bd43ab3685aea9c5b3b74a4d7c9ea1cf40070ca7fb998",
+        "viewKey": "606e9b1087636b5c49fae5c3895de7de284e279c1f483cee1cb8aa61998697a8159675e7626ba5b6e72571753245a163b67912c632c1865c0ad5140f9188740b",
+        "incomingViewKey": "a7c09bfaf0cf05f6612408e7b7b8b67b10a35bbe66df052af0fc0cedad26dd06",
+        "outgoingViewKey": "792733ae07f1adc6fe9937578ef5c4c62684a11a3d5c49ee74554996fddecc9c",
+        "publicAddress": "12ff1c08a13d088f5a32dc32856c4802fdcd456d249bf598c1c862bdfc512107",
+        "createdAt": {
+          "hash": {
+            "type": "Buffer",
+            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+          },
+          "sequence": 1
+        },
+        "scanningEnabled": true,
+        "proofAuthorizingKey": "8ed1d285981ae911bcd04fbcca375f5e4ca9cfa556e98a6d1645ecef721b6308"
+      },
+      "head": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "4791D7AE9F97DF100EF1558E84772D6A09B43762388283F75C6F20A32A88AA86",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:CWScPwTfahtcIMboVijiRAd5hMgWKrjBrcqXOcyYUTM="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:kuoQg7iqkHOZbvaPo4S47KRDH5yAp/FntwfS9Qip60E="
+        },
+        "target": "9282972777491357380673661573939192202192629606981189395159182914949423",
+        "randomness": "0",
+        "timestamp": 1719441722383,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAZnIqq8GI+k1soBWMVkwTI+IF1w8RptHRWvDsIVXv1LOSG15YUnoylKYevcaKzyEV2wxE4fxLJah/mZyejjt1h1D8JYrJI4pWZ7PZP24uHWOGJjtZfI8xo2ci1FdHJbaDwXPRaQp/L+Vh4dkvu6pAaia4A4TNwe6p5kjt4PZOuVMK0XF/ZYaHC8AajbbqWlQ2W9TNhwDa9UTD+jLExW1DF///HKanqNVsEkE48orp3sSQ0xn8j2AoNsvjA0NHY7h750eUv/JrypqZzxGgGlK/Uas6ySweqZogvmcevTgZTEjYtrVK1l7ChwkK2fKWpo1Pn1Lg0NtNt2fqeaqcZJCy1V51zZgZ4GcG+SMH030h/PKPf+88FMHk4W6UDVEGBxRqiyDo2LzrWI5OtACMX7GWjVmXREdwYtcVWW0akUdUHMWGHLiu2LB6Gx6VznR+75ksPpBxGWB0c+/B4ctP+aeAhtvCPGZR6w1ILh1QnxT72rmn1bfTBNsJ8nnu+zml5Xrfzg6/4XsoZryqto6BR2lAEjilGdHzidQvuPnG44WPHEgHbszzRucDs0Usk96uV3WBhT+fJ5njuBfv2HD04IMJpHdzFEANjzggw3wi1jSHqUkltjsR5xX9xElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwFSb9Otwas5kPt7gNIWpLZ+HcswCkTmqOjOZmWm7SjQRSV3u0wU5t2gIgnZwz2J3ghl6TLwziif1z0XNzvIfiAA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "466643FB4B18A594EF5DBB72ED5B4BF5ABE28D2E1EC1D21751AEE7D51FBFD15F",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:zyTGIUK6jeU1Ir1DyS5BTmP3ldDdnxxqTI4dZNkVa0g="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:LFCORxJMq7CzP89Fk9vHv5iBkgXlcetC7lcy2zUFi2Q="
+        },
+        "target": "9255858786337818395603165512831024101510453493377417362192396248796027",
+        "randomness": "0",
+        "timestamp": 1719441722848,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAB6XmNKp1IY1aEURzAqClfKG/fy/G4zdecGyD2x+B7Kelb9cDyxG6fMF21oVZ87u44EfCCKQDjrVvO6ORC2aSOCGxt9JHO+DJrmL4HGJqAwumHFVtVGgO9p9Er/p303UAB7Az46NXKB1+8sE43C2bNNhgvw4gYxgjU3d1PqZqs08TaQEJLLpX5DU2xkAAkUfhDGkl3w4GsgiCE6wcjNLHIedkqnmNPnhrLUeqJCSSut+xraTLuKPsFj9F9eBNWlAic4XcT4XjG/iK4zvY3DMfTKDi3M6+zpqNDqWLU4fMY1afTr42eqDb5zdaS898Mf67pML/5agQ6gTkhCDCSTcWOHrpyEJVduXbbarmEqoOAVjStgpz7bT2x+jFwcc9+WxCCBoxydOWK1oAABatXfPp/L49tEqp7laroroRjhsDjCql3ZkIxgw8itbXFrX61Bc2/KODWhhbwT/GPwc8p9kzPlk0XCTC3FroB9ZX6A6b/gl1VExsArUFNk2TRqfKqZjuB+3oXCKZiKqQ+k5QJrYwYsuHCMZfeuwzLaduPs8XjuM5rkgLAEPtVUjPNWd66KXymp6xzcF2jbBOGED52luOjRwMe58wGoKYcEGVw9fCmFiBU53pS6nvfElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwBbOg6xkDd2TUpT7SGMFhk7mVfpTs9qNVhPvgkmJBG1O+Lx2kh9m/ChxDDn8/KgzIMyNkRFr6DsusJF3EXSkAAw=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "B58450CD35422E5444F91873E650DC3F2CF8E786579285BDF92C55F6D6E08173",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:6qloozS5eLcmWGvV+SkTYcF5t0xSQVv9zk4Q/GcP7ks="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:bOgn8i0XizwLH4BR6KZI68hq/3tF2XIZkFzXXutixwU="
+        },
+        "target": "9228823284279306817296266184515742822248210830185427859262273659833347",
+        "randomness": "0",
+        "timestamp": 1719441723332,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 6,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAPlTDIPH+5KJOavtB06clP3o926BhqmULU6lOcwv4+xKArGOM7GDKRSnUNrFxzyC2TlIcEHckCBJ/1o4CKyJyEjPA3Z3E7A56Yw+ho4TPdUuQftQpaJCIawzeno96qTDhSpqfVVK7SHiYLScjTLyManq8b+KFBeO1mK8M7spJHPMSR4sy4ZNoWO16DcKWR8S0RAaRE+HWarUzn8npKJ5SWDRy9G1oDPrmzJyPNZd902uR65bvMBzSPsuDQ0psttmvbDRuGizinxELPAD48x/uD0yWPRNVsz3KsZIoPteRyYKa22erA8L69d0FYPpVuNgl5Yh5hQ2F6cUz9DJyOuUNWN3hR2FC0I+NuD8CMQC9MSJ0wyOu9tCSEWFNaWHNPlkOu/+hjcCJRBN5EJLIpFuHMUZVcJW4wKJqPt94LRIepAFHzSPVOy0qsgufLXIc9QOqk8csuJMEv+iQU4u5PaFHBihVvUwS2fIWE3xT5LsNFC494509RrNQkH/Wk2yj+UotZn475ZcNpDyhsUoDSZazc16O3ojcGZ3WVAHvN3/qi0QqV4JILiMcxnocyimS5JgoB1yaeMK2bGWkND6Bw+H+z8eBWnEWEO4dXEZWx5ymRVJOX06UFa6TNklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwV1zcPBDJn9ojn0ISFZ/oT/1kYxVbwU+D5ZC+aP+tj4NaT6ZN4n/5PW1OG5OUpfNgnr2KU0VvBOvVtYd2tPMaBg=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 5,
+        "previousBlockHash": "B482FC6360EDDBD188F0FC05287C2FA687583C062192C3737CF836ED179EB8C1",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:Wv+VfZYw0Y+eVslZb19l4M2X2CdLiWm05kjIpZ0qyic="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:FRBKSxosajxBo4ELpBQCL2iF+f1Jc8GXYGhzqRAIgww="
+        },
+        "target": "9201866281654531936596795386791503876274441021197252859723586932895305",
+        "randomness": "0",
+        "timestamp": 1719441723791,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 7,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAgcY9hi1n/ejp07obbwNB+8IEmPjRas1IH4LyS0Ru9FilZV+UUZoxOkonNJ/MqV0BUqWCcNPsLN4MW0WUpCTYtQDolVa1p/ZrC4BAXhPl/s2Op0RJw6WbaErKgq9V8s9S9HJAQdBANSEEZzMoiFoszDt6UMdw/yhVePJqegbcGqMTKbxGq7Csw2Q1d4SD/SOvcVHr7db1dIthic13H80+JYTqlWv2POgM+o6vsJp+9HeLSKYGAfCdFZivDyCaKmjWR/uerw3Fd5Fa6Z9B4hgaTUsg0BPKs32rNBXQBs2+42dIo9IoY9vpbvpFfJ4mtMHyEIcQLbhmLaBl+bTWiRC0BSUjtsH/wzRtwyRQjkwf+GAOe5BdlLmUhXFOABp5idZg2hnM3aglQfeSJkvJVQVuBGCffH4XR8fiAYpIRamQwtMFNPHvFc/reY1Qew8WmlJ2zNNo+2/TGz/fQlqyRR4TQ/QBby/LZ73ZGRBj02/6tpmHNafiO/yig4K5QPod7/w1VnSQef+c10U97dHxa5FhR+cZplJfVCHnA0hq32l1RoY9G6bFISazQsZdzCq89OFBl0vZXTKryFPGpcsp2OhJrmY8+lMaj2sPahGnxF0OyK8ge7ptPrU9eklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwSU3pHewJqqCx6vPFXUijDU4+dVQbkUIvFcjjo24Sftxyg3QBH0k38MPHtLE3CtuzDZSMzZbYPT7/lupzKz09CA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 6,
+        "previousBlockHash": "92BDAC53C9E46C08D28E7B5F42D873AD7740D9DA8E6671C658E4EDBAC4D65F27",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:ymX9ZhiQmvKURrRAWADntPSogpuulpZubDclLilywyQ="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:lQXSmilggkyT+uHihSzAP3A49aib6QfmFoEH0O6s2aI="
+        },
+        "target": "9174987784651351638043000274530578397566067964335270621952759689537226",
+        "randomness": "0",
+        "timestamp": 1719441724261,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 8,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAboCjeRJkAvi2tcNO+D4UJNicmWF0rozhHdMyFknr4pKyXkDINjF013wrOvy95oZcNCjU/FXlRvLHcnfNnh+fe1NL2Y1dUYG9rElI67VRe1SYlnmmG0Rvrs95ObuZTnoVTp7v1qj5r18834JV+4WXBIxWee4n1LCnEoy2Z2t/zOQJPAGV7nrzpMw/xs+zr8bs4GEl+a9VMDcP+foCEVwagTr8iuxdlSnSo+daLAbXZqK0n48re7hkaxq2hNK/zGsPJ1MS+VvQIvO/+nbR6IK8Ev3mr+WY6mX531UIFJXweKfhQzfGIKjtfRgX0jWvYAP1WSa/WH/No+cGD0JNnW9EQxJEQujJyYWq5fe5zPEaYlaf00bdr0uENHPPf/Nm+L8NaUF9S2QS9Emkv+mQkE5QP3mw1klOMYIe5pg51mesXPJ+uCxQKCi4v7b2PsMRGoXJMu+vpIaELQpw3TTt00VlTS7/8u57sQFsIiXSdZU2uWbcYGFLMsaOCVL8FAi8xbizqkCmncEO4+c1BDt4IoJdcCEGd8AweW09Tc05Wyn/93KqMY+YcArebYFKa8Ox62V1T42Fh5IkuPjmXhK7GAzU77evl03TA/VRAuA2BtmgPrFLnXfcCXl9/klyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwawhG1frCkchqhA+Dk+hMmuc7QhhB/Kj/P9PriQwAsghJhUWdWXRm7y1rLsOaEXdy53klgVh598Jlk12bBCExBA=="
+        }
+      ]
+    },
+    {
+      "value": {
+        "version": 4,
+        "id": "d3fb02e9-e057-4488-8ee5-776e98a95832",
+        "name": "b",
+        "spendingKey": "6b56d56e3307f99c16185bb7ae745a2c5d5e2750296a9c006dd6b8f7bd668d09",
+        "viewKey": "9125d6ca8bfdee1648ddfeb582e3342dc190b8b01bdf9adc6da7e8729692384385b00b181f670011c76c16cb5e67bfcf5bd9441410da8df7fc9cad095d9edaf2",
+        "incomingViewKey": "51a727e16a0be7e2b97b7dd528b4231d27346ffc10e01ff95d21fbcf2d042605",
+        "outgoingViewKey": "f9f3036afc899e86e59114786107175f84c55a23c9c1510e694b3a36e83a6959",
+        "publicAddress": "bd5031bf9cb4087f3069771013b389ea777cd9239fddb51a336b81273f044658",
+        "createdAt": {
+          "hash": {
+            "type": "Buffer",
+            "data": "base64:DB8f5WPbF66VwBmmV7BJ3g/M1epyx0+0vepdatNnVwY="
+          },
+          "sequence": 6
+        },
+        "scanningEnabled": true,
+        "proofAuthorizingKey": "17293732da2ea50bedb20d45d87054bd8a5612b989f82b6c34e09c857c585304"
+      },
+      "head": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:DB8f5WPbF66VwBmmV7BJ3g/M1epyx0+0vepdatNnVwY="
+        },
+        "sequence": 6
+      }
+    },
+    {
+      "header": {
+        "sequence": 7,
+        "previousBlockHash": "0C1F1FE563DB17AE95C019A657B049DE0FCCD5EA72C74FB4BDEA5D6AD3675706",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:N3ATvm8lufM1rk6wyRWgp8+BM/aVcpHsvGz2gJ7kfxA="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:76y+Po/GE64VvnutdpKl6U6B8GqPi3eBb6tZFmRGkYA="
+        },
+        "target": "9148187795366513087508709149025146424715856256637674150531751753357577",
+        "randomness": "0",
+        "timestamp": 1719441724731,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 9,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAlSavJP4InzBX36z/iM/PlcD/t9MYWTVQWgL6qgLHaBKEX0ZdvSdDwZOEkAimcbkmeJkyhcbBxv38bS4wlhhlPINKRWShGyrkkx313CEImoGGpPSbklrqORWwwL5j39WWrOfgMm78NkkkAsoiYBgy8jdW8+uD/5FW0e7XoYzvyGUX3M7OeFVfaaJY6mRTi8oSBezVZyAevBJl5a3vsN7QyZRXdtNT4fQd+Dt/zDtBe2+m7fS78GTI6xKkvSrHreMscdK3/gUOvDibX64BhQYAmNS+nvY7/ywapHngJuRa1UjsaOm5/6vKV93Njx4mH60NP5Ld3kignMVb9o6MEeAfwLLSMkzxwVNASydKSwTfL1M/aIz0XeOoODyEAcPw2D1UeOBYf0Lr7i7wVvniV4XMXRMHcTGdo6tdRy7LvV6ziogmHFPTd8Hb7ovGINqots1msah+kCPs8JNuhdEuinFdsi2ExUAO5SX235lENWya8//aRNRti4IuA/P4OMVMpQ2TPhwCEa1zP0ds+vgSUmzHghazLLPRj2bdrQPvmKkEK6WG4UgcPUDsCNlsQmzSHZn4RVUQM3Zdj3BxklKiqFqWvh9q75/41g+r9qzkEwEUjEvK2Iv6uG0DBUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw8GB2r5+jcduJ3AHZAccMM/gKGcxPuMQmcovNB9efttPsR6he/57tprIY0uRySZ5aQ0mzHhYzi26R9ki8uiiuAA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 8,
+        "previousBlockHash": "9BD5C0D1F722DE36579E2FBE9961B5E1A4D2C3DA6B77C5195450FFFE7CA6E7B6",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:p5YfW0brP61LtOloOp9jgWexJy8oNt/KJ3g6Fw8MJ2g="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:HCPGx500t1evPWdtEc/LncU5TAedjob8/sYhK3RbIvY="
+        },
+        "target": "9121466311864876128923245652724724632104869735746188813030060672759072",
+        "randomness": "0",
+        "timestamp": 1719441725197,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 10,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAArP4v5qoPhEx1Ig1ccVMB+sStk1ZxSkn+QTY3zSYickSRv7SO0KlXsci//yVMyH0Yqu6oLmOYFRAhhwOQPu4H4HhurAIGux+ZnlXAM1d7CaCkNO60wcOGxxo6nSTqblg4Yg5TTY4m+y9HBuvjQRvdBmR1TJ214Hq84w1mnjL+k7IPmmujJLPsZtTarlJt3UYebNMSLtqPqabUy5emWwcKNUD7P92st8vDZgxutrXiqM6lhkQTL7r3jeCngaekzkbH89ZwKVFoBIa7AR+ocVUmvBF0Wi8NtFt2SO42qzWufiQx+hcezxKLTtYFdcOJ3DasRUp9cEPv31cPw1sC61D3hOVpwLvP1P9KU7u5q6JL9uIW3vfgPBi6Us1HBOyGAR1bjlFolSltR306ys7hXrJU7py+Lmpyeiy6tEycfUuHP+r7ApnHKSqW8k1sqSIxzbX9vY8AjYNHdWp6bwpSNBn59AaxlBejMY18cTI9jCL1OJLbGi46Z4PvYzMnKPVixHyCWVkoAAnmkKQsGXGZBDrY5EYRXfERxkun4mrzo9NlFr5sOiG4TWfsz2B/FQOJRVLB3Mx1HIHXJ4LP6jlP4+VoYPcvRMneXvY19m2jhTmz8FggcHSdzPG5QElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwkqi/ZSTnMp8qNRLXx55SbglxuBMIxFoylHDjfnDxQTMepPKUCIPZrZAUUdoVp4apCz43/7yZ6348ShDR+j21Aw=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 9,
+        "previousBlockHash": "6B4D69F0949383DB8FDF24297DAC2425532007FDFD7A25ADD90676435BA1D86E",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:vDbEB8W1fxR5mChrwiqsiO9K4fbk1By4Z9jpMz3WugE="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:/Q9bBFoh2VEVU3hCwwyEeO2ApkAxEJ4MfvsxVDq9Ftk="
+        },
+        "target": "9094823328238119324660168503613036415495463326164889575918026009508991",
+        "randomness": "0",
+        "timestamp": 1719441725665,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 11,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAfz5rQhRv2LBNplPaQ+NoyVfp06EWxT06seFXZOF++1S1iWKU8HyorFHN9Sv8Ht6MRTlL/BJH5xlPxk2Q7uJGUHvMWNYrYpfn0VlgODodVqC5+M2qGyrvKBdbPl0m9QLjpMwMerjGFQMsPgSTTUClB3nAbYF9lVwnFE+9EPXhQWwRBY3rlpJbZK1sNgr8suuXm4KJ3phM/ADfxEbwYkO8S8stBvGAYRQCxBTt9lpetnS2opy5lRj1mcDisOqbgXNPZWhqHludnnr9Bmt91c9KmbJwJlSyTVqtOJ4AEhoH9SJLH7rs8cKQCkJvmbGsjW4VGxraiH+/X2EjT+IEnE6xCBcTc+nqiwo4VePsgc+ingnsBw64nTGaAQpGnwdIqb5pAxIOm/rrdpefaTl/60Qmy40/KnNEeM6wLWu/gMwLsioSCwu+FCBqxtcANgpDfPjct0xjEHkhnJmMPgXKdq1+6ck8HWYY+EYWJ2/iE0+Hl6j/tnQITJQ7N59LICPv3ZHoyMBzh/IGwD5uQOb8JbELwe4Q8Sje83FoDaxNVoj0s/c84xBqO067bsBh1QkoxftJKh7HP6XcWRCL62VgsA9UGDFOhcZ+O0HVyvPTTmDC4kcxl6XUUpk48Elyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwDrM4b0FM0s6fmfR6ipUs7INRo7EsioJr6Xyl75ONFu0WvVglWLtZS9YgjLe9iKsXF2AGORwu/LTou2A2L0nZDQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 10,
+        "previousBlockHash": "62A65BD939DAF14EB812793DAD1D68A266B0BCFB28C1AA9F5515AD0587B278A5",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:30GdhXpk+n+fdrFVsXASqdE2WONKm/R/nrN4Vz3mpkk="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:Yj+qdmmsGqfavNNYPMBJFxm8SSQAOZSRxHm9FtlfEBw="
+        },
+        "target": "9068258834662928698220540790897658244352076778286486653826470223999191",
+        "randomness": "0",
+        "timestamp": 1719441726164,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 12,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAALPlrZRN+QtSZwyPJLy8lyUnHIvNRT7dPZp8KCxZxIzajyEKRYomauhJNnI9RqQCe4QuosEBFd3QufrhusPFx9FK7AsKGs8Mc1uOe5k2vg6eOLVTjwAnhn7k2Lc39xmpSvE8ofKFOPGai+PFIBuNx+aJnJUVY6hhP0v/0ENrex1QBxThKWyBV+4+vTqSWCXTO4SBAhmnXtox6wK1ZOmaq4HJqimB+fP31e2VBY5sFEHKCq5BuoWQVgCY/1PsU71LLJkRmCUwYgAWLfTwVfF0EwOlSVs50TG5W/rhE7gjzUA7dOhN+4jiUTlpF+VbBS6p1tzWAgfSJtyBjTgA9Bbc2hR5aW3WitwAzJvBvVB4v43A5CE4OFEBSFK/LFyieCfRguWcu4eTjSH70QoSC2oPArO0pFicRipSTyDCRcJgLidBPWVjwVnzpVGZAeZ0tmsdCf+m27orjKo7KWiWut9gn0YFOZwsDKyLWRKTrNHcgCWsysFYjM06BUC5Amn/1BvQCHZWUgi3IFFJNiELTf9XnhTS9F1XnJjjZ2HZWClSQnhT2W9x7o29v1yiv/gfZg3l3ntNtF9IRMe2Zbs6kDSk9A6EyiGHFaWVuRRZTxy545FGLR+J/d03dHUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwyQwNLQepGN1OnDu1Muhv2MqHQ4xFe/YRgZQTNXmGtUOrbJwJL9QPT/Jvd18qPZtuE/Q998PMgc/Ku/uUnAc1AQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 11,
+        "previousBlockHash": "0697AD0245CC3C719CF76286F5C3240C079739B00010E8F0F56B33EB7F115422",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:pTTTACel4n/TI5E8pC4OfkpmN/EGiE6uCOF7va/nVFE="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:SN/R5FVlbTQjQ4zdbX50e3lYih0ZJS34ZANClBCDSFk="
+        },
+        "target": "9041772817458669358631436925553476123971485443441062513642264290171806",
+        "randomness": "0",
+        "timestamp": 1719441726654,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 13,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAcSX496FUPqOo4TjxtcTJqOJRxy4epG6ODKzmXaPDiT6tqmamSHBb7AUPM4Bt3cE1I05zqNs+vNQGGskW/gkVVp0JB/Mbfg0S/Q9fHx0m/fSA2LwK1kPnu7qAl+QSToDygk0h8PFn5wCh/TCN83X+VYEtSS9JStlgHHmcp3RTOCYQ5OEsn6ZqAiHiBMbvN7wQ1e8ZCoMU1C7vB/bhahqh9XhfJxuM9duvpUzWf1ABl5SK9ymQw3Lsa7pOw6BFwtl0ZzK+L136imutpyTZ4IMDT2RP/UYFAqQAN3r1DyZ9z+HeyOKC2ZWiJ8jjuqvCcANG62WXTQfhqHsZ+6DhBTb9n4KpxqBsxx4afJz0382XxCRRAlu2A26s0NWtUnFH+05HF1Ho2rjojh97JR3V59l84nCWDJMrO9aTTFeNbG01fSpegIUqraPG+afinlZKufkKOM2W/qOq+i47c8eLlWNrdpSDZ+w24qoCyQdW5WHYJOMfz2eKd2YvphEklqK7pYRmp3uXRQicum971Rs8qIo4S+Hze7ijRk/pO1zqmfwkzw+0XJBKDH2QejItxWlUnq55WwFQjU8seMN84dSizfYdn5FBc+yltI4xOj2CLAd1iU1KUcBOB5kpIUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwx3/YX2hVCm/eHIvDALpWilSatlN5BqfDouDTE+VaHSDD4m9HNKVwZpecj7PF/AKo3fBowJcylj+YwAxxvg7ZCQ=="
+        }
+      ]
+    }
+  ],
+  "WalletScanner restarts scanning when accounts are reset": [
+    {
+      "value": {
+        "version": 4,
+        "id": "1d470276-d2ea-41cf-8904-079670baca37",
+        "name": "a",
+        "spendingKey": "31f0b594e6a695a50328c7874f9d23f72a4fb297d49f3b1512db5969a7d0ce25",
+        "viewKey": "004f4b700a6548829f2595590d5ac8c1be1e8dc306bca774a1a7a1d7c42c379864fcb81fda30fae499a587a80d3cd7c5207c3bf2c90c463898a1de0903c51712",
+        "incomingViewKey": "2854702acce3ba91d33a3e2853a718d9626f5b37e4100e36c657f8813e2bce04",
+        "outgoingViewKey": "0d44394d2615186e9480110ae402b81e69128ecf1e3c3c462b2cdbb323519328",
+        "publicAddress": "63193f684d12f5f2189cb682334aca7c19564f0400b50258b43eebd7875bdf34",
+        "createdAt": {
+          "hash": {
+            "type": "Buffer",
+            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+          },
+          "sequence": 1
+        },
+        "scanningEnabled": true,
+        "proofAuthorizingKey": "a01d10fb10b31e4ae723892a440753e3b8c40ff23b6f635de2f8fd915109e606"
+      },
+      "head": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "4791D7AE9F97DF100EF1558E84772D6A09B43762388283F75C6F20A32A88AA86",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:o/aMntQ2IGPF18tp3O2D3KzGHRuLXZTqgQ+SVBflPTg="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:WLUEt6WpH5tQWoWuTDEgAngpK3UuO78z/jOIiB0JSO4="
+        },
+        "target": "9282972777491357380673661573939192202192629606981189395159182914949423",
+        "randomness": "0",
+        "timestamp": 1719441727667,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAZ9WrJ5qT6rk3666j+0MGkC51IY7ge8UuYWnJ2Aai2p2SjokDjnRaEclv6MHxahvqHnpjQBffym1WDIwkxuFHmhcJWMIz5WQwuPI9/heDZt+OPD91L2/Mz37pDoG6M7gD9ShaNRC3SAb4U4WZg+v/HFsKjCXTXIaJC1mCGxJTfJ0EZGS+Etsuinks0pOu30tdSY7vq2dMpuREpmRVHh3M+p+lCPhtBLULlp/rwWuBEr6llY4KcIkqICURe49pRwumxprhtzkYloXquamstGvA8FjRh7aJ86rqK3JDln0PuE2dXpaGVa8KPPtgQv3o0dwnZU0k+AfcnYLIRznvWKGD0ec53Hv47P7qc5jBuErBvHiKf8z2qpGg5jzsfK1FjGhrqYSmnml4EIMac8otmeMPPtynwMUN8ZVlEZ/K/juUB0RZGPSR4fhroLUFIqi8fmOQvYBt9to8ycSwpmCPlu/MnOPpF3u3BdaYux35n4QFU93JwLNj+xOkNzDgbHn9uAwgsj9O7Ky9E/cZQLmBX8T3pNAJOiEDh+zxFw5ItvpAL9GqlYzV3R4rN4fvJoQ7NFyHavocIH/2e2iE1kEnPMpAEEoKC2w+SpCR5rp7jj0rL6ruOxMZF57PbUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwDe91Aey5ZIoY6QgZpSDQb7EcUpirBsMb9fUyns9pqYbLlNxpUPODCLYm/w9qfTRY0hbrfnuwJ5Ksr4hBEEfhAw=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "9516FF4C8650796025AF4FC6A13FC033766F1E6F32FB203E3562DAAFB9DF0794",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:n7WhruSOYlHdzmXQ8623/m6JA4f4UNHJvw49tRgF6Es="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:TcR8dCjz1KafvPTpoXyaOdrfX452N0ky+VIy7+oRcpo="
+        },
+        "target": "9255858786337818395603165512831024101510453493377417362192396248796027",
+        "randomness": "0",
+        "timestamp": 1719441728127,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAzawMVj35WwB5iqVoxBvfa/MH8coQ59PAIidM7hSNd7u4XqrDEKQHo7DGK/UfWpRKZIFACWyWMa7NuFTY+byae5k6NPkOrXzvynGy+FRrc+Wxgiko1nc8iwYjWCv4eVATbSgW7nNzwaXFb+aKVYI6gOpAbWuIkWqo09TvSF+cG8YFRYkSSdjyxf7QACJI4Ltis/qChWSKEApBflq0SYk8M8ubbJKi6FbDl7Syq8bcnnW5aspJeOTzInfk1+xuIwRW0KJMn+ZayDuTywF/xqPOYJmu5CZrmgQPQ6mOP/pSR5ixzuggufDGyyws3gDW12saJQnM88T+BUVFBCF9nTCkFeFBPjm6DevmOtthtd42pytHNEbt9WgdLjrg4jssyJMSdV0Qp7VV+2TkIoV3kbYqEhUXrU6sZfeSfyWFcBVt4Nicr1z03qGFfZEjOzb7IKJf4PBgtk0chiUkf1NwcvaRHR7B+bIm+0tftxR+/1yaFGfJJ1crJYfr4k+ENHMFH+xHDL7Cknr1xyve9VQMMIRVmXPk3yy/lrVCilrrJGz5QCgJutiNNp5f7K4hq+7s4reQn6PlXBtjDG1+5HywBVHYpsJVSTxf05FFRRE4ESgNS76nqYS2VLz74klyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw0/P2UgYHAJ8OVGWRUsY5K4szn30ehU7Phu5nG0Q98/Ijg3o+WTPBbUGhg2OaH5GAti+FCi+MENAB1IYQfQzhAw=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "1CC0F6BE54A623A0B0AC13E0A41A14ADE49A0E214B3E26F2FCCC109993F8F76F",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:s/TbP//NX4N1uVEg4cAjgzAsCsMBivJawUN03ssIyhY="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:AoNUIkCzQdk6lISiTioaAD6h4GcqiGLFCjPlZzPLoVU="
+        },
+        "target": "9228823284279306817296266184515742822248210830185427859262273659833347",
+        "randomness": "0",
+        "timestamp": 1719441728574,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 6,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA/f8lGM1diIN/TGfxQa5m4Yh5gbEYdtBrAMeFmrp52MiCrS+R9HkZvTbzqyt7zewkoA6TMjJmiuWrgWyGNfu4csVpIrTJ/CUY/FC7LHHs7qSK76JEUW0x4UrbP7fJqvUKcxHSv2POYPfFsniAd/j3/AEr947rXk/vEbfK9PonGZIBPca/Pw9AQVOioqeiPJOHabEUHXvXtFdmgCf4GZHArNuRxIPmHYNPPevamn2x/Ey4nn+iB0ouM+/meFKa+RZfrWhY6YKkX01hSR35SQLVKkXdYulQBx0fVggplXh1OKQhtTuMq7ht2jr2eY3KaiLM7JgNt97CFNJbOcS18T6Ji4/lw6Dwax+JaI1gbtO79IVl/6JdEARBZqwS+0FPYvk6forfgLp0OyJx6zeSx/jmYTMss1h7tI0Z1l7ncyzVCOx6Sg+N5E0HtAHUesnW8YxYo9kDnM7el4ogd1jIAEBOV6yuIvZ6DAgfLdHQzFJ6ph11R/JyTwSxalxRfqtJPcesd7NL8pbL+FO8/2wgv0U2JhuMqx1TAZi/AaaYtFvVoQnsFdfVi6cT0EqIqsprKDiPcCbZWnKD7/opbo3+DmHtgoUW8ipOWQPNwegIYbNtUlmqH/YI3+aTq0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw5VIIZj/q1ET+T7hlOn3tMl4l/VLHOYvcUlXqDsFU8ktlzQr1NX7qIXNV/3fZQu2u4aktXiz1/ZG/g8ZAv5jiAA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 5,
+        "previousBlockHash": "76CA8ADA5607F4B0D5B17ED4F9D47E09174EE39FBB7A3094298B2CA23D2A9745",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:+LliQic2PDDrTqKNNxZagq3h8/AvRKz5r4w2z+kEsWo="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:P7S39hVJs4dVJgBEECmP54qPs3Bv+07+9aV/1eqTDoA="
+        },
+        "target": "9201866281654531936596795386791503876274441021197252859723586932895305",
+        "randomness": "0",
+        "timestamp": 1719441729028,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 7,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAxeeweRxo6iD3UcX4YXg1XwMknBV1aVkLwNfgye3ZDcOJVsC2JE/9012EEZ2ts8MQs7/PkGwHhvNuUOxQg6+sDv+NjzvGPYPiiTn4FNBhxbCsDx2f8M6KT0arJtIslzdQPehs3OVemEILnv+YT/tfGcyfWLpRg8Z5FHirnEN6qocGgUTBt95RADnq7z7Vnixy4MbiArkO8I5fjNcfwDouZTRJwFiQO8QnHiAHg9vUJGeRPGNC/4BILyT5gHnoFoTgxl/w9RZf9ReTQ+NvBIOgueSi7Q3Ppr98HQwTxVDoW9q1yBRa2hey/DF7WSs8EEmdRvZiqeDp0pjDwnGPXpUgXQAxsu4BaasNvB8mexjSWKwudPEHmkk9tQOBIZZzgmo4LvGtt7IbeTL9Omy9CYigpHm0DPtENirBtzaQbtBny2UUcvQH0X7vslfFrMg0tfW7BR6TrEOk5P7fMhfsX942WzqWv4h9hbrTMeN4j40N/8VeOObAES7rCL88qANBNUybNDVsWVQLxRhgoS7jSKjSKqcfPrIVzAj6pjJBQclh7veuYP9UaGD5fj8jVdSKsZAJ18SYOd2y2JSGHNBkXyIq/Bbm4k2A+mWDMVXlEMaI7G6LbuGEbEfhnUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw8v24RV1PeDi9MINLvOGvzD7M0IqLrTLyK9tHcaUUWSaQjUMMRVnUeFbzIM+0P2tGnclKf8NXpbsZjdtSi65jAQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 6,
+        "previousBlockHash": "FE9F2C2EF1A280EE9F453B561E9E0EDB9DF95CA68A8CFB61206B06C63245CD0B",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:+06hDLNIGHR6hgoU3FNLh2fO5Er6p5RYs5AsN0wSvQU="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:mciVbP+cWYTL43++zveilipF5aqb5Epyy8towzxjFkg="
+        },
+        "target": "9174987784651351638043000274530578397566067964335270621952759689537226",
+        "randomness": "0",
+        "timestamp": 1719441729496,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 8,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAICBDDjaZTzDXobtlSEQHQNuc7wbFkF5LDqtvgnEoSj64ZMHwTi2MSIM+mOeeUHalIr1lQn15FhOc+vR21CxnMATPpQTutKO5mSp1xXUDEUmYn8CHjUuEUT53aIzftuXqE3xEa3NHxmA+uf30HEgC5j/B8mnPBesNw+JeYisBd3ISJ/9boxXBUK4J/MmFv/H3KZA+JBGDteH+/AIE5WyQyjL0YAVTK0frAr20W80+sZmEHpeL87oSpUMoSp2dmTLc387TQVXgqZ+uEiGDsNeycoWGMI0oCIV/lQmeo8xj4aXxRteViJDfoU5wt/v/I95DALPR+wMPRdQiKwr9ReuCEztGVVOK535c8QimYYaKQpVW1iVZ1+aa7W76kO0cJM0s1lG8o1uT4ktFMS/XK+6pGkmO3eiAPduR+PTq6ARH75MKAjDarGTHPD8WVzttDkFWMvnB2rHtFSrL8eO3Z1jKmt7OGLHvxPvoVlYA5nKNr2j1emesyGmmVS9p4Pn1IZUnSVuemDaoF/jpbSwWyfLSVvPd97ARQkitNQS/n0rlO+7AeIlruw7gOutSduazCDIoQYJGcNGYtjToyhtRSIdTeFUhzHMK9ZMT9apQ9mmDJqS2QK9S2+Lhbklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwHCCkwG0JEW+vfgElBFXqaqC+qmQw6+8fLbv4HdV7h5c4McA0TJEe+ChIrc8h6exdmKOGOsQvUjGvvDR41zuoDA=="
+        }
+      ]
+    }
+  ]
+}

--- a/ironfish/src/wallet/scanner/noteDecryptor.test.ts
+++ b/ironfish/src/wallet/scanner/noteDecryptor.test.ts
@@ -1,0 +1,147 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Assert } from '../../assert'
+import { Block } from '../../primitives'
+import { createNodeTest, useAccountFixture, useMinerBlockFixture } from '../../testUtilities'
+import { Account } from '../../wallet'
+import { BackgroundNoteDecryptor, DecryptNotesFromTransactionsCallback } from './noteDecryptor'
+
+describe('BackgroundNoteDecryptor', () => {
+  const nodeTest = createNodeTest()
+
+  /**
+   * Creates a series of notes on the chain, and returns the blocks that contain such notes.
+   */
+  const createTestNotes = async (
+    spec: ReadonlyArray<[account: Account, notesCount: number]>,
+  ): Promise<Array<Block>> => {
+    const blocks = []
+    for (const [account, notesCount] of spec) {
+      for (let i = 0; i < notesCount; i++) {
+        const block = await useMinerBlockFixture(
+          nodeTest.chain,
+          undefined,
+          account,
+          nodeTest.wallet,
+        )
+        await expect(nodeTest.chain).toAddBlock(block)
+        blocks.push(block)
+      }
+    }
+    return blocks
+  }
+
+  it('decrypts notes belonging to different accounts', async () => {
+    const accountA = await useAccountFixture(nodeTest.wallet, 'a')
+    const accountB = await useAccountFixture(nodeTest.wallet, 'b')
+
+    const blocks = await createTestNotes([
+      [accountA, 5],
+      [accountB, 3],
+      [accountA, 2],
+      [accountB, 2],
+    ])
+    expect(blocks.length).toBe(12)
+
+    const decryptor = new BackgroundNoteDecryptor(nodeTest.workerPool, nodeTest.sdk.config, {
+      decryptForSpender: true,
+    })
+
+    decryptor.start()
+
+    const callback = jest.fn<
+      ReturnType<DecryptNotesFromTransactionsCallback>,
+      jest.ArgumentsOf<DecryptNotesFromTransactionsCallback>
+    >()
+
+    for (const block of blocks) {
+      await decryptor.decryptNotesFromBlock(
+        block.header,
+        block.transactions,
+        [accountA, accountB],
+        callback,
+      )
+    }
+
+    await decryptor.flush()
+    decryptor.stop()
+
+    // Check that the callback was called the right number of times
+    expect(callback).toHaveBeenCalledTimes(2 * blocks.length)
+
+    // Check that the correct number of notes was decrypted
+    const totalNotesCount = new Map<string, number>()
+    for (const [account, _blockHeader, transactions] of callback.mock.calls) {
+      let notesForAccount = totalNotesCount.get(account.id) ?? 0
+      notesForAccount += transactions
+        .map(({ decryptedNotes }) => decryptedNotes.length)
+        .reduce((acc, item) => acc + item, 0)
+      totalNotesCount.set(account.id, notesForAccount)
+    }
+    expect(totalNotesCount).toEqual(
+      new Map([
+        [accountA.id, 7],
+        [accountB.id, 5],
+      ]),
+    )
+
+    // Check the individual callback calls
+    const expectedCalls = [
+      { account: accountA, block: blocks[0], decrypted: true },
+      { account: accountB, block: blocks[0], decrypted: false },
+      { account: accountA, block: blocks[1], decrypted: true },
+      { account: accountB, block: blocks[1], decrypted: false },
+      { account: accountA, block: blocks[2], decrypted: true },
+      { account: accountB, block: blocks[2], decrypted: false },
+      { account: accountA, block: blocks[3], decrypted: true },
+      { account: accountB, block: blocks[3], decrypted: false },
+      { account: accountA, block: blocks[4], decrypted: true },
+      { account: accountB, block: blocks[4], decrypted: false },
+
+      { account: accountA, block: blocks[5], decrypted: false },
+      { account: accountB, block: blocks[5], decrypted: true },
+      { account: accountA, block: blocks[6], decrypted: false },
+      { account: accountB, block: blocks[6], decrypted: true },
+      { account: accountA, block: blocks[7], decrypted: false },
+      { account: accountB, block: blocks[7], decrypted: true },
+
+      { account: accountA, block: blocks[8], decrypted: true },
+      { account: accountB, block: blocks[8], decrypted: false },
+      { account: accountA, block: blocks[9], decrypted: true },
+      { account: accountB, block: blocks[9], decrypted: false },
+
+      { account: accountA, block: blocks[10], decrypted: false },
+      { account: accountB, block: blocks[10], decrypted: true },
+      { account: accountA, block: blocks[11], decrypted: false },
+      { account: accountB, block: blocks[11], decrypted: true },
+    ]
+    expect(callback).toHaveBeenCalledTimes(expectedCalls.length)
+
+    let noteIndex = nodeTest.chain.genesis.noteSize
+
+    for (const [callIndex, { account, block, decrypted }] of expectedCalls.entries()) {
+      const transactions = block.transactions.map((transaction) => {
+        const decryptedNotes = []
+        if (decrypted) {
+          Assert.isNotNull(noteIndex)
+          decryptedNotes.push({
+            index: noteIndex,
+            forSpender: false,
+            hash: expect.anything(),
+            nullifier: expect.anything(),
+            serializedNote: expect.anything(),
+          })
+          noteIndex += 1
+        }
+        return { transaction, decryptedNotes }
+      })
+      expect(callback).toHaveBeenNthCalledWith(
+        callIndex + 1,
+        account,
+        block.header,
+        transactions,
+      )
+    }
+  })
+})

--- a/ironfish/src/wallet/scanner/noteDecryptor.ts
+++ b/ironfish/src/wallet/scanner/noteDecryptor.ts
@@ -1,0 +1,221 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Assert } from '../../assert'
+import { Config } from '../../fileStores'
+import { BlockHeader } from '../../primitives'
+import { Transaction } from '../../primitives/transaction'
+import { AsyncQueue } from '../../utils/asyncQueue'
+import { WorkerPool } from '../../workerPool'
+import { Job } from '../../workerPool/job'
+import {
+  DecryptedNote,
+  DecryptNotesOptions,
+  DecryptNotesRequest,
+  DecryptNotesResponse,
+} from '../../workerPool/tasks/decryptNotes'
+import { JobAbortedError } from '../../workerPool/tasks/jobAbort'
+import { Account } from '../account/account'
+
+export type DecryptNotesFromTransactionsCallback = (
+  account: Account,
+  blockHeader: BlockHeader,
+  transactions: Array<{ transaction: Transaction; decryptedNotes: Array<DecryptedNote> }>,
+) => Promise<void>
+
+export class BackgroundNoteDecryptor {
+  private isStarted = false
+
+  private triggerFlushed: (() => void) | null = null
+  private triggerStopped: (() => void) | null = null
+
+  private onFlushed: Promise<void> = Promise.resolve()
+  private onStopped: Promise<void> = Promise.resolve()
+
+  private readonly workerPool: WorkerPool
+  private readonly options: DecryptNotesOptions
+  private readonly decryptQueue: AsyncQueue<{
+    job: Job
+    accounts: ReadonlyArray<Account>
+    blockHeader: BlockHeader
+    transactions: ReadonlyArray<Transaction>
+    callback: DecryptNotesFromTransactionsCallback
+  }>
+
+  constructor(workerPool: WorkerPool, config: Config, options: DecryptNotesOptions) {
+    this.workerPool = workerPool
+    this.options = options
+
+    let queueSize = 8 * workerPool.numWorkers
+    const maxQueueSize = config.get('walletSyncingMaxConcurrency')
+    if (maxQueueSize > 0) {
+      queueSize = Math.min(queueSize, maxQueueSize)
+    }
+    queueSize = Math.max(queueSize, 1)
+    this.decryptQueue = new AsyncQueue(queueSize)
+  }
+
+  start(abort?: AbortController) {
+    if (!this.isStarted) {
+      this.isStarted = true
+      this.onStopped = new Promise((resolve) => (this.triggerStopped = resolve))
+      void this.decryptLoop()
+
+      if (abort) {
+        abort.signal.addEventListener('abort', this.stop.bind(this))
+      }
+    }
+  }
+
+  stop() {
+    if (this.isStarted) {
+      this.isStarted = false
+      for (const { job } of this.decryptQueue) {
+        job.abort()
+      }
+      this.decryptQueue.clear()
+      if (this.triggerStopped) {
+        this.triggerStopped()
+      }
+    }
+  }
+
+  private async decryptLoop(): Promise<void> {
+    while (this.isStarted) {
+      if (this.decryptQueue.isEmpty() && this.triggerFlushed) {
+        this.triggerFlushed()
+        this.triggerFlushed = null
+      }
+
+      const item = await Promise.race([this.decryptQueue.pop(), this.onStopped])
+      if (!item) {
+        break
+      }
+
+      const { job, accounts, blockHeader, transactions, callback } = item
+
+      let decryptNotesResponse
+      try {
+        decryptNotesResponse = await job.result()
+      } catch (e) {
+        if (e instanceof JobAbortedError) {
+          break
+        }
+        throw e
+      }
+
+      if (!this.isStarted) {
+        break
+      }
+
+      Assert.isInstanceOf(decryptNotesResponse, DecryptNotesResponse)
+      const decryptedNotes = decryptNotesResponse.mapToAccounts(
+        accounts.map((account) => ({ accountId: account.id })),
+      )
+
+      for (const { account, decryptedTransactions } of regroupNotes(
+        accounts,
+        transactions,
+        decryptedNotes,
+      )) {
+        if (!this.isStarted) {
+          break
+        }
+        await callback(account, blockHeader, decryptedTransactions)
+      }
+    }
+  }
+
+  /**
+   * Waits for all the in flight decrypt requests to be fully processed.
+   */
+  async flush(): Promise<void> {
+    if (!this.isStarted) {
+      return
+    }
+    await this.onFlushed
+  }
+
+  decryptNotesFromBlock(
+    blockHeader: BlockHeader,
+    transactions: ReadonlyArray<Transaction>,
+    accounts: ReadonlyArray<Account>,
+    callback: DecryptNotesFromTransactionsCallback,
+  ): Promise<void> {
+    if (!this.isStarted) {
+      throw new Error('decryptor was not started')
+    }
+
+    if (!this.triggerFlushed) {
+      this.onFlushed = new Promise((resolve) => (this.triggerFlushed = resolve))
+    }
+
+    const accountKeys = accounts.map((account) => ({
+      incomingViewKey: account.incomingViewKey,
+      outgoingViewKey: account.outgoingViewKey,
+      viewKey: account.viewKey,
+    }))
+    Assert.isNotNull(blockHeader.noteSize)
+
+    const encryptedNotes = []
+    let currentNoteIndex = transactions
+      .map((transaction) => transaction.notes.length)
+      .reduce((accumulator, numNotes) => accumulator - numNotes, blockHeader.noteSize)
+
+    for (const transaction of transactions) {
+      for (const note of transaction.notes) {
+        encryptedNotes.push({ serializedNote: note.serialize(), currentNoteIndex })
+        currentNoteIndex++
+      }
+    }
+
+    const decryptNotesRequest = new DecryptNotesRequest(
+      accountKeys,
+      encryptedNotes,
+      this.options,
+    )
+    const job = this.workerPool.execute(decryptNotesRequest)
+
+    return this.decryptQueue.push({
+      job,
+      accounts,
+      blockHeader,
+      transactions,
+      callback,
+    })
+  }
+}
+
+/**
+ * Reassociates each decrypted note to its corresponding transaction.
+ */
+function* regroupNotes(
+  accounts: ReadonlyArray<Account>,
+  transactions: ReadonlyArray<Transaction>,
+  decryptedNotes: ReadonlyMap<string, ReadonlyArray<DecryptedNote | null>>,
+): Generator<{
+  account: Account
+  decryptedTransactions: Array<{
+    transaction: Transaction
+    decryptedNotes: Array<DecryptedNote>
+  }>
+}> {
+  for (const account of accounts) {
+    let notesOffset = 0
+    const flatNotes: ReadonlyArray<DecryptedNote | null> = decryptedNotes.get(account.id) ?? []
+    const groupedNotes: Array<{
+      transaction: Transaction
+      decryptedNotes: Array<DecryptedNote>
+    }> = []
+
+    for (const transaction of transactions) {
+      const decryptedNotes = flatNotes
+        .slice(notesOffset, notesOffset + transaction.notes.length)
+        .filter((note) => note !== null) as Array<DecryptedNote>
+      groupedNotes.push({ transaction, decryptedNotes })
+      notesOffset += transaction.notes.length
+    }
+
+    yield { account, decryptedTransactions: groupedNotes }
+  }
+}

--- a/ironfish/src/wallet/scanner/walletScanner.test.ts
+++ b/ironfish/src/wallet/scanner/walletScanner.test.ts
@@ -1,0 +1,472 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Asset } from '@ironfish/rust-nodejs'
+import { Assert } from '../../assert'
+import { Blockchain } from '../../blockchain'
+import { Block, BlockHeader } from '../../primitives'
+import { createNodeTest, useAccountFixture, useMinerBlockFixture } from '../../testUtilities'
+import { AsyncUtils } from '../../utils'
+import { Account, Wallet } from '../../wallet'
+import { BackgroundNoteDecryptor } from './noteDecryptor'
+
+describe('WalletScanner', () => {
+  const nodeTest = createNodeTest()
+
+  beforeEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  /**
+   * Creates a series of notes on the chain, and returns the blocks that contain such notes.
+   */
+  const createTestNotes = async (
+    chain: Blockchain,
+    wallet: Wallet,
+    spec: ReadonlyArray<[account: Account, notesCount: number]>,
+  ): Promise<Array<Block>> => {
+    const blocks = []
+    for (const [account, notesCount] of spec) {
+      for (let i = 0; i < notesCount; i++) {
+        const block = await useMinerBlockFixture(chain, undefined, account, wallet)
+        await expect(chain).toAddBlock(block)
+        blocks.push(block)
+      }
+    }
+    return blocks
+  }
+
+  it('adds transactions to the wallet db with decrypted notes', async () => {
+    const connectBlockForAccount = jest.spyOn(nodeTest.wallet, 'connectBlockForAccount')
+
+    const account = await useAccountFixture(nodeTest.wallet, 'a')
+    const blocks = await createTestNotes(nodeTest.chain, nodeTest.wallet, [[account, 3]])
+
+    expect(connectBlockForAccount).not.toHaveBeenCalled()
+    await nodeTest.wallet.scan()
+    expect(connectBlockForAccount).toHaveBeenCalledTimes(3)
+
+    const initialNoteIndex = nodeTest.chain.genesis.noteSize
+    Assert.isNotNull(initialNoteIndex)
+
+    for (const [i, block] of blocks.entries()) {
+      expect(block.transactions.length).toBe(1)
+
+      expect(connectBlockForAccount).toHaveBeenNthCalledWith(
+        i + 1,
+        account,
+        block.header,
+        block.transactions.map((transaction) => ({
+          transaction,
+          decryptedNotes: [
+            expect.objectContaining({
+              index: i + initialNoteIndex,
+              forSpender: false,
+              hash: expect.anything(),
+              nullifier: expect.anything(),
+              serializedNote: expect.anything(),
+            }),
+          ],
+        })),
+        true,
+      )
+
+      for (const transaction of block.transactions) {
+        const storedTransaction = await account.getTransaction(transaction.hash())
+        expect(storedTransaction).toBeDefined()
+        expect(storedTransaction?.blockHash).toEqual(block.header.hash)
+        expect(storedTransaction?.sequence).toEqual(block.header.sequence)
+      }
+    }
+
+    const allStoredTransactions = await AsyncUtils.materialize(account.getTransactions())
+    expect(allStoredTransactions.length).toBe(3)
+
+    await expect(account.getBalance(Asset.nativeId(), 0)).resolves.toMatchObject({
+      confirmed: 3n * 2000000000n,
+      unconfirmed: 3n * 2000000000n,
+    })
+  })
+
+  it('updates the account head hash', async () => {
+    const account = await useAccountFixture(nodeTest.wallet, 'a')
+    const blocks = await createTestNotes(nodeTest.chain, nodeTest.wallet, [[account, 3]])
+
+    await nodeTest.wallet.scan()
+
+    const accountHead = await account.getHead()
+    expect(accountHead?.hash).toEqualHash(blocks[2].header.hash)
+  })
+
+  it('ignores accounts that have scanning disabled', async () => {
+    const connectBlockForAccount = jest.spyOn(nodeTest.wallet, 'connectBlockForAccount')
+
+    const accountA = await useAccountFixture(nodeTest.wallet, 'a')
+    const accountB = await useAccountFixture(nodeTest.wallet, 'b')
+    const accountC = await useAccountFixture(nodeTest.wallet, 'c')
+    const accountD = await useAccountFixture(nodeTest.wallet, 'd')
+
+    await accountB.updateScanningEnabled(false)
+    await accountD.updateScanningEnabled(false)
+
+    const blocks = await createTestNotes(nodeTest.chain, nodeTest.wallet, [
+      [accountA, 1],
+      [accountB, 1],
+      [accountC, 1],
+      [accountD, 1],
+      [accountD, 1],
+      [accountB, 1],
+      [accountA, 1],
+      [accountC, 1],
+    ])
+
+    expect(connectBlockForAccount).not.toHaveBeenCalled()
+    await nodeTest.wallet.scan()
+    expect(connectBlockForAccount).toHaveBeenCalledTimes(16)
+
+    const initialNoteIndex = nodeTest.chain.genesis.noteSize
+    Assert.isNotNull(initialNoteIndex)
+
+    const expectedConnectedAccountBlocks = [
+      { account: accountA, block: blocks[0], decryptedNoteIndexes: [initialNoteIndex] },
+      { account: accountC, block: blocks[0], decryptedNoteIndexes: [] },
+      { account: accountA, block: blocks[1], decryptedNoteIndexes: [] },
+      { account: accountC, block: blocks[1], decryptedNoteIndexes: [] },
+      { account: accountA, block: blocks[2], decryptedNoteIndexes: [] },
+      { account: accountC, block: blocks[2], decryptedNoteIndexes: [initialNoteIndex + 2] },
+      { account: accountA, block: blocks[3], decryptedNoteIndexes: [] },
+      { account: accountC, block: blocks[3], decryptedNoteIndexes: [] },
+      { account: accountA, block: blocks[4], decryptedNoteIndexes: [] },
+      { account: accountC, block: blocks[4], decryptedNoteIndexes: [] },
+      { account: accountA, block: blocks[5], decryptedNoteIndexes: [] },
+      { account: accountC, block: blocks[5], decryptedNoteIndexes: [] },
+      { account: accountA, block: blocks[6], decryptedNoteIndexes: [initialNoteIndex + 6] },
+      { account: accountC, block: blocks[6], decryptedNoteIndexes: [] },
+      { account: accountA, block: blocks[7], decryptedNoteIndexes: [] },
+      { account: accountC, block: blocks[7], decryptedNoteIndexes: [initialNoteIndex + 7] },
+    ]
+
+    for (const [
+      i,
+      { account, block, decryptedNoteIndexes },
+    ] of expectedConnectedAccountBlocks.entries()) {
+      expect(block.transactions.length).toBe(1)
+
+      expect(connectBlockForAccount).toHaveBeenNthCalledWith(
+        i + 1,
+        account,
+        block.header,
+        block.transactions.map((transaction) => ({
+          transaction,
+          decryptedNotes: decryptedNoteIndexes.map(
+            (index) =>
+              expect.objectContaining({
+                index,
+                forSpender: false,
+                hash: expect.anything(),
+                nullifier: expect.anything(),
+                serializedNote: expect.anything(),
+              }) as unknown,
+          ),
+        })),
+        true,
+      )
+
+      for (const transaction of block.transactions) {
+        const storedTransaction = await account.getTransaction(transaction.hash())
+        if (!decryptedNoteIndexes.length) {
+          expect(storedTransaction).not.toBeDefined()
+        } else {
+          expect(storedTransaction).toBeDefined()
+          expect(storedTransaction?.blockHash).toEqual(block.header.hash)
+          expect(storedTransaction?.sequence).toEqual(block.header.sequence)
+        }
+      }
+    }
+
+    await expect(nodeTest.wallet.getBalance(accountA, Asset.nativeId())).resolves.toMatchObject(
+      {
+        confirmed: 2n * 2000000000n,
+        unconfirmed: 2n * 2000000000n,
+      },
+    )
+    await expect(nodeTest.wallet.getBalance(accountB, Asset.nativeId())).resolves.toMatchObject(
+      {
+        confirmed: 0n,
+        unconfirmed: 0n,
+      },
+    )
+    await expect(nodeTest.wallet.getBalance(accountC, Asset.nativeId())).resolves.toMatchObject(
+      {
+        confirmed: 2n * 2000000000n,
+        unconfirmed: 2n * 2000000000n,
+      },
+    )
+    await expect(nodeTest.wallet.getBalance(accountD, Asset.nativeId())).resolves.toMatchObject(
+      {
+        confirmed: 0n,
+        unconfirmed: 0n,
+      },
+    )
+
+    expect((await accountA.getHead())?.hash).toEqualHash(blocks[7].header.hash)
+    expect((await accountB.getHead())?.hash).toEqualHash(nodeTest.chain.genesis.hash)
+    expect((await accountC.getHead())?.hash).toEqualHash(blocks[7].header.hash)
+    expect((await accountD.getHead())?.hash).toEqualHash(nodeTest.chain.genesis.hash)
+  })
+
+  it('skips decryption for accounts with createdAt later than the block header', async () => {
+    const accountA = await useAccountFixture(nodeTest.wallet, 'a')
+    expect(accountA.createdAt?.hash).toEqualHash(nodeTest.chain.genesis.hash)
+
+    const firstBlocks = await createTestNotes(nodeTest.chain, nodeTest.wallet, [[accountA, 3]])
+
+    const accountB = await useAccountFixture(nodeTest.wallet, 'b')
+    expect(accountB.createdAt?.hash).toEqualHash(firstBlocks[2].header.hash)
+
+    const lastBlocks = await createTestNotes(nodeTest.chain, nodeTest.wallet, [[accountB, 3]])
+
+    const decryptNotesFromBlock = jest.spyOn(
+      BackgroundNoteDecryptor.prototype,
+      'decryptNotesFromBlock',
+    )
+
+    await nodeTest.wallet.reset()
+    await nodeTest.wallet.scan()
+
+    const genesisBlock = await nodeTest.chain.getBlock(nodeTest.chain.genesis)
+    Assert.isNotNull(genesisBlock)
+
+    const blocks = [genesisBlock, ...firstBlocks, ...lastBlocks]
+
+    expect(decryptNotesFromBlock).toHaveBeenCalledTimes(blocks.length)
+
+    for (const [i, block] of blocks.slice(1, 3).entries()) {
+      expect(decryptNotesFromBlock).toHaveBeenNthCalledWith(
+        i + 2,
+        block.header,
+        block.transactions,
+        [expect.objectContaining({ incomingViewKey: accountA.incomingViewKey })],
+        expect.anything(),
+      )
+    }
+    for (const [i, block] of blocks.slice(3).entries()) {
+      expect(decryptNotesFromBlock).toHaveBeenNthCalledWith(
+        i + 4,
+        block.header,
+        block.transactions,
+        [
+          expect.objectContaining({ incomingViewKey: accountA.incomingViewKey }),
+          expect.objectContaining({ name: accountB.name }),
+        ],
+        expect.anything(),
+      )
+    }
+  })
+
+  it('skips blocks preceeding the lowest createdAt', async () => {
+    const decryptNotesFromBlock = jest.spyOn(
+      BackgroundNoteDecryptor.prototype,
+      'decryptNotesFromBlock',
+    )
+    const connectBlockForAccount = jest.spyOn(nodeTest.wallet, 'connectBlockForAccount')
+
+    const accountA = await useAccountFixture(nodeTest.wallet, 'a')
+    const firstBlocks = await createTestNotes(nodeTest.chain, nodeTest.wallet, [[accountA, 3]])
+    await nodeTest.wallet.removeAccount(accountA)
+
+    const accountB = await useAccountFixture(nodeTest.wallet, 'b')
+    const lastBlocks = await createTestNotes(nodeTest.chain, nodeTest.wallet, [[accountB, 3]])
+
+    await nodeTest.wallet.reset()
+    await nodeTest.wallet.scan()
+
+    const blocks = [firstBlocks[2], ...lastBlocks]
+
+    expect(decryptNotesFromBlock).toHaveBeenCalledTimes(blocks.length)
+    expect(connectBlockForAccount).toHaveBeenCalledTimes(blocks.length)
+
+    for (const [i, block] of blocks.entries()) {
+      expect(decryptNotesFromBlock).toHaveBeenNthCalledWith(
+        i + 1,
+        block.header,
+        block.transactions,
+        [expect.objectContaining({ incomingViewKey: accountB.incomingViewKey })],
+        expect.anything(),
+      )
+      expect(connectBlockForAccount).toHaveBeenNthCalledWith(
+        i + 1,
+        expect.objectContaining({ incomingViewKey: accountB.incomingViewKey }),
+        block.header,
+        expect.anything(),
+        true,
+      )
+    }
+  })
+
+  describe('restarts scanning', () => {
+    // Set up the BackgroundNoteDecryptor so that we can pause and resume the
+    // scan after each block that gets processed.
+    let continueScan: () => void = () => {}
+    let notifyDecryptCall: ((blockHeader: BlockHeader) => void) | null = null
+    let decryptCallPromise: Promise<BlockHeader> | null = null
+
+    const nextDecryptCall = async (): Promise<BlockHeader> => {
+      Assert.isNotNull(decryptCallPromise)
+      const blockHeader = await decryptCallPromise
+      decryptCallPromise = new Promise((resolve) => {
+        notifyDecryptCall = resolve
+      })
+      return blockHeader
+    }
+
+    const patchWalletScanner = (wallet: Wallet) => {
+      const connectBlockOrig = wallet.scanner.connectBlock.bind(wallet.scanner)
+      jest
+        .spyOn(wallet.scanner, 'connectBlock')
+        .mockImplementation(async (blockHeader, ...args) => {
+          Assert.isNotNull(notifyDecryptCall)
+          notifyDecryptCall(blockHeader)
+          void connectBlockOrig(blockHeader, ...args)
+          return new Promise((resolve) => {
+            continueScan = resolve
+          })
+        })
+
+      decryptCallPromise = new Promise((resolve) => {
+        notifyDecryptCall = resolve
+      })
+    }
+
+    it('when accounts are imported', async () => {
+      const { chain, wallet } = await nodeTest.createSetup({
+        config: { walletSyncingMaxQueueSize: 1 },
+      })
+      patchWalletScanner(wallet)
+
+      // Create 2 accounts, and remove the first one (so that we can re-import it later)
+      const genesisBlock = await chain.getBlock(chain.genesis)
+      Assert.isNotNull(genesisBlock)
+      const blocks = [genesisBlock]
+      const accountA = await useAccountFixture(wallet, 'a')
+      blocks.push(...(await createTestNotes(chain, wallet, [[accountA, 5]])))
+      const accountB = await useAccountFixture(wallet, 'b')
+      blocks.push(...(await createTestNotes(chain, wallet, [[accountB, 5]])))
+      await wallet.removeAccount(accountA)
+
+      expect(blocks.length).toBe(11)
+
+      // Start scanning
+      await wallet.reset()
+      const scanPromise = wallet.scan()
+
+      // Check that the scanning begins at the `accountB` creation block (and scan a few blocks)
+      for (let i = 5; i <= 8; i++) {
+        continueScan()
+        const firstBlockHeader = await nextDecryptCall()
+        expect(firstBlockHeader.hash).toEqualHash(blocks[i].header.hash)
+      }
+
+      // Now import `accountA`
+      await wallet.importAccount(accountA.serialize())
+
+      // Check that scanning resumes at the `accountA` creation block (and scan till the end)
+      for (let i = 0; i <= 10; i++) {
+        continueScan()
+        const blockHeader = await nextDecryptCall()
+        expect(blockHeader.hash).toEqualHash(blocks[i].header.hash)
+      }
+
+      // Scan should be done
+      continueScan()
+      await scanPromise
+    })
+
+    it('when accounts are deleted', async () => {
+      const { chain, wallet } = await nodeTest.createSetup({
+        config: { walletSyncingMaxQueueSize: 1 },
+      })
+      patchWalletScanner(wallet)
+
+      // Create 2 accounts
+      const genesisBlock = await chain.getBlock(chain.genesis)
+      Assert.isNotNull(genesisBlock)
+      const blocks = [genesisBlock]
+      const accountA = await useAccountFixture(wallet, 'a')
+      blocks.push(...(await createTestNotes(chain, wallet, [[accountA, 5]])))
+      const accountB = await useAccountFixture(wallet, 'b')
+      blocks.push(...(await createTestNotes(chain, wallet, [[accountB, 5]])))
+
+      expect(blocks.length).toBe(11)
+
+      // Start scanning
+      await wallet.reset()
+      const scanPromise = wallet.scan()
+
+      // Check that the scanning begins at the `accountA` creation block (and scan a few blocks)
+      for (let i = 0; i <= 2; i++) {
+        continueScan()
+        const blockHeader = await nextDecryptCall()
+        expect(blockHeader.hash).toEqualHash(blocks[i].header.hash)
+      }
+
+      // Now delete `accountA`
+      //
+      // (Need to use `removeAccountByName` instead of `removeAccount` because
+      // the previous call to `wallet.reset()` has caused the account id to
+      // change)
+      await wallet.removeAccountByName(accountA.name)
+
+      // Check that scanning skips blocks and resumes at the `accountB` creation block (and scan till the end)
+      for (let i = 5; i <= 10; i++) {
+        continueScan()
+        const blockHeader = await nextDecryptCall()
+        expect(blockHeader.hash).toEqualHash(blocks[i].header.hash)
+      }
+
+      // Scan should be done
+      continueScan()
+      await scanPromise
+    })
+
+    it('when accounts are reset', async () => {
+      const { chain, wallet } = await nodeTest.createSetup({
+        config: { walletSyncingMaxQueueSize: 1 },
+      })
+      patchWalletScanner(wallet)
+
+      const genesisBlock = await chain.getBlock(chain.genesis)
+      Assert.isNotNull(genesisBlock)
+      const blocks = [genesisBlock]
+      const account = await useAccountFixture(wallet, 'a')
+      blocks.push(...(await createTestNotes(chain, wallet, [[account, 5]])))
+
+      expect(blocks.length).toBe(6)
+
+      // Start scanning
+      await wallet.reset()
+      const scanPromise = wallet.scan()
+
+      // Check that the scanning begins at the genesis block (and scan a few blocks)
+      for (let i = 0; i <= 3; i++) {
+        continueScan()
+        const blockHeader = await nextDecryptCall()
+        expect(blockHeader.hash).toEqualHash(blocks[i].header.hash)
+      }
+
+      // Reset the wallet
+      await wallet.reset()
+
+      // Check that scanning restarts from the genesis block (and scan till the end)
+      for (let i = 0; i <= 5; i++) {
+        continueScan()
+        const blockHeader = await nextDecryptCall()
+        expect(blockHeader.hash).toEqualHash(blocks[i].header.hash)
+      }
+
+      // Scan should be done
+      continueScan()
+      await scanPromise
+    })
+  })
+})

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -146,6 +146,7 @@ export class Wallet {
 
     this.scanner = new WalletScanner({
       wallet: this,
+      workerPool: this.workerPool,
       logger: this.logger,
       config: this.config,
       nodeClient: this.nodeClient,
@@ -614,7 +615,6 @@ export class Wallet {
 
     for (const account of accounts) {
       const decryptedNotes = decryptedNotesByAccountId.get(account.id) ?? []
-
       await this.backfillAssets(account, decryptedNotes, transaction.mints)
       await account.addPendingTransaction(transaction, decryptedNotes, head.sequence)
     }

--- a/ironfish/src/workerPool/pool.ts
+++ b/ironfish/src/workerPool/pool.ts
@@ -225,7 +225,7 @@ export class WorkerPool {
     await this.execute(request).result()
   }
 
-  private execute(request: Readonly<WorkerMessage>): Job {
+  execute(request: Readonly<WorkerMessage>): Job {
     // Ensure that workers are started before handling jobs
     this.start()
 


### PR DESCRIPTION
## Summary

A wallet scan currently works like this:

```mermaid
graph LR;
  r[read block]-->d[decrypt notes]
  d-->u[update accounts]
  u-.->r
```

*read block* and *update accounts* are primarily IO-bound operations, and they run in the main thread only. This means that while *read block* and *update accounts* are running, the CPUs are under-utilized.

To maximize CPU utilization (and therefore improve scan performance), the scan has been changed to look like this:

```mermaid
graph LR;
  r[read block]-.->r
  r-->q[queue]
  q-->d[decrypt notes]
  d-->u[update accounts]
```

With this new algorithm, *read block* will try to read as many blocks as possible, without stopping, and place them on a queue. The queue is consumed and notes are decrypted in parallel inside the worker threads. Because *read block* is significantly faster than *decrypt notes*, the queue will normally be almost full, and so the worker threads are fully utilized.

## Testing Plan

* Unit tests
* `wallet:rescan`

## Documentation

N/A

## Breaking Change

N/A