### PR TITLE
supports setting createdAt on account import

### DIFF
--- a/ironfish-cli/src/commands/wallet/import.ts
+++ b/ironfish-cli/src/commands/wallet/import.ts
@@ -23,6 +23,9 @@ export class ImportCommand extends IronfishCommand {
     name: Flags.string({
       description: 'the name to use for the account',
     }),
+    createdAt: Flags.integer({
+      description: 'Block sequence to begin scanning from for the imported account',
+    }),
   }
 
   static args = {
@@ -87,6 +90,7 @@ export class ImportCommand extends IronfishCommand {
           account,
           rescan: flags.rescan,
           name: flags.name,
+          createdAt: flags.createdAt,
         })
       } catch (e) {
         if (

--- a/ironfish/src/rpc/routes/wallet/__fixtures__/importAccount.test.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/__fixtures__/importAccount.test.ts.fixture
@@ -1,0 +1,30 @@
+{
+  "Route wallet/importAccount should set the account createdAt field to the createdAt sequence": [
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "4791D7AE9F97DF100EF1558E84772D6A09B43762388283F75C6F20A32A88AA86",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:OrFh1gNPebpwyD0EOBJXhvWSWcNIqvOofpmIUdQuMxg="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:o67WawihP0SziWZCyKRf8E9IJLHEAKJRxtHegUciYYU="
+        },
+        "target": "9282972777491357380673661573939192202192629606981189395159182914949423",
+        "randomness": "0",
+        "timestamp": 1718920385337,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAKVqg+LxkGFUdgVMSHhIIrp1oG0U1gg3WxwKonNL3I16NB/NqRoZxzc+mlx6IX3v2Ch+S+aHHTzXnVwJoMNsy5KGWbqGPvb1RP+fM/H6mmbCnik9BEtu8uYv12x4XjDqAohBRAPoUG0AjYAAhpQLSXnvQ7bF6grHEj+agByDw45kVAnz+nVhTFp3ODOCH4HGMqylTTG7329MZgUGXXOSIqWKCLYjIpACsiyEsz1Y/XP+54h9oHmUwm2ObkGOLFXb6D0PHxfKTEWg+jJNU6XVGUDY9BVt6SgYyWE+qA8ForJYDgxHly6kPsDy1WMYhAHpLpvSF4oyvwUoVa8qQDmVhtS8k/F7aRjCICP94DaPs/IvvesJkXI/gmp6mBsZyS/hxwQUNPi/OOqUZzDKvVthYcKwTIJcxt2W99bVKv2UnIc9+ay/WZ6m/Tm8zm0EO2lCqZXOer6eR7sQUStydjRgl8TYyHyl4htkK8gsS5hWQarJLIgGClFAYs+zicp/me4Pn8aK+8G1h4BuLApM+TJotvIzbISyMnkOB9c9x1H01T3txQYAeAgoLtLhNbI6Pz6VPNTes9GYWCiCH6FBudyyW+7ug95kJSU54xrOvdkBjHNX6bd17okg8Rklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwDj/3ANmFakpfmgyAW39nTxSIjLTJION9L6HdYthgi2QyZ4ClO1gzlXZKRnMfu8E6JLAtC7M6ZEfe0m+JysV5Ag=="
+        }
+      ]
+    }
+  ]
+}

--- a/ironfish/src/rpc/routes/wallet/importAccount.ts
+++ b/ironfish/src/rpc/routes/wallet/importAccount.ts
@@ -17,6 +17,7 @@ export type ImportAccountRequest = {
   account: string
   name?: string
   rescan?: boolean
+  createdAt?: number
 }
 
 export type ImportResponse = {
@@ -29,6 +30,7 @@ export const ImportAccountRequestSchema: yup.ObjectSchema<ImportAccountRequest> 
     rescan: yup.boolean().optional().default(true),
     name: yup.string().optional(),
     account: yup.string().defined(),
+    createdAt: yup.number().optional(),
   })
   .defined()
 
@@ -49,7 +51,9 @@ routes.register<typeof ImportAccountRequestSchema, ImportResponse>(
       request.data.account = await decryptEncodedAccount(request.data.account, context.wallet)
 
       const decoded = decodeAccountImport(request.data.account, { name: request.data.name })
-      const account = await context.wallet.importAccount(decoded)
+      const account = await context.wallet.importAccount(decoded, {
+        createdAt: request.data.createdAt,
+      })
 
       if (!context.wallet.hasDefaultAccount) {
         await context.wallet.setDefaultAccount(account.name)

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -1310,7 +1310,10 @@ export class Wallet {
     await account.updateHead({ hash, sequence }, tx)
   }
 
-  async importAccount(accountValue: AccountImport): Promise<Account> {
+  async importAccount(
+    accountValue: AccountImport,
+    options?: { createdAt?: number },
+  ): Promise<Account> {
     let multisigKeys = accountValue.multisigKeys
     const name = accountValue.name
 
@@ -1346,7 +1349,15 @@ export class Wallet {
 
     validateAccountImport(accountValue)
 
-    let createdAt = accountValue.createdAt
+    let createdAt = options?.createdAt
+      ? {
+          sequence: options?.createdAt,
+          // hash is no longer used, set to empty buffer
+          hash: Buffer.alloc(32, 0),
+          networkId: this.networkId,
+        }
+      : accountValue.createdAt
+
     if (createdAt?.networkId !== this.networkId) {
       if (createdAt?.networkId !== undefined) {
         this.logger.warn(


### PR DESCRIPTION
## Summary

adds a 'createdAt' field to ImportAccountRequest that takes a sequence to use for the account's createdAt field

if a 'createdAt' sequence is passed to importAccount, then the account's createdAt uses that sequence and an empty hash (hash is no longer used in createdAt)

adds createdAt flag to wallet:import command

## Testing Plan

- adds unit test for rpc
- manual testing with cli

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[X] Yes
```

https://github.com/iron-fish/website/pull/712

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
