### PR TITLE
Test ESLint Warnings

### DIFF
--- a/config/eslint-config-ironfish/index.js
+++ b/config/eslint-config-ironfish/index.js
@@ -39,7 +39,7 @@ module.exports = {
       rules: {
         // It's common to want to mock functions with noops. This could be
         // turned off for non-test code as well if it's a common pattern.
-        '@typescript-eslint/no-empty-function': 'off',
+        '@typescript-eslint/no-empty-function': 'warn',
         // Jest's asymmetric matchers (e.g expect.any(Date)) are typed with
         // any return values. Fixing this either requires casting every use
         // the matchers to unknown, or defining a custom matcher, which seems
@@ -67,7 +67,7 @@ module.exports = {
 
   rules: {
     'ironfish/no-vague-imports': 'error',
-    'ironfish/no-buffer-cmp': 'error',
+    'ironfish/no-buffer-cmp': 'warn',
 
     // Catches expressions that aren't assigned
     '@typescript-eslint/no-unused-expressions': [
@@ -106,7 +106,7 @@ module.exports = {
     ],
 
     // Prefer using the Logger library rather than directly using the console for output.
-    'no-console': 'error',
+    'no-console': 'warn',
     'no-new-wrappers': 'error',
     'simple-import-sort/imports': [
       'error',

--- a/ironfish/src/wallet/scanner/noteDecryptor.ts
+++ b/ironfish/src/wallet/scanner/noteDecryptor.ts
@@ -68,6 +68,11 @@ export class BackgroundNoteDecryptor {
   }
 
   stop() {
+    const c = Buffer.from('asdf')
+    const d = Buffer.from('qwer')
+    if (c === d) {
+      console.log(c)
+    }
     if (this.isStarted) {
       this.isStarted = false
       for (const { job } of this.decryptQueue) {


### PR DESCRIPTION
## Summary

Testing to see if ESLint warnings behave differently in CI for some reason.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
