### PR TITLE
Add a development-only feature to print statistics related to notes encryption

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1517,6 +1517,7 @@ dependencies = [
  "napi-derive",
  "num_cpus",
  "rand",
+ "signal-hook",
 ]
 
 [[package]]
@@ -2508,6 +2509,25 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest 0.10.6",
+]
+
+[[package]]
+name = "signal-hook"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1586,7 +1586,7 @@ dependencies = [
 [[package]]
 name = "jubjub"
 version = "0.9.0"
-source = "git+https://github.com/iron-fish/jubjub.git?branch=blstrs#a1a0c2ed69eec4d5d5e87842e2a40849f7fa4633"
+source = "git+https://github.com/iron-fish/jubjub.git?branch=blstrs#6fac532975e23acd3fa670bc0383d027f09403e5"
 dependencies = [
  "bitvec",
  "blst",

--- a/ironfish-rust-nodejs/Cargo.toml
+++ b/ironfish-rust-nodejs/Cargo.toml
@@ -23,7 +23,8 @@ workspace = true
 [lib]
 crate-type = ["cdylib"]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+stats = ["ironfish/note-encryption-stats", "jubjub/stats", "dep:signal-hook"]
 
 [dependencies]
 base64 = "0.13.0"
@@ -35,6 +36,7 @@ napi-derive = "2.13.0"
 jubjub = { git = "https://github.com/iron-fish/jubjub.git", branch = "blstrs" }
 rand = "0.8.5"
 num_cpus = "1.16.0"
+signal-hook = { version = "0.3.17", optional = true, default-features = false, features = ["iterator"] }
 
 [build-dependencies]
 napi-build = "2.0.1"

--- a/ironfish-rust-nodejs/package.json
+++ b/ironfish-rust-nodejs/package.json
@@ -14,6 +14,7 @@
     "artifacts": "napi artifacts",
     "build": "yarn clean && napi build --platform --release",
     "build:debug": "napi build --platform",
+    "build:stats": "yarn clean && napi build --platform --release --features=stats",
     "prepublishOnly": "napi prepublish --skip-gh-release",
     "test:slow": "jest --testPathIgnorePatterns --testMatch \"**/*.test.slow.ts\"",
     "clean": "rimraf target"

--- a/ironfish-rust-nodejs/src/lib.rs
+++ b/ironfish-rust-nodejs/src/lib.rs
@@ -24,6 +24,9 @@ pub mod rolling_filter;
 pub mod signal_catcher;
 pub mod structs;
 
+#[cfg(feature = "stats")]
+pub mod stats;
+
 fn to_napi_err(err: impl Display) -> napi::Error {
     Error::from_reason(err.to_string())
 }

--- a/ironfish-rust-nodejs/src/stats.rs
+++ b/ironfish-rust-nodejs/src/stats.rs
@@ -1,0 +1,89 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#![cfg(feature = "stats")]
+
+use napi::JsObject;
+use napi_derive::module_exports;
+use signal_hook::{consts::signal::SIGUSR1, iterator::Signals};
+use std::fmt::Write as FmtWrite;
+use std::io::{self, Write as IoWrite};
+use std::sync::Once;
+use std::thread;
+
+fn print_stats(colors: bool) {
+    let ecpm_stats = jubjub::stats();
+    let note_stats = ironfish::merkle_note::stats::get();
+
+    // Write the stats in a buffer first, then write the buffer to stderr. The goal of the buffer
+    // is to attempt to write the stats in a single syscall, so that the stats output will not be
+    // interleaved with the rest of the output from the main process. This may not always work
+    // (depending on the buffering performed by stderr), but it is better than calling `print!`
+    // directly.
+    let mut s = String::new();
+
+    write!(
+        &mut s,
+        "\n\
+         {highlight}Elliptic Curve Point Multiplication Stats:\n\
+         • affine muls: {affine_muls}\n\
+         • extended muls: {extended_muls}\n\
+         Note Encryption Stats:\n\
+         • total: {note_construct}\n\
+         Note Decryption Stats:\n\
+         • for owner: {note_dec_for_owner} ({note_dec_for_owner_ok} [{note_dec_for_owner_ok_percent:.2}%] successful)\n\
+         • for spender: {note_dec_for_spender} ({note_dec_for_spender_ok} [{note_dec_for_spender_ok_percent:.2}%] successful){reset}\n\
+         \n",
+        highlight = if colors { "\x1b[1;31m" } else { "" },
+        reset = if colors { "\x1b[0m" } else { "" },
+        affine_muls = ecpm_stats.affine_muls,
+        extended_muls = ecpm_stats.extended_muls,
+        note_construct = note_stats.construct,
+        note_dec_for_owner = note_stats.decrypt_note_for_owner.total,
+        note_dec_for_owner_ok = note_stats.decrypt_note_for_owner.successful,
+        note_dec_for_owner_ok_percent =
+            note_stats.decrypt_note_for_owner.successful as f64 /
+            note_stats.decrypt_note_for_owner.total as f64 * 100.,
+        note_dec_for_spender = note_stats.decrypt_note_for_spender.total,
+        note_dec_for_spender_ok = note_stats.decrypt_note_for_spender.successful,
+        note_dec_for_spender_ok_percent =
+            note_stats.decrypt_note_for_spender.successful as f64 /
+            note_stats.decrypt_note_for_spender.total as f64 * 100.,
+    ).expect("failed to write stats to buffer");
+
+    let mut stderr = io::stderr().lock();
+    stderr
+        .write_all(s.as_bytes())
+        .and_then(|()| stderr.flush())
+        .expect("failed to write stats to stderr");
+}
+
+/// Prints statistics whenever SIGUSR1 is sent to this process.
+fn print_stats_on_signal() {
+    let mut signals = Signals::new([SIGUSR1]).expect("failed to set up signal handler");
+    for _ in signals.forever() {
+        print_stats(true);
+    }
+}
+
+pub fn setup_signal_handler() {
+    thread::spawn(print_stats_on_signal);
+}
+
+/// Sets up the stats signal handler when the N-API module is imported.
+///
+/// Technically, the `module_exports` macro is supposed to be used on code that sets up the
+/// JavaScript exports. Here we are abusing the functionality a little bit by performing other side
+/// actions. However, given that all the code contained in this module is for development only and
+/// will never be released to the public, we consider this use acceptable.
+#[module_exports]
+fn init(_exports: JsObject) -> napi::Result<()> {
+    // Due to how Node worker threads work, this N-API module will be imported multiple times (once
+    // for the main thread, then once for each worker thread spawned). We use `Once` here to avoid
+    // setting up multiple signal handlers, which would result in duplicate stats messages being
+    // emitted after receiving a signal.
+    static START: Once = Once::new();
+    START.call_once(setup_signal_handler);
+    Ok(())
+}

--- a/ironfish-rust/Cargo.toml
+++ b/ironfish-rust/Cargo.toml
@@ -26,6 +26,7 @@ workspace = true
 [features]
 benchmark = []
 download-params = ["dep:reqwest"]
+note-encryption-stats = []
 
 [lib]
 name = "ironfish"

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -89,6 +89,16 @@ delta = "0.5.1 -> 0.5.1@git:311baf8865f6e21527d1f20750d8f2cf5c9e531a"
 importable = false
 notes = "Unreleased changes required by ironfish-frost to support multisig wallets"
 
+[[audits.signal-hook]]
+who = "andrea <andrea@iflabs.network>"
+criteria = "safe-to-deploy"
+version = "0.3.17"
+
+[[audits.signal-hook-registry]]
+who = "andrea <andrea@iflabs.network>"
+criteria = "safe-to-deploy"
+delta = "1.4.1 -> 1.4.2"
+
 [[audits.siphasher]]
 who = "Andrea <andrea@iflabs.network>"
 criteria = "safe-to-deploy"

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -63,7 +63,8 @@ delta = "1.9.3 -> 2.2.6"
 [[audits.jubjub]]
 who = "Andrea <andrea@iflabs.network>"
 criteria = "safe-to-deploy"
-delta = "0.9.0 -> 0.9.0@git:a1a0c2ed69eec4d5d5e87842e2a40849f7fa4633"
+delta = "0.9.0 -> 0.9.0@git:6fac532975e23acd3fa670bc0383d027f09403e5"
+importable = false
 notes = "Fork of the official jubjub owned by Iron Fish"
 
 [[audits.mio]]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -37,7 +37,7 @@ audit-as-crates-io = true
 [policy.ironfish_zkp]
 audit-as-crates-io = true
 
-[policy."jubjub:0.9.0@git:a1a0c2ed69eec4d5d5e87842e2a40849f7fa4633"]
+[policy."jubjub:0.9.0@git:6fac532975e23acd3fa670bc0383d027f09403e5"]
 audit-as-crates-io = true
 
 [policy."reddsa:0.5.1@git:311baf8865f6e21527d1f20750d8f2cf5c9e531a"]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -182,10 +182,6 @@ criteria = "safe-to-deploy"
 version = "0.2.4"
 criteria = "safe-to-deploy"
 
-[[exemptions.cobs]]
-version = "0.2.3"
-criteria = "safe-to-deploy"
-
 [[exemptions.const-crc32]]
 version = "1.2.0"
 criteria = "safe-to-deploy"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -133,6 +133,12 @@ who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"
 version = "0.2.0"
 
+[[audits.bytecode-alliance.audits.cobs]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+version = "0.2.3"
+notes = "No `unsafe` code in the crate and no usage of `std`"
+
 [[audits.bytecode-alliance.audits.constant_time_eq]]
 who = "Nick Fitzgerald <fitzgen@gmail.com>"
 criteria = "safe-to-deploy"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -304,6 +304,11 @@ criteria = "safe-to-deploy"
 version = "1.0.17"
 notes = "plenty of unsafe pointer and vec tricks, but in well-structured and commented code that appears to be correct"
 
+[[audits.bytecode-alliance.audits.signal-hook-registry]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "1.4.1"
+
 [[audits.bytecode-alliance.audits.slab]]
 who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
## Summary

This commit adds an optional feature (that can be enabled only during local development) to print the number of cryptographic operations performed for note decryption and encryption.

This feature is enabled by building `ironfish-rust-nodejs` through `yarn build:stats`. After doing that, and after starting `ironfish-cli` through `yarn start <command>`, it is possible to trigger the printing of the statistics by sending `SIGUSR1` to the CLI process. The statistics will look like this:

```
Elliptic Curve Point Multiplication Stats:
• affine muls: 0
• extended muls: 752
Note Encryption Stats:
• total: 3
Note Decryption Stats:
• for owner: 107 (17 [15.89%] successful)
• for spender: 3 (3 [100.00%] successful)
```

All the code related to this feature is in Rust only, and hidden behind a feature flag. The JS/TS code is untouched. As such, this commit has no impact on release builds of Iron Fish.

## Testing Plan

* `cd ironfish-rust-nodejs && yarn build:stats`
* `cd ironfish-cli && yarn start start`
* Send SIGUSR1 to the Node process (e.g. `pkill -USR1 -f '^/usr/bin/node --expose-gc .* bin/run .*'`)
* Observe the stats being printed out

## Documentation

N/A

## Breaking Change

N/A