### PR TITLE
stops scanState meter on scan completion

### DIFF
--- a/ironfish/src/wallet/scanner/scanState.ts
+++ b/ironfish/src/wallet/scanner/scanState.ts
@@ -51,6 +51,7 @@ export class ScanState {
   }
 
   signalComplete(): void {
+    this.speed.stop()
     this.runningResolve()
   }
 


### PR DESCRIPTION
## Summary

when started the Meter class sets an interval to update its underlying arrays. if the meter is not stopped then this interval will keep running and keep the meter in the heap and leaks the meter memory.

the WalletScanner creates a new ScanState and a new Meter for each scan. when the wallet is at the head of the chain this creates a new scan each time a block is added.

fixes the memory leak by ensuring that the ScanState Meter is stopped when the scan completes and its interval function is cleared

## Testing Plan

memory profiling with Chrome Developer Tools

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
