### PR TITLE
adds minimal verification to ironfish transactions for evm

### DIFF
--- a/ironfish-cli/src/commands/test-evm.ts
+++ b/ironfish-cli/src/commands/test-evm.ts
@@ -4,7 +4,7 @@
 import { LegacyTransaction } from '@ethereumjs/tx'
 import { Account, Address } from '@ethereumjs/util'
 import { generateKey } from '@ironfish/rust-nodejs'
-import { IronfishEvm } from '@ironfish/sdk'
+import { IronfishEvm } from '@ironfish/sdk/src/evm'
 import { IronfishCommand } from '../command'
 import { LocalFlags } from '../flags'
 

--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -10,6 +10,7 @@ import { BlockHasher } from '../blockHasher'
 import { Consensus } from '../consensus'
 import { VerificationResultReason, Verifier } from '../consensus/verifier'
 import { Event } from '../event'
+import { IronfishEvm } from '../evm'
 import { Config } from '../fileStores'
 import { FileSystem } from '../fileSystems'
 import { createRootLogger, Logger } from '../logger'
@@ -61,6 +62,8 @@ export class Blockchain {
   location: string
   files: FileSystem
   consensus: Consensus
+  // TODO: the EVM creation is async, so this has to be optional for the constructor
+  evm?: IronfishEvm
   seedGenesisBlock: SerializedBlock
   config: Config
   blockHasher: BlockHasher
@@ -237,6 +240,8 @@ export class Blockchain {
 
     this.opened = true
     await this.blockchainDb.open()
+    this.evm = await IronfishEvm.create(this.blockchainDb)
+
     await this.load()
   }
 

--- a/ironfish/src/consensus/__fixtures__/verifier.evm.test.ts.fixture
+++ b/ironfish/src/consensus/__fixtures__/verifier.evm.test.ts.fixture
@@ -56,5 +56,63 @@
         "sequence": 1
       }
     }
+  ],
+  "Verifier Transaction returns false when evm transaction has invalid signature": [
+    {
+      "value": {
+        "version": 4,
+        "id": "1c9174a4-194a-463d-8125-4faf8128623e",
+        "name": "sender",
+        "spendingKey": "f081dcae86647a25d2122757e2d6e52e00f73b12bfdaa5e9e9e66c42147223f0",
+        "viewKey": "4aa54c19dbdf91c811e329a573c05bdef300a2da9273a7d2db4aac81693c0f0fe5527e70d518c36976bf36117f055557fc2652b025a977803c0f7fbfb3dfec01",
+        "incomingViewKey": "bd6bb3dc6f949986bc59593bb3283fe868e8a1ffc2eea3389951ed518611cd00",
+        "outgoingViewKey": "5b87a80685e4062e0b4ab21188b8eb12f938c2f20d3deb6022c440c52eb6b5c7",
+        "publicAddress": "6ba5b329d9314091c3825c6be3e8526a9aa2bd67cbde315b34f90ec09479a232",
+        "createdAt": {
+          "hash": {
+            "type": "Buffer",
+            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+          },
+          "sequence": 1
+        },
+        "scanningEnabled": true,
+        "proofAuthorizingKey": "b8caa152be85cd2802d0f3ed74107d182e9443dc0084db13bac0064c6c53a105"
+      },
+      "head": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "value": {
+        "version": 4,
+        "id": "4b74aed4-8ca2-44fc-82d3-16ff62873536",
+        "name": "recipient",
+        "spendingKey": "7a3a421f2ef5fdef7c4d7b904b6335edf3f90bd456f8629d211439b4578c4d6d",
+        "viewKey": "22d213caed6423c89b285e60cf33df873cce1ef311ab50aa83719cba704fb5cba01cc8a46aaca1b743e863f228521dc1a10c505cca24d3aaa166fb5db784f504",
+        "incomingViewKey": "18004cdcc27dc21b356979c4db43f8dfa786b53e8338f279bf89d126f8f6b406",
+        "outgoingViewKey": "5742be45d24c5331bc0b6fe9ded6a50c1e94e4f3b8847590c1d1561a3519f708",
+        "publicAddress": "62e162a4194f0441abb9d1f52b63ee4389dcae1e59a2356d4e95617ad6c6f5bd",
+        "createdAt": {
+          "hash": {
+            "type": "Buffer",
+            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+          },
+          "sequence": 1
+        },
+        "scanningEnabled": true,
+        "proofAuthorizingKey": "997481264e565307380c243573a244dfb3c9430ac19be097d76e9a8da9ed0308"
+      },
+      "head": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+        },
+        "sequence": 1
+      }
+    }
   ]
 }

