### PR TITLE
fixes stateManager persistence

### DIFF
--- a/ironfish-cli/src/commands/evm/persist-state.ts
+++ b/ironfish-cli/src/commands/evm/persist-state.ts
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Account, Address } from '@ethereumjs/util'
+import { IronfishCommand } from '../../command'
+import { LocalFlags } from '../../flags'
+
+export class PersistStateTestEvmCommand extends IronfishCommand {
+  static description = `Test adding EVM support to the Iron Fish network`
+
+  static flags = { ...LocalFlags }
+
+  async start(): Promise<void> {
+    const node = await this.sdk.node()
+    await node.openDB()
+
+    const persistentAddress = Address.fromString('0x3c6c6d51f71a0f146cf79843e888feb20258f567')
+    const persistentAccount = await node.chain.blockchainDb.stateManager.getAccount(
+      persistentAddress,
+    )
+    const persistentBalance = persistentAccount?.balance ?? 0n
+    this.log(
+      `Account at address ${persistentAddress.toString()} has balance ${persistentBalance}`,
+    )
+
+    await node.chain.blockchainDb.stateManager.checkpoint()
+    await node.chain.blockchainDb.stateManager.putAccount(
+      persistentAddress,
+      new Account(0n, persistentBalance + 1n),
+    )
+    await node.chain.blockchainDb.stateManager.commit()
+
+    await node.closeDB()
+  }
+}

--- a/ironfish/src/evm/stateManager.ts
+++ b/ironfish/src/evm/stateManager.ts
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { DefaultStateManager, DefaultStateManagerOpts } from '@ethereumjs/statemanager'
+import { Trie } from '@ethereumjs/trie'
+import { ValueEncoding } from '@ethereumjs/util'
+import { IDatabase } from '../storage'
+import { EvmStateDB } from './database'
+
+export type IronfishStateManagerOpts = Omit<DefaultStateManagerOpts, 'trie'>
+
+export class IronfishStateManager extends DefaultStateManager {
+  db: EvmStateDB
+
+  constructor(db: IDatabase, opts?: IronfishStateManagerOpts) {
+    super(opts)
+    this.db = new EvmStateDB(db)
+  }
+
+  async open(): Promise<void> {
+    this._trie = await Trie.create({
+      db: this.db,
+      useKeyHashing: true,
+      valueEncoding: ValueEncoding.Bytes,
+      useRootPersistence: true,
+      common: this.common,
+    })
+  }
+}


### PR DESCRIPTION
## Summary

defines a custom IronfishStateManager extension of the DefaultStateManager

adds an 'open' method that initializes the Trie on the database using 'Trie.create'

the 'Trie' constructor always initializes the Trie with an empty root, which renders existing data unreachable

## Testing Plan

adds a 'persist-state' command to test and demonstrate data persistence

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
