### PR TITLE
add ledger flag to send command

### DIFF
--- a/ironfish-cli/src/commands/wallet/send.ts
+++ b/ironfish-cli/src/commands/wallet/send.ts
@@ -8,6 +8,7 @@ import {
   isValidPublicAddress,
   RawTransaction,
   RawTransactionSerde,
+  RpcClient,
   TimeUtils,
   Transaction,
 } from '@ironfish/sdk'
@@ -20,6 +21,7 @@ import { promptCurrency } from '../../utils/currency'
 import { promptExpiration } from '../../utils/expiration'
 import { getExplorer } from '../../utils/explorer'
 import { selectFee } from '../../utils/fees'
+import { Ledger } from '../../utils/ledger'
 import { getSpendPostTimeInMs, updateSpendPostTimeInMs } from '../../utils/spendPostTime'
 import {
   displayTransactionSummary,
@@ -109,6 +111,10 @@ export class Send extends IronfishCommand {
       char: 'n',
       description: 'The note hashes to include in the transaction',
       multiple: true,
+    }),
+    ledger: Flags.boolean({
+      default: false,
+      description: 'Send a transaction using a Ledger device',
     }),
   }
 
@@ -273,6 +279,11 @@ export class Send extends IronfishCommand {
       this.exit(0)
     }
 
+    if (flags.ledger) {
+      await this.sendTransactionWithLedger(client, raw, from, flags.watch, flags.confirm)
+      this.exit(0)
+    }
+
     const spendPostTime = getSpendPostTimeInMs(this.sdk)
 
     const transactionTimer = new TransactionTimer(spendPostTime, raw)
@@ -347,6 +358,85 @@ export class Send extends IronfishCommand {
     }
 
     if (flags.watch) {
+      this.log('')
+
+      await watchTransaction({
+        client,
+        logger: this.logger,
+        account: from,
+        hash: transaction.hash().toString('hex'),
+      })
+    }
+  }
+
+  private async sendTransactionWithLedger(
+    client: RpcClient,
+    raw: RawTransaction,
+    from: string | undefined,
+    watch: boolean,
+    confirm: boolean,
+  ): Promise<void> {
+    const ledger = new Ledger(this.logger)
+    try {
+      await ledger.connect()
+    } catch (e) {
+      if (e instanceof Error) {
+        this.error(e.message)
+      } else {
+        throw e
+      }
+    }
+
+    const publicKey = (await client.wallet.getAccountPublicKey({ account: from })).content
+      .publicKey
+
+    const ledgerPublicKey = await ledger.getPublicAddress()
+
+    if (publicKey !== ledgerPublicKey) {
+      this.error(
+        `The public key on the ledger device does not match the public key of the account '${from}'`,
+      )
+    }
+
+    const buildTransactionResponse = await client.wallet.buildTransaction({
+      account: from,
+      rawTransaction: RawTransactionSerde.serialize(raw).toString('hex'),
+    })
+
+    const unsignedTransaction = buildTransactionResponse.content.unsignedTransaction
+
+    const signature = (await ledger.sign(unsignedTransaction)).toString('hex')
+
+    this.log(`\nSignature: ${signature}`)
+
+    const addSignatureResponse = await client.wallet.addSignature({
+      unsignedTransaction,
+      signature,
+    })
+
+    const signedTransaction = addSignatureResponse.content.transaction
+    const bytes = Buffer.from(signedTransaction, 'hex')
+
+    const transaction = new Transaction(bytes)
+
+    this.log(`\nSigned Transaction: ${signedTransaction}`)
+    this.log(`\nHash: ${transaction.hash().toString('hex')}`)
+    this.log(`Fee: ${CurrencyUtils.render(transaction.fee(), true)}`)
+
+    await confirmOrQuit('', confirm)
+
+    const addTransactionResponse = await client.wallet.addTransaction({
+      transaction: signedTransaction,
+      broadcast: true,
+    })
+
+    if (addTransactionResponse.content.accepted === false) {
+      this.error(
+        `Transaction '${transaction.hash().toString('hex')}' was not accepted into the mempool`,
+      )
+    }
+
+    if (watch) {
       this.log('')
 
       await watchTransaction({


### PR DESCRIPTION
## Summary

Add `--ledger` to `wallet:send` command. 

## Testing Plan

Send transactions with a ledger device using the `--ledger` flag with the `--watch` and `--confirm` flags. Send a transaction with another account that isn't the ledger account. 

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
