### PR TITLE
ensures that postTransaction uses a spending account

### DIFF
--- a/ironfish/src/rpc/routes/wallet/postTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/postTransaction.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
 import { RawTransactionSerde } from '../../../primitives/rawTransaction'
+import { Account } from '../../../wallet'
 import { RpcValidationError } from '../../adapters'
 import { ApiNamespace } from '../namespaces'
 import { routes } from '../router'
@@ -55,7 +56,9 @@ routes.register<typeof PostTransactionRequestSchema, PostTransactionResponse>(
       throw new RpcValidationError('Unable to determine sender account for raw transaction')
     }
 
-    const account = context.wallet.getAccountByPublicAddress(sender)
+    const account = context.wallet.findAccount(
+      (account: Account) => account.publicAddress === sender && account.isSpendingAccount(),
+    )
 
     if (account === null) {
       throw new RpcValidationError(

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -1537,22 +1537,18 @@ export class Wallet {
     this.defaultAccount = nextId
   }
 
-  getAccountByName(name: string): Account | null {
+  findAccount(predicate: (account: Account) => boolean): Account | null {
     for (const account of this.accounts.values()) {
-      if (name === account.name) {
+      if (predicate(account)) {
         return account
       }
     }
+
     return null
   }
 
-  getAccountByPublicAddress(publicAddress: string): Account | null {
-    for (const account of this.accounts.values()) {
-      if (publicAddress === account.publicAddress) {
-        return account
-      }
-    }
-    return null
+  getAccountByName(name: string): Account | null {
+    return this.findAccount((account) => account.name === name)
   }
 
   getAccount(id: string): Account | null {


### PR DESCRIPTION
## Summary

replaces 'getAccountByPublicAddress' with a more generic 'findAccount' that takes a predicate

uses findAccount in postTransaction to find the account that has the same public address and is a spending account

fixes issue where wallet has a spending account and a view only account with the same public address and cannot post a transaction

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
