### PR TITLE
DecryptNotes: move the code that groups notes by account from WorkerPool to the response class

### DIFF
--- a/ironfish/src/workerPool/pool.ts
+++ b/ironfish/src/workerPool/pool.ts
@@ -4,7 +4,6 @@
 
 import { getCpuCount, UnsignedTransaction } from '@ironfish/rust-nodejs'
 import _ from 'lodash'
-import { Assert } from '../assert'
 import { VerificationResult, VerificationResultReason } from '../consensus'
 import { createRootLogger, Logger } from '../logger'
 import { Meter, MetricsMonitor } from '../metrics'
@@ -205,28 +204,7 @@ export class WorkerPool {
       throw new Error('Invalid response')
     }
 
-    // The response contains a linear array of notes for efficiency, but we
-    // need to return a more structured response
-
-    const decryptedNotesByAccount = new Map<string, Array<DecryptedNote | null>>()
-    for (const { accountId } of accountKeys) {
-      decryptedNotesByAccount.set(accountId, [])
-    }
-
-    let index = 0
-    for (const _ of encryptedNotes) {
-      for (const { accountId } of accountKeys) {
-        const nextNote: DecryptedNote | null | undefined = response.notes[index++]
-        const accountDecryptedNotes = decryptedNotesByAccount.get(accountId)
-        Assert.isNotUndefined(nextNote)
-        Assert.isNotUndefined(accountDecryptedNotes)
-        accountDecryptedNotes.push(nextNote)
-      }
-    }
-
-    Assert.isEqual(index, response.notes.length)
-
-    return decryptedNotesByAccount
+    return response.mapToAccounts(accountKeys)
   }
 
   /**

--- a/ironfish/src/workerPool/tasks/decryptNotes.test.ts
+++ b/ironfish/src/workerPool/tasks/decryptNotes.test.ts
@@ -101,6 +101,39 @@ describe('DecryptNotesResponse', () => {
     const deserializedResponse = DecryptNotesResponse.deserializePayload(request.jobId, buffer)
     expect(deserializedResponse.notes).toHaveLength(length)
   })
+
+  describe('mapToAccounts', () => {
+    it('returns a map linking each account to its notes', () => {
+      const accounts = 'abcdefghijklmnopqrstuvwxyz'
+        .split('')
+        .map((letter) => ({ accountId: letter }))
+      const notesPerAccount = 100
+      const length = accounts.length * notesPerAccount
+
+      const request = new DecryptNotesResponse(
+        Array.from({ length }, () => ({
+          forSpender: false,
+          index: 1,
+          hash: Buffer.alloc(32, 1),
+          nullifier: Buffer.alloc(32, 1),
+          serializedNote: Buffer.alloc(DECRYPTED_NOTE_LENGTH, 1),
+        })),
+        0,
+      )
+
+      const accountsToNotes = request.mapToAccounts(accounts)
+      expect(accountsToNotes.size).toBe(accounts.length)
+
+      const returnedAccounts = Array.from(accountsToNotes.keys())
+        .sort()
+        .map((accountId) => ({ accountId }))
+      expect(returnedAccounts).toEqual(accounts)
+
+      for (const notes of accountsToNotes.values()) {
+        expect(notes.length).toBe(notesPerAccount)
+      }
+    })
+  })
 })
 
 describe('DecryptNotesTask', () => {


### PR DESCRIPTION
## Summary

The goal of this PR is to move that chunk of code to a location where it's more easily reusable. The plan is to use the new method introduced here in PR-5058: that PR will be changed to not call `WorkerPool.decryptNotes()` anymore, but rather call `WorkerPool.execute()` to obtain the individual jobs.

## Testing Plan

Unit tests

## Documentation

N/A

## Breaking Change

N/A