### PR TITLE
Renders transaction summary at the end of the sign command.

### DIFF
--- a/ironfish-cli/src/commands/wallet/sign.ts
+++ b/ironfish-cli/src/commands/wallet/sign.ts
@@ -8,10 +8,7 @@ import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 import { longPrompt } from '../../utils/input'
 import { Ledger } from '../../utils/ledger'
-import {
-  renderTransactionDetails,
-  watchTransaction
-} from '../../utils/transaction'
+import { renderTransactionDetails, watchTransaction } from '../../utils/transaction'
 
 export class SignTransaction extends IronfishCommand {
   static description = `Sign an unsigned transaction`

--- a/ironfish-cli/src/commands/wallet/sign.ts
+++ b/ironfish-cli/src/commands/wallet/sign.ts
@@ -8,7 +8,10 @@ import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 import { longPrompt } from '../../utils/input'
 import { Ledger } from '../../utils/ledger'
-import { watchTransaction } from '../../utils/transaction'
+import {
+  renderTransactionDetails,
+  watchTransaction
+} from '../../utils/transaction'
 
 export class SignTransaction extends IronfishCommand {
   static description = `Sign an unsigned transaction`
@@ -72,6 +75,8 @@ export class SignTransaction extends IronfishCommand {
     this.log(`\nSigned Transaction: ${signedTransaction}`)
     this.log(`\nHash: ${transaction.hash().toString('hex')}`)
     this.log(`Fee: ${CurrencyUtils.render(transaction.fee(), true)}`)
+
+    await renderTransactionDetails(client, transaction, account, this.logger)
 
     if (flags.broadcast && response.content.accepted === false) {
       this.error(


### PR DESCRIPTION
## Summary

Renders transaction summary at the end of the sign command.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