--- a/ironfish/src/consensus/__fixtures__/verifier.evm.test.ts.fixture
+++ b/ironfish/src/consensus/__fixtures__/verifier.evm.test.ts.fixture
@@ -1,0 +1,60 @@
+{
+  "Verifier Transaction returns true on evm transactions": [
+    {
+      "value": {
+        "version": 4,
+        "id": "851729eb-dbd6-49a7-93f4-389b0edb63a3",
+        "name": "test",
+        "spendingKey": "07e4f8f99434bfa6a5bd06c803eae871f2a93f0cf5bebaf6092ee983c36cb211",
+        "viewKey": "99f0c30ab6262c27b6f5c1688bf4b73df63e74f84e1baec6b30e62b1d329a210df478e1ae4dd50152853e9f8537765c9961c329f3a23679f1ec3f9e08990a235",
+        "incomingViewKey": "fe6ac931ca9edfe2bea31f6e63aed2bf9f8dcad1ce65f178b1ff502460048f03",
+        "outgoingViewKey": "dbc1f53afddc88366c6834d6e8ffa68704c49b6703350f337e695c399139a093",
+        "publicAddress": "fcb8273092a42493ce0486def892eeeda9f9243b85f776186ba6f928a3ea8632",
+        "createdAt": {
+          "hash": {
+            "type": "Buffer",
+            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+          },
+          "sequence": 1
+        },
+        "scanningEnabled": true,
+        "proofAuthorizingKey": "1fabe826dce7eb0171bc7498ef71b36488365c7420cf389c49d2966d4057e403"
+      },
+      "head": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "value": {
+        "version": 4,
+        "id": "53de5ec3-7330-466e-bdf4-e0cae0b7302d",
+        "name": "recipient",
+        "spendingKey": "a147c3b24b8d09803a272caf3f9a7fcbea28050b2f08b54265d85abf8aa6f5c6",
+        "viewKey": "3a6a647896e21bcd1e3066684990cdf9fe681cc14a4d99707054607c2aa3bd8ec35a952347bf768a9aeedc83ead4472f82c353906ac696755fd9bb5b60f34b88",
+        "incomingViewKey": "a6f08c4cb1de2799c3a08766962fb3cf8afe1117a12ce71a7dc22285ec59a505",
+        "outgoingViewKey": "7610229c8025251fd70f02eec7fc35356ea59d5f19b7b24b588bd3b5e6eb7203",
+        "publicAddress": "033a9596a6602fb2fed3abf88556d571d4f4c29601bae0cc8a1d3e6fa1851f19",
+        "createdAt": {
+          "hash": {
+            "type": "Buffer",
+            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+          },
+          "sequence": 1
+        },
+        "scanningEnabled": true,
+        "proofAuthorizingKey": "5a10887861b2a1ccd9508e42cad6dfa19203260b1b32b0d91e88d5a3730a4401"
+      },
+      "head": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+        },
+        "sequence": 1
+      }
+    }
+  ]
+}

--- a/ironfish/src/consensus/__fixtures__/verifier.evm.test.ts.fixture
+++ b/ironfish/src/consensus/__fixtures__/verifier.evm.test.ts.fixture
@@ -114,5 +114,121 @@
         "sequence": 1
       }
     }
