### PR TITLE
adds IronfishEvm methods to simulate tx execution

### DIFF
--- a/ironfish-cli/src/commands/test-evm.ts
+++ b/ironfish-cli/src/commands/test-evm.ts
@@ -4,7 +4,7 @@
 import { LegacyTransaction } from '@ethereumjs/tx'
 import { Account, Address } from '@ethereumjs/util'
 import { generateKey } from '@ironfish/rust-nodejs'
-import { IronfishEvm } from '@ironfish/sdk'
+import { IronfishEvm } from '@ironfish/sdk/src/evm'
 import { IronfishCommand } from '../command'
 import { LocalFlags } from '../flags'
 
@@ -50,8 +50,7 @@ export class TestEvmCommand extends IronfishCommand {
     this.log(
       `Sending ${tx.value} from ${senderAddress.toString()} to ${recipientAddress.toString()}`,
     )
-    const signed = tx.sign(senderPrivateKey)
-    const result = await evm.simulateTx({ tx: signed })
+    const result = await evm.runTx({ tx: tx.sign(senderPrivateKey) })
     this.log(`Amount spent for gas: ${result.amountSpent}`)
 
     senderBalance =

--- a/ironfish-cli/src/commands/test-evm.ts
+++ b/ironfish-cli/src/commands/test-evm.ts
@@ -4,7 +4,7 @@
 import { LegacyTransaction } from '@ethereumjs/tx'
 import { Account, Address } from '@ethereumjs/util'
 import { generateKey } from '@ironfish/rust-nodejs'
-import { IronfishEvm } from '@ironfish/sdk/src/evm'
+import { IronfishEvm } from '@ironfish/sdk'
 import { IronfishCommand } from '../command'
 import { LocalFlags } from '../flags'
 
@@ -50,7 +50,8 @@ export class TestEvmCommand extends IronfishCommand {
     this.log(
       `Sending ${tx.value} from ${senderAddress.toString()} to ${recipientAddress.toString()}`,
     )
-    const result = await evm.runTx({ tx: tx.sign(senderPrivateKey) })
+    const signed = tx.sign(senderPrivateKey)
+    const result = await evm.simulateTx({ tx: signed })
     this.log(`Amount spent for gas: ${result.amountSpent}`)
 
     senderBalance =

--- a/ironfish/src/evm/__fixtures__/evm.test.ts.fixture
+++ b/ironfish/src/evm/__fixtures__/evm.test.ts.fixture
@@ -1,0 +1,60 @@
+{
+  "IronfishEvm simulateTx returns true on evm transactions": [
+    {
+      "value": {
+        "version": 4,
+        "id": "6fc6ceef-80fb-47a2-9840-a12ec5be7c96",
+        "name": "sender",
+        "spendingKey": "443c77e9dd3ab6323152519b4e81dfb7b0fe40fed116a2487b15f9a44c1f5d60",
+        "viewKey": "b4be324ffa721f2a163acf3ccf6a85218f1f1434333aebef4f4d0843f54b1b877c4b5b078b36fbb6565068951d545cbd5847d7eeb5205e4d50111fd8bd0346b4",
+        "incomingViewKey": "3bf03e35817c992300da2e89cc9fb31635585fb0a8fa11e61edd2263d830a600",
+        "outgoingViewKey": "87c70ca47d75d942f92c07d3d5d85c2da3b281cfd5bd1487d01def6ee3ceb4b3",
+        "publicAddress": "3d9158a4d661ea65f1d7bf829a39b05f500a3bee1e0cae01c59e2fdbbe51ea1d",
+        "createdAt": {
+          "hash": {
+            "type": "Buffer",
+            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+          },
+          "sequence": 1
+        },
+        "scanningEnabled": true,
+        "proofAuthorizingKey": "d7c0224f5bdff7abc1a1ab369f7e806475f6857f9ed51a1e39b5931f119ee706"
+      },
+      "head": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "value": {
+        "version": 4,
+        "id": "5beeb5d5-4af8-48b6-ae6b-a8c0e13feb27",
+        "name": "recipient",
+        "spendingKey": "25c7432321f9229f2809b3925fe09e5f85eaeeccdf8fd626518488b2dcebd9a8",
+        "viewKey": "b5beac982016157f284624cea5c70f640d780e3d0dfdec467837833d00cda5ad5bcfdd53823a094f7bc348dc6cd22801a7128c4479d6e7a5a364418776105816",
+        "incomingViewKey": "3a66f8bdf478146421206980d96f76c50f6f8aa029985773cf7706ed05bbcc07",
+        "outgoingViewKey": "26d69c6594f8208df0414fdc94ffa696b32eb6e57966f0fc24384f8b0b730a44",
+        "publicAddress": "91d293c8ebfb5657cfbd61239a5c6b049bac1465ef3e3bcdeb495264fbe56d3d",
+        "createdAt": {
+          "hash": {
+            "type": "Buffer",
+            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+          },
+          "sequence": 1
+        },
+        "scanningEnabled": true,
+        "proofAuthorizingKey": "1b73dab129f48477f6e83430b5ecf0d688130eb93ec215ed2fae095383052606"
+      },
+      "head": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+        },
+        "sequence": 1
+      }
+    }
+  ]
+}

