### PR TITLE
Fix `Worker` handling of `JobAborted` requests

### DIFF
--- a/ironfish/src/workerPool/tasks/jobAbort.ts
+++ b/ironfish/src/workerPool/tasks/jobAbort.ts
@@ -12,8 +12,8 @@ export class JobAbortedMessage extends WorkerMessage {
     return
   }
 
-  static deserializePayload(): JobAbortedError {
-    return new JobAbortedError()
+  static deserializePayload(): JobAbortedMessage {
+    return new JobAbortedMessage()
   }
 
   getSize(): number {

--- a/ironfish/src/workerPool/worker.ts
+++ b/ironfish/src/workerPool/worker.ts
@@ -223,7 +223,7 @@ export class Worker {
       case WorkerMessageType.DecryptNotes:
         return DecryptNotesRequest.deserializePayload(jobId, request)
       case WorkerMessageType.JobAborted:
-        throw new Error('JobAbort should not be sent as a request')
+        return JobAbortedMessage.deserializePayload()
       case WorkerMessageType.JobError:
         throw new Error('JobError should not be sent as a request')
       case WorkerMessageType.Sleep:


### PR DESCRIPTION
## Summary

`Job.abort()` sends a `JobAborted` request to the worker. `Worker.onMessageFromParent()` is able to handle such requests, but `Worker.parseRequest()` rejects them. Fixed `Worker.parseRequest()` so that such requests are no longer rejected.

Also fixed `JobAbortedMessage.deserializePayload()` to return the correct type.

## Testing Plan

## Documentation

N/A

## Breaking Change

N/A