### PR TITLE
Update remaining artifact github actions to v4

### DIFF
--- a/.github/workflows/deploy-npm-ironfish-rust-nodejs.yml
+++ b/.github/workflows/deploy-npm-ironfish-rust-nodejs.yml
@@ -34,7 +34,7 @@ jobs:
         run: npm install --no-workspaces
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: ironfish-rust-nodejs/artifacts
 

--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -51,7 +51,7 @@ jobs:
             echo "Runner architecture does not match specified architecture"
             exit 1
           fi
-      
+
       # needed for distutils, which is used by nodegyp, arm64 mac runners have 3.12
       - name: Set up Python
         uses: actions/setup-python@v3
@@ -193,7 +193,7 @@ jobs:
           xcrun notarytool submit "${{ steps.set_paths.outputs.zip }}" --keychain-profile "notarytool-profile" --wait
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.set_paths.outputs.name }}
           path: tools/${{ steps.set_paths.outputs.zip }}


### PR DESCRIPTION
## Summary

These jobs were still using v3, which is incompatible with v4 internally even though we didn't use any of the external stuff that changed.

https://github.com/iron-fish/ironfish/actions/runs/9653954995

## Testing Plan

## Documentation

N/A

## Breaking Change

N/A