--- a/ironfish/src/evm/__fixtures__/evm.test.ts.fixture
+++ b/ironfish/src/evm/__fixtures__/evm.test.ts.fixture
@@ -1,5 +1,5 @@
 {
-  "IronfishEvm simulateTx returns true on evm transactions": [
+  "IronfishEvm simulateTx does not modify database": [
     {
       "value": {
         "version": 4,

--- a/ironfish/src/evm/database.ts
+++ b/ironfish/src/evm/database.ts
@@ -14,7 +14,7 @@ export class HexStringEncoding implements IDatabaseEncoding<string> {
   deserialize = (buffer: Buffer): string => buffer.toString('hex')
 }
 
-class EvmStateEncoding implements IDatabaseEncoding<Uint8Array> {
+export class EvmStateEncoding implements IDatabaseEncoding<Uint8Array> {
   serialize = (value: Uint8Array): Buffer => Buffer.from(value)
   deserialize = (buffer: Buffer): Uint8Array => buffer
 }

--- a/ironfish/src/evm/evm.test.ts
+++ b/ironfish/src/evm/evm.test.ts
@@ -1,0 +1,55 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { LegacyTransaction } from '@ethereumjs/tx'
+import { Account as EthAccount, Address } from '@ethereumjs/util'
+import { Assert } from '../assert'
+import { createNodeTest, useAccountFixture } from '../testUtilities'
+
+describe('IronfishEvm', () => {
+  describe('simulateTx', () => {
+    const nodeTest = createNodeTest()
+
+    it('returns true on evm transactions', async () => {
+      const senderAccountIf = await useAccountFixture(nodeTest.node.wallet, 'sender')
+      const recipientAccountIf = await useAccountFixture(nodeTest.node.wallet, 'recipient')
+
+      const senderPrivateKey = Uint8Array.from(Buffer.from(senderAccountIf.spendingKey, 'hex'))
+      const recipientPrivateKey = Uint8Array.from(
+        Buffer.from(recipientAccountIf.spendingKey, 'hex'),
+      )
+
+      const senderAddress = Address.fromPrivateKey(senderPrivateKey)
+      const recipientAddress = Address.fromPrivateKey(recipientPrivateKey)
+
+      const senderAccountBefore = new EthAccount(BigInt(0), 500000n)
+
+      await nodeTest.chain.blockchainDb.stateManager.checkpoint()
+      await nodeTest.chain.blockchainDb.stateManager.putAccount(
+        senderAddress,
+        senderAccountBefore,
+      )
+      await nodeTest.chain.blockchainDb.stateManager.commit()
+
+      const tx = new LegacyTransaction({
+        to: recipientAddress,
+        value: 200000n,
+        gasLimit: 21000n,
+        gasPrice: 7n,
+      })
+      const signed = tx.sign(senderPrivateKey)
+
+      Assert.isNotUndefined(nodeTest.chain.evm)
+
+      const result = await nodeTest.chain.evm.simulateTx({ tx: signed })
+
+      expect(result.totalGasSpent).toEqual(21000n)
+
+      const senderAccountAfter = await nodeTest.chain.blockchainDb.stateManager.getAccount(
+        senderAddress,
+      )
+
+      expect(senderAccountAfter?.balance).toEqual(senderAccountBefore.balance)
+    })
+  })
+})

--- a/ironfish/src/evm/evm.ts
+++ b/ironfish/src/evm/evm.ts
@@ -40,14 +40,12 @@ export class IronfishEvm {
   }
 
   async simulateTx(opts: RunTxOpts): Promise<RunTxResult> {
-    return this.withStatelessVM(async (vm) => {
+    return this.withCopy(async (vm) => {
       return vm.runTx(opts)
     })
   }
 
-  private async withStatelessVM<TResult>(
-    handler: (copy: VM) => Promise<TResult>,
-  ): Promise<TResult> {
+  private async withCopy<TResult>(handler: (copy: VM) => Promise<TResult>): Promise<TResult> {
     const vm = await this.vm.shallowCopy()
 
     await vm.evm.stateManager.checkpoint()

--- a/ironfish/src/evm/evm.ts
+++ b/ironfish/src/evm/evm.ts
@@ -48,12 +48,12 @@ export class IronfishEvm {
   private async withStatelessVM<TResult>(handler: (copy: VM) => TResult): Promise<TResult> {
     const vm = await this.vm.shallowCopy()
 
-    await vm.evm.journal.checkpoint()
+    await vm.evm.stateManager.checkpoint()
 
     try {
       return handler(vm)
     } finally {
-      await vm.evm.journal.revert()
+      await vm.evm.stateManager.revert()
     }
   }
 }

--- a/ironfish/src/evm/evm.ts
+++ b/ironfish/src/evm/evm.ts
@@ -38,6 +38,24 @@ export class IronfishEvm {
       events: [],
     }
   }
+
+  async simulateTx(opts: RunTxOpts): Promise<RunTxResult> {
+    return this.withStatelessVM(async (vm) => {
+      return vm.runTx(opts)
+    })
+  }
+
+  private async withStatelessVM<TResult>(handler: (copy: VM) => TResult): Promise<TResult> {
+    const vm = await this.vm.shallowCopy()
+
+    await vm.evm.journal.checkpoint()
+
+    try {
+      return handler(vm)
+    } finally {
+      await vm.evm.journal.revert()
+    }
+  }
 }
 
 type EvmShield = {

--- a/ironfish/src/evm/evm.ts
+++ b/ironfish/src/evm/evm.ts
@@ -45,13 +45,15 @@ export class IronfishEvm {
     })
   }
 
-  private async withStatelessVM<TResult>(handler: (copy: VM) => TResult): Promise<TResult> {
+  private async withStatelessVM<TResult>(
+    handler: (copy: VM) => Promise<TResult>,
+  ): Promise<TResult> {
     const vm = await this.vm.shallowCopy()
 
     await vm.evm.stateManager.checkpoint()
 
     try {
-      return handler(vm)
+      return await handler(vm)
     } finally {
       await vm.evm.stateManager.revert()
     }


### PR DESCRIPTION
## Summary

adds 'withCopy', inspired by withTransaction, to use a shallow copy of the underlying vm for execution

using challowCopy creates a vm instance with empty caches over the committed database state. use of shallowCopy follows the example of gas estimation https://github.com/ethereumjs/ethereumjs-monorepo/blob/cc2848a1f3fc0ebb8c04cf6e9f76b0992e506c2c/packages/client/src/rpc/modules/eth.ts#L535

wraps handler execution with checkpoint/revert logic over the evm journal to ensure that cached state is not committed to the database

updates EvmStateDB to return itself in shallowCopy so that it does not create a duplicate datastore

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
