### PR TITLE
Move transactions outside of options

### DIFF
--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -321,23 +321,26 @@ export class Wallet {
     }
   }
 
-  async reset(options?: {
-    resetCreatedAt?: boolean
-    resetScanningEnabled?: boolean
-    tx?: IDatabaseTransaction
-  }): Promise<void> {
-    await this.resetAccounts(options)
+  async reset(
+    options?: {
+      resetCreatedAt?: boolean
+      resetScanningEnabled?: boolean
+    },
+    tx?: IDatabaseTransaction,
+  ): Promise<void> {
+    await this.resetAccounts(options, tx)
   }
 
-  resetAccounts(options?: {
-    resetCreatedAt?: boolean
-    resetScanningEnabled?: boolean
-    tx?: IDatabaseTransaction
-  }): Promise<void> {
-    return this.walletDb.db.withTransaction(options?.tx, async (tx) => {
-      const txOptions = { ...options, tx }
+  resetAccounts(
+    options?: {
+      resetCreatedAt?: boolean
+      resetScanningEnabled?: boolean
+    },
+    tx?: IDatabaseTransaction,
+  ): Promise<void> {
+    return this.walletDb.db.withTransaction(tx, async (tx) => {
       for (const account of this.listAccounts()) {
-        await this.resetAccount(account, txOptions)
+        await this.resetAccount(account, options, tx)
       }
     })
   }
@@ -1424,8 +1427,8 @@ export class Wallet {
     options?: {
       resetCreatedAt?: boolean
       resetScanningEnabled?: boolean
-      tx?: IDatabaseTransaction
     },
+    tx?: IDatabaseTransaction,
   ): Promise<void> {
     const newAccount = new Account({
       accountValue: {
@@ -1439,7 +1442,7 @@ export class Wallet {
 
     this.logger.debug(`Resetting account name: ${account.name}, id: ${account.id}`)
 
-    await this.walletDb.db.withTransaction(options?.tx, async (tx) => {
+    await this.walletDb.db.withTransaction(tx, async (tx) => {
       await this.walletDb.setAccount(newAccount, tx)
 
       if (newAccount.createdAt !== null) {


### PR DESCRIPTION
## Summary

If we keep the DB transaction outside of options objects to the end, starting transactions becomes cleaner. Most places already do this.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