+  ],
+  "Verifier EVM Transaction returns true on evm transactions": [
+    {
+      "value": {
+        "version": 4,
+        "id": "b2be6227-0e5a-4cc9-b305-5464d2242841",
+        "name": "sender",
+        "spendingKey": "b934a58bc43f66deb2bf15039d8703db23f1d5ba0b7b75b0bfa30dcb578118f9",
+        "viewKey": "d579136d0b2a33f5d1c678194cb003347d5eb3c7765cf8af6dbdef2c1538e9f3ea7e1bf2485183255c9c1a58bc3dd0694223f0b0b43a44fe22b66145ae4d7b1a",
+        "incomingViewKey": "fd9f2b2ed65f082b2bf01f68e46d514717d5d3265fde33d68b685680768dd002",
+        "outgoingViewKey": "2f0c34efbfad6c8c40e2aaecaf6ea6cbe85284d96bcacfa3c7cab7990d60d820",
+        "publicAddress": "f976b7d1c6f964de2666b86ebd3a243bab821442c768a30265d1625e3dee2f8a",
+        "createdAt": {
+          "hash": {
+            "type": "Buffer",
+            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+          },
+          "sequence": 1
+        },
+        "scanningEnabled": true,
+        "proofAuthorizingKey": "c6b293d50d63d1c4729bf58da173dfa1063227d9e67943f1f8e4e19b1b793b0c"
+      },
+      "head": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "value": {
+        "version": 4,
+        "id": "363b06d2-d885-4148-a06e-40970ac4d4ba",
+        "name": "recipient",
+        "spendingKey": "54debf1a81d3812c93cb06de47aaec202346c09694d6079c31b3774b214894a1",
+        "viewKey": "cca42a6c452063fca1bb1794a5e530baf94a957d6d261b63171e9377ab905829891573205dbac8c54e78630cfca1dd7063469983d3cfc95a1b5179a5bed64ab2",
+        "incomingViewKey": "5c9682196d2ee2c10eee214d678443f62971c2922214cb69e63340a4318eec02",
+        "outgoingViewKey": "6658d78c29e76a178442bf589042a4cb41081540caba5de8522a076b995c002a",
+        "publicAddress": "eff7b47a40ba396e65701498d81f12f72a43e980d8069d614a036350a5e5182d",
+        "createdAt": {
+          "hash": {
+            "type": "Buffer",
+            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+          },
+          "sequence": 1
+        },
+        "scanningEnabled": true,
+        "proofAuthorizingKey": "20f57626fd78afc515be0bbaed9392dd48f7760a0f9c51ea9156e544fc229209"
+      },
+      "head": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+        },
+        "sequence": 1
+      }
+    }
+  ],
+  "Verifier EVM Transaction returns false when evm transaction has invalid signature": [
+    {
+      "value": {
+        "version": 4,
+        "id": "bf41e412-7f7b-48c6-a257-c00ab6c80290",
+        "name": "sender",
+        "spendingKey": "7531c7adbd1238c5b761c085b32aef8620d1b2a398b4503f27000f7bde1bb71d",
+        "viewKey": "4171cf41ce9f79d1994b4fa709d6b38b8a8f196a6e914d3dea33ed1c4fc6c59c8d6d6595b1bd1d0af1b622f31231291fe051f728007ca5da5d7848c57cdb2c12",
+        "incomingViewKey": "7366f40096bc149b37293552902c434f554cf011825cc65ee26edd591dd1aa07",
+        "outgoingViewKey": "b87ffc7a03c959152082acca63d2fe49d5a3fdcfe863947a7bef0e32d21c16ab",
+        "publicAddress": "87f9c4973f3c2062618b229b5508188557025581039005ee753531e51e3c82c3",
+        "createdAt": {
+          "hash": {
+            "type": "Buffer",
+            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+          },
+          "sequence": 1
+        },
+        "scanningEnabled": true,
+        "proofAuthorizingKey": "cfaf3608f885e27d3360da5638745b44ea4dda01ddcb1e0ef06516330c75520e"
+      },
+      "head": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "value": {
+        "version": 4,
+        "id": "7724892a-a5e3-4172-aac2-c69a363dbacd",
+        "name": "recipient",
+        "spendingKey": "cacd94b0568b04b943efbfe07df4e7cb96ba04c2ab2851604e885d80739d749d",
+        "viewKey": "26fbfac7d9be73c7c2602643fede443a9d127a8d34e42399779aee3e77acdf1757ab99d918ed68f49a2d0e5f2403715602784809a508f0a26438e48cfc455853",
+        "incomingViewKey": "dfc59816c0649b141cac2869f4e53f35257221383bd89eec3a6dfd5330044607",
+        "outgoingViewKey": "6e9943f794829cf0018869c21d77f8c258ff593026dcaf0835b3a5848d7ffa8c",
+        "publicAddress": "13f769a306b9a70b9e13c0ae87663c65e843d205a12735df9673114db117ba23",
+        "createdAt": {
+          "hash": {
+            "type": "Buffer",
+            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+          },
+          "sequence": 1
+        },
+        "scanningEnabled": true,
+        "proofAuthorizingKey": "a41450e3ec494cf7c8331db10df656b904de3edecec2fe26cb681bddecc4bc07"
+      },
+      "head": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+        },
+        "sequence": 1
+      }
+    }
   ]
 }

