### PR TITLE
implements BlockchainDBTransaction to wrap EVM state changes

### DIFF
--- a/ironfish-cli/src/commands/chain/repair.ts
+++ b/ironfish-cli/src/commands/chain/repair.ts
@@ -1,7 +1,13 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { Assert, BlockHeader, FullNode, IDatabaseTransaction, TimeUtils } from '@ironfish/sdk'
+import {
+  Assert,
+  BlockchainDBTransaction,
+  BlockHeader,
+  FullNode,
+  TimeUtils,
+} from '@ironfish/sdk'
 import { Flags, ux } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { LocalFlags } from '../../flags'
@@ -124,7 +130,7 @@ export default class RepairChain extends IronfishCommand {
     const total = TREE_END ? TREE_END - TREE_START : Number(node.chain.head.sequence)
     let done = 0
 
-    let tx: IDatabaseTransaction | null = null
+    let tx: BlockchainDBTransaction | null = null
     let header = await node.chain.getHeaderAtSequence(TREE_START)
     let block = header ? await node.chain.getBlock(header) : null
     let prev = await node.chain.getHeaderAtSequence(TREE_START - 1)
@@ -146,7 +152,7 @@ export default class RepairChain extends IronfishCommand {
 
     while (block) {
       if (tx === null) {
-        tx = node.chain.blockchainDb.db.transaction()
+        tx = node.chain.blockchainDb.transaction()
       }
 
       await node.chain.saveConnect(block, prev || null, tx)

--- a/ironfish-cli/src/commands/chain/rewind.ts
+++ b/ironfish-cli/src/commands/chain/rewind.ts
@@ -81,7 +81,7 @@ async function disconnectBlocks(chain: Blockchain, toDisconnect: number): Promis
 
     Assert.isNotNull(headBlock)
 
-    await chain.blockchainDb.db.transaction(async (tx) => {
+    await chain.blockchainDb.transaction(async (tx) => {
       await chain.disconnect(headBlock, tx)
     })
 

--- a/ironfish-cli/src/commands/test-evm.ts
+++ b/ironfish-cli/src/commands/test-evm.ts
@@ -30,11 +30,12 @@ export class TestEvmCommand extends IronfishCommand {
 
     const senderAccount = new Account(BigInt(0), 500000n)
 
-    await evm.stateManager.checkpoint()
-    await evm.stateManager.putAccount(senderAddress, senderAccount)
-    await evm.stateManager.commit()
+    await node.chain.blockchainDb.stateManager.checkpoint()
+    await node.chain.blockchainDb.stateManager.putAccount(senderAddress, senderAccount)
+    await node.chain.blockchainDb.stateManager.commit()
 
-    let senderBalance = (await evm.stateManager.getAccount(senderAddress))?.balance ?? 0n
+    let senderBalance =
+      (await node.chain.blockchainDb.stateManager.getAccount(senderAddress))?.balance ?? 0n
     this.log(
       `Sender account at address ${senderAddress.toString()} has balance ${senderBalance}`,
     )
@@ -52,11 +53,12 @@ export class TestEvmCommand extends IronfishCommand {
     const result = await evm.runTx({ tx: tx.sign(senderPrivateKey) })
     this.log(`Amount spent for gas: ${result.amountSpent}`)
 
-    senderBalance = (await evm.stateManager.getAccount(senderAddress))?.balance ?? 0n
+    senderBalance =
+      (await node.chain.blockchainDb.stateManager.getAccount(senderAddress))?.balance ?? 0n
     this.log(`Sender at address ${recipientAddress.toString()} has balance ${senderBalance}`)
 
     const recipientBalance =
-      (await evm.stateManager.getAccount(recipientAddress))?.balance ?? 0n
+      (await node.chain.blockchainDb.stateManager.getAccount(recipientAddress))?.balance ?? 0n
     this.log(
       `Recipient at address ${recipientAddress.toString()} has balance ${recipientBalance}`,
     )

--- a/ironfish/src/blockchain/database/blockchaindb.test.ts
+++ b/ironfish/src/blockchain/database/blockchaindb.test.ts
@@ -1,0 +1,92 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Account, Address, hexToBytes } from '@ethereumjs/util'
+import { createNodeTest } from '../../testUtilities'
+
+describe('BlockchainDBTransaction', () => {
+  const nodeTest = createNodeTest()
+
+  it('should update state if tx succeeds', async () => {
+    const { node } = nodeTest
+    const stateManager = node.chain.blockchainDb.stateManager
+
+    const address = new Address(hexToBytes('0x0e5069fd80d59b92e359dade34f6a66f0bf8dcc5'))
+    const account = new Account(BigInt(0), 100000n)
+
+    await expect(
+      node.chain.blockchainDb.stateManager.getAccount(address),
+    ).resolves.toBeUndefined()
+
+    await node.chain.blockchainDb.withTransaction(null, async (_) => {
+      await stateManager.checkpoint()
+      await stateManager.putAccount(address, account)
+      await stateManager.commit()
+    })
+
+    const newAccount = await node.chain.blockchainDb.stateManager.getAccount(address)
+
+    expect(newAccount).not.toBeUndefined()
+    expect(newAccount?.balance).toEqual(100000n)
+  })
+
+  it('should not update the stateManager state root if tx succeeds', async () => {
+    const { node } = nodeTest
+    const stateManager = node.chain.blockchainDb.stateManager
+    const stateRoot = await stateManager.getStateRoot()
+
+    const address = new Address(hexToBytes('0x0e5069fd80d59b92e359dade34f6a66f0bf8dcc5'))
+    const account = new Account(BigInt(0), 100000n)
+
+    await node.chain.blockchainDb.withTransaction(null, async (_) => {
+      await stateManager.checkpoint()
+      await stateManager.putAccount(address, account)
+      await stateManager.commit()
+    })
+    const newStateRoot = await stateManager.getStateRoot()
+
+    expect(newStateRoot).not.toEqual(stateRoot)
+  })
+
+  it('should revert state changes if tx aborts', async () => {
+    const { node } = nodeTest
+    const stateManager = node.chain.blockchainDb.stateManager
+
+    const address = new Address(hexToBytes('0x0e5069fd80d59b92e359dade34f6a66f0bf8dcc5'))
+    const account = new Account(BigInt(0), 100000n)
+
+    await expect(
+      node.chain.blockchainDb.stateManager.getAccount(address),
+    ).resolves.toBeUndefined()
+
+    await node.chain.blockchainDb.withTransaction(null, async (tx) => {
+      await stateManager.checkpoint()
+      await stateManager.putAccount(address, account)
+      await stateManager.commit()
+      await tx.abort()
+    })
+
+    await expect(
+      node.chain.blockchainDb.stateManager.getAccount(address),
+    ).resolves.toBeUndefined()
+  })
+
+  it('should not change the stateManager state root if tx aborts', async () => {
+    const { node } = nodeTest
+    const stateManager = node.chain.blockchainDb.stateManager
+    const stateRoot = await stateManager.getStateRoot()
+
+    const address = new Address(hexToBytes('0x0e5069fd80d59b92e359dade34f6a66f0bf8dcc5'))
+    const account = new Account(BigInt(0), 100000n)
+
+    await node.chain.blockchainDb.withTransaction(null, async (tx) => {
+      await stateManager.checkpoint()
+      await stateManager.putAccount(address, account)
+      await stateManager.commit()
+      await tx.abort()
+    })
+    const newStateRoot = await stateManager.getStateRoot()
+
+    expect(newStateRoot).toEqual(stateRoot)
+  })
+})

--- a/ironfish/src/blockchain/database/blockchaindb.test.ts
+++ b/ironfish/src/blockchain/database/blockchaindb.test.ts
@@ -30,7 +30,7 @@ describe('BlockchainDBTransaction', () => {
     expect(newAccount?.balance).toEqual(100000n)
   })
 
-  it('should not update the stateManager state root if tx succeeds', async () => {
+  it('should update the stateManager state root if tx succeeds', async () => {
     const { node } = nodeTest
     const stateManager = node.chain.blockchainDb.stateManager
     const stateRoot = await stateManager.getStateRoot()

--- a/ironfish/src/blockchain/database/blockchaindb.ts
+++ b/ironfish/src/blockchain/database/blockchaindb.ts
@@ -4,7 +4,6 @@
 import { DefaultStateManager } from '@ethereumjs/statemanager'
 import { Trie } from '@ethereumjs/trie'
 import { ValueEncoding } from '@ethereumjs/util'
-import { BufferMap } from 'buffer-map'
 import { Assert } from '../../assert'
 import { EvmStateDB } from '../../evm/database'
 import { FileSystem } from '../../fileSystems'
@@ -408,7 +407,7 @@ export class BlockchainDBTransaction implements IDatabaseTransaction {
   tx: IDatabaseTransaction
   stateManager: DefaultStateManager
   checkpoint = false
-  cache: BufferMap<unknown>
+  cache: Map<Buffer, unknown>
 
   constructor(db: IDatabase, stateManager: DefaultStateManager) {
     this.tx = db.transaction()

--- a/ironfish/src/blockchain/index.ts
+++ b/ironfish/src/blockchain/index.ts
@@ -3,4 +3,4 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 export * from './blockchain'
-export { VERSION_DATABASE_CHAIN } from './database/blockchaindb'
+export { VERSION_DATABASE_CHAIN, BlockchainDBTransaction } from './database/blockchaindb'

--- a/ironfish/src/chainProcessor.test.ts
+++ b/ironfish/src/chainProcessor.test.ts
@@ -100,7 +100,7 @@ describe('ChainProcessor', () => {
     await processor.update()
     expect(processor.hash?.equals(blockA3.header.hash)).toBe(true)
 
-    await chain.blockchainDb.db.transaction(async (tx) => {
+    await chain.blockchainDb.transaction(async (tx) => {
       await chain.disconnect(blockA3, tx)
       await chain.disconnect(blockA2, tx)
     })

--- a/ironfish/src/consensus/verifier.evm.test.ts
+++ b/ironfish/src/consensus/verifier.evm.test.ts
@@ -38,9 +38,9 @@ describe('Verifier', () => {
 
       const senderAccount = new EthAccount(BigInt(0), 500000n)
 
-      await nodeTest.chain.evm?.stateManager.checkpoint()
-      await nodeTest.chain.evm?.stateManager.putAccount(senderAddress, senderAccount)
-      await nodeTest.chain.evm?.stateManager.commit()
+      await nodeTest.chain.blockchainDb.stateManager.checkpoint()
+      await nodeTest.chain.blockchainDb.stateManager.putAccount(senderAddress, senderAccount)
+      await nodeTest.chain.blockchainDb.stateManager.commit()
 
       const tx = new LegacyTransaction({
         to: recipientAddress,
@@ -81,9 +81,9 @@ describe('Verifier', () => {
 
       const senderAccount = new EthAccount(BigInt(0), 500000n)
 
-      await nodeTest.chain.evm?.stateManager.checkpoint()
-      await nodeTest.chain.evm?.stateManager.putAccount(senderAddress, senderAccount)
-      await nodeTest.chain.evm?.stateManager.commit()
+      await nodeTest.chain.blockchainDb.stateManager.checkpoint()
+      await nodeTest.chain.blockchainDb.stateManager.putAccount(senderAddress, senderAccount)
+      await nodeTest.chain.blockchainDb.stateManager.commit()
 
       const tx = new LegacyTransaction({
         to: recipientAddress,

--- a/ironfish/src/evm/evm.ts
+++ b/ironfish/src/evm/evm.ts
@@ -2,38 +2,25 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { EVM } from '@ethereumjs/evm'
-import { DefaultStateManager } from '@ethereumjs/statemanager'
-import { Trie } from '@ethereumjs/trie'
-import { ValueEncoding } from '@ethereumjs/util'
 import { RunTxOpts, RunTxResult, VM } from '@ethereumjs/vm'
 import { BlockchainDB } from '../blockchain/database/blockchaindb'
 import { EvmBlockchain } from './blockchain'
-import { EvmStateDB } from './database'
 
 export class IronfishEvm {
-  stateManager: DefaultStateManager
   private vm: VM
 
-  constructor(stateManager: DefaultStateManager, vm: VM) {
-    this.stateManager = stateManager
+  constructor(vm: VM) {
     this.vm = vm
   }
 
   static async create(blockchainDb: BlockchainDB): Promise<IronfishEvm> {
     const blockchain = new EvmBlockchain(blockchainDb)
-    const evmDB = new EvmStateDB(blockchainDb.db)
-    const trie = await Trie.create({
-      db: evmDB,
-      valueEncoding: ValueEncoding.Bytes,
-      useRootPersistence: true,
-    })
-    const stateManager = new DefaultStateManager({ trie })
 
-    const evm = await EVM.create({ blockchain, stateManager })
+    const evm = await EVM.create({ blockchain, stateManager: blockchainDb.stateManager })
 
-    const vm = await VM.create({ evm, stateManager })
+    const vm = await VM.create({ evm, stateManager: blockchainDb.stateManager })
 
-    return new IronfishEvm(stateManager, vm)
+    return new IronfishEvm(vm)
   }
 
   async runTx(opts: RunTxOpts): Promise<RunTxResult> {

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -1068,7 +1068,7 @@ export class PeerNetwork {
     let block = this.blockFetcher.getFullBlock(message.blockHash)
 
     if (block === null) {
-      block = await this.chain.blockchainDb.db.withTransaction(null, async (tx) => {
+      block = await this.chain.blockchainDb.withTransaction(null, async (tx) => {
         const header = await this.chain.getHeader(message.blockHash, tx)
 
         if (header === null) {
@@ -1134,7 +1134,7 @@ export class PeerNetwork {
   private async onGetCompactBlockRequest(
     message: GetCompactBlockRequest,
   ): Promise<GetCompactBlockResponse> {
-    const block = await this.chain.blockchainDb.db.withTransaction(null, async (tx) => {
+    const block = await this.chain.blockchainDb.withTransaction(null, async (tx) => {
       const header = await this.chain.getHeader(message.blockHash, tx)
 
       if (header === null) {

--- a/ironfish/src/storage/database/transaction.ts
+++ b/ironfish/src/storage/database/transaction.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { BufferMap } from 'buffer-map'
 import { IDatabaseStore } from './store'
 import { DatabaseSchema, SchemaKey, SchemaValue } from './types'
 
@@ -22,7 +21,7 @@ import { DatabaseSchema, SchemaKey, SchemaValue } from './types'
  * or write is performed on it.
  */
 export interface IDatabaseTransaction {
-  cache: BufferMap<unknown>
+  cache: Map<Buffer, unknown>
 
   /**
    * Lock the database

--- a/ironfish/src/storage/database/transaction.ts
+++ b/ironfish/src/storage/database/transaction.ts
@@ -2,6 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import { BufferMap } from 'buffer-map'
+import { IDatabaseStore } from './store'
+import { DatabaseSchema, SchemaKey, SchemaValue } from './types'
+
 /**
  * Stores all operations applied to the transaction and then applies
  * them atomically to the database once it's committed. Locks the
@@ -18,6 +22,8 @@
  * or write is performed on it.
  */
 export interface IDatabaseTransaction {
+  cache: BufferMap<unknown>
+
   /**
    * Lock the database
    */
@@ -37,6 +43,33 @@ export interface IDatabaseTransaction {
    * Abort the transaction and release the database lock
    * */
   abort(): Promise<void>
+
+  has<Schema extends DatabaseSchema>(
+    store: IDatabaseStore<Schema>,
+    key: SchemaKey<Schema>,
+  ): Promise<boolean>
+
+  get<Schema extends DatabaseSchema>(
+    store: IDatabaseStore<Schema>,
+    key: SchemaKey<Schema>,
+  ): Promise<SchemaValue<Schema> | undefined>
+
+  put<Schema extends DatabaseSchema>(
+    store: IDatabaseStore<Schema>,
+    key: SchemaKey<Schema>,
+    value: SchemaValue<Schema>,
+  ): Promise<void>
+
+  add<Schema extends DatabaseSchema>(
+    store: IDatabaseStore<Schema>,
+    key: SchemaKey<Schema>,
+    value: SchemaValue<Schema>,
+  ): Promise<void>
+
+  del<Schema extends DatabaseSchema>(
+    store: IDatabaseStore<Schema>,
+    key: SchemaKey<Schema>,
+  ): Promise<void>
 
   /**
    * The number of pending operations

--- a/ironfish/src/storage/levelup/store.ts
+++ b/ironfish/src/storage/levelup/store.ts
@@ -58,7 +58,7 @@ export class LevelupStore<Schema extends DatabaseSchema> extends DatabaseStore<S
   ): Promise<SchemaValue<Schema> | undefined> {
     const [encodedKey] = this.encode(key)
 
-    if (ENABLE_TRANSACTIONS && transaction instanceof LevelupTransaction) {
+    if (ENABLE_TRANSACTIONS && transaction) {
       return transaction.get(this, key)
     }
 
@@ -92,7 +92,6 @@ export class LevelupStore<Schema extends DatabaseSchema> extends DatabaseStore<S
     )
 
     if (ENABLE_TRANSACTIONS && transaction) {
-      Assert.isInstanceOf(transaction, LevelupTransaction)
       await transaction.acquireLock()
 
       for (const [key, value] of transaction.cache.entries()) {
@@ -222,15 +221,12 @@ export class LevelupStore<Schema extends DatabaseSchema> extends DatabaseStore<S
     key: SchemaKey<Schema>,
     value: SchemaValue<Schema>,
     transaction?: IDatabaseTransaction,
-  ): Promise<void>
-  async put(a: unknown, b: unknown, c?: unknown): Promise<void> {
-    const { key, value, transaction } = parsePut<Schema>(a, b, c)
-
+  ): Promise<void> {
     if (key === undefined) {
       throw new Error('No key defined')
     }
 
-    if (ENABLE_TRANSACTIONS && transaction instanceof LevelupTransaction) {
+    if (ENABLE_TRANSACTIONS && transaction) {
       return transaction.put(this, key, value)
     }
 
@@ -242,14 +238,12 @@ export class LevelupStore<Schema extends DatabaseSchema> extends DatabaseStore<S
     key: SchemaKey<Schema>,
     value: SchemaValue<Schema>,
     transaction?: IDatabaseTransaction,
-  ): Promise<void>
-  async add(a: unknown, b: unknown, c?: unknown): Promise<void> {
-    const { key, value, transaction } = parsePut<Schema>(a, b, c)
+  ): Promise<void> {
     if (key === undefined) {
       throw new Error('No key defined')
     }
 
-    if (ENABLE_TRANSACTIONS && transaction instanceof LevelupTransaction) {
+    if (ENABLE_TRANSACTIONS && transaction) {
       return transaction.add(this, key, value)
     }
 
@@ -262,7 +256,7 @@ export class LevelupStore<Schema extends DatabaseSchema> extends DatabaseStore<S
   }
 
   async del(key: SchemaKey<Schema>, transaction?: IDatabaseTransaction): Promise<void> {
-    if (ENABLE_TRANSACTIONS && transaction instanceof LevelupTransaction) {
+    if (ENABLE_TRANSACTIONS && transaction) {
       return transaction.del(this, key)
     }
 
@@ -292,41 +286,5 @@ export class LevelupStore<Schema extends DatabaseSchema> extends DatabaseStore<S
       return this.valueEncoding.deserialize(value)
     }
     return value
-  }
-}
-
-function parsePut<Schema extends DatabaseSchema>(
-  keyOrValue: unknown,
-  valueOrTransaction: unknown,
-  transaction?: unknown,
-): {
-  key?: SchemaKey<Schema>
-  value?: SchemaValue<Schema>
-  transaction?: IDatabaseTransaction
-} {
-  if (transaction instanceof LevelupTransaction) {
-    return {
-      key: keyOrValue as SchemaKey<Schema>,
-      value: valueOrTransaction as SchemaValue<Schema>,
-      transaction: transaction,
-    }
-  }
-
-  if (valueOrTransaction instanceof LevelupTransaction) {
-    return {
-      value: keyOrValue as SchemaValue<Schema>,
-      transaction: valueOrTransaction,
-    }
-  }
-
-  if (valueOrTransaction !== undefined) {
-    return {
-      key: keyOrValue as SchemaKey<Schema>,
-      value: valueOrTransaction as SchemaValue<Schema>,
-    }
-  }
-
-  return {
-    value: keyOrValue as SchemaValue<Schema>,
   }
 }

--- a/ironfish/src/typedefs/buffer-map.d.ts
+++ b/ironfish/src/typedefs/buffer-map.d.ts
@@ -14,15 +14,21 @@ declare module 'buffer-map' {
     delete(key: Buffer): boolean
     clear(): void
 
-    [Symbol.iterator](): Iterator<[Buffer, T]>
+    [Symbol.iterator](): Generator<[Buffer, T]>
 
     *entries(): Generator<[Buffer, T]>
     *keys(): Generator<Buffer>
     *values(): Generator<T>
+    forEach(
+      callbackfn: (value: T, key: Buffer, map: Map<Buffer, T>) => void,
+      thisArg?: BufferMap<T>,
+    ): void
 
     toKeys(): Buffer[]
     toValues(): T[]
     toArray(): T[]
+
+    [Symbol.toStringTag]: string
   }
 
   export class BufferSet<T = Buffer> implements Iterable<Buffer> {

--- a/ironfish/src/wallet/scanner/remoteChainProcessor.test.ts
+++ b/ironfish/src/wallet/scanner/remoteChainProcessor.test.ts
@@ -119,7 +119,7 @@ describe('RemoteChainProcessor', () => {
     await processor.update()
     expect(processor.hash?.equals(blockA3.header.hash)).toBe(true)
 
-    await chain.blockchainDb.db.transaction(async (tx) => {
+    await chain.blockchainDb.transaction(async (tx) => {
       await chain.disconnect(blockA3, tx)
       await chain.disconnect(blockA2, tx)
     })

--- a/ironfish/src/wallet/wallet.test.ts
+++ b/ironfish/src/wallet/wallet.test.ts
@@ -2187,7 +2187,7 @@ describe('Wallet', () => {
       expect(transactionValue?.blockHash).toEqualHash(blockA2.header.hash)
       expect(transactionValue?.sequence).toEqual(blockA2.header.sequence)
 
-      await node.chain.blockchainDb.db.transaction(async (tx) => {
+      await node.chain.blockchainDb.transaction(async (tx) => {
         await node.chain.disconnect(blockA2, tx)
       })
 
@@ -2219,7 +2219,7 @@ describe('Wallet', () => {
 
       expect(accountAHead?.hash).toEqualHash(blockA2.header.hash)
 
-      await node.chain.blockchainDb.db.transaction(async (tx) => {
+      await node.chain.blockchainDb.transaction(async (tx) => {
         await node.chain.disconnect(blockA2, tx)
       })
 
@@ -2251,7 +2251,7 @@ describe('Wallet', () => {
       const balanceAfterConnect = await accountA.getUnconfirmedBalance(Asset.nativeId())
       expect(balanceAfterConnect.unconfirmed).toEqual(1999999998n)
 
-      await node.chain.blockchainDb.db.transaction(async (tx) => {
+      await node.chain.blockchainDb.transaction(async (tx) => {
         await node.chain.disconnect(blockA2, tx)
       })
 
@@ -2492,7 +2492,7 @@ describe('Wallet', () => {
 
       await accountA.updateScanningEnabled(false)
 
-      await node.chain.blockchainDb.db.transaction(async (tx) => {
+      await node.chain.blockchainDb.transaction(async (tx) => {
         await node.chain.disconnect(blockA2, tx)
       })
 


### PR DESCRIPTION
## Summary

the ethereumjs packages implement their own systems for committing changes to the underlying database

plumbing our own database transaction objects down through several layers will require significant refactoring to evm caching and database access

BlockchainDBTransaction wraps an IDatabaseTransaction and inserts logic to use the evm stateManager's checkpoint logic for committing and reverting state changes

implements transaction and withTransaction methods on the BlockchainDB and replaces access of the underlying db instance with these transaction methods to ensure that BlockchainDBTransactions are used

moves stateManager directly onto BlockchainDB to support access in transaction context

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
