### PR TITLE
Make unsignedTransaction flag visible in send command.

### DIFF
--- a/ironfish-cli/src/commands/wallet/send.ts
+++ b/ironfish-cli/src/commands/wallet/send.ts
@@ -96,7 +96,6 @@ export class Send extends IronfishCommand {
         'Return raw transaction. Use it to create a transaction but not post to the network',
     }),
     unsignedTransaction: Flags.boolean({
-      hidden: true,
       default: false,
       description:
         'Return a serialized UnsignedTransaction. Use it to create a transaction and build proofs but not post to the network',

--- a/ironfish-cli/src/commands/wallet/send.ts
+++ b/ironfish-cli/src/commands/wallet/send.ts
@@ -254,6 +254,8 @@ export class Send extends IronfishCommand {
       raw = RawTransactionSerde.deserialize(bytes)
     }
 
+    displayTransactionSummary(raw, assetData, amount, from, to, memo)
+
     if (flags.rawTransaction) {
       this.log('Raw Transaction')
       this.log(RawTransactionSerde.serialize(raw).toString('hex'))
@@ -270,8 +272,6 @@ export class Send extends IronfishCommand {
       this.log(response.content.unsignedTransaction)
       this.exit(0)
     }
-
-    displayTransactionSummary(raw, assetData, amount, from, to, memo)
 
     const spendPostTime = getSpendPostTimeInMs(this.sdk)
 


### PR DESCRIPTION
Make unsignedTransaction flag visible in send command. Will be required for adding signatures using ledger devices to this transaction. 

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
