### PR TITLE
removes references to account createdAt hash

### DIFF
--- a/ironfish/src/rpc/routes/wallet/resetAccount.test.ts
+++ b/ironfish/src/rpc/routes/wallet/resetAccount.test.ts
@@ -22,7 +22,7 @@ describe('Route wallet/resetAccount', () => {
 
     const account = await useAccountAndAddFundsFixture(routeTest.wallet, routeTest.chain)
 
-    expect(account.createdAt?.hash).toEqualBuffer(block1.header.hash)
+    expect(account.createdAt?.sequence).toEqual(block1.header.sequence)
     expect((await account.getBalance(Asset.nativeId(), 0))?.confirmed).toBe(2000000000n)
 
     await account.updateScanningEnabled(false)
@@ -49,7 +49,7 @@ describe('Route wallet/resetAccount', () => {
 
     const account = await useAccountAndAddFundsFixture(routeTest.wallet, routeTest.chain)
 
-    expect(account.createdAt?.hash).toEqualBuffer(block1.header.hash)
+    expect(account.createdAt?.sequence).toEqual(block1.header.sequence)
 
     await routeTest.client
       .request<ResetAccountResponse>('wallet/resetAccount', {

--- a/ironfish/src/wallet/wallet.test.ts
+++ b/ironfish/src/wallet/wallet.test.ts
@@ -730,14 +730,12 @@ describe('Wallet', () => {
       // create an account so that createdAt will be non-null
       const accountB = await useAccountFixture(nodeA.wallet, 'accountB')
 
-      expect(accountB.createdAt?.hash).toEqualHash(block3.header.hash)
       expect(accountB.createdAt?.sequence).toEqual(3)
 
       const accountBImport = await nodeB.wallet.importAccount(
         toAccountImport(accountB, false, nodeB.wallet.networkId),
       )
 
-      expect(accountBImport.createdAt?.hash).toEqualHash(block3.header.hash)
       expect(accountBImport.createdAt?.sequence).toEqual(3)
     })
 
@@ -765,7 +763,6 @@ describe('Wallet', () => {
         toAccountImport(accountB, false, nodeB.wallet.networkId),
       )
 
-      expect(accountBImport.createdAt?.hash).toEqualHash(block3.header.hash)
       expect(accountBImport.createdAt?.sequence).toEqual(3)
 
       const accountBImportHead = await accountBImport.getHead()
@@ -792,7 +789,6 @@ describe('Wallet', () => {
       // create an account on nodeA so that createdAt will be non-null
       const accountB = await useAccountFixture(nodeA.wallet, 'accountB')
 
-      expect(accountB.createdAt?.hash).toEqualHash(block3.header.hash)
       expect(accountB.createdAt?.sequence).toEqual(3)
 
       const accountBImport = await nodeB.wallet.importAccount(
@@ -943,7 +939,6 @@ describe('Wallet', () => {
 
       const account = await node.wallet.createAccount('test')
 
-      expect(account.createdAt?.hash).toEqualHash(block2.header.hash)
       expect(account.createdAt?.sequence).toEqual(block2.header.sequence)
     })
 
@@ -2011,7 +2006,6 @@ describe('Wallet', () => {
       await node.chain.addBlock(block2)
       await node.wallet.scan()
 
-      expect(accountA.createdAt?.hash).toEqualHash(block2.header.hash)
       expect(accountA.createdAt?.sequence).toEqual(block2.header.sequence)
     })
 
@@ -2042,7 +2036,6 @@ describe('Wallet', () => {
       await node.chain.addBlock(block2)
       await node.wallet.scan()
 
-      expect(accountA.createdAt?.hash).toEqualHash(block2.header.hash)
       expect(accountA.createdAt?.sequence).toEqual(block2.header.sequence)
 
       const block3 = await useMinerBlockFixture(node.chain, 3, accountA)
@@ -2050,7 +2043,6 @@ describe('Wallet', () => {
       await node.wallet.scan()
 
       // see that createdAt is unchanged
-      expect(accountA.createdAt?.hash).toEqualHash(block2.header.hash)
       expect(accountA.createdAt?.sequence).toEqual(block2.header.sequence)
     })
 
@@ -2070,7 +2062,6 @@ describe('Wallet', () => {
       const accountB = await useAccountFixture(nodeA.wallet, 'b')
 
       expect(accountB.createdAt).not.toBeNull()
-      expect(accountB.createdAt?.hash).toEqualHash(block3.header.hash)
       expect(accountB.createdAt?.sequence).toEqual(block3.header.sequence)
 
       // reset wallet
@@ -2583,7 +2574,6 @@ describe('Wallet', () => {
       // create second account so that createdAt will be non-null
       let accountB: Account | null = await useAccountFixture(node.wallet, 'b')
 
-      expect(accountB.createdAt?.hash).toEqualHash(block2.header.hash)
       expect(accountB.createdAt?.sequence).toEqual(block2.header.sequence)
 
       await node.wallet.resetAccount(accountB, { resetCreatedAt: false })
@@ -2593,7 +2583,6 @@ describe('Wallet', () => {
       Assert.isNotNull(accountB)
 
       // createdAt should still refer to block2
-      expect(accountB.createdAt?.hash).toEqualHash(block2.header.hash)
       expect(accountB.createdAt?.sequence).toEqual(block2.header.sequence)
 
       // reset createdAt

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -22,7 +22,7 @@ import { Side } from '../merkletree/merkletree'
 import { Witness } from '../merkletree/witness'
 import { Mutex } from '../mutex'
 import { BlockHeader } from '../primitives'
-import { GENESIS_BLOCK_PREVIOUS, GENESIS_BLOCK_SEQUENCE } from '../primitives/block'
+import { GENESIS_BLOCK_SEQUENCE } from '../primitives/block'
 import { BurnDescription } from '../primitives/burnDescription'
 import { MintDescription } from '../primitives/mintDescription'
 import { Note } from '../primitives/note'
@@ -1372,11 +1372,11 @@ export class Wallet {
       await this.walletDb.setAccount(account, tx)
 
       if (createdAt !== null) {
-        const previousBlockHash = await this.chainGetPreviousBlockHash(createdAt.hash)
+        const previousBlock = await this.chainGetBlock({ sequence: createdAt.sequence - 1 })
 
-        const head = previousBlockHash
+        const head = previousBlock
           ? {
-              hash: previousBlockHash,
+              hash: Buffer.from(previousBlock.block.hash, 'hex'),
               sequence: createdAt.sequence - 1,
             }
           : null
@@ -1426,13 +1426,13 @@ export class Wallet {
       await this.walletDb.setAccount(newAccount, tx)
 
       if (newAccount.createdAt !== null) {
-        const previousBlockHash = await this.chainGetPreviousBlockHash(
-          newAccount.createdAt.hash,
-        )
+        const previousBlock = await this.chainGetBlock({
+          sequence: newAccount.createdAt.sequence - 1,
+        })
 
-        const head = previousBlockHash
+        const head = previousBlock
           ? {
-              hash: previousBlockHash,
+              hash: Buffer.from(previousBlock.block.hash, 'hex'),
               sequence: newAccount.createdAt.sequence - 1,
             }
           : null
@@ -1642,22 +1642,6 @@ export class Wallet {
       this.logger.error(ErrorUtils.renderError(error, true))
       throw error
     }
-  }
-
-  async chainGetPreviousBlockHash(hash: Buffer): Promise<Buffer | null> {
-    const block = await this.chainGetBlock({ hash: hash.toString('hex') })
-
-    if (block === null) {
-      return null
-    }
-
-    const previousBlockHash = Buffer.from(block.block.previousBlockHash, 'hex')
-
-    if (previousBlockHash.equals(GENESIS_BLOCK_PREVIOUS)) {
-      return null
-    }
-
-    return previousBlockHash
   }
 
   private async getChainAsset(id: Buffer): Promise<{

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -1377,7 +1377,7 @@ export class Wallet {
         const head = previousBlock
           ? {
               hash: Buffer.from(previousBlock.block.hash, 'hex'),
-              sequence: createdAt.sequence - 1,
+              sequence: previousBlock.block.sequence,
             }
           : null
 
@@ -1433,7 +1433,7 @@ export class Wallet {
         const head = previousBlock
           ? {
               hash: Buffer.from(previousBlock.block.hash, 'hex'),
-              sequence: newAccount.createdAt.sequence - 1,
+              sequence: previousBlock.block.sequence,
             }
           : null
 


### PR DESCRIPTION
## Summary

now that we use networkId in account imports to determine whether the createdAt sequence refers to a block on the same chain the hash is no longer needed. it is mostly vestigial, like the appendix or the wings of a kiwi bird

these changes remove remaining references to createdAt.hash

## Testing Plan

existing unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
