### PR TITLE
Fast construction of `NoteEncrypted` during wallet scans

### DIFF
--- a/ironfish-rust-nodejs/index.d.ts
+++ b/ironfish-rust-nodejs/index.d.ts
@@ -117,7 +117,7 @@ export class Asset {
 }
 export type NativeNoteEncrypted = NoteEncrypted
 export class NoteEncrypted {
-  constructor(jsBytes: Buffer)
+  constructor(jsBytes: Buffer, skipValidation?: boolean | undefined | null)
   serialize(): Buffer
   equals(other: NoteEncrypted): boolean
   /**

--- a/ironfish-rust-nodejs/src/structs/note_encrypted.rs
+++ b/ironfish-rust-nodejs/src/structs/note_encrypted.rs
@@ -37,9 +37,16 @@ pub struct NativeNoteEncrypted {
 #[napi]
 impl NativeNoteEncrypted {
     #[napi(constructor)]
-    pub fn new(js_bytes: JsBuffer) -> Result<Self> {
+    pub fn new(js_bytes: JsBuffer, skip_validation: Option<bool>) -> Result<Self> {
         let bytes = js_bytes.into_value()?;
-        let note = MerkleNote::read(bytes.as_ref()).map_err(to_napi_err)?;
+        let skip_validation = skip_validation.unwrap_or(false);
+
+        let note = if !skip_validation {
+            MerkleNote::read(bytes.as_ref())
+        } else {
+            MerkleNote::read_unchecked(bytes.as_ref())
+        }
+        .map_err(to_napi_err)?;
 
         Ok(NativeNoteEncrypted { note })
     }

--- a/ironfish-rust/src/serializing/mod.rs
+++ b/ironfish-rust/src/serializing/mod.rs
@@ -34,6 +34,16 @@ pub(crate) fn read_point<G: GroupEncoding, R: io::Read>(mut reader: R) -> Result
         .ok_or_else(|| IronfishError::new(IronfishErrorKind::InvalidData))
 }
 
+pub(crate) fn read_point_unchecked<G: GroupEncoding, R: io::Read>(
+    mut reader: R,
+) -> Result<G, IronfishError> {
+    let mut point_repr = G::Repr::default();
+    reader.read_exact(point_repr.as_mut())?;
+
+    Option::from(G::from_bytes_unchecked(&point_repr))
+        .ok_or_else(|| IronfishError::new(IronfishErrorKind::InvalidData))
+}
+
 /// Output the bytes as a hexadecimal String
 pub fn bytes_to_hex(bytes: &[u8]) -> String {
     let mut hex: Vec<u8> = vec![0; bytes.len() * 2];

--- a/ironfish/src/primitives/noteEncrypted.ts
+++ b/ironfish/src/primitives/noteEncrypted.ts
@@ -22,9 +22,16 @@ export class NoteEncrypted {
 
   private noteEncrypted: NativeNoteEncrypted | null = null
   private referenceCount = 0
+  /**
+   * Used to record whether the note has already been previously validated, and
+   * thus does not need to be checked anymore after parsing. Used to speed up
+   * construction of `NativeNoteEncrypted` in `takeReference`.
+   */
+  private skipValidation: boolean
 
-  constructor(noteEncryptedSerialized: Buffer) {
+  constructor(noteEncryptedSerialized: Buffer, options?: { skipValidation?: boolean }) {
     this.noteEncryptedSerialized = noteEncryptedSerialized
+    this.skipValidation = options?.skipValidation ?? false
 
     const reader = bufio.read(noteEncryptedSerialized, true)
 
@@ -57,7 +64,11 @@ export class NoteEncrypted {
   takeReference(): NativeNoteEncrypted {
     this.referenceCount++
     if (this.noteEncrypted === null) {
-      this.noteEncrypted = new NativeNoteEncrypted(this.noteEncryptedSerialized)
+      this.noteEncrypted = new NativeNoteEncrypted(
+        this.noteEncryptedSerialized,
+        this.skipValidation,
+      )
+      this.skipValidation = true
     }
     return this.noteEncrypted
   }

--- a/ironfish/src/wallet/scanner/walletScanner.ts
+++ b/ironfish/src/wallet/scanner/walletScanner.ts
@@ -82,6 +82,7 @@ export class WalletScanner {
 
       const decryptor = new BackgroundNoteDecryptor(this.workerPool, this.config, {
         decryptForSpender: false,
+        skipNoteValidation: true,
       })
 
       const chainProcessor = this.getChainProcessor(start)

--- a/ironfish/src/workerPool/tasks/decryptNotes.test.ts
+++ b/ironfish/src/workerPool/tasks/decryptNotes.test.ts
@@ -32,6 +32,7 @@ describe('DecryptNotesRequest', () => {
       ],
       {
         decryptForSpender: true,
+        skipNoteValidation: false,
       },
       0,
     )


### PR DESCRIPTION
## Summary

Wallet scans get the blocks/transactions/notes from the chain db. The chain db contains data that has already been validated in the past (or that otherwise is assumed to be valid). For this reason, it should be possible to speed up scans by skipping expensive validation performed when parsing notes.

More specifically, `NoteEncrypted` parses some elliptic curve points in compressed form. The regular parsing done through `jubjub::SubgroupPoint::from_bytes()` involves an expensive check: it checks whether the uncompressed point belongs to the prime-order subgroup. This check is perfromed using elliptic curve point multiplication, which is the most predominant and slowest operation happening during wallet scans.

Due to this check, for each note, the wallet currently performs two elliptic curve point multiplications: one to parse the note, another to attempt the actual decryption. By using `from_bytes_unchecked()` instead of `from_bytes()` we can skip the first multiplication, effectively improving note decryption performance by a factor of *almost* 2x.

This change only affects the performance of wallet scans. Note parsing and decryption outside of a scan is unaffected at the moment. In the future, we can disable validation in other contexts as we see fit.

## Testing Plan

Observe the number of elliptic curve point multiplications happening during a scan before and after this change (using the feature introduced in GH-5074).

## Documentation

N/A

## Breaking Change

N/A