### PR TITLE
fixes dkg round3 prompt for secret package

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/dkg/round3.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/round3.ts
@@ -52,7 +52,7 @@ export class DkgRound3Command extends IronfishCommand {
     let round2SecretPackage = flags.round2SecretPackage
     if (!round2SecretPackage) {
       round2SecretPackage = await ux.prompt(
-        `Enter the encrypted secret package for participant ${participantName}`,
+        `Enter the round 2 encrypted secret package for participant ${participantName}`,
         {
           required: true,
         },


### PR DESCRIPTION
## Summary

makes it explicit that this should be the round 2 secret package

## Testing Plan

manual testing: 
<img width="519" alt="image" src="https://github.com/iron-fish/ironfish/assets/57735705/fb5bdeeb-7539-4983-bd9c-801514018016">


## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
