### PR TITLE
Wallet cleanup should use an iter to load records

### DIFF
--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -1478,6 +1478,7 @@ export class Wallet {
 
   async removeAccount(account: Account, tx?: IDatabaseTransaction): Promise<void> {
     this.accounts.delete(account.id)
+
     await this.walletDb.db.withTransaction(tx, async (tx) => {
       if (account.id === this.defaultAccount) {
         await this.walletDb.setDefaultAccount(null, tx)

--- a/ironfish/src/wallet/walletdb/walletdb.ts
+++ b/ironfish/src/wallet/walletdb/walletdb.ts
@@ -1129,13 +1129,13 @@ export class WalletDB {
   }
 
   async cleanupDeletedAccounts(recordsToCleanup: number, signal?: AbortSignal): Promise<void> {
-    for (const [accountId] of await this.accountIdsToCleanup.getAll()) {
+    for await (const [accountId] of this.accountIdsToCleanup.getAllIter()) {
       const prefix = calculateAccountPrefix(accountId)
       const range = StorageUtils.getPrefixKeyRange(prefix)
 
       for (const store of this.cacheStores) {
         for await (const key of store.getAllKeysIter(undefined, range)) {
-          if (signal?.aborted === true || recordsToCleanup === 0) {
+          if (signal?.aborted === true || recordsToCleanup <= 0) {
             return
           }
 
@@ -1145,6 +1145,7 @@ export class WalletDB {
       }
 
       await this.accountIdsToCleanup.del(accountId)
+      recordsToCleanup--
     }
   }
 


### PR DESCRIPTION
## Summary

In the case that the records to cleanup is very high, we shouldn't load all of them in memory before cleaning up. We should only load 1 leveldb memory block at most. This will ensure if there is a bad feedback loop this list won't permanently grow and continue to use more memory as it tries to clean up accounts.

This also ensures that the account record deletion is considered a record so deleting thousands of empty account cleanup records doesn't run forever.

## Testing Plan
Running this with a lot of wallets and using the reset command.

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