--- a/ironfish/src/consensus/verifier.evm.test.ts
+++ b/ironfish/src/consensus/verifier.evm.test.ts
@@ -1,0 +1,143 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+jest.mock('ws')
+
+import '../testUtilities/matchers/blockchain'
+import { LegacyTransaction } from '@ethereumjs/tx'
+import { Account as EthAccount, Address } from '@ethereumjs/util'
+import { generateKey } from '@ironfish/rust-nodejs'
+import { DEVNET_GENESIS } from '../networks'
+import { Transaction } from '../primitives'
+import { EvmDescription, legacyTransactionToEvmDescription } from '../primitives/evmDescription'
+import { TransactionVersion } from '../primitives/transaction'
+import { createNodeTest, useAccountFixture, useTxSpendsFixture } from '../testUtilities'
+import { Consensus } from './consensus'
+
+describe('Verifier', () => {
+  describe('Transaction', () => {
+    const nodeTest = createNodeTest(undefined, {
+      networkDefinition: {
+        id: 1000,
+        bootstrapNodes: [],
+        genesis: DEVNET_GENESIS,
+        consensus: {
+          allowedBlockFutureSeconds: 15,
+          genesisSupplyInIron: 42000000,
+          targetBlockTimeInSeconds: 60,
+          targetBucketTimeInSeconds: 10,
+          maxBlockSizeBytes: 524288,
+          minFee: 0,
+          enableAssetOwnership: null,
+          enableEvmDescriptions: 1,
+          enforceSequentialBlockTime: 1,
+          enableFishHash: null,
+          enableIncreasedDifficultyChange: null,
+          checkpoints: [],
+        },
+      },
+    })
+
+    it('returns true on normal transactions', async () => {
+      const { transaction: tx } = await useTxSpendsFixture(nodeTest.node)
+      const serialized = tx.serialize()
+
+      const result = await nodeTest.chain.verifier.verifyNewTransaction(
+        new Transaction(serialized),
+      )
+
+      expect(result).toEqual({ valid: true })
+    })
+
+    it.only('returns true on evm transactions', async () => {
+      jest
+        .spyOn(Consensus.prototype, 'getActiveTransactionVersion')
+        .mockImplementation(() => TransactionVersion.V3)
+
+      const sender_account = await useAccountFixture(nodeTest.node.wallet, 'sender')
+      const recipient_account = await useAccountFixture(nodeTest.node.wallet, 'recipient')
+
+      const senderPrivateKey = Uint8Array.from(Buffer.from(sender_account.spendingKey, 'hex'))
+      const recipientPrivateKey = Uint8Array.from(
+        Buffer.from(recipient_account.spendingKey, 'hex'),
+      )
+
+      const senderAddress = Address.fromPrivateKey(senderPrivateKey)
+      const recipientAddress = Address.fromPrivateKey(recipientPrivateKey)
+
+      const senderAccount = new EthAccount(BigInt(0), 500000n)
+
+      await nodeTest.chain.evm?.stateManager.checkpoint()
+      await nodeTest.chain.evm?.stateManager.putAccount(senderAddress, senderAccount)
+      await nodeTest.chain.evm?.stateManager.commit()
+
+      console.log('senderAddress', senderAddress.toString())
+
+      const tx = new LegacyTransaction({
+        to: recipientAddress,
+        value: 200000n,
+        gasLimit: 21000n,
+        gasPrice: 7n,
+      })
+      const signed = tx.sign(senderPrivateKey)
+      console.log('legacy1', signed.toJSON())
+
+      const evmDescription: EvmDescription = legacyTransactionToEvmDescription(signed)
+
+      const raw = await nodeTest.wallet.createTransaction({
+        account: sender_account,
+        outputs: [],
+        fee: 0n,
+        expiration: 0,
+        expirationDelta: 0,
+        evm: evmDescription,
+      })
+      const transaction = raw.post(sender_account.spendingKey)
+      const deserialized = new Transaction(transaction.serialize())
+      const result = await nodeTest.chain.verifier.verifyNewTransaction(deserialized)
+
+      expect(result).toEqual({ valid: true })
+    })
+
+    // it('returns false when evm transaction has invalid signature', async () => {
+    //   jest
+    //     .spyOn(nodeTest.wallet.consensus, 'getActiveTransactionVersion')
+    //     .mockReturnValue(TransactionVersion.V3)
+
+    //   const senderKey = generateKey()
+    //   const receipientKey = generateKey()
+
+    //   const senderPrivateKey = Uint8Array.from(Buffer.from(senderKey.spendingKey, 'hex'))
+    //   const recipientPrivateKey = Uint8Array.from(Buffer.from(receipientKey.spendingKey, 'hex'))
+
+    //   const senderAddress = Address.fromPrivateKey(senderPrivateKey)
+    //   const recipientAddress = Address.fromPrivateKey(recipientPrivateKey)
+
+    //   const senderAccount = new EthAccount(BigInt(0), 500000n)
+
+    //   await nodeTest.chain.evm?.stateManager.checkpoint()
+    //   await nodeTest.chain.evm?.stateManager.putAccount(senderAddress, senderAccount)
+    //   await nodeTest.chain.evm?.stateManager.commit()
+
+    //   const tx = new LegacyTransaction({
+    //     to: recipientAddress,
+    //     value: 200000n,
+    //     gasLimit: 21000n,
+    //     gasPrice: 7n,
+    //   })
+    //   const evmDescription: EvmDescription = legacyTransactionToEvmDescription(
+    //     tx.sign(senderPrivateKey),
+    //   )
+    //   // break signature
+    //   evmDescription.s = Buffer.alloc(32, 0)
+
+    //   const { transaction } = await useTxSpendsFixture(nodeTest.node, { evm: evmDescription })
+    //   const result = await nodeTest.chain.verifier.verifyNewTransaction(
+    //     new Transaction(transaction.serialize()),
+    //   )
+
+    //   expect(result).toEqual({ valid: false })
+    // })
+  })
+})

