### PR TITLE
Replace ux.prompt for oclif 4.x upgrade prep

### DIFF
--- a/ironfish-cli/src/commands/faucet.ts
+++ b/ironfish-cli/src/commands/faucet.ts
@@ -7,6 +7,7 @@ import { Flags, ux } from '@oclif/core'
 import { IronfishCommand } from '../command'
 import { RemoteFlags } from '../flags'
 import { ONE_FISH_IMAGE, TWO_FISH_IMAGE } from '../images'
+import { inputPrompt } from '../ui'
 
 const FAUCET_DISABLED = false
 
@@ -47,9 +48,7 @@ export class FaucetCommand extends IronfishCommand {
 
     if (!email) {
       email =
-        (await ux.prompt('Enter your email to stay updated with Iron Fish', {
-          required: false,
-        })) || undefined
+        (await inputPrompt('Enter your email to stay updated with Iron Fish')) || undefined
     }
 
     // Create an account if one is not set
@@ -59,9 +58,7 @@ export class FaucetCommand extends IronfishCommand {
     if (!accountName) {
       this.log(`You don't have a default account set up yet. Let's create one first!`)
       accountName =
-        (await ux.prompt('Please enter the name of your new Iron Fish account', {
-          required: false,
-        })) || 'default'
+        (await inputPrompt('Please enter the name of your new Iron Fish account')) || 'default'
 
       await client.wallet.createAccount({ name: accountName, default: true })
     }
@@ -89,17 +86,17 @@ export class FaucetCommand extends IronfishCommand {
     this.log(
       `
 
-    ${TWO_FISH_IMAGE}
+        ${TWO_FISH_IMAGE}
 
-Congratulations! The Iron Fish Faucet just added your request to the queue!
+    Congratulations! The Iron Fish Faucet just added your request to the queue!
 
-It will be processed within the next hour and $IRON will be sent directly to your account.
+    It will be processed within the next hour and $IRON will be sent directly to your account.
 
-Check your balance by running:
-  - ironfish wallet:balance
+    Check your balance by running:
+      - ironfish wallet:balance
 
-Learn how to send a transaction by running:
-  - ironfish wallet:send --help`,
+    Learn how to send a transaction by running:
+      - ironfish wallet:send --help`,
     )
   }
 }

--- a/ironfish-cli/src/commands/wallet/chainport/send.ts
+++ b/ironfish-cli/src/commands/wallet/chainport/send.ts
@@ -17,7 +17,7 @@ import { Flags, ux } from '@oclif/core'
 import inquirer from 'inquirer'
 import { IronfishCommand } from '../../../command'
 import { HexFlag, IronFlag, RemoteFlags, ValueFlag } from '../../../flags'
-import { confirmOrQuit } from '../../../ui'
+import { confirmOrQuit, inputPrompt } from '../../../ui'
 import { selectAsset } from '../../../utils'
 import {
   ChainportBridgeTransaction,
@@ -173,9 +173,7 @@ export class BridgeCommand extends IronfishCommand {
     }
 
     if (!to) {
-      to = await ux.prompt('Enter the public address of the recipient', {
-        required: true,
-      })
+      to = await inputPrompt('Enter the public address of the recipient', true)
     }
 
     if (!isEthereumAddress(to)) {

--- a/ironfish-cli/src/commands/wallet/create.ts
+++ b/ironfish-cli/src/commands/wallet/create.ts
@@ -2,9 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { Args, ux } from '@oclif/core'
+import { Args } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
+import { inputPrompt } from '../../ui'
 
 export class CreateCommand extends IronfishCommand {
   static description = `Create a new account for sending and receiving coins`
@@ -25,9 +26,7 @@ export class CreateCommand extends IronfishCommand {
     let name = args.account
 
     if (!name) {
-      name = await ux.prompt('Enter the name of the account', {
-        required: true,
-      })
+      name = await inputPrompt('Enter the name of the account', true)
     }
 
     const client = await this.sdk.connectRpc()

--- a/ironfish-cli/src/commands/wallet/delete.ts
+++ b/ironfish-cli/src/commands/wallet/delete.ts
@@ -5,6 +5,7 @@
 import { Args, Flags, ux } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
+import { inputPrompt } from '../../ui'
 
 export class DeleteCommand extends IronfishCommand {
   static description = `Permanently delete an account`
@@ -39,7 +40,7 @@ export class DeleteCommand extends IronfishCommand {
     ux.action.stop()
 
     if (response.content.needsConfirm) {
-      const value = await ux.prompt(`Are you sure? Type ${account} to confirm`)
+      const value = await inputPrompt(`Are you sure? Type ${account} to confirm`)
 
       if (value !== account) {
         this.log(`Aborting: ${value} did not match ${account}`)

--- a/ironfish-cli/src/commands/wallet/import.ts
+++ b/ironfish-cli/src/commands/wallet/import.ts
@@ -10,6 +10,7 @@ import {
 import { Args, Flags, ux } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
+import { inputPrompt } from '../../ui'
 import { importFile, importPipe, longPrompt } from '../../utils/input'
 import { Ledger } from '../../utils/ledger'
 
@@ -92,9 +93,7 @@ export class ImportCommand extends IronfishCommand {
       this.log()
       this.log(`Found existing account with name '${flags.name}'`)
 
-      const name = await ux.prompt('Enter a different name for the account', {
-        required: true,
-      })
+      const name = await inputPrompt('Enter a different name for the account', true)
       if (name === flags.name) {
         this.error(`Entered the same name: '${name}'`)
       }
@@ -125,9 +124,7 @@ export class ImportCommand extends IronfishCommand {
             this.log(e.codeMessage)
           }
 
-          const name = await ux.prompt(message, {
-            required: true,
-          })
+          const name = await inputPrompt(message, true)
           if (name === flags.name) {
             this.error(`Entered the same name: '${name}'`)
           }

--- a/ironfish-cli/src/commands/wallet/mint.ts
+++ b/ironfish-cli/src/commands/wallet/mint.ts
@@ -17,7 +17,7 @@ import {
 import { Flags, ux } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { IronFlag, RemoteFlags, ValueFlag } from '../../flags'
-import { confirmOrQuit, confirmPrompt } from '../../ui'
+import { confirmOrQuit, confirmPrompt, inputPrompt } from '../../ui'
 import { selectAsset } from '../../utils/asset'
 import { promptCurrency } from '../../utils/currency'
 import { promptExpiration } from '../../utils/expiration'
@@ -158,16 +158,11 @@ export class Mint extends IronfishCommand {
 
     if (isMintingNewAsset) {
       if (!name) {
-        name = await ux.prompt('Enter the name for the new asset', {
-          required: true,
-        })
+        name = await inputPrompt('Enter the name for the new asset', true)
       }
 
       if (!metadata) {
-        metadata = await ux.prompt('Enter metadata for the new asset', {
-          default: '',
-          required: false,
-        })
+        metadata = await inputPrompt('Enter metadata for the new asset')
       }
 
       const newAsset = new Asset(accountPublicKey, name, metadata)

--- a/ironfish-cli/src/commands/wallet/multisig/dealer/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dealer/create.ts
@@ -6,6 +6,7 @@ import { AccountImport } from '@ironfish/sdk/src/wallet/exporter'
 import { Flags, ux } from '@oclif/core'
 import { IronfishCommand } from '../../../../command'
 import { RemoteFlags } from '../../../../flags'
+import { inputPrompt } from '../../../../ui'
 import { longPrompt } from '../../../../utils/input'
 
 export class MultisigCreateDealer extends IronfishCommand {
@@ -54,9 +55,7 @@ export class MultisigCreateDealer extends IronfishCommand {
 
     let minSigners = flags.minSigners
     if (!minSigners) {
-      const input = await ux.prompt('Enter the number of minimum signers', {
-        required: true,
-      })
+      const input = await inputPrompt('Enter the number of minimum signers', true)
       minSigners = parseInt(input)
       if (isNaN(minSigners) || minSigners < 2) {
         this.error('Minimum number of signers must be at least 2')
@@ -131,7 +130,7 @@ export class MultisigCreateDealer extends IronfishCommand {
 
     let name = inputName
     do {
-      name = name ?? (await ux.prompt('Enter a name for the coordinator', { required: true }))
+      name = name ?? (await inputPrompt('Enter a name for the coordinator', true))
 
       if (accountNames.has(name)) {
         this.log(`Account with name ${name} already exists`)

--- a/ironfish-cli/src/commands/wallet/multisig/dkg/round1.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/round1.ts
@@ -1,9 +1,10 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { Flags, ux } from '@oclif/core'
+import { Flags } from '@oclif/core'
 import { IronfishCommand } from '../../../../command'
 import { RemoteFlags } from '../../../../flags'
+import { inputPrompt } from '../../../../ui'
 import { longPrompt } from '../../../../utils/input'
 import { selectSecret } from '../../../../utils/multisig'
 
@@ -57,9 +58,7 @@ export class DkgRound1Command extends IronfishCommand {
 
     let minSigners = flags.minSigners
     if (!minSigners) {
-      const input = await ux.prompt('Enter the number of minimum signers', {
-        required: true,
-      })
+      const input = await inputPrompt('Enter the number of minimum signers', true)
       minSigners = parseInt(input)
       if (isNaN(minSigners) || minSigners < 2) {
         this.error('Minimum number of signers must be at least 2')

--- a/ironfish-cli/src/commands/wallet/multisig/dkg/round2.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/round2.ts
@@ -1,9 +1,10 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { Flags, ux } from '@oclif/core'
+import { Flags } from '@oclif/core'
 import { IronfishCommand } from '../../../../command'
 import { RemoteFlags } from '../../../../flags'
+import { inputPrompt } from '../../../../ui'
 import { longPrompt } from '../../../../utils/input'
 import { selectSecret } from '../../../../utils/multisig'
 
@@ -41,9 +42,9 @@ export class DkgRound2Command extends IronfishCommand {
 
     let round1SecretPackage = flags.round1SecretPackage
     if (!round1SecretPackage) {
-      round1SecretPackage = await ux.prompt(
+      round1SecretPackage = await inputPrompt(
         `Enter the round 1 secret package for participant ${participantName}`,
-        { required: true },
+        true,
       )
     }
 

--- a/ironfish-cli/src/commands/wallet/multisig/dkg/round3.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/round3.ts
@@ -1,9 +1,10 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { Flags, ux } from '@oclif/core'
+import { Flags } from '@oclif/core'
 import { IronfishCommand } from '../../../../command'
 import { RemoteFlags } from '../../../../flags'
+import { inputPrompt } from '../../../../ui'
 import { longPrompt } from '../../../../utils/input'
 import { selectSecret } from '../../../../utils/multisig'
 
@@ -51,11 +52,9 @@ export class DkgRound3Command extends IronfishCommand {
 
     let round2SecretPackage = flags.round2SecretPackage
     if (!round2SecretPackage) {
-      round2SecretPackage = await ux.prompt(
+      round2SecretPackage = await inputPrompt(
         `Enter the round 2 encrypted secret package for participant ${participantName}`,
-        {
-          required: true,
-        },
+        true,
       )
     }
 

--- a/ironfish-cli/src/commands/wallet/multisig/participant/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/participant/create.ts
@@ -2,9 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { RPC_ERROR_CODES, RpcRequestError } from '@ironfish/sdk'
-import { Flags, ux } from '@oclif/core'
+import { Flags } from '@oclif/core'
 import { IronfishCommand } from '../../../../command'
 import { RemoteFlags } from '../../../../flags'
+import { inputPrompt } from '../../../../ui'
 
 export class MultisigIdentityCreate extends IronfishCommand {
   static description = `Create a multisig participant identity`
@@ -21,9 +22,7 @@ export class MultisigIdentityCreate extends IronfishCommand {
     const { flags } = await this.parse(MultisigIdentityCreate)
     let name = flags.name
     if (!name) {
-      name = await ux.prompt('Enter a name for the identity', {
-        required: true,
-      })
+      name = await inputPrompt('Enter a name for the identity', true)
     }
 
     const client = await this.sdk.connectRpc()
@@ -38,9 +37,7 @@ export class MultisigIdentityCreate extends IronfishCommand {
         ) {
           this.log()
           this.log(e.codeMessage)
-          name = await ux.prompt('Enter a new name for the identity', {
-            required: true,
-          })
+          name = await inputPrompt('Enter a new name for the identity', true)
         } else {
           throw e
         }

--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -12,11 +12,11 @@ import {
   TimeUtils,
   Transaction,
 } from '@ironfish/sdk'
-import { Flags, ux } from '@oclif/core'
+import { Flags } from '@oclif/core'
 import inquirer from 'inquirer'
 import { IronfishCommand } from '../../../command'
 import { HexFlag, IronFlag, RemoteFlags } from '../../../flags'
-import { confirmOrQuit, table } from '../../../ui'
+import { confirmOrQuit, inputPrompt, table } from '../../../ui'
 import { getAssetsByIDs, selectAsset } from '../../../utils'
 import { getExplorer } from '../../../utils/explorer'
 import { selectFee } from '../../../utils/fees'
@@ -132,9 +132,7 @@ export class CombineNotesCommand extends IronfishCommand {
 
     // eslint-disable-next-line no-constant-condition
     while (true) {
-      const result = await ux.prompt('Enter the number of notes', {
-        required: true,
-      })
+      const result = await inputPrompt('Enter the number of notes', true)
 
       const notesToCombine = parseInt(result)
 
@@ -288,8 +286,7 @@ export class CombineNotesCommand extends IronfishCommand {
 
     const totalAmount = notes.reduce((acc, note) => acc + BigInt(note.value), 0n)
 
-    const memo =
-      flags.memo ?? (await ux.prompt('Enter the memo (or leave blank)', { required: false }))
+    const memo = flags.memo ?? (await inputPrompt('Enter the memo (or leave blank)'))
 
     const expiration = await this.calculateExpiration(client, spendPostTime, numberOfNotes)
 

--- a/ironfish-cli/src/commands/wallet/send.ts
+++ b/ironfish-cli/src/commands/wallet/send.ts
@@ -11,10 +11,10 @@ import {
   TimeUtils,
   Transaction,
 } from '@ironfish/sdk'
-import { Flags, ux } from '@oclif/core'
+import { Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { HexFlag, IronFlag, RemoteFlags, ValueFlag } from '../../flags'
-import { confirmOrQuit } from '../../ui'
+import { confirmOrQuit, inputPrompt } from '../../ui'
 import { selectAsset } from '../../utils/asset'
 import { promptCurrency } from '../../utils/currency'
 import { promptExpiration } from '../../utils/expiration'
@@ -199,13 +199,10 @@ export class Send extends IronfishCommand {
     }
 
     if (!to) {
-      to = await ux.prompt('Enter the public address of the recipient', {
-        required: true,
-      })
+      to = await inputPrompt('Enter the public address of the recipient', true)
     }
 
-    const memo =
-      flags.memo ?? (await ux.prompt('Enter the memo (or leave blank)', { required: false }))
+    const memo = flags.memo ?? (await inputPrompt('Enter the memo (or leave blank)'))
 
     if (!isValidPublicAddress(to)) {
       this.log(`A valid public address is required`)

--- a/ironfish-cli/src/ui/index.ts
+++ b/ironfish-cli/src/ui/index.ts
@@ -2,6 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-export * from './confirm'
+export * from './prompt'
 export * from './progressBar'
 export * from './table'

--- a/ironfish-cli/src/ui/prompt.ts
+++ b/ironfish-cli/src/ui/prompt.ts
@@ -5,6 +5,29 @@
 import { ux } from '@oclif/core'
 import inquirer from 'inquirer'
 
+async function _inputPrompt(message: string): Promise<string> {
+  const result: { prompt: string } = await inquirer.prompt({
+    type: 'input',
+    name: 'prompt',
+    message: `${message}:`,
+  })
+  return result.prompt.trim()
+}
+
+export async function inputPrompt(message: string, required: boolean = false): Promise<string> {
+  let userInput: string = ''
+
+  if (required) {
+    while (!userInput) {
+      userInput = await _inputPrompt(message)
+    }
+  } else {
+    userInput = await _inputPrompt(message)
+  }
+
+  return userInput
+}
+
 export async function confirmPrompt(message: string): Promise<boolean> {
   const result: { prompt: boolean } = await inquirer.prompt({
     type: 'confirm',

--- a/ironfish-cli/src/utils/currency.ts
+++ b/ironfish-cli/src/utils/currency.ts
@@ -4,7 +4,7 @@
 
 import { Asset } from '@ironfish/rust-nodejs'
 import { Assert, CurrencyUtils, Logger, RpcAssetVerification, RpcClient } from '@ironfish/sdk'
-import { ux } from '@oclif/core'
+import { inputPrompt } from '../ui'
 
 /**
  * This prompts the user to enter an amount of currency in the major
@@ -57,9 +57,7 @@ export async function promptCurrency(options: {
 
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const input = await ux.prompt(text, {
-      required: options.required,
-    })
+    const input = await inputPrompt(text, options.required)
 
     if (!input) {
       return null

--- a/ironfish-cli/src/utils/expiration.ts
+++ b/ironfish-cli/src/utils/expiration.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { Logger, RpcClient } from '@ironfish/sdk'
-import { ux } from '@oclif/core'
+import { inputPrompt } from '../ui'
 
 export async function promptExpiration(options: {
   client: RpcClient
@@ -17,7 +17,7 @@ export async function promptExpiration(options: {
 
     const prompt = `Enter an expiration block sequence for the transaction. You can also enter 0 for no expiration, or leave blank to use the default. The current chain head is ${headSequence}`
 
-    const input = await ux.prompt(prompt, { required: false })
+    const input = await inputPrompt(prompt)
     if (!input) {
       return
     }


### PR DESCRIPTION
## Summary

ux.prompt is being removed in oclif 4.x, so in preparation for that, we will use inquirer for input prompts. We are already using inquirer for selection and confirm prompts, so there isn't really anything new in this change.

## Testing Plan

## Documentation

N/A

## Breaking Change

N/A