### PR TITLE
Adds error handling to chainport requests

### DIFF
--- a/ironfish-cli/src/utils/chainport/types.ts
+++ b/ironfish-cli/src/utils/chainport/types.ts
@@ -66,3 +66,7 @@ export type ChainportTransactionStatus =
       created_at: string | null
       port_in_ack: boolean | null
     }
+
+export type ChainportError = {
+  Error: string
+}


### PR DESCRIPTION
1. Adds a new makeChainportRequest function that wraps the existing makeRequest function and adds error handling for chainport requests
2. This function takes a generic type parameter T that represents the expected response type
3. If the response is not successful, the function throws an error with the response status and message

For reference, this is their new error return type schema https://iflabs.slack.com/archives/C0677Q1AGDD/p1718793349123629

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
