### PR TITLE
Add check for locked ledger device

### DIFF
--- a/ironfish-cli/src/utils/ledger.ts
+++ b/ironfish-cli/src/utils/ledger.ts
@@ -25,6 +25,10 @@ export class Ledger {
   connect = async () => {
     const transport = await TransportNodeHid.create(3000, 3000)
 
+    if (transport.deviceModel) {
+      this.logger.debug(`${transport.deviceModel.productName} found.`)
+    }
+
     const app = new IronfishApp(transport)
 
     const appInfo = await app.appInfo()
@@ -32,9 +36,17 @@ export class Ledger {
 
     if (appInfo.appName !== 'Ironfish') {
       this.logger.debug(appInfo.appName ?? 'no app name')
-      this.logger.debug(appInfo.returnCode.toString())
+      this.logger.debug(appInfo.returnCode.toString(16))
       this.logger.debug(appInfo.errorMessage.toString())
-      throw new Error('Please open the Iron Fish app on your ledger device')
+
+      // references:
+      // https://github.com/LedgerHQ/ledger-live/blob/173bb3c84cc855f83ab8dc49362bc381afecc31e/libs/ledgerjs/packages/errors/src/index.ts#L263
+      // https://github.com/Zondax/ledger-ironfish/blob/bf43a4b8d403d15138699ee3bb1a3d6dfdb428bc/docs/APDUSPEC.md?plain=1#L25
+      if (appInfo.returnCode === 0x5515) {
+        throw new Error('Please unlock your Ledger device.')
+      }
+
+      throw new Error('Please open the Iron Fish app on your ledger device.')
     }
 
     if (appInfo.appVersion) {


### PR DESCRIPTION
## Summary

Specifically calling out to the user to unlock the ledger device if it is locked. This is a different error for an unlocked device but a closed Ironfish ledger app.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
