### PR TITLE
Update the Jest workers used during GitHub CI runs to 4

### DIFF
--- a/.github/workflows/ci-regenerate-fixtures.yml
+++ b/.github/workflows/ci-regenerate-fixtures.yml
@@ -33,10 +33,10 @@ jobs:
         run: node ./tools/delete-fixtures.js
 
       - name: Run tests
-        run: JEST_TIMEOUT=1000000000 yarn test:coverage --maxWorkers=2 --workerIdleMemoryLimit=2000MB
+        run: JEST_TIMEOUT=1000000000 yarn test:coverage --maxWorkers=4 --workerIdleMemoryLimit=2000MB
 
       - name: Run slow tests
-        run: JEST_TIMEOUT=1000000000 yarn test:slow:coverage --maxWorkers=2 --workerIdleMemoryLimit=2000MB
+        run: JEST_TIMEOUT=1000000000 yarn test:slow:coverage --maxWorkers=4 --workerIdleMemoryLimit=2000MB
 
       - name: Report Status
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
         run: yarn --non-interactive --frozen-lockfile
 
       - name: Run tests
-        run: yarn test:coverage --maxWorkers=2 --workerIdleMemoryLimit=2000MB
+        run: yarn test:coverage --maxWorkers=4 --workerIdleMemoryLimit=2000MB
 
       - name: Check for missing fixtures
         run: |
@@ -100,7 +100,7 @@ jobs:
         run: yarn --non-interactive --frozen-lockfile
 
       - name: Run slow tests & coverage
-        run: yarn test:slow:coverage --maxWorkers=2 --workerIdleMemoryLimit=2000MB
+        run: yarn test:slow:coverage --maxWorkers=4 --workerIdleMemoryLimit=2000MB
 
       - name: Check for missing fixtures
         run: |


### PR DESCRIPTION
## Summary

The number of CPU cores on GitHub CI runners [used to be 2](https://stackoverflow.com/questions/76639509/how-many-cores-are-used-by-github-actions-runners), but [now it's 4](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories), hence updating our CI files to make full use of them, with the goal of making tests complete faster.

## Testing Plan

Run checks on this PR and verify that they run faster.

## Documentation

N/A

## Breaking Change

N/A