### PR TITLE
add stateCommitment to block header

### DIFF
--- a/ironfish/src/blockHasher.test.ts
+++ b/ironfish/src/blockHasher.test.ts
@@ -5,6 +5,7 @@
 import { blake3 } from '@napi-rs/blake-hash'
 import { BlockHasher, serializeHeaderBlake3, serializeHeaderFishHash } from './blockHasher'
 import { Consensus } from './consensus'
+import { INITIAL_STATE_ROOT } from './evm'
 import { Target } from './primitives'
 import { RawBlockHeader } from './primitives/blockheader'
 import { FISH_HASH_CONTEXT } from './testUtilities'
@@ -43,6 +44,7 @@ describe('Hashes blocks with correct hashing algorithm', () => {
     randomness: BigInt(25),
     timestamp: new Date(1598467858637),
     graffiti: Buffer.alloc(32, 'graffiti'),
+    stateCommitment: INITIAL_STATE_ROOT,
   }
 
   it('Hashes block headers with blake3 before the activation sequence', () => {

--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -1004,7 +1004,7 @@ export class Blockchain {
 
       graffiti = graffiti ? graffiti : Buffer.alloc(32)
 
-      const stateRoot = Buffer.from(await this.blockchainDb.stateManager.getStateRoot())
+      const stateCommitment = Buffer.from(await this.blockchainDb.stateManager.getStateRoot())
 
       const rawHeader = {
         sequence: previousSequence + 1,
@@ -1015,7 +1015,7 @@ export class Blockchain {
         randomness: BigInt(0),
         timestamp,
         graffiti,
-        stateRoot,
+        stateCommitment,
       }
 
       const header = this.newBlockHeaderFromRaw(rawHeader, noteSize, BigInt(0))

--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -1004,6 +1004,8 @@ export class Blockchain {
 
       graffiti = graffiti ? graffiti : Buffer.alloc(32)
 
+      const stateRoot = Buffer.from(await this.blockchainDb.stateManager.getStateRoot())
+
       const rawHeader = {
         sequence: previousSequence + 1,
         previousBlockHash,
@@ -1013,6 +1015,7 @@ export class Blockchain {
         randomness: BigInt(0),
         timestamp,
         graffiti,
+        stateRoot,
       }
 
       const header = this.newBlockHeaderFromRaw(rawHeader, noteSize, BigInt(0))
@@ -1282,6 +1285,7 @@ export class Blockchain {
     await this.nullifiers.connectBlock(block, tx)
 
     for (const transaction of block.transactions) {
+      // TODO(hughy): execute evm transaction
       await this.saveConnectedMintsToAssetsStore(transaction, tx)
       await this.saveConnectedBurnsToAssetsStore(transaction, tx)
       await this.blockchainDb.putTransactionHashToBlockHash(

--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -1005,7 +1005,10 @@ export class Blockchain {
 
       graffiti = graffiti ? graffiti : Buffer.alloc(32)
 
-      const stateCommitment = Buffer.from(await this.blockchainDb.stateManager.getStateRoot())
+      let stateCommitment = undefined
+      if (this.consensus.isActive('enableEvmDescriptions', previousSequence + 1)) {
+        stateCommitment = Buffer.from(await this.blockchainDb.stateManager.getStateRoot())
+      }
 
       const rawHeader = {
         sequence: previousSequence + 1,

--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -995,6 +995,7 @@ export class Blockchain {
         for (const note of transaction.notes) {
           blockNotes.push(note)
         }
+        // TODO: execute EVM transactions
       }
 
       await this.notes.addBatch(blockNotes, tx)

--- a/ironfish/src/blockchain/database/headers.ts
+++ b/ironfish/src/blockchain/database/headers.ts
@@ -35,6 +35,10 @@ export class HeaderEncoding implements IDatabaseEncoding<HeaderValue> {
     bw.writeVarBytes(BigIntUtils.toBytesLE(value.header.work))
     bw.writeHash(value.header.hash)
 
+    if (value.header.stateCommitment) {
+      bw.writeHash(value.header.stateCommitment)
+    }
+
     return bw.render()
   }
 
@@ -53,6 +57,11 @@ export class HeaderEncoding implements IDatabaseEncoding<HeaderValue> {
     const work = BigIntUtils.fromBytesLE(reader.readVarBytes())
     const hash = reader.readHash()
 
+    let stateCommitment = undefined
+    if (reader.left()) {
+      stateCommitment = reader.readHash()
+    }
+
     const rawHeader = {
       sequence,
       previousBlockHash,
@@ -62,6 +71,7 @@ export class HeaderEncoding implements IDatabaseEncoding<HeaderValue> {
       randomness,
       timestamp: new Date(timestamp),
       graffiti,
+      stateCommitment,
     }
     const header = new BlockHeader(rawHeader, hash, noteSize, work)
 
@@ -81,6 +91,9 @@ export class HeaderEncoding implements IDatabaseEncoding<HeaderValue> {
     size += 32 // graffiti
     size += bufio.sizeVarBytes(BigIntUtils.toBytesLE(value.header.work))
     size += 32 // hash
+    if (value.header.stateCommitment) {
+      size += 32
+    }
 
     return size
   }

--- a/ironfish/src/consensus/verifier.test.ts
+++ b/ironfish/src/consensus/verifier.test.ts
@@ -85,7 +85,9 @@ describe('Verifier', () => {
 
     it('returns false on transactions larger than max size', async () => {
       const { transaction } = await useTxSpendsFixture(nodeTest.node)
-      nodeTest.chain.consensus.parameters.maxBlockSizeBytes = getBlockWithMinersFeeSize()
+      nodeTest.chain.consensus.parameters.maxBlockSizeBytes = getBlockWithMinersFeeSize(
+        transaction.version(),
+      )
 
       const result = Verifier.verifyCreatedTransaction(transaction, nodeTest.chain.consensus)
 

--- a/ironfish/src/consensus/verifier.ts
+++ b/ironfish/src/consensus/verifier.ts
@@ -18,7 +18,7 @@ import { BurnDescription } from '../primitives/burnDescription'
 import { EvmDescription, evmDescriptionToLegacyTransaction } from '../primitives/evmDescription'
 import { MintDescription } from '../primitives/mintDescription'
 import { Target } from '../primitives/target'
-import { Transaction } from '../primitives/transaction'
+import { Transaction, TransactionVersion } from '../primitives/transaction'
 import { IDatabaseTransaction } from '../storage'
 import { BufferUtils } from '../utils/buffer'
 import { WorkerPool } from '../workerPool'
@@ -306,8 +306,11 @@ export class Verifier {
     return { valid: true }
   }
 
-  static getMaxTransactionBytes(maxBlockSizeBytes: number): number {
-    return maxBlockSizeBytes - getBlockWithMinersFeeSize()
+  static getMaxTransactionBytes(
+    maxBlockSizeBytes: number,
+    transactionVersion: TransactionVersion,
+  ): number {
+    return maxBlockSizeBytes - getBlockWithMinersFeeSize(transactionVersion)
   }
 
   /**
@@ -320,7 +323,10 @@ export class Verifier {
   ): VerificationResult {
     if (
       getTransactionSize(transaction) >
-      Verifier.getMaxTransactionBytes(consensus.parameters.maxBlockSizeBytes)
+      Verifier.getMaxTransactionBytes(
+        consensus.parameters.maxBlockSizeBytes,
+        transaction.version(),
+      )
     ) {
       return { valid: false, reason: VerificationResultReason.MAX_TRANSACTION_SIZE_EXCEEDED }
     }

--- a/ironfish/src/consensus/verifier.ts
+++ b/ironfish/src/consensus/verifier.ts
@@ -537,6 +537,13 @@ export class Verifier {
         return spendVerification
       }
 
+      const stateRoot = await this.chain.blockchainDb.stateManager.getStateRoot()
+      // TODO(hughy): add hard fork activation logic
+      // for now, allow block headers not to have stateRoot
+      if (header.stateRoot && !header.stateRoot?.equals(stateRoot)) {
+        return { valid: false, reason: VerificationResultReason.EVM_STATE_ROOT }
+      }
+
       return { valid: true }
     })
   }
@@ -754,6 +761,7 @@ export enum VerificationResultReason {
   EVM_TRANSACTION_FAILED = 'EVM transaction failed',
   EVM_TRANSACTION_INVALID_SIGNATURE = 'EVM transaction has invalid signature',
   EVM_UNKNOWN_ERROR = 'EVM unknown error',
+  EVM_STATE_ROOT = 'EVM state root not equal',
 }
 
 /**

--- a/ironfish/src/consensus/verifier.ts
+++ b/ironfish/src/consensus/verifier.ts
@@ -537,11 +537,11 @@ export class Verifier {
         return spendVerification
       }
 
-      const stateCommitment = await this.chain.blockchainDb.stateManager.getStateRoot()
-      // TODO(hughy): add hard fork activation logic
-      // for now, allow block headers not to have stateCommitment
-      if (header.stateCommitment && !header.stateCommitment?.equals(stateCommitment)) {
-        return { valid: false, reason: VerificationResultReason.EVM_STATE_COMMITMENT }
+      if (this.chain.consensus.isActive('enableEvmDescriptions', header.sequence)) {
+        const stateCommitment = await this.chain.blockchainDb.stateManager.getStateRoot()
+        if (!header.stateCommitment?.equals(stateCommitment)) {
+          return { valid: false, reason: VerificationResultReason.EVM_STATE_COMMITMENT }
+        }
       }
 
       return { valid: true }

--- a/ironfish/src/consensus/verifier.ts
+++ b/ironfish/src/consensus/verifier.ts
@@ -537,11 +537,11 @@ export class Verifier {
         return spendVerification
       }
 
-      const stateRoot = await this.chain.blockchainDb.stateManager.getStateRoot()
+      const stateCommitment = await this.chain.blockchainDb.stateManager.getStateRoot()
       // TODO(hughy): add hard fork activation logic
-      // for now, allow block headers not to have stateRoot
-      if (header.stateRoot && !header.stateRoot?.equals(stateRoot)) {
-        return { valid: false, reason: VerificationResultReason.EVM_STATE_ROOT }
+      // for now, allow block headers not to have stateCommitment
+      if (header.stateCommitment && !header.stateCommitment?.equals(stateCommitment)) {
+        return { valid: false, reason: VerificationResultReason.EVM_STATE_COMMITMENT }
       }
 
       return { valid: true }
@@ -761,7 +761,7 @@ export enum VerificationResultReason {
   EVM_TRANSACTION_FAILED = 'EVM transaction failed',
   EVM_TRANSACTION_INVALID_SIGNATURE = 'EVM transaction has invalid signature',
   EVM_UNKNOWN_ERROR = 'EVM unknown error',
-  EVM_STATE_ROOT = 'EVM state root not equal',
+  EVM_STATE_COMMITMENT = 'EVM state commitment does not match',
 }
 
 /**

--- a/ironfish/src/evm/evm.ts
+++ b/ironfish/src/evm/evm.ts
@@ -6,6 +6,13 @@ import { RunTxOpts, RunTxResult, VM } from '@ethereumjs/vm'
 import { BlockchainDB } from '../blockchain/database/blockchaindb'
 import { EvmBlockchain } from './blockchain'
 
+export const INITIAL_STATE_ROOT = Buffer.from(
+  // TODO(hughy): replace with state root after inserting global contract
+  // keccak256 hash of RLP-encoded empty string
+  '56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421',
+  'hex',
+)
+
 export class IronfishEvm {
   private vm: VM
 

--- a/ironfish/src/mining/manager.test.slow.ts
+++ b/ironfish/src/mining/manager.test.slow.ts
@@ -367,7 +367,9 @@ describe('Mining manager', () => {
       )
 
       node.memPool.acceptTransaction(transaction)
-      chain.consensus.parameters.maxBlockSizeBytes = getBlockWithMinersFeeSize()
+      chain.consensus.parameters.maxBlockSizeBytes = getBlockWithMinersFeeSize(
+        transaction.version(),
+      )
 
       const templates = await collectTemplates(node.miningManager, 2)
       const fullTemplate = templates.find((t) => t.transactions.length > 1)
@@ -376,7 +378,7 @@ describe('Mining manager', () => {
 
       // Expand max block size, should allow transaction to be added to block
       chain.consensus.parameters.maxBlockSizeBytes =
-        getBlockWithMinersFeeSize() + getTransactionSize(transaction)
+        getBlockWithMinersFeeSize(transaction.version()) + getTransactionSize(transaction)
 
       const templates2 = await collectTemplates(node.miningManager, 2)
       const fullTemplate2 = templates2.find((t) => t.transactions.length > 1)

--- a/ironfish/src/mining/manager.ts
+++ b/ironfish/src/mining/manager.ts
@@ -12,8 +12,8 @@ import { MetricsMonitor } from '../metrics'
 import {
   getBlockSize,
   getBlockWithMinersFeeSize,
+  getMinersFeeTransactionSize,
   getTransactionSize,
-  MINERS_FEE_TRANSACTION_SIZE_BYTES,
 } from '../network/utils/serializers'
 import { FullNode } from '../node'
 import { Block } from '../primitives/block'
@@ -309,7 +309,10 @@ export class MiningManager {
   ): Promise<SerializedBlockTemplate> {
     const newBlockSequence = currentBlock.header.sequence + 1
 
-    let currBlockSize = getBlockWithMinersFeeSize()
+    const transactionVersion =
+      this.chain.consensus.getActiveTransactionVersion(newBlockSequence)
+
+    let currBlockSize = getBlockWithMinersFeeSize(transactionVersion)
     let transactions: Transaction[] = []
 
     let minersFee: Transaction
@@ -338,7 +341,7 @@ export class MiningManager {
 
     const txSize = getTransactionSize(minersFee)
     Assert.isEqual(
-      MINERS_FEE_TRANSACTION_SIZE_BYTES,
+      getMinersFeeTransactionSize(transactionVersion),
       txSize,
       "Incorrect miner's fee transaction size used during block creation",
     )

--- a/ironfish/src/network/utils/serializers.ts
+++ b/ironfish/src/network/utils/serializers.ts
@@ -11,9 +11,7 @@ import {
 } from '../../primitives/block'
 import { RawBlockHeader } from '../../primitives/blockheader'
 import { Target } from '../../primitives/target'
-import { Transaction } from '../../primitives/transaction'
-
-export const MINERS_FEE_TRANSACTION_SIZE_BYTES = 664
+import { Transaction, TransactionVersion } from '../../primitives/transaction'
 
 const BLOCK_TRANSACTIONS_LENGTH_BYTES = 2
 
@@ -106,10 +104,20 @@ export function getBlockSize(block: RawBlock): number {
   return size
 }
 
-export function getBlockWithMinersFeeSize(): number {
+export function getBlockWithMinersFeeSize(transactionVersion: TransactionVersion): number {
   return (
-    getBlockHeaderSize() + BLOCK_TRANSACTIONS_LENGTH_BYTES + MINERS_FEE_TRANSACTION_SIZE_BYTES
+    getBlockHeaderSize() +
+    BLOCK_TRANSACTIONS_LENGTH_BYTES +
+    getMinersFeeTransactionSize(transactionVersion)
   )
+}
+
+export function getMinersFeeTransactionSize(transactionVersion: TransactionVersion): number {
+  let size = 664
+  if (transactionVersion >= TransactionVersion.V3) {
+    size += 1
+  }
+  return size
 }
 
 export function writeCompactBlock(

--- a/ironfish/src/primitives/blockheader.ts
+++ b/ironfish/src/primitives/blockheader.ts
@@ -150,6 +150,8 @@ export class BlockHeader {
    */
   public readonly graffiti: Buffer
 
+  public readonly stateRoot?: Buffer
+
   /**
    * (For internal uses - excluded when sent over the network)
    * The size of the notes tree after adding transactions from this block.
@@ -173,6 +175,7 @@ export class BlockHeader {
     this.randomness = raw.randomness
     this.timestamp = raw.timestamp || new Date()
     this.graffiti = raw.graffiti
+    this.stateRoot = raw.stateRoot
     this.noteSize = noteSize ?? null
     this.work = work
     this.hash = hash
@@ -203,6 +206,9 @@ export class BlockHeader {
     bw.writeBigU256BE(this.target.asBigInt())
     bw.writeU64(this.timestamp.getTime())
     bw.writeBytes(this.graffiti)
+    if (this.stateRoot) {
+      bw.writeHash(this.stateRoot)
+    }
 
     return bw.render()
   }
@@ -225,6 +231,7 @@ export class BlockHeader {
       randomness: this.randomness,
       timestamp: this.timestamp,
       graffiti: this.graffiti,
+      stateRoot: this.stateRoot,
     }
   }
 }
@@ -238,6 +245,7 @@ export type RawBlockHeader = {
   randomness: bigint
   timestamp: Date
   graffiti: Buffer
+  stateRoot?: Buffer
 }
 
 export type SerializedBlockHeader = {
@@ -251,6 +259,7 @@ export type SerializedBlockHeader = {
   noteSize: number | null
   work?: string
   graffiti: string
+  stateRoot?: Buffer
 }
 
 export class BlockHeaderSerde {
@@ -266,6 +275,7 @@ export class BlockHeaderSerde {
       graffiti: GraffitiSerdeInstance.serialize(header.graffiti),
       noteSize: header.noteSize,
       work: header.work.toString(),
+      stateRoot: header.stateRoot,
     }
   }
 
@@ -282,6 +292,7 @@ export class BlockHeaderSerde {
         randomness: BigInt(data.randomness),
         timestamp: new Date(data.timestamp),
         graffiti: Buffer.from(GraffitiSerdeInstance.deserialize(data.graffiti)),
+        stateRoot: data.stateRoot,
       },
       data.noteSize,
       data.work ? BigInt(data.work) : BigInt(0),

--- a/ironfish/src/primitives/blockheader.ts
+++ b/ironfish/src/primitives/blockheader.ts
@@ -150,7 +150,7 @@ export class BlockHeader {
    */
   public readonly graffiti: Buffer
 
-  public readonly stateRoot?: Buffer
+  public readonly stateCommitment?: Buffer
 
   /**
    * (For internal uses - excluded when sent over the network)
@@ -175,7 +175,7 @@ export class BlockHeader {
     this.randomness = raw.randomness
     this.timestamp = raw.timestamp || new Date()
     this.graffiti = raw.graffiti
-    this.stateRoot = raw.stateRoot
+    this.stateCommitment = raw.stateCommitment
     this.noteSize = noteSize ?? null
     this.work = work
     this.hash = hash
@@ -206,8 +206,8 @@ export class BlockHeader {
     bw.writeBigU256BE(this.target.asBigInt())
     bw.writeU64(this.timestamp.getTime())
     bw.writeBytes(this.graffiti)
-    if (this.stateRoot) {
-      bw.writeHash(this.stateRoot)
+    if (this.stateCommitment) {
+      bw.writeHash(this.stateCommitment)
     }
 
     return bw.render()
@@ -215,7 +215,7 @@ export class BlockHeader {
 
   getSize(): number {
     let size = 180
-    if (this.stateRoot) {
+    if (this.stateCommitment) {
       size += 32
     }
     return size
@@ -239,7 +239,7 @@ export class BlockHeader {
       randomness: this.randomness,
       timestamp: this.timestamp,
       graffiti: this.graffiti,
-      stateRoot: this.stateRoot,
+      stateCommitment: this.stateCommitment,
     }
   }
 }
@@ -253,7 +253,7 @@ export type RawBlockHeader = {
   randomness: bigint
   timestamp: Date
   graffiti: Buffer
-  stateRoot?: Buffer
+  stateCommitment?: Buffer
 }
 
 export type SerializedBlockHeader = {
@@ -267,7 +267,7 @@ export type SerializedBlockHeader = {
   noteSize: number | null
   work?: string
   graffiti: string
-  stateRoot?: Buffer
+  stateCommitment?: Buffer
 }
 
 export class BlockHeaderSerde {
@@ -283,7 +283,7 @@ export class BlockHeaderSerde {
       graffiti: GraffitiSerdeInstance.serialize(header.graffiti),
       noteSize: header.noteSize,
       work: header.work.toString(),
-      stateRoot: header.stateRoot,
+      stateCommitment: header.stateCommitment,
     }
   }
 
@@ -300,7 +300,7 @@ export class BlockHeaderSerde {
         randomness: BigInt(data.randomness),
         timestamp: new Date(data.timestamp),
         graffiti: Buffer.from(GraffitiSerdeInstance.deserialize(data.graffiti)),
-        stateRoot: data.stateRoot,
+        stateCommitment: data.stateCommitment,
       },
       data.noteSize,
       data.work ? BigInt(data.work) : BigInt(0),

--- a/ironfish/src/primitives/blockheader.ts
+++ b/ironfish/src/primitives/blockheader.ts
@@ -197,7 +197,7 @@ export class BlockHeader {
    * Serialize the block header into a buffer for hashing and mining
    */
   serialize(): Buffer {
-    const bw = bufio.write(180)
+    const bw = bufio.write(this.getSize())
     bw.writeBigU64BE(this.randomness)
     bw.writeU32(this.sequence)
     bw.writeHash(this.previousBlockHash)
@@ -211,6 +211,14 @@ export class BlockHeader {
     }
 
     return bw.render()
+  }
+
+  getSize(): number {
+    let size = 180
+    if (this.stateRoot) {
+      size += 32
+    }
+    return size
   }
 
   equals(other: BlockHeader): boolean {

--- a/ironfish/src/primitives/blockheader.ts
+++ b/ironfish/src/primitives/blockheader.ts
@@ -197,7 +197,7 @@ export class BlockHeader {
    * Serialize the block header into a buffer for hashing and mining
    */
   serialize(): Buffer {
-    const bw = bufio.write(this.getSize())
+    const bw = bufio.write(getHeaderSize(this))
     bw.writeBigU64BE(this.randomness)
     bw.writeU32(this.sequence)
     bw.writeHash(this.previousBlockHash)
@@ -211,14 +211,6 @@ export class BlockHeader {
     }
 
     return bw.render()
-  }
-
-  getSize(): number {
-    let size = 180
-    if (this.stateCommitment) {
-      size += 32
-    }
-    return size
   }
 
   equals(other: BlockHeader): boolean {
@@ -306,4 +298,12 @@ export class BlockHeaderSerde {
       data.work ? BigInt(data.work) : BigInt(0),
     )
   }
+}
+
+export function getHeaderSize(header: BlockHeader | RawBlockHeader): number {
+  let size = 180
+  if (header.stateCommitment) {
+    size += 32
+  }
+  return size
 }

--- a/ironfish/src/rpc/routes/miner/submitBlock.ts
+++ b/ironfish/src/rpc/routes/miner/submitBlock.ts
@@ -34,6 +34,7 @@ const serializedBlockTemplateSchema: yup.ObjectSchema<SubmitBlockRequest> = yup
         randomness: yup.string().required(),
         timestamp: yup.number().required(),
         graffiti: yup.string().required(),
+        stateCommitment: yup.string().optional(),
       })
       .required()
       .defined(),

--- a/ironfish/src/serde/BlockTemplateSerde.ts
+++ b/ironfish/src/serde/BlockTemplateSerde.ts
@@ -19,6 +19,7 @@ export type SerializedBlockTemplate = {
     randomness: string
     timestamp: number
     graffiti: string
+    stateCommitment?: string
   }
   transactions: string[]
   previousBlockInfo?: {
@@ -38,6 +39,7 @@ export class RawBlockTemplateSerde {
       randomness: BigIntUtils.writeBigU64BE(block.header.randomness).toString('hex'),
       timestamp: block.header.timestamp.getTime(),
       graffiti: block.header.graffiti.toString('hex'),
+      stateCommitment: block.header.stateCommitment?.toString('hex'),
     }
     const previousBlockInfo = {
       target: BigIntUtils.writeBigU256BE(previousBlock.header.target.asBigInt()).toString(
@@ -71,6 +73,9 @@ export class RawBlockTemplateSerde {
         ),
         timestamp: new Date(blockTemplate.header.timestamp),
         graffiti: Buffer.from(blockTemplate.header.graffiti, 'hex'),
+        stateCommitment: blockTemplate.header.stateCommitment
+          ? Buffer.from(blockTemplate.header.stateCommitment, 'hex')
+          : undefined,
       },
       transactions: blockTemplate.transactions.map(
         (t) => new Transaction(Buffer.from(t, 'hex')),


### PR DESCRIPTION
## Summary

adds an optional stateCommitment field to the block header

updates serialization and deserialization of block headers to include the stateCommitment, if present

adds logic to verifyConnectedBlock to verify that the stateCommitment from the header is equal to the stateRoot from the state manager after all transactions have been executed

## Testing Plan

set activation sequence for EVM on devnet and started mining blocks that include stateCommitment after activation sequence

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
