### PR TITLE
Simplify ChainProcessor return logic

### DIFF
--- a/ironfish/src/__fixtures__/chainProcessor.test.ts.fixture
+++ b/ironfish/src/__fixtures__/chainProcessor.test.ts.fixture
@@ -292,5 +292,33 @@
         }
       ]
     }
+  ],
+  "ChainProcessor should remain stable if hash is head": [
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "4791D7AE9F97DF100EF1558E84772D6A09B43762388283F75C6F20A32A88AA86",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:DHVQe7C8CrO0PQZrmqpIxHOyLQ/s/kqcMd/SzDSE4ks="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:BsNJJNbVpE4ABdLMBD0o/FQ9JT/kOctfk16EtQLu878="
+        },
+        "target": "9282972777491357380673661573939192202192629606981189395159182914949423",
+        "randomness": "0",
+        "timestamp": 1719347456625,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAdsfrXOYvO2c+rICPEMxgSLNBscHmG1y5ml5fPjnjS6CYLq3OUb2AYi/gYXO0s6RIK1iIRIZvjC0ckGS93XmCmZqGhWPIPd664zIe3oO272iz/wTnBdq0yBvDuV9nSTBSk7LLVSsEZgj+M7p1H/HuHHZY6lGJNANRUKXNuyBGBOIFVHeJABxe8HvrGdxviove8KY++mSrMzJTN4OIFv1XUbAJSUUWRMMBFKaZxy0papGpCp8LQ7wur7mQO1/5M+W93RFpwqZn87LnVSPOqG3ns5y7zl2jsQJDNJ1bTbjqm5TFEA7ZLZQUj6qsTMHZpLb0mblNEX/wo5jPPKzSxCAtQrUMjAk8AgSYChpr+lyU1t+Siq0dZ/eRB158YsPHtWJNgSFu/bVZXT5woVjzHdZO8f1z3DpPK1OkMq5OiKqC8INKpWWTo09Mkse2XTwWSRP5uZuh9/2+yTQySYEfRqcP0j3sFxo2M3bmAXArWlFP7EdITysrEMzkLPiVwAD5edM3/hkw4lsws4f2VeVe9WUCIVSRjztOB1s5jE5+6CI+/y1v04/2c5lLlYTBzsSYF/dHYOSpIHHGGpE8tuOZoJMMlbmYGNFmRy/KCxCjfuzgDwwMXKAtW9K5R0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw9U2y863G+KW6lppD3d7rHCmm60FWDhKO99ASS8BSsHHgA0Wgp16gyaLFfs/r3DhRCCuvb1keyzpTDAiMShraDQ=="
+        }
+      ]
+    }
   ]
 }


### PR DESCRIPTION
## Summary

We only ever cared if work was done, not that the specific hash was changed from the original. This does change the behaviour, but I looked at everywhere it's used and it should not affect the overall behaviour.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
