### PR TITLE
updates error handling to their new API response 400 object

### DIFF
--- a/ironfish-cli/src/utils/chainport/requests.ts
+++ b/ironfish-cli/src/utils/chainport/requests.ts
@@ -5,7 +5,6 @@ import axios from 'axios'
 import { getConfig } from './config'
 import {
   ChainportBridgeTransaction,
-  ChainportError,
   ChainportNetwork,
   ChainportTransactionStatus,
   ChainportVerifiedToken,
@@ -61,12 +60,8 @@ export const fetchChainportBridgeTransaction = async (
 
 const makeChainportRequest = async <T extends object>(url: string): Promise<T> => {
   const response = await axios
-    .get<T | ChainportError>(url)
+    .get<T>(url)
     .then((response) => {
-      if ('Error' in response.data) {
-        throw new Error(response.data.Error)
-      }
-
       return response.data
     })
     .catch((error) => {

--- a/ironfish-cli/src/utils/chainport/requests.ts
+++ b/ironfish-cli/src/utils/chainport/requests.ts
@@ -70,7 +70,13 @@ const makeChainportRequest = async <T extends object>(url: string): Promise<T> =
       return response.data
     })
     .catch((error) => {
-      throw new Error('Chainport error: ' + error)
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      const chainportError = error.response?.data?.error?.description as string
+      if (chainportError) {
+        throw new Error(chainportError)
+      } else {
+        throw new Error('Chainport error - ' + error)
+      }
     })
 
   return response

--- a/ironfish-cli/src/utils/chainport/types.ts
+++ b/ironfish-cli/src/utils/chainport/types.ts
@@ -66,7 +66,3 @@ export type ChainportTransactionStatus =
       created_at: string | null
       port_in_ack: boolean | null
     }
-
-export type ChainportError = {
-  Error: string
-}


### PR DESCRIPTION
## Summary

Reflects the latest changes from Chainport's API error objects

Example error blacklisted address: 

![image](https://github.com/iron-fish/ironfish/assets/13268167/c62eab28-b4eb-4318-8a1e-729f9bef8651)


Example error exception thrown on Chainport's end: 

![image](https://github.com/iron-fish/ironfish/assets/13268167/7b3714d4-a2f2-49a2-a7a5-b1b92869713a)

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
