### PR TITLE
Import duplicate spending key says account name

### DIFF
--- a/ironfish/src/wallet/errors.ts
+++ b/ironfish/src/wallet/errors.ts
@@ -43,6 +43,15 @@ export class DuplicateAccountNameError extends Error {
   }
 }
 
+export class DuplicateSpendingKeyError extends Error {
+  name = this.constructor.name
+
+  constructor(name: string) {
+    super()
+    this.message = `Account already exists with provided spending key: ${name}`
+  }
+}
+
 export class DuplicateMultisigSecretNameError extends Error {
   name = this.constructor.name
 

--- a/ironfish/src/wallet/wallet.test.ts
+++ b/ironfish/src/wallet/wallet.test.ts
@@ -22,7 +22,11 @@ import {
 } from '../testUtilities'
 import { AsyncUtils, BufferUtils, ORE_TO_IRON } from '../utils'
 import { Account, TransactionStatus, TransactionType } from '../wallet'
-import { MaxMemoLengthError } from './errors'
+import {
+  DuplicateAccountNameError,
+  DuplicateSpendingKeyError,
+  MaxMemoLengthError,
+} from './errors'
 import { toAccountImport } from './exporter'
 import { AssetStatus, Wallet } from './wallet'
 
@@ -499,7 +503,7 @@ describe('Wallet', () => {
       expect(node.wallet.accountExists(account.name)).toEqual(true)
 
       await expect(node.wallet.importAccount(account)).rejects.toThrow(
-        'Account already exists with the name',
+        DuplicateAccountNameError,
       )
     })
 
@@ -513,9 +517,7 @@ describe('Wallet', () => {
       const clone = { ...account }
       clone.name = 'Different name'
 
-      await expect(node.wallet.importAccount(clone)).rejects.toThrow(
-        'Account already exists with provided spending key',
-      )
+      await expect(node.wallet.importAccount(clone)).rejects.toThrow(DuplicateSpendingKeyError)
     })
 
     it('should be able to import an account from solely its view keys', async () => {

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -46,6 +46,7 @@ import { AssetBalances } from './assetBalances'
 import {
   DuplicateAccountNameError,
   DuplicateMultisigSecretNameError,
+  DuplicateSpendingKeyError,
   MaxMemoLengthError,
   NotEnoughFundsError,
 } from './errors'
@@ -1348,12 +1349,14 @@ export class Wallet {
       throw new DuplicateAccountNameError(name)
     }
 
-    const accounts = this.listAccounts()
-    if (
-      accountValue.spendingKey &&
-      accounts.find((a) => accountValue.spendingKey === a.spendingKey)
-    ) {
-      throw new Error(`Account already exists with provided spending key`)
+    if (accountValue.spendingKey) {
+      const duplicateSpendingAccount = this.listAccounts().find(
+        (a) => accountValue.spendingKey === a.spendingKey,
+      )
+
+      if (duplicateSpendingAccount) {
+        throw new DuplicateSpendingKeyError(duplicateSpendingAccount.name)
+      }
     }
 
     validateAccountImport(accountValue)


### PR DESCRIPTION
## Summary

When importing an account twice, it would not print out the name of the account with the duplicate spending key. This will now include that in the message.

It also improves tests to check the error type instead of error message. We should avoid testing error messages in tests if there is a proper typed error to check.

Created in response to this, https://github.com/iron-fish/ironfish/issues/5084

## Testing Plan

1. Create a spending key account
   - `ironfish wallet:create foobar`
2. Export account
   - `ironfish wallet:export foobar --mnemonic`
3. Import account
   - `ironfish wallet:import --name bazmonkey <mnemonic>`
4. Check error includes the name `foobar` which already contains the mneomonic
   - `Account (foobar) already exists with provided spending key`
5. Delete account `ironfish wallet:delete foobar`

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
