### PR TITLE
updating bidirectional mapping for asset to contract/token

### DIFF
--- a/ironfish/src/blockchain/schema.ts
+++ b/ironfish/src/blockchain/schema.ts
@@ -47,7 +47,12 @@ export interface AssetSchema extends DatabaseSchema {
   value: AssetValue
 }
 
-export interface AssetToContractSchema extends DatabaseSchema {
+export interface AssetToContractTokenSchema extends DatabaseSchema {
+  key: Buffer
+  value: Buffer
+}
+
+export interface ContractTokenToAssetSchema extends DatabaseSchema {
   key: Buffer
   value: Buffer
 }


### PR DESCRIPTION
## Summary
Updates mapping of Asset ID (ironfish) to EVM (contract token) to be bidirectional. Uses a prefix on the storage to prevent collisions.

## Testing Plan
tests pass
## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
