### PR TITLE
Have WalletScanner use chain directly if available

### DIFF
--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -327,6 +327,7 @@ export class FullNode {
       networkId: network.id,
       nodeClient: memoryClient,
       logger,
+      chain,
     })
 
     const node = new FullNode({

--- a/ironfish/src/wallet/scanner/chainProcessorWithTransactions.ts
+++ b/ironfish/src/wallet/scanner/chainProcessorWithTransactions.ts
@@ -1,0 +1,45 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { Assert } from '../../assert'
+import { Blockchain } from '../../blockchain'
+import { ChainProcessor } from '../../chainProcessor'
+import { Event } from '../../event'
+import { Logger } from '../../logger'
+import { BlockHeader, Transaction } from '../../primitives'
+
+export class ChainProcessorWithTransactions {
+  chainProcessor: ChainProcessor
+  onAdd = new Event<[{ header: BlockHeader; transactions: Transaction[] }]>()
+  onRemove = new Event<[{ header: BlockHeader; transactions: Transaction[] }]>()
+
+  get hash(): Buffer | null {
+    return this.chainProcessor.hash
+  }
+  set hash(value: Buffer | null) {
+    this.chainProcessor.hash = value
+  }
+
+  async update(options?: { signal?: AbortSignal }): Promise<{ hashChanged: boolean }> {
+    return this.chainProcessor.update(options)
+  }
+
+  constructor(options: { logger?: Logger; chain: Blockchain; head: Buffer | null }) {
+    this.chainProcessor = new ChainProcessor(options)
+
+    this.chainProcessor.onAdd.on(async (header: BlockHeader) => {
+      const block = await this.chainProcessor.chain.getBlock(header)
+      Assert.isNotNull(block)
+      const transactions = block.transactions
+      await this.onAdd.emitAsync({ header, transactions })
+    })
+
+    this.chainProcessor.onRemove.on(async (header: BlockHeader) => {
+      const block = await this.chainProcessor.chain.getBlock(header)
+      Assert.isNotNull(block)
+      const transactions = block.transactions
+      await this.onRemove.emitAsync({ header, transactions })
+    })
+  }
+}

--- a/ironfish/src/wallet/wallet.test.ts
+++ b/ironfish/src/wallet/wallet.test.ts
@@ -385,7 +385,7 @@ describe('Wallet', () => {
       expect(head?.hash).toEqualHash(node.chain.genesis.hash)
 
       // set max syncing queue to 1 so that wallet only fetches one block at a time
-      node.wallet.scanner.maxQueueSize = 1
+      node.wallet.scanner.config.set('walletSyncingMaxQueueSize', 1)
 
       await node.wallet.scan()
 

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import type { Blockchain } from '../blockchain'
 import {
   Asset,
   generateKey,
@@ -120,6 +121,7 @@ export class Wallet {
     consensus,
     networkId,
     nodeClient,
+    chain,
   }: {
     config: Config
     database: WalletDB
@@ -129,6 +131,7 @@ export class Wallet {
     consensus: Consensus
     networkId: number
     nodeClient: RpcClient | null
+    chain: Blockchain | null
   }) {
     this.config = config
     this.logger = logger.withTag('accounts')
@@ -144,9 +147,9 @@ export class Wallet {
     this.scanner = new WalletScanner({
       wallet: this,
       logger: this.logger,
+      config: this.config,
       nodeClient: this.nodeClient,
-      maxQueueSize: this.config.get('walletSyncingMaxQueueSize'),
-      config: config,
+      chain: chain,
     })
   }
 


### PR DESCRIPTION
## Summary

This PR changes it so if you're running the wallet inside of the node,
instead of iterating the chain using the RPC system it'll use the
chain directly. This is a large performance optimziation when scaanning
the blockchain.

## Testing Plan

There is no new test here, but the RemoteChainProcessor has tests, and the ChainProcessor already has tests.

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
