### PR TITLE
Suppress logs during nodeless wallet rescans

### DIFF
--- a/ironfish-cli/src/commands/wallet/rescan.ts
+++ b/ironfish-cli/src/commands/wallet/rescan.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import { setLogLevelFromConfig } from '@ironfish/sdk'
 import { Flags, ux } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
@@ -38,6 +39,12 @@ export class RescanCommand extends IronfishCommand {
     ux.action.start('Asking node to start scanning', undefined, {
       stdout: true,
     })
+
+    // Suppress log messages from the wallet scanner, to prevent those messages
+    // from interfering with the progress bar. This problem can occur only if
+    // not connected to a remote node (i.e. we're running with the in-memory
+    // rpc).
+    setLogLevelFromConfig('wallet:error')
 
     const response = client.wallet.rescan({ follow })
 


### PR DESCRIPTION
## Summary

Running `wallet:rescan` when not connected to a node produces output like the following:

```
Scanning blocks: [░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░] 0% | 60 / 624032 | 0.00 / sec | ETA: N/AAdded block seq: 100, hash: 00000...bd9a1
Scanning blocks: [░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░] 0% | 128 / 624032 | 0.00 / sec | ETA: N/AAdded block seq: 200, hash: 00000...c61b7
Scanning blocks: [░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░] 0% | 282 / 624032 | 0.00 / sec | ETA: N/AAdded block seq: 300, hash: 00000...194db
```

That is: the progress bar output is disrupted by the scanner logs.

This commit suppresses the logs coming from the wallet so that the progress bar is the only output displayed.

## Testing Plan

Run `yarn start wallet:rescan` while a node is NOT running and observe the output.

## Documentation

N/A

## Breaking Change

N/A