### PR TITLE
Optimize `WalletDB.loadNoteHash()` to avoid hitting the database if the note nullifier is known to be absent

### DIFF
--- a/ironfish/src/utils/bloomFilter.test.ts
+++ b/ironfish/src/utils/bloomFilter.test.ts
@@ -1,0 +1,53 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { randomBytes } from 'crypto'
+import { BloomFilter } from './bloomFilter'
+
+describe('BloomFilter', () => {
+  describe('maybeHas', () => {
+    it('always returns false when empty', () => {
+      const filter = new BloomFilter(256)
+
+      for (let i = 0; i < 1000; i++) {
+        const item = randomBytes(32)
+        expect(filter.maybeHas(item)).toBe(false)
+      }
+    })
+
+    it('returns true for all items that were explicitly put', () => {
+      const filter = new BloomFilter(256)
+
+      for (let i = 0; i < 1000; i++) {
+        const item = randomBytes(32)
+        filter.put(item)
+        expect(filter.maybeHas(item)).toBe(true)
+      }
+    })
+
+    it('returns true for items that were not explicitly but, but have the same prefix as previously put items', () => {
+      const filter = new BloomFilter(512)
+
+      const samePrefix = [
+        Buffer.from([1, 2, 3, 4, 5, 6, 7, 8]),
+        Buffer.from([1, 2, 3, 4, 9, 10, 11, 12]),
+        Buffer.from([1, 2, 3, 4, 13, 14, 15, 16]),
+      ]
+      const differentPrefix = [
+        Buffer.from([1, 1, 1, 1, 1, 1, 1, 1]),
+        Buffer.from([2, 2, 2, 2, 2, 2, 2, 2]),
+        Buffer.from([3, 3, 3, 3, 3, 3, 3, 3]),
+      ]
+
+      filter.put(samePrefix[0])
+
+      for (const item of samePrefix) {
+        expect(filter.maybeHas(item)).toBe(true)
+      }
+      for (const item of differentPrefix) {
+        expect(filter.maybeHas(item)).toBe(false)
+      }
+    })
+  })
+})

--- a/ironfish/src/utils/bloomFilter.ts
+++ b/ironfish/src/utils/bloomFilter.ts
@@ -1,0 +1,77 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+function isPowerOf2(n: number): boolean {
+  // This checks that n is non-zero, and that n and n-1 have no bits in common
+  // (taken from https://stackoverflow.com/a/30924333)
+  return !!(n && !(n & (n - 1)))
+}
+
+/**
+ * Simple implementation of a bloom filter. This is a set-like data structure
+ * that can be used to check whether certain items may or may not be present in
+ * the set. This is a probabilistic data structure that does not return false
+ * negatives, but may return false positives.
+ *
+ * Usually, bloom filters work by computing the hash of each item added to the
+ * set. This implementation differs in that it does not compute any hash for
+ * efficiency, and instead assumes that each item contains random data. Items
+ * that share the same prefix will result in collisions/false positives.
+ */
+export class BloomFilter {
+  private readonly bitMask: number
+  private readonly bitArray: Buffer
+
+  constructor(bits: number) {
+    if (bits < 8) {
+      // Need to have at least 1 byte
+      throw new Error(`bits must be at least 8 (got ${bits})`)
+    }
+    if (bits >= 1 << 30) {
+      // `bits` cannot exceed 2**30 because `indexOf` relies on
+      // `Buffer.readUInt32LE` (also, the array would be larger than 128 MiB,
+      // which may not be desiderable). This is 30 and not 32 because `1 << 32
+      // === 1` and `1 << 31 === -2147483648`
+      throw new Error(`bits cannot exceed 2**30 (got ${bits})`)
+    }
+    if (!isPowerOf2(bits)) {
+      // Having `bits` as a power of 2 means that `bytes` (calculated below)
+      // will be a power of 2, and this allows efficient items lookup without
+      // using any modulo operator
+      throw new Error(`bits must be a power of 2`)
+    }
+    const bytes = bits >> 3
+    this.bitArray = Buffer.alloc(bytes)
+    this.bitMask = bits - 1
+  }
+
+  private indexOf(item: Buffer): [byte: number, bit: number] {
+    // One of the assumption for this BloomFilter is that the items contain
+    // random data, so that we can skip hashing it. With that assumption in
+    // mind, we take the first `bits` out of `item` and use that as the index
+    // in the array.
+    const index = item.readUInt32LE(0) & this.bitMask
+    const byte = index >> 3
+    const bit = index & 0b111
+    return [byte, bit]
+  }
+
+  /**
+   * Adds the item to the set.
+   */
+  put(item: Buffer) {
+    const [byte, bit] = this.indexOf(item)
+    this.bitArray[byte] |= 1 << bit
+  }
+
+  /**
+   * Returns true if the item *may* have been previously added by a call to
+   * `put()`, false otherwise. This method may return false positives, but
+   * never returns false negatives.
+   */
+  maybeHas(item: Buffer): boolean {
+    const [byte, bit] = this.indexOf(item)
+    return !!(this.bitArray[byte] & (1 << bit))
+  }
+}

--- a/ironfish/src/wallet/walletdb/__fixtures__/walletdb.test.ts.fixture
+++ b/ironfish/src/wallet/walletdb/__fixtures__/walletdb.test.ts.fixture
@@ -730,5 +730,65 @@
         }
       ]
     }
+  ],
+  "WalletDB loadNoteHash loads the hash of a note given its nullifier": [
+    {
+      "value": {
+        "version": 4,
+        "id": "16812363-20b7-4d3b-a5f1-d63f9c500e9e",
+        "name": "test",
+        "spendingKey": "42c4d417d5a6da2900cbfc8a32bfbedd8c96e1848dc4a22ec6b9386fd30d7f36",
+        "viewKey": "d220f7afded99beec10b955b4cd9e193f59a9b0cc3a6f0d5d284f606a442cbc52f1fdbfe00b35666fde4b01bddfb5179988d1b521ee318ebe4e7914e0aa080b7",
+        "incomingViewKey": "ff5905b8bd1238d6e7b48082ec38caa20b3481e4a3cd0ddcbdf4d071b347a406",
+        "outgoingViewKey": "805590598f08f2f6c3994315b8da4d0810049f010b33c46b5928487357f86250",
+        "publicAddress": "0a26afc3a56a3cbccd3eae6784885776df78f406235edcbd622feef724329220",
+        "createdAt": {
+          "hash": {
+            "type": "Buffer",
+            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+          },
+          "sequence": 1
+        },
+        "scanningEnabled": true,
+        "proofAuthorizingKey": "6a7b7fecfdb8b21f5521e323d7867fd556bdfaffc93679527f099e0118014d0d"
+      },
+      "head": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+        },
+        "sequence": 1
+      }
+    }
+  ],
+  "WalletDB loadNoteHash avoids hitting the database if the nullifier is known to be not present": [
+    {
+      "value": {
+        "version": 4,
+        "id": "de2f768a-27d8-42b1-b23f-50423f469bbb",
+        "name": "test",
+        "spendingKey": "c3c9ba31682cab87d2388ad28e3c8a8e1141e802ab69beb1d2024dab7371d95c",
+        "viewKey": "38bfce8064573739fbe71f220bd1b055d85fa928bb12cab6ea6cec39228524c49011b98abac356d07ce11a9073d5257935459935c704f49189de32f7450cf7d4",
+        "incomingViewKey": "9ae8ad607e7429180f9c9b5c00c405945d0ece39ebc0bfb7298b7635ce2d9e06",
+        "outgoingViewKey": "d682f910ae6d4d1f55de2def975d4db0f66f9289fbdb503cd4a12672fdd03063",
+        "publicAddress": "89380c90a6c6829f7302e919932fa1b8f50c38c92f30f7313f4ce425062ebecc",
+        "createdAt": {
+          "hash": {
+            "type": "Buffer",
+            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+          },
+          "sequence": 1
+        },
+        "scanningEnabled": true,
+        "proofAuthorizingKey": "fd03d976919b66a79480321fb7a04076897c7feb5180df93089d78e39503b90a"
+      },
+      "head": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+        },
+        "sequence": 1
+      }
+    }
   ]
 }

--- a/ironfish/src/wallet/walletdb/walletdb.ts
+++ b/ironfish/src/wallet/walletdb/walletdb.ts
@@ -29,6 +29,7 @@ import {
 import { getPrefixesKeyRange, StorageUtils } from '../../storage/database/utils'
 import { createDB } from '../../storage/utils'
 import { BufferUtils } from '../../utils'
+import { BloomFilter } from '../../utils/bloomFilter'
 import { WorkerPool } from '../../workerPool'
 import { Account, calculateAccountPrefix } from '../account/account'
 import { AccountValue, AccountValueEncoding } from './accountValue'
@@ -146,6 +147,8 @@ export class WalletDB {
   }>
 
   cacheStores: Array<IDatabaseStore<DatabaseSchema>>
+
+  nullifierBloomFilter: BloomFilter | null = null
 
   constructor({
     files,
@@ -740,12 +743,40 @@ export class WalletDB {
     }
   }
 
+  private loadNullifierBloomFilter(tx?: IDatabaseTransaction): Promise<BloomFilter> {
+    if (this.nullifierBloomFilter) {
+      return Promise.resolve(this.nullifierBloomFilter)
+    } else {
+      return this.db.withTransaction(tx, async (tx) => {
+        if (this.nullifierBloomFilter) {
+          // A concurrent call to this function already created the filter
+          return this.nullifierBloomFilter
+        }
+
+        const nullifierBloomFilter = new BloomFilter(0x800000) // 1 MiB bloom filter
+        for await (const [_accountPrefix, nullifier] of this.nullifierToNoteHash.getAllKeysIter(
+          tx,
+        )) {
+          nullifierBloomFilter.put(nullifier)
+        }
+
+        this.nullifierBloomFilter = nullifierBloomFilter
+        return nullifierBloomFilter
+      })
+    }
+  }
+
   async loadNoteHash(
     account: Account,
     nullifier: Buffer,
     tx?: IDatabaseTransaction,
   ): Promise<Buffer | undefined> {
-    return this.nullifierToNoteHash.get([account.prefix, nullifier], tx)
+    const nullifierFilter = await this.loadNullifierBloomFilter(tx)
+    if (nullifierFilter.maybeHas(nullifier)) {
+      return this.nullifierToNoteHash.get([account.prefix, nullifier], tx)
+    } else {
+      return undefined
+    }
   }
 
   async saveNullifierNoteHash(
@@ -755,6 +786,9 @@ export class WalletDB {
     tx?: IDatabaseTransaction,
   ): Promise<void> {
     await this.nullifierToNoteHash.put([account.prefix, nullifier], noteHash, tx)
+    if (this.nullifierBloomFilter) {
+      this.nullifierBloomFilter.put(nullifier)
+    }
   }
 
   async *loadNullifierToNoteHash(
@@ -780,6 +814,9 @@ export class WalletDB {
     nullifier: Buffer,
     tx?: IDatabaseTransaction,
   ): Promise<void> {
+    // `nullifierBloomFilter` is unchanged after calling this method. The
+    // assumption is that this method is called rarely, and so special logic to
+    // "reset" the bloom filter is not deemed necessary.
     await this.nullifierToNoteHash.del([account.prefix, nullifier], tx)
   }
 
@@ -791,7 +828,7 @@ export class WalletDB {
   ): Promise<void> {
     await this.db.withTransaction(tx, async (tx) => {
       if (note.nullifier) {
-        await this.nullifierToNoteHash.put([account.prefix, note.nullifier], noteHash, tx)
+        await this.saveNullifierNoteHash(account, note.nullifier, noteHash, tx)
       }
 
       await this.setNoteHashSequence(account, noteHash, note.sequence, tx)
@@ -1229,7 +1266,12 @@ export class WalletDB {
     nullifier: Buffer,
     tx?: IDatabaseTransaction,
   ): Promise<Buffer | undefined> {
-    return this.nullifierToTransactionHash.get([account.prefix, nullifier], tx)
+    const nullifierFilter = await this.loadNullifierBloomFilter(tx)
+    if (nullifierFilter.maybeHas(nullifier)) {
+      return this.nullifierToTransactionHash.get([account.prefix, nullifier], tx)
+    } else {
+      return undefined
+    }
   }
 
   async saveNullifierToTransactionHash(
@@ -1243,6 +1285,9 @@ export class WalletDB {
       transaction.hash(),
       tx,
     )
+    if (this.nullifierBloomFilter) {
+      this.nullifierBloomFilter.put(nullifier)
+    }
   }
 
   async deleteNullifierToTransactionHash(
@@ -1250,6 +1295,9 @@ export class WalletDB {
     nullifier: Buffer,
     tx?: IDatabaseTransaction,
   ): Promise<void> {
+    // `nullifierBloomFilter` is unchanged after calling this method. The
+    // assumption is that this method is called rarely, and so special logic to
+    // "reset" the bloom filter is not deemed necessary.
     await this.nullifierToTransactionHash.del([account.prefix, nullifier], tx)
   }
 


### PR DESCRIPTION
## Summary

This commit adds an in-memory bloom filter to remember which nullifiers are stored in the database. The bloom filter is used by `WalletDB.loadNoteHash()` to avoid querying the database if the given nullifier is known to be not present.

While at it, `WalletDB.getTransactionHashFromNullifier()` was optimized in the same way.

## Testing Plan

* unit tests
* `wallet:rescan`

## Documentation

N/A

## Breaking Change

N/A