### PR TITLE
Include the git commit hash in Docker images

### DIFF
--- a/ironfish-cli/Dockerfile
+++ b/ironfish-cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-bookworm as build
+FROM node:20-bookworm AS build
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 RUN \

--- a/ironfish-cli/scripts/build-docker.sh
+++ b/ironfish-cli/scripts/build-docker.sh
@@ -3,8 +3,14 @@ set -euo pipefail
 cd "$(dirname "$0")/../.."
 
 cat .gitignore - > .dockerignore <<EOF
-# do not send the .git directory to the Docker daemon to make builds faster
+# Do not send all the files from the .git directory to the Docker daemon to
+# make builds faster. Send only the strictly necessary files/directories to
+# make git know the hash of the HEAD.
 .git
+!.git/HEAD
+!.git/refs
+!.git/objects
+.git/objects/*
 EOF
 
 echo "Building Docker Image"


### PR DESCRIPTION
## Summary

Send to the Docker build daemon the necessary files from the `.git` directory so that the build scripts can extract the hash of the HEAD commit.

Also fixed a style warning while at it.

## Testing Plan

1. Run `ironfish-cli/scripts/build-docker.sh` *before* this change
1. Observe that `docker run --rm ironfish:latest status` reports `git src`
1. Run `ironfish-cli/scripts/build-docker.sh` *after* this change
1. Observe that `docker run --rm ironfish:latest status` reports something like `git 2c1b2737`

## Documentation

N/A

## Breaking Change

N/A