### PR TITLE
Use a sparse array in `DecryptNotesResponse`

### DIFF
--- a/ironfish/src/rpc/routes/wallet/utils.ts
+++ b/ironfish/src/rpc/routes/wallet/utils.ts
@@ -80,7 +80,7 @@ export async function getTransactionNotes(
     Assert.isNotUndefined(decryptedSends)
 
     for (const note of decryptedSends) {
-      if (note === null) {
+      if (note === undefined) {
         continue
       }
 

--- a/ironfish/src/wallet/scanner/noteDecryptor.ts
+++ b/ironfish/src/wallet/scanner/noteDecryptor.ts
@@ -239,7 +239,7 @@ export class BackgroundNoteDecryptor {
 function* regroupNotes(
   accounts: ReadonlyArray<Account>,
   transactions: ReadonlyArray<Transaction>,
-  decryptedNotes: ReadonlyMap<string, ReadonlyArray<DecryptedNote | null>>,
+  decryptedNotes: ReadonlyMap<string, ReadonlyArray<DecryptedNote | undefined>>,
 ): Generator<{
   account: Account
   decryptedTransactions: Array<{
@@ -249,7 +249,8 @@ function* regroupNotes(
 }> {
   for (const account of accounts) {
     let notesOffset = 0
-    const flatNotes: ReadonlyArray<DecryptedNote | null> = decryptedNotes.get(account.id) ?? []
+    const flatNotes: ReadonlyArray<DecryptedNote | undefined> =
+      decryptedNotes.get(account.id) ?? []
     const groupedNotes: Array<{
       transaction: Transaction
       decryptedNotes: Array<DecryptedNote>
@@ -258,7 +259,7 @@ function* regroupNotes(
     for (const transaction of transactions) {
       const decryptedNotes = flatNotes
         .slice(notesOffset, notesOffset + transaction.notes.length)
-        .filter((note) => note !== null) as Array<DecryptedNote>
+        .filter((note) => note !== undefined) as Array<DecryptedNote>
       groupedNotes.push({ transaction, decryptedNotes })
       notesOffset += transaction.notes.length
     }

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -353,7 +353,7 @@ export class Wallet {
     accounts: ReadonlyArray<Account>,
   ): Promise<Map<string, Array<DecryptedNote>>> {
     const workloadSize = 20
-    const notePromises: Array<Promise<Map<string, Array<DecryptedNote | null>>>> = []
+    const notePromises: Array<Promise<Map<string, Array<DecryptedNote | undefined>>>> = []
     let decryptNotesPayloads = []
 
     let currentNoteIndex = initialNoteIndex
@@ -388,7 +388,9 @@ export class Wallet {
       for (const [accountId, decryptedNotes] of partialResult.entries()) {
         const list = mergedResults.get(accountId)
         Assert.isNotUndefined(list)
-        list.push(...(decryptedNotes.filter((note) => note !== null) as Array<DecryptedNote>))
+        list.push(
+          ...(decryptedNotes.filter((note) => note !== undefined) as Array<DecryptedNote>),
+        )
       }
     }
 
@@ -398,7 +400,7 @@ export class Wallet {
   private decryptNotesFromTransaction(
     accounts: ReadonlyArray<Account>,
     encryptedNotes: Array<DecryptNotesItem>,
-  ): Promise<Map<string, Array<DecryptedNote | null>>> {
+  ): Promise<Map<string, Array<DecryptedNote | undefined>>> {
     const accountKeys = accounts.map((account) => ({
       accountId: account.id,
       incomingViewKey: Buffer.from(account.incomingViewKey, 'hex'),

--- a/ironfish/src/workerPool/pool.ts
+++ b/ironfish/src/workerPool/pool.ts
@@ -196,7 +196,7 @@ export class WorkerPool {
     accountKeys: ReadonlyArray<{ accountId: string } & DecryptNotesAccountKey>,
     encryptedNotes: ReadonlyArray<DecryptNotesItem>,
     options: DecryptNotesOptions,
-  ): Promise<Map<string, Array<DecryptedNote | null>>> {
+  ): Promise<Map<string, Array<DecryptedNote | undefined>>> {
     const request = new DecryptNotesRequest(accountKeys, encryptedNotes, options)
 
     const response = await this.execute(request).result()

--- a/ironfish/src/workerPool/tasks/decryptNotes.test.ts
+++ b/ironfish/src/workerPool/tasks/decryptNotes.test.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { DECRYPTED_NOTE_LENGTH, ENCRYPTED_NOTE_LENGTH } from '@ironfish/rust-nodejs'
+import { Assert } from '../../assert'
 import {
   createNodeTest,
   serializePayloadToBuffer,
@@ -13,6 +14,7 @@ import {
 import { ACCOUNT_KEY_LENGTH } from '../../wallet'
 import { VIEW_KEY_LENGTH } from '../../wallet/walletdb/accountValue'
 import {
+  DecryptedNote,
   DecryptNotesRequest,
   DecryptNotesResponse,
   DecryptNotesSharedAccountKeys,
@@ -121,7 +123,7 @@ describe('DecryptNotesResponse', () => {
           nullifier: Buffer.alloc(32, 1),
           serializedNote: Buffer.alloc(DECRYPTED_NOTE_LENGTH, 1),
         },
-        null,
+        undefined,
       ],
       0,
     )
@@ -146,6 +148,38 @@ describe('DecryptNotesResponse', () => {
     const buffer = serializePayloadToBuffer(request)
     const deserializedResponse = DecryptNotesResponse.deserializePayload(request.jobId, buffer)
     expect(deserializedResponse.notes).toHaveLength(length)
+  })
+
+  it('uses sparses arrays to minimize memory usage', () => {
+    const notes = []
+    const notesLength = 10000
+    const testNote = {
+      forSpender: false,
+      index: 1,
+      hash: Buffer.alloc(32, 1),
+      nullifier: Buffer.alloc(32, 1),
+      serializedNote: Buffer.alloc(DECRYPTED_NOTE_LENGTH, 1),
+    }
+    notes[1000] = testNote
+    notes[2000] = testNote
+    notes[3000] = testNote
+    notes.length = notesLength
+    expect(notes).toHaveLength(notesLength)
+
+    const response = new DecryptNotesResponse(notes, 0)
+    const buffer = serializePayloadToBuffer(response)
+    const deserializedResponse = DecryptNotesResponse.deserializePayload(response.jobId, buffer)
+
+    expect(deserializedResponse.notes).toHaveLength(notesLength)
+    expect(deserializedResponse.notes).toEqual(notes)
+
+    const explicitlySetNotes = new Array<DecryptedNote>()
+    deserializedResponse.notes.forEach((note) => {
+      Assert.isNotUndefined(note)
+      explicitlySetNotes.push(note)
+    })
+    expect(explicitlySetNotes).toHaveLength(3)
+    expect(explicitlySetNotes).toEqual([testNote, testNote, testNote])
   })
 
   describe('mapToAccounts', () => {
@@ -283,7 +317,7 @@ describe('DecryptNotesTask', () => {
       )
       const responseNoSpender = task.execute(requestNoSpender)
 
-      expect(responseNoSpender).toMatchObject({ notes: [null] })
+      expect(responseNoSpender).toMatchObject({ notes: [undefined] })
     })
   })
 })


### PR DESCRIPTION
## Summary

Most of the note decryption will fail. Currently, if a `DecryptNotesResponse` contains 100 undecrypted notes, it will create a dense array containing 100 `null` values, causing unnecessary large memory allocations and large memory writes. It was in fact observed that the arrays from `DecryptNotesResponse` were one of the top contributors to memory usage during wallet scans.

This commit changes the implementation so that now `DecryptNotesResponse` would create a sparse array containing no values at all. This means that, when no notes are decrypted (i.e. the most common case), all `DecryptNotesResponse` objects consume the same amount of memory, regardless of how many accounts are in the wallet, or how many encrypted notes were requested.

This was shown to reduce the peak memory usage of the node process, as well as reduce the number of minor page faults.

## Testing Plan

## Documentation

N/A

## Breaking Change

N/A