### PR TITLE
Add lint rule to not use Promise.race

### DIFF
--- a/config/eslint-config-ironfish/index.js
+++ b/config/eslint-config-ironfish/index.js
@@ -68,6 +68,7 @@ module.exports = {
   rules: {
     'ironfish/no-vague-imports': 'error',
     'ironfish/no-buffer-cmp': 'error',
+    'ironfish/no-promise-race': 'error',
 
     // Catches expressions that aren't assigned
     '@typescript-eslint/no-unused-expressions': [

--- a/config/eslint-plugin-ironfish/index.js
+++ b/config/eslint-plugin-ironfish/index.js
@@ -42,4 +42,19 @@ module.exports.rules = {
       };
     },
   },
+  "no-promise-race": {
+    create(context) {
+      return {
+        MemberExpression: function (node) {
+          if (node.object.name === 'Promise' && node.property.name === 'race') {
+            context.report({
+              node,
+              message:
+                "Promise.race leaks memory. You can work around it by using PromiseUtils.split to pass resolve/reject to other Promises. See https://github.com/nodejs/node/issues/17469#issuecomment-685216777 for more details.",
+            });
+          }
+        },
+      };
+    },
+  },
 };

--- a/ironfish/src/utils/asyncQueue.test.ts
+++ b/ironfish/src/utils/asyncQueue.test.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { AsyncQueue } from './asyncQueue'
+import { PromiseUtils } from './promise'
 
 describe('AsyncQueue', () => {
   it('yields items in the same order as they were added', async () => {
@@ -81,7 +82,11 @@ describe('AsyncQueue', () => {
         () => 'otherPromise',
       )
 
-      const resolved = await Promise.race([pushPromise, otherPromise])
+      const [promise, res, rej] = PromiseUtils.split()
+      pushPromise.then(res, rej)
+      otherPromise.then(res, rej)
+
+      const resolved = await promise
       expect(resolved).toBe('otherPromise')
 
       // After popping an element, the promise returned by push should resolve
@@ -101,7 +106,11 @@ describe('AsyncQueue', () => {
         () => 'otherPromise',
       )
 
-      const resolved = await Promise.race([popPromise, otherPromise])
+      const [promise, res, rej] = PromiseUtils.split()
+      popPromise.then(res, rej)
+      otherPromise.then(res, rej)
+
+      const resolved = await promise
       expect(resolved).toBe('otherPromise')
 
       // After pushing a new element, the promise returned by pop should


### PR DESCRIPTION
## Summary

@andiflabs did some great investigation to discover that Promise.race leaks memory, and the TL;DR is it'll be easiest to generally avoid using Promise.race. I added a lint rule to catch uses of this in the future, and added workarounds for our current use.

## Testing Plan

Run `status -f` and watch the memory usage while rescanning to observe it doesn't rapidly increase.

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