--- a/ironfish/src/consensus/verifier.evm.test.ts
+++ b/ironfish/src/consensus/verifier.evm.test.ts
@@ -7,7 +7,6 @@ jest.mock('ws')
 import '../testUtilities/matchers/blockchain'
 import { LegacyTransaction } from '@ethereumjs/tx'
 import { Account as EthAccount, Address } from '@ethereumjs/util'
-import { DEVNET_GENESIS } from '../networks'
 import { Transaction } from '../primitives'
 import { EvmDescription, legacyTransactionToEvmDescription } from '../primitives/evmDescription'
 import { TransactionVersion } from '../primitives/transaction'
@@ -17,27 +16,7 @@ import { VerificationResultReason } from './verifier'
 
 describe('Verifier', () => {
   describe('EVM Transaction', () => {
-    const nodeTest = createNodeTest(undefined, {
-      networkDefinition: {
-        id: 1000,
-        bootstrapNodes: [],
-        genesis: DEVNET_GENESIS,
-        consensus: {
-          allowedBlockFutureSeconds: 15,
-          genesisSupplyInIron: 42000000,
-          targetBlockTimeInSeconds: 60,
-          targetBucketTimeInSeconds: 10,
-          maxBlockSizeBytes: 524288,
-          minFee: 0,
-          enableAssetOwnership: null,
-          enableEvmDescriptions: 1,
-          enforceSequentialBlockTime: 1,
-          enableFishHash: null,
-          enableIncreasedDifficultyChange: null,
-          checkpoints: [],
-        },
-      },
-    })
+    const nodeTest = createNodeTest()
 
     beforeAll(() => {
       jest
@@ -45,7 +24,6 @@ describe('Verifier', () => {
         .mockImplementation(() => TransactionVersion.V3)
     })
 
-    // TODO write failure test
     it('returns true on evm transactions', async () => {
       const senderAccountIf = await useAccountFixture(nodeTest.node.wallet, 'sender')
       const recipientAccountIf = await useAccountFixture(nodeTest.node.wallet, 'recipient')

--- a/ironfish/src/consensus/verifier.test.ts
+++ b/ironfish/src/consensus/verifier.test.ts
@@ -5,6 +5,8 @@
 jest.mock('ws')
 
 import '../testUtilities/matchers/blockchain'
+import { LegacyTransaction } from '@ethereumjs/tx'
+import { Account as EthAccount, Address } from '@ethereumjs/util'
 import {
   Asset,
   generateKey,
@@ -17,6 +19,7 @@ import { Assert } from '../assert'
 import { getBlockSize, getBlockWithMinersFeeSize } from '../network/utils/serializers'
 import { Block, BlockHeader, Transaction } from '../primitives'
 import { transactionCommitment } from '../primitives/blockheader'
+import { EvmDescription, legacyTransactionToEvmDescription } from '../primitives/evmDescription'
 import { MintDescription } from '../primitives/mintDescription'
 import { Target } from '../primitives/target'
 import { SerializedTransaction, TransactionVersion } from '../primitives/transaction'
@@ -33,6 +36,7 @@ import {
 } from '../testUtilities'
 import { useFixture } from '../testUtilities/fixtures/fixture'
 import { Account, Wallet } from '../wallet'
+import { Consensus } from './consensus'
 import { VerificationResultReason, Verifier } from './verifier'
 
 describe('Verifier', () => {

--- a/ironfish/src/consensus/verifier.test.ts
+++ b/ironfish/src/consensus/verifier.test.ts
@@ -5,8 +5,6 @@
 jest.mock('ws')
 
 import '../testUtilities/matchers/blockchain'
-import { LegacyTransaction } from '@ethereumjs/tx'
-import { Account as EthAccount, Address } from '@ethereumjs/util'
 import {
   Asset,
   generateKey,
@@ -19,7 +17,6 @@ import { Assert } from '../assert'
 import { getBlockSize, getBlockWithMinersFeeSize } from '../network/utils/serializers'
 import { Block, BlockHeader, Transaction } from '../primitives'
 import { transactionCommitment } from '../primitives/blockheader'
-import { EvmDescription, legacyTransactionToEvmDescription } from '../primitives/evmDescription'
 import { MintDescription } from '../primitives/mintDescription'
 import { Target } from '../primitives/target'
 import { SerializedTransaction, TransactionVersion } from '../primitives/transaction'
@@ -36,7 +33,6 @@ import {
 } from '../testUtilities'
 import { useFixture } from '../testUtilities/fixtures/fixture'
 import { Account, Wallet } from '../wallet'
-import { Consensus } from './consensus'
 import { VerificationResultReason, Verifier } from './verifier'
 
 describe('Verifier', () => {

--- a/ironfish/src/consensus/verifier.ts
+++ b/ironfish/src/consensus/verifier.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { LegacyTransaction } from '@ethereumjs/tx'
 import { Asset } from '@ironfish/rust-nodejs'
 import { BufferMap, BufferSet } from 'buffer-map'
 import { Assert } from '../assert'
@@ -333,17 +332,17 @@ export class Verifier {
       }
     }
 
-    const nullifierVerify = Verifier.verifyInternalNullifiers(transaction.spends)
+    const nullifierVerify = this.verifyInternalNullifiers(transaction.spends)
     if (!nullifierVerify.valid) {
       return nullifierVerify
     }
 
-    const mintVerify = Verifier.verifyMints(transaction.mints)
+    const mintVerify = this.verifyMints(transaction.mints)
     if (!mintVerify.valid) {
       return mintVerify
     }
 
-    const burnVerify = Verifier.verifyBurns(transaction.burns)
+    const burnVerify = this.verifyBurns(transaction.burns)
     if (!burnVerify.valid) {
       return burnVerify
     }

--- a/ironfish/src/consensus/verifier.ts
+++ b/ironfish/src/consensus/verifier.ts
@@ -575,6 +575,7 @@ export class Verifier {
 
     const tx = evmDescriptionToLegacyTransaction(evmDescription)
     try {
+      // TODO(jwp): use a new method to verify the transaction without committing state, will require db tx
       const result = await this.chain.evm.runTx({ tx })
       if (result.execResult.exceptionError) {
         return { valid: false, reason: VerificationResultReason.EVM_TRANSACTION_FAILED }

--- a/ironfish/src/primitives/evmDescription.ts
+++ b/ironfish/src/primitives/evmDescription.ts
@@ -1,6 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { LegacyTransaction } from '@ethereumjs/tx'
+import { bigIntToBytes, bytesToBigInt } from '@ethereumjs/util'
 
 export interface EvmDescription {
   nonce: bigint
@@ -10,4 +12,31 @@ export interface EvmDescription {
   v: number
   r: Buffer
   s: Buffer
+}
+
+export function legacyTransactionToEvmDescription(tx: LegacyTransaction): EvmDescription {
+  return {
+    nonce: BigInt(tx.nonce),
+    to: tx.to ? Buffer.from(tx.to.bytes) : Buffer.alloc(0),
+    value: BigInt(tx.value),
+    data: Buffer.from(tx.data),
+    v: Number(tx.v),
+    r: tx.r ? Buffer.from(bigIntToBytes(tx.r)) : Buffer.alloc(0),
+    s: tx.s ? Buffer.from(bigIntToBytes(tx.s)) : Buffer.alloc(0),
+  }
+}
+
+export function evmDescriptionToLegacyTransaction(desc: EvmDescription): LegacyTransaction {
+  return new LegacyTransaction({
+    nonce: desc.nonce,
+    to: desc.to.length > 0 ? desc.to : undefined,
+    value: desc.value,
+    data: desc.data,
+    v: BigInt(desc.v),
+    r: desc.r.length > 0 ? bytesToBigInt(desc.r) : undefined,
+    s: desc.s.length > 0 ? bytesToBigInt(desc.s) : undefined,
+    // TODO(jwp) gas constants are hardcoded
+    gasLimit: 21000n,
+    gasPrice: 7n,
+  })
 }

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -24,6 +24,7 @@ import { Mutex } from '../mutex'
 import { BlockHeader } from '../primitives'
 import { GENESIS_BLOCK_PREVIOUS, GENESIS_BLOCK_SEQUENCE } from '../primitives/block'
 import { BurnDescription } from '../primitives/burnDescription'
+import { EvmDescription } from '../primitives/evmDescription'
 import { MintDescription } from '../primitives/mintDescription'
 import { Note } from '../primitives/note'
 import { NoteEncrypted } from '../primitives/noteEncrypted'
@@ -98,7 +99,7 @@ export class Wallet {
   readonly scanner: WalletScanner
   readonly nodeClient: RpcClient | null
   private readonly config: Config
-  private readonly consensus: Consensus
+  readonly consensus: Consensus
   readonly networkId: number
 
   protected rebroadcastAfter: number
@@ -781,6 +782,7 @@ export class Wallet {
     outputs?: TransactionOutput[]
     mints?: MintData[]
     burns?: BurnDescription[]
+    evm?: EvmDescription
     fee?: bigint
     feeRate?: bigint
     expiration?: number
@@ -859,6 +861,10 @@ export class Wallet {
 
       if (options.feeRate) {
         raw.fee = getFee(options.feeRate, raw.postedSize(options.account.publicAddress))
+      }
+
+      if (options.evm) {
+        raw.evm = options.evm
       }
 
       await this.fund(raw, {


### PR DESCRIPTION
## Summary
Simple `EvmDescription` verification via the EVM. This is a roundtrip transaction that passes through rust, to node typescript, and then to EVM.

Simply verifies the transaction is executable. Only form of validation explicitly done is signature for the unit test.
## Testing Plan
tests pass
## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
