### PR TITLE
Implement custom CLI table logic

### DIFF
--- a/ironfish-cli/package.json
+++ b/ironfish-cli/package.json
@@ -77,6 +77,8 @@
     "inquirer": "8.2.5",
     "json-colorizer": "2.2.2",
     "keccak": "3.0.4",
+    "natural-orderby": "3.0.2",
+    "string-width": "4.2.3",
     "supports-hyperlinks": "2.2.0",
     "tar": "6.1.11",
     "uuid": "8.3.2"

--- a/ironfish-cli/src/commands/chain/genesisadd.ts
+++ b/ironfish-cli/src/commands/chain/genesisadd.ts
@@ -10,11 +10,11 @@ import {
   IJSON,
   isValidPublicAddress,
 } from '@ironfish/sdk'
-import { Flags, ux } from '@oclif/core'
+import { Flags } from '@oclif/core'
 import fs from 'fs/promises'
 import { IronfishCommand } from '../../command'
 import { LocalFlags } from '../../flags'
-import { confirmOrQuit } from '../../ui'
+import { confirmOrQuit, table, TableColumns } from '../../ui'
 
 export default class GenesisAddCommand extends IronfishCommand {
   static hidden = true
@@ -80,7 +80,7 @@ export default class GenesisAddCommand extends IronfishCommand {
     // Log genesis block info
     this.log(`Genesis block will be modified with the following values in a new transaction:`)
     this.log(`Allocations:`)
-    const columns: ux.Table.table.Columns<GenesisBlockAllocation> = {
+    const columns: TableColumns<GenesisBlockAllocation> = {
       identity: {
         header: 'ADDRESS',
         get: (row: GenesisBlockAllocation) => row.publicAddress,
@@ -97,7 +97,7 @@ export default class GenesisAddCommand extends IronfishCommand {
       },
     }
 
-    ux.table(allocations, columns, {
+    table(allocations, columns, {
       printLine: this.log.bind(this),
     })
 

--- a/ironfish-cli/src/commands/chain/genesisblock.ts
+++ b/ironfish-cli/src/commands/chain/genesisblock.ts
@@ -12,11 +12,11 @@ import {
   makeGenesisBlock,
   Target,
 } from '@ironfish/sdk'
-import { Flags, ux } from '@oclif/core'
+import { Flags } from '@oclif/core'
 import fs from 'fs/promises'
 import { IronfishCommand } from '../../command'
 import { LocalFlags } from '../../flags'
-import { confirmOrQuit } from '../../ui'
+import { confirmOrQuit, table, TableColumns } from '../../ui'
 
 export default class GenesisBlockCommand extends IronfishCommand {
   static description = 'Create and serialize a genesis block'
@@ -135,7 +135,7 @@ export default class GenesisBlockCommand extends IronfishCommand {
     this.log(`Genesis block will be created with the following values:`)
     this.log(`\nDifficulty: ${target.toDifficulty()}\n`)
     this.log(`Allocations:`)
-    const columns: ux.Table.table.Columns<GenesisBlockAllocation> = {
+    const columns: TableColumns<GenesisBlockAllocation> = {
       identity: {
         header: 'ADDRESS',
         get: (row: GenesisBlockAllocation) => row.publicAddress,
@@ -152,7 +152,7 @@ export default class GenesisBlockCommand extends IronfishCommand {
       },
     }
 
-    ux.table(info.allocations, columns, {
+    table(info.allocations, columns, {
       printLine: this.log.bind(this),
     })
 

--- a/ironfish-cli/src/commands/mempool/transactions.ts
+++ b/ironfish-cli/src/commands/mempool/transactions.ts
@@ -2,10 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { getFeeRate, GetMempoolTransactionResponse, MinMax, Transaction } from '@ironfish/sdk'
-import { Flags, ux } from '@oclif/core'
+import { Flags } from '@oclif/core'
 import { InferredFlags } from '@oclif/core/lib/interfaces'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
+import { table, TableColumns } from '../../ui'
 import { TableFlags } from '../../utils/table'
 
 const { sort: _, ...tableFlags } = TableFlags
@@ -154,7 +155,7 @@ function renderTable(
   response: GetMempoolTransactionResponse[],
   flags: InferredFlags<typeof TransactionsCommand.flags>,
 ): string {
-  const columns: ux.Table.table.Columns<TransactionRow> = {
+  const columns: TableColumns<TransactionRow> = {
     position: {
       header: 'POSITION',
       minWidth: 4,
@@ -210,7 +211,7 @@ function renderTable(
   let result = ''
 
   const limit = flags.csv ? 0 : flags.show
-  ux.table(getRows(response, limit), columns, {
+  table(getRows(response, limit), columns, {
     printLine: (line) => (result += `${String(line)}\n`),
     ...flags,
   })

--- a/ironfish-cli/src/commands/mempool/transactions.ts
+++ b/ironfish-cli/src/commands/mempool/transactions.ts
@@ -6,8 +6,7 @@ import { Flags } from '@oclif/core'
 import { InferredFlags } from '@oclif/core/lib/interfaces'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
-import { table, TableColumns } from '../../ui'
-import { TableFlags } from '../../utils/table'
+import { table, TableColumns, TableFlags } from '../../ui'
 
 const { sort: _, ...tableFlags } = TableFlags
 

--- a/ironfish-cli/src/commands/peers/banned.ts
+++ b/ironfish-cli/src/commands/peers/banned.ts
@@ -2,10 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { BannedPeerResponse, GetBannedPeersResponse, PromiseUtils } from '@ironfish/sdk'
-import { Flags, ux } from '@oclif/core'
+import { Flags } from '@oclif/core'
 import blessed from 'blessed'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
+import { table, TableColumns } from '../../ui'
 import { TableFlags } from '../../utils/table'
 
 const { sort, ...tableFlags } = TableFlags
@@ -67,7 +68,7 @@ export class BannedCommand extends IronfishCommand {
 }
 
 function renderTable(content: GetBannedPeersResponse): string {
-  const columns: ux.Table.table.Columns<BannedPeerResponse> = {
+  const columns: TableColumns<BannedPeerResponse> = {
     identity: {
       minWidth: 45,
       header: 'IDENTITY',
@@ -86,7 +87,7 @@ function renderTable(content: GetBannedPeersResponse): string {
 
   let result = ''
 
-  ux.table(content.peers, columns, {
+  table(content.peers, columns, {
     printLine: (line) => (result += `${String(line)}\n`),
   })
 

--- a/ironfish-cli/src/commands/peers/banned.ts
+++ b/ironfish-cli/src/commands/peers/banned.ts
@@ -6,8 +6,7 @@ import { Flags } from '@oclif/core'
 import blessed from 'blessed'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
-import { table, TableColumns } from '../../ui'
-import { TableFlags } from '../../utils/table'
+import { table, TableColumns, TableFlags } from '../../ui'
 
 const { sort, ...tableFlags } = TableFlags
 

--- a/ironfish-cli/src/commands/peers/index.ts
+++ b/ironfish-cli/src/commands/peers/index.ts
@@ -7,8 +7,7 @@ import { InferredFlags } from '@oclif/core/lib/interfaces'
 import blessed from 'blessed'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
-import { table, TableColumns } from '../../ui'
-import { TableFlags } from '../../utils/table'
+import { table, TableColumns, TableFlags } from '../../ui'
 
 type GetPeerResponsePeer = GetPeersResponse['peers'][0]
 

--- a/ironfish-cli/src/commands/peers/index.ts
+++ b/ironfish-cli/src/commands/peers/index.ts
@@ -2,11 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { GetPeersResponse, PromiseUtils } from '@ironfish/sdk'
-import { Flags, ux } from '@oclif/core'
+import { Flags } from '@oclif/core'
 import { InferredFlags } from '@oclif/core/lib/interfaces'
 import blessed from 'blessed'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
+import { table, TableColumns } from '../../ui'
 import { TableFlags } from '../../utils/table'
 
 type GetPeerResponsePeer = GetPeersResponse['peers'][0]
@@ -96,7 +97,7 @@ function renderTable(
   content: GetPeersResponse,
   flags: InferredFlags<typeof ListCommand.flags>,
 ): string {
-  let columns: ux.Table.table.Columns<GetPeerResponsePeer> = {
+  let columns: TableColumns<GetPeerResponsePeer> = {
     identity: {
       header: 'IDENTITY',
       get: (row: GetPeerResponsePeer) => {
@@ -224,7 +225,7 @@ function renderTable(
 
   let result = ''
 
-  ux.table(peers, columns, {
+  table(peers, columns, {
     printLine: (line) => (result += `${String(line)}\n`),
     ...flags,
   })

--- a/ironfish-cli/src/commands/wallet/assets.ts
+++ b/ironfish-cli/src/commands/wallet/assets.ts
@@ -12,9 +12,9 @@ import { BufferUtils } from '@ironfish/sdk'
 import { Args, Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
-import { table } from '../../ui'
+import { table, TableFlags } from '../../ui'
 import { renderAssetWithVerificationStatus } from '../../utils'
-import { TableCols, TableFlags } from '../../utils/table'
+import { TableCols } from '../../utils/table'
 
 const MAX_ASSET_METADATA_COLUMN_WIDTH = ASSET_METADATA_LENGTH + 1
 const MIN_ASSET_METADATA_COLUMN_WIDTH = ASSET_METADATA_LENGTH / 2 + 1

--- a/ironfish-cli/src/commands/wallet/assets.ts
+++ b/ironfish-cli/src/commands/wallet/assets.ts
@@ -9,9 +9,10 @@ import {
   PUBLIC_ADDRESS_LENGTH,
 } from '@ironfish/rust-nodejs'
 import { BufferUtils } from '@ironfish/sdk'
-import { Args, Flags, ux } from '@oclif/core'
+import { Args, Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
+import { table } from '../../ui'
 import { renderAssetWithVerificationStatus } from '../../utils'
 import { TableCols, TableFlags } from '../../utils/table'
 
@@ -59,7 +60,7 @@ export class AssetsCommand extends IronfishCommand {
     let showHeader = !flags['no-header']
 
     for await (const asset of response.contentStream()) {
-      ux.table(
+      table(
         [asset],
         {
           name: TableCols.fixedWidth({
@@ -77,6 +78,7 @@ export class AssetsCommand extends IronfishCommand {
           id: {
             header: 'ID',
             minWidth: ASSET_ID_LENGTH + 1,
+            get: (row) => row.id,
           },
           metadata: TableCols.fixedWidth({
             header: 'Metadata',
@@ -85,6 +87,7 @@ export class AssetsCommand extends IronfishCommand {
           }),
           createdTransactionHash: {
             header: 'Created Transaction Hash',
+            get: (row) => row.createdTransactionHash,
           },
           supply: {
             header: 'Supply',

--- a/ironfish-cli/src/commands/wallet/balances.ts
+++ b/ironfish-cli/src/commands/wallet/balances.ts
@@ -5,9 +5,8 @@ import { BufferUtils, CurrencyUtils, GetBalancesResponse, RpcAsset } from '@iron
 import { Args, Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
-import { table, TableColumns } from '../../ui'
+import { table, TableColumns, TableFlags } from '../../ui'
 import { compareAssets, renderAssetWithVerificationStatus } from '../../utils'
-import { TableFlags } from '../../utils/table'
 
 type AssetBalancePairs = { asset: RpcAsset; balance: GetBalancesResponse['balances'][number] }
 

--- a/ironfish-cli/src/commands/wallet/balances.ts
+++ b/ironfish-cli/src/commands/wallet/balances.ts
@@ -2,9 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { BufferUtils, CurrencyUtils, GetBalancesResponse, RpcAsset } from '@ironfish/sdk'
-import { Args, Flags, ux } from '@oclif/core'
+import { Args, Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
+import { table, TableColumns } from '../../ui'
 import { compareAssets, renderAssetWithVerificationStatus } from '../../utils'
 import { TableFlags } from '../../utils/table'
 
@@ -64,7 +65,7 @@ export class BalancesCommand extends IronfishCommand {
       })
     }
 
-    let columns: ux.Table.table.Columns<AssetBalancePairs> = {
+    let columns: TableColumns<AssetBalancePairs> = {
       assetName: {
         header: 'Asset Name',
         get: ({ asset }) =>
@@ -129,6 +130,6 @@ export class BalancesCommand extends IronfishCommand {
       ),
     )
 
-    ux.table(assetBalancePairs, columns, { ...flags })
+    table(assetBalancePairs, columns, { ...flags })
   }
 }

--- a/ironfish-cli/src/commands/wallet/multisig/participants/index.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/participants/index.ts
@@ -1,9 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { ux } from '@oclif/core'
 import { IronfishCommand } from '../../../../command'
 import { RemoteFlags } from '../../../../flags'
+import { table } from '../../../../ui'
 
 export class MultisigParticipants extends IronfishCommand {
   static description = 'List out all the participant names and identities'
@@ -27,7 +27,7 @@ export class MultisigParticipants extends IronfishCommand {
     // sort identities by name
     participants.sort((a, b) => a.name.localeCompare(b.name))
 
-    ux.table(
+    table(
       participants,
       {
         name: {

--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -16,7 +16,7 @@ import { Flags, ux } from '@oclif/core'
 import inquirer from 'inquirer'
 import { IronfishCommand } from '../../../command'
 import { HexFlag, IronFlag, RemoteFlags } from '../../../flags'
-import { confirmOrQuit } from '../../../ui'
+import { confirmOrQuit, table } from '../../../ui'
 import { getAssetsByIDs, selectAsset } from '../../../utils'
 import { getExplorer } from '../../../utils/explorer'
 import { selectFee } from '../../../utils/fees'
@@ -452,7 +452,7 @@ export class CombineNotesCommand extends IronfishCommand {
 
     if (resultingNotes) {
       this.log('')
-      ux.table(
+      table(
         resultingNotes,
         {
           hash: {

--- a/ironfish-cli/src/commands/wallet/notes/index.ts
+++ b/ironfish-cli/src/commands/wallet/notes/index.ts
@@ -2,9 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { CurrencyUtils, RpcAsset } from '@ironfish/sdk'
-import { Args, Flags, ux } from '@oclif/core'
+import { Args, Flags } from '@oclif/core'
 import { IronfishCommand } from '../../../command'
 import { RemoteFlags } from '../../../flags'
+import { table } from '../../../ui'
 import { TableCols, TableFlags } from '../../../utils/table'
 
 const { sort: _, ...tableFlags } = TableFlags
@@ -48,19 +49,22 @@ export class NotesCommand extends IronfishCommand {
         )
       }
 
-      ux.table(
+      table(
         [note],
         {
           memo: {
             header: 'Memo',
             // Maximum memo length is 32 bytes
             minWidth: 33,
+            get: (row) => row.memo,
           },
           sender: {
             header: 'Sender',
+            get: (row) => row.sender,
           },
           transactionHash: {
             header: 'From Transaction',
+            get: (row) => row.transactionHash,
           },
           isSpent: {
             header: 'Spent',
@@ -86,6 +90,7 @@ export class NotesCommand extends IronfishCommand {
           },
           noteHash: {
             header: 'Note Hash',
+            get: (row) => row.noteHash,
           },
           nullifier: {
             header: 'Nullifier',

--- a/ironfish-cli/src/commands/wallet/notes/index.ts
+++ b/ironfish-cli/src/commands/wallet/notes/index.ts
@@ -5,8 +5,8 @@ import { CurrencyUtils, RpcAsset } from '@ironfish/sdk'
 import { Args, Flags } from '@oclif/core'
 import { IronfishCommand } from '../../../command'
 import { RemoteFlags } from '../../../flags'
-import { table } from '../../../ui'
-import { TableCols, TableFlags } from '../../../utils/table'
+import { table, TableFlags } from '../../../ui'
+import { TableCols } from '../../../utils/table'
 
 const { sort: _, ...tableFlags } = TableFlags
 export class NotesCommand extends IronfishCommand {

--- a/ironfish-cli/src/commands/wallet/status.ts
+++ b/ironfish-cli/src/commands/wallet/status.ts
@@ -1,10 +1,10 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { ux } from '@oclif/core'
 import chalk from 'chalk'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
+import { table } from '../../ui'
 import { TableFlags } from '../../utils/table'
 
 export class StatusCommand extends IronfishCommand {
@@ -22,17 +22,20 @@ export class StatusCommand extends IronfishCommand {
 
     const response = await client.wallet.getAccountsStatus()
 
-    ux.table(
+    table(
       response.content.accounts,
       {
         name: {
+          get: (row) => row.name,
           header: 'Account Name',
           minWidth: 11,
         },
         id: {
+          get: (row) => row.id,
           header: 'Account ID',
         },
         viewOnly: {
+          get: (row) => row.viewOnly,
           header: 'View Only',
         },
         headHash: {

--- a/ironfish-cli/src/commands/wallet/status.ts
+++ b/ironfish-cli/src/commands/wallet/status.ts
@@ -4,8 +4,7 @@
 import chalk from 'chalk'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
-import { table } from '../../ui'
-import { TableFlags } from '../../utils/table'
+import { table, TableFlags } from '../../ui'
 
 export class StatusCommand extends IronfishCommand {
   static description = `Get status of all accounts`

--- a/ironfish-cli/src/commands/wallet/transaction/index.ts
+++ b/ironfish-cli/src/commands/wallet/transaction/index.ts
@@ -12,6 +12,7 @@ import {
 import { Args, Flags, ux } from '@oclif/core'
 import { IronfishCommand } from '../../../command'
 import { RemoteFlags } from '../../../flags'
+import { table } from '../../../ui'
 import {
   displayChainportTransactionSummary,
   extractChainportDataFromTransaction,
@@ -126,7 +127,7 @@ export class TransactionCommand extends IronfishCommand {
         })
       }
 
-      ux.table(noteAssetPairs, {
+      table(noteAssetPairs, {
         amount: {
           header: 'Amount',
           get: ({ asset, note }) =>
@@ -157,7 +158,7 @@ export class TransactionCommand extends IronfishCommand {
 
     if (transaction.spends.length > 0) {
       this.log(`\n---Spends---\n`)
-      ux.table(transaction.spends, {
+      table(transaction.spends, {
         size: {
           header: 'Size',
           get: (spend) => spend.size,
@@ -183,9 +184,10 @@ export class TransactionCommand extends IronfishCommand {
       )
 
       this.log(`\n---Asset Balance Deltas---\n`)
-      ux.table(assetBalanceDeltas, {
+      table(assetBalanceDeltas, {
         assetId: {
           header: 'Asset ID',
+          get: (assetBalanceDelta) => assetBalanceDelta.assetId,
         },
         delta: {
           header: 'Balance Change',

--- a/ironfish-cli/src/commands/wallet/transactions.ts
+++ b/ironfish-cli/src/commands/wallet/transactions.ts
@@ -13,10 +13,10 @@ import {
 import { Args, Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
-import { table, TableColumns } from '../../ui'
+import { table, TableColumns, TableFlags } from '../../ui'
 import { getAssetsByIDs } from '../../utils'
 import { extractChainportDataFromTransaction } from '../../utils/chainport'
-import { Format, TableCols, TableFlags } from '../../utils/table'
+import { Format, TableCols } from '../../utils/table'
 
 const { sort: _, ...tableFlags } = TableFlags
 export class TransactionsCommand extends IronfishCommand {

--- a/ironfish-cli/src/commands/wallet/transactions.ts
+++ b/ironfish-cli/src/commands/wallet/transactions.ts
@@ -10,9 +10,10 @@ import {
   RpcAsset,
   TransactionType,
 } from '@ironfish/sdk'
-import { Args, Flags, ux } from '@oclif/core'
+import { Args, Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
+import { table, TableColumns } from '../../ui'
 import { getAssetsByIDs } from '../../utils'
 import { extractChainportDataFromTransaction } from '../../utils/chainport'
 import { Format, TableCols, TableFlags } from '../../utils/table'
@@ -68,8 +69,6 @@ export class TransactionsCommand extends IronfishCommand {
         ? Format.csv
         : flags.output === 'json'
         ? Format.json
-        : flags.output === 'yaml'
-        ? Format.yaml
         : Format.cli
 
     const client = await this.sdk.connectRpc()
@@ -120,7 +119,7 @@ export class TransactionsCommand extends IronfishCommand {
         transactionRows = this.getTransactionRows(assetLookup, transaction, format)
       }
 
-      ux.table(transactionRows, columns, {
+      table(transactionRows, columns, {
         printLine: this.log.bind(this),
         ...flags,
         'no-header': !showHeader,
@@ -260,48 +259,57 @@ export class TransactionsCommand extends IronfishCommand {
     extended: boolean,
     notes: boolean,
     format: Format,
-  ): ux.Table.table.Columns<PartialRecursive<TransactionRow>> {
-    let columns: ux.Table.table.Columns<PartialRecursive<TransactionRow>> = {
+  ): TableColumns<PartialRecursive<TransactionRow>> {
+    let columns: TableColumns<PartialRecursive<TransactionRow>> = {
       timestamp: TableCols.timestamp({
         streaming: true,
       }),
       status: {
         header: 'Status',
         minWidth: 12,
+        get: (row) => row.status ?? '',
       },
       type: {
         header: 'Type',
         minWidth: notes ? 18 : 8,
+        get: (row) => row.type ?? '',
       },
       hash: {
         header: 'Hash',
         minWidth: 32,
+        get: (row) => row.hash ?? '',
       },
       notesCount: {
         header: 'Notes',
         minWidth: 5,
         extended: true,
+        get: (row) => row.notesCount ?? '',
       },
       spendsCount: {
         header: 'Spends',
         minWidth: 5,
         extended: true,
+        get: (row) => row.spendsCount ?? '',
       },
       mintsCount: {
         header: 'Mints',
         minWidth: 5,
         extended: true,
+        get: (row) => row.mintsCount ?? '',
       },
       burnsCount: {
         header: 'Burns',
         minWidth: 5,
         extended: true,
+        get: (row) => row.burnsCount ?? '',
       },
       expiration: {
         header: 'Expiration',
+        get: (row) => row.expiration ?? '',
       },
       submittedSequence: {
         header: 'Submitted Sequence',
+        get: (row) => row.submittedSequence ?? '',
       },
       feePaid: {
         header: 'Fee Paid ($IRON)',
@@ -327,12 +335,15 @@ export class TransactionsCommand extends IronfishCommand {
         ...columns,
         sender: {
           header: 'Sender Address',
+          get: (row) => row.sender ?? '',
         },
         recipient: {
           header: 'Recipient Address',
+          get: (row) => row.recipient ?? '',
         },
         memo: {
           header: 'Memo',
+          get: (row) => row.memo ?? '',
         },
       }
     }
@@ -342,6 +353,7 @@ export class TransactionsCommand extends IronfishCommand {
         group: {
           header: '',
           minWidth: 3,
+          get: (row) => row.group ?? '',
         },
         ...columns,
       }
@@ -385,4 +397,5 @@ type TransactionRow = {
   submittedSequence: number
   sender: string
   recipient: string
+  memo?: string
 }

--- a/ironfish-cli/src/ui/confirm.ts
+++ b/ironfish-cli/src/ui/confirm.ts
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { ux } from '@oclif/core'
+import inquirer from 'inquirer'
+
+export async function confirmPrompt(message: string): Promise<boolean> {
+  const result: { prompt: boolean } = await inquirer.prompt({
+    type: 'confirm',
+    // Add a new-line for readability, manually. If the prefix is set to a new-line, it seems to
+    // add a space before the message, which is unwanted.
+    message: `\n${message}`,
+    name: 'prompt',
+    prefix: '',
+  })
+  return result.prompt
+}
+
+export async function confirmOrQuit(message?: string, confirm?: boolean): Promise<void> {
+  if (confirm) {
+    return
+  }
+
+  const confirmed = await confirmPrompt(message || 'Do you confirm?')
+
+  if (!confirmed) {
+    ux.log('Operation aborted.')
+    ux.exit(0)
+  }
+}

--- a/ironfish-cli/src/ui/index.ts
+++ b/ironfish-cli/src/ui/index.ts
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+export * from './confirm'
+export * from './progressBar'
+export * from './table'

--- a/ironfish-cli/src/ui/progressBar.ts
+++ b/ironfish-cli/src/ui/progressBar.ts
@@ -3,28 +3,26 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { Assert, Meter, TimeUtils } from '@ironfish/sdk'
-import { ux } from '@oclif/core'
 import * as cliProgress from 'cli-progress'
-import inquirer from 'inquirer'
 
-const progressBarCompleteChar = '\u2588'
-const progressBarIncompleteChar = '\u2591'
+const PROGRESS_BAR_COMPLETE_CHAR = '\u2588'
+const PROGRESS_BAR_INCOMPLETE_CHAR = '\u2591'
 
 export const ProgressBarPresets = {
   basic: {
-    barCompleteChar: progressBarCompleteChar,
-    barIncompleteChar: progressBarIncompleteChar,
+    barCompleteChar: PROGRESS_BAR_COMPLETE_CHAR,
+    barIncompleteChar: PROGRESS_BAR_INCOMPLETE_CHAR,
     format: '{title}: [{bar}] {percentage}% | ETA: {estimate}',
   },
   default: {
-    barCompleteChar: progressBarCompleteChar,
-    barIncompleteChar: progressBarIncompleteChar,
+    barCompleteChar: PROGRESS_BAR_COMPLETE_CHAR,
+    barIncompleteChar: PROGRESS_BAR_INCOMPLETE_CHAR,
     format:
       '{title}: [{bar}] {percentage}% | {formattedValue} / {formattedTotal} | ETA: {estimate}',
   },
   withSpeed: {
-    barCompleteChar: progressBarCompleteChar,
-    barIncompleteChar: progressBarIncompleteChar,
+    barCompleteChar: PROGRESS_BAR_COMPLETE_CHAR,
+    barIncompleteChar: PROGRESS_BAR_INCOMPLETE_CHAR,
     format:
       '{title}: [{bar}] {percentage}% | {formattedValue} / {formattedTotal} | {speed} / sec | ETA: {estimate}',
   },
@@ -109,30 +107,5 @@ export class ProgressBar {
   setTotal(total: number): void {
     this.total = total
     this.bar.setTotal(total)
-  }
-}
-
-export async function confirmPrompt(message: string): Promise<boolean> {
-  const result: { prompt: boolean } = await inquirer.prompt({
-    type: 'confirm',
-    // Add a new-line for readability, manually. If the prefix is set to a new-line, it seems to
-    // add a space before the message, which is unwanted.
-    message: `\n${message}`,
-    name: 'prompt',
-    prefix: '',
-  })
-  return result.prompt
-}
-
-export async function confirmOrQuit(message?: string, confirm?: boolean): Promise<void> {
-  if (confirm) {
-    return
-  }
-
-  const confirmed = await confirmPrompt(message || 'Do you confirm?')
-
-  if (!confirmed) {
-    ux.log('Operation aborted.')
-    ux.exit(0)
   }
 }

--- a/ironfish-cli/src/ui/table.ts
+++ b/ironfish-cli/src/ui/table.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { Assert } from '@ironfish/sdk'
-import { ux } from '@oclif/core'
+import { Flags, ux } from '@oclif/core'
 import chalk from 'chalk'
 import { orderBy } from 'natural-orderby'
 import stringWidth from 'string-width'
@@ -29,6 +29,27 @@ export interface TableOptions {
   output?: string
   printLine?(this: void, s: unknown): unknown
   sort?: string
+}
+
+export const TableFlags = {
+  csv: Flags.boolean({
+    description: 'output is csv format [alias: --output=csv]',
+  }),
+  extended: Flags.boolean({
+    description: 'show extra columns',
+  }),
+  'no-header': Flags.boolean({
+    description: 'hide table header from output',
+    exclusive: ['csv'],
+  }),
+  output: Flags.string({
+    description: 'output in a more machine friendly format',
+    exclusive: ['csv'],
+    options: ['csv', 'json'],
+  }),
+  sort: Flags.string({
+    description: "property to sort by (prepend '-' for descending)",
+  }),
 }
 
 export function table<T extends Record<string, unknown>>(

--- a/ironfish-cli/src/ui/table.ts
+++ b/ironfish-cli/src/ui/table.ts
@@ -1,0 +1,230 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { Assert } from '@ironfish/sdk'
+import { ux } from '@oclif/core'
+import chalk from 'chalk'
+import { orderBy } from 'natural-orderby'
+import stringWidth from 'string-width'
+
+const WIDE_DASH = '─'
+
+export interface TableColumn<T extends Record<string, unknown>> {
+  // The return type of this function can be extended, it's really just to avoid
+  // being `unknown`. Anything that has a `.toString()` function can be added
+  // here with no extra changes.
+  get(this: void, row: T): string | number | bigint | boolean
+  header: string
+  extended?: boolean
+  minWidth?: number
+}
+
+export type TableColumns<T extends Record<string, unknown>> = { [key: string]: TableColumn<T> }
+
+export interface TableOptions {
+  [key: string]: unknown
+  extended?: boolean
+  'no-header'?: boolean
+  output?: string
+  printLine?(this: void, s: unknown): unknown
+  sort?: string
+}
+
+export function table<T extends Record<string, unknown>>(
+  data: T[],
+  columns: TableColumns<T>,
+  options: TableOptions = {},
+): void {
+  new Table(data, columns, options).render()
+}
+
+class Table<T extends Record<string, unknown>> {
+  data: T[]
+  columns: (TableColumn<T> & { extended: boolean; key: string; width?: number })[]
+  options: TableOptions & { extended: boolean; printLine(s: unknown): unknown }
+
+  constructor(data: T[], columns: TableColumns<T>, options: TableOptions) {
+    this.data = data
+    this.columns = Object.entries(columns).map(([key, column]) => {
+      const extended = column.extended || false
+      return {
+        ...column,
+        extended,
+        key,
+      }
+    })
+    this.options = {
+      extended: options.extended || false,
+      'no-header': options['no-header'],
+      output: options.csv ? 'csv' : options.output,
+      printLine: options.printLine ?? ux.log.bind(ux),
+      sort: options.sort,
+    }
+  }
+
+  render() {
+    // Generate the rendered text to be displayed
+    let rows: Record<string, string>[] = []
+    for (const data of this.data) {
+      const row: Record<string, string> = {}
+      for (const column of this.columns) {
+        // Only show columns marked as extended if the table is set to show
+        // extended columns
+        if (!this.options.extended && column.extended === true) {
+          continue
+        }
+        row[column.key] = column.get(data).toString()
+      }
+      rows.push(row)
+    }
+
+    // Sort the rows given the column to sort by
+    if (this.options.sort) {
+      let sortOrder: 'asc' | 'desc'
+      let header: string
+      if (this.options.sort[0] === '-') {
+        sortOrder = 'desc'
+        header = this.options.sort.slice(1)
+      } else {
+        sortOrder = 'asc'
+        header = this.options.sort
+      }
+
+      const column = this.columns.find((c) => c.header.toLowerCase() === header.toLowerCase())
+      Assert.isNotUndefined(column, `No column found with name '${header}'`)
+
+      rows = orderBy(rows, column.key, sortOrder)
+    }
+
+    switch (this.options.output) {
+      case 'csv': {
+        this.renderCsv(rows)
+        break
+      }
+
+      case 'json': {
+        this.renderJson(rows)
+        break
+      }
+
+      default: {
+        this.renderTerminal(rows)
+      }
+    }
+  }
+
+  renderCsv(rows: Record<string, string>[]) {
+    const columnHeaders = []
+    for (const column of this.columns) {
+      // Only show columns marked as extended if the table is set to show
+      // extended columns
+      if (!this.options.extended && column.extended === true) {
+        continue
+      }
+      columnHeaders.push(sanitizeCsvValue(column.header))
+    }
+    this.options.printLine(columnHeaders.join(','))
+
+    for (const row of rows) {
+      const rowValues = []
+      for (const value of Object.values(row)) {
+        rowValues.push(sanitizeCsvValue(value))
+      }
+      this.options.printLine(rowValues.join(','))
+    }
+  }
+
+  renderJson(rows: Record<string, string>[]) {
+    this.options.printLine(JSON.stringify(rows, null, 2))
+  }
+
+  renderTerminal(rows: Record<string, string>[]) {
+    // Find column lengths
+    for (const column of this.columns) {
+      column.width = maxColumnLength(column, rows)
+    }
+
+    if (!this.options['no-header']) {
+      // Print headers
+      const columnHeaders = []
+      for (const column of this.columns) {
+        // Only show columns marked as extended if the table is set to show
+        // extended columns
+        if (!this.options.extended && column.extended === true) {
+          continue
+        }
+        Assert.isNotUndefined(column.width)
+        const spacerLength = column.width - stringWidth(column.header)
+        columnHeaders.push(`${column.header}${' '.repeat(spacerLength)}`)
+      }
+      this.options.printLine(chalk.bold(` ${columnHeaders.join(' ')}`))
+
+      // Print header underline
+      const columnUnderlines = []
+      for (const column of this.columns) {
+        // Only show columns marked as extended if the table is set to show
+        // extended columns
+        if (!this.options.extended && column.extended === true) {
+          continue
+        }
+        Assert.isNotUndefined(column.width)
+        columnUnderlines.push(WIDE_DASH.repeat(column.width))
+      }
+      this.options.printLine(chalk.bold(` ${columnUnderlines.join(' ')}`))
+    }
+
+    // Print rows
+    for (const row of rows) {
+      const rowValues = []
+      for (const [key, value] of Object.entries(row)) {
+        const column = this.columns.find((c) => c.key === key)
+        Assert.isNotUndefined(column)
+        Assert.isNotUndefined(column.width)
+        const spacerLength = column.width - stringWidth(value)
+        rowValues.push(`${value}${' '.repeat(spacerLength)}`)
+      }
+      this.options.printLine(` ${rowValues.join(' ')}`)
+    }
+  }
+}
+
+function maxColumnLength<T extends Record<string, string>>(
+  column: { key: string; header: string; minWidth?: number },
+  data: T[],
+): number {
+  let maxLength = stringWidth(column.header)
+
+  for (const row of data) {
+    const length = stringWidth(row[column.key])
+    if (length > maxLength) {
+      maxLength = length
+    }
+  }
+
+  if (column.minWidth != null && column.minWidth > maxLength) {
+    return column.minWidth
+  }
+
+  return maxLength
+}
+
+function sanitizeCsvValue(value: string): string {
+  const newValue = value
+
+  // Double-quotes must be escaped with another double-quote
+  newValue.replace('"', '""')
+
+  // If the value contains any of these special characters, it needs to be
+  // wrapped in double-quotes
+  if (
+    newValue.includes('"') ||
+    newValue.includes('\r') ||
+    newValue.includes('\n') ||
+    newValue.includes(',')
+  ) {
+    return `"${newValue}"`
+  }
+
+  return newValue
+}

--- a/ironfish-cli/src/utils/table.ts
+++ b/ironfish-cli/src/utils/table.ts
@@ -6,6 +6,7 @@ import { ASSET_NAME_LENGTH } from '@ironfish/rust-nodejs'
 import { Assert, BufferUtils, TimeUtils } from '@ironfish/sdk'
 import { Flags, ux } from '@oclif/core'
 import { table } from '@oclif/core/lib/cli-ux/styled/table'
+import { TableColumn } from '../ui'
 
 /**
  * Estimated max length of the longest TimeUtils.renderTime()
@@ -28,7 +29,7 @@ const timestamp = <T extends Record<string, unknown>>(options?: {
   field?: string
   get?: (row: Record<string, unknown>) => string
   minWidth?: number
-}): Partial<table.Column<T>> => {
+}): TableColumn<T> => {
   const header = options?.header ?? 'Timestamp'
   const field = options?.field ?? 'timestamp'
 
@@ -107,9 +108,9 @@ const asset = <T extends Record<string, unknown>>(options?: {
 const fixedWidth = <T extends Record<string, unknown>>(options: {
   width: number
   get: (row: T) => string
-  header?: string
+  header: string
   extended?: boolean
-}): Partial<table.Column<T>> => {
+}): TableColumn<T> => {
   return {
     ...options,
     get: (row) => truncateCol(options.get(row), options.width),
@@ -129,7 +130,6 @@ export enum Format {
   cli = 'cli',
   csv = 'csv',
   json = 'json',
-  yaml = 'yaml',
 }
 
 export const TableCols = { timestamp, asset, fixedWidth }

--- a/ironfish-cli/src/utils/table.ts
+++ b/ironfish-cli/src/utils/table.ts
@@ -4,7 +4,6 @@
 
 import { ASSET_NAME_LENGTH } from '@ironfish/rust-nodejs'
 import { Assert, BufferUtils, TimeUtils } from '@ironfish/sdk'
-import { Flags, ux } from '@oclif/core'
 import { table } from '@oclif/core/lib/cli-ux/styled/table'
 import { TableColumn } from '../ui'
 
@@ -133,20 +132,3 @@ export enum Format {
 }
 
 export const TableCols = { timestamp, asset, fixedWidth }
-
-const { 'no-truncate': _, ...tableFlags } = ux.table.flags()
-
-export const TableFlags = {
-  ...tableFlags,
-  truncate: Flags.boolean({
-    description: 'truncate output to fit screen',
-    default: false,
-    allowNo: true,
-  }),
-  'no-truncate': Flags.boolean({
-    hidden: true,
-    default(context) {
-      return Promise.resolve(!context.flags['truncate'])
-    },
-  }),
-}

--- a/ironfish-cli/src/utils/table.ts
+++ b/ironfish-cli/src/utils/table.ts
@@ -4,7 +4,6 @@
 
 import { ASSET_NAME_LENGTH } from '@ironfish/rust-nodejs'
 import { Assert, BufferUtils, TimeUtils } from '@ironfish/sdk'
-import { table } from '@oclif/core/lib/cli-ux/styled/table'
 import { TableColumn } from '../ui'
 
 /**
@@ -63,12 +62,15 @@ const timestamp = <T extends Record<string, unknown>>(options?: {
 const asset = <T extends Record<string, unknown>>(options?: {
   extended?: boolean
   format?: Format
-}): Partial<Record<string, table.Column<T>>> => {
+}): Partial<Record<string, TableColumn<T>>> => {
   if (options?.extended || options?.format !== Format.cli) {
     return {
       assetId: {
         header: 'Asset ID',
-        get: (row) => row['assetId'],
+        get: (row) => {
+          Assert.isString(row.assetId)
+          return row.assetId
+        },
         minWidth: MAX_ASSET_NAME_COLUMN_WIDTH,
         extended: options?.extended ?? false,
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7880,6 +7880,11 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
+natural-orderby@3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/natural-orderby/-/natural-orderby-3.0.2.tgz#1b874d685fbd68beab2c6e7d14f298e03d631ec3"
+  integrity sha512-x7ZdOwBxZCEm9MM7+eQCjkrNLrW3rkBKNHVr78zbtqnMGVNlnDi6C/eUEYgxHNrcbu0ymvjzcwIL/6H1iHri9g==
+
 natural-orderby@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/natural-orderby/-/natural-orderby-2.0.3.tgz#8623bc518ba162f8ff1cdb8941d74deb0fdcc016"
@@ -9700,6 +9705,15 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
+string-width@4.2.3, "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
 string-width@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
@@ -9708,15 +9722,6 @@ string-width@^1.0.1:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^2.0.0:
   version "2.1.1"


### PR DESCRIPTION
## Summary

Since oclif 4.x removes their table feature, lets implement our own. The logic
is straight-forward enough that doing this was a reasonable task. The
alternative CLI table libraries didn't have the specific features we use, and
were generally over-engineered for our use.

This does remove some functionality that we were not using, as well as
potentially removing some extra usability that users may miss. We can re-add
these things as needed.

## Testing Plan

Manually tested the commands side-by-side

## Documentation

N/A

## Breaking Change

N/A