### PR TITLE
turns off gas fees for evm transactions

### DIFF
--- a/ironfish-cli/src/commands/evm/deploy-contract.ts
+++ b/ironfish-cli/src/commands/evm/deploy-contract.ts
@@ -25,7 +25,7 @@ export class TestEvmCommand extends IronfishCommand {
     const senderPrivateKey = Uint8Array.from(Buffer.from(senderKey.spendingKey, 'hex'))
     const senderAddress = Address.fromPrivateKey(senderPrivateKey)
 
-    const senderAccount = new Account(BigInt(0), 50_000_000n)
+    const senderAccount = new Account(BigInt(0), 0n)
 
     await node.chain.blockchainDb.stateManager.checkpoint()
     await node.chain.blockchainDb.stateManager.putAccount(senderAddress, senderAccount)
@@ -34,7 +34,6 @@ export class TestEvmCommand extends IronfishCommand {
     // Deploy the global contract
     const tx = new LegacyTransaction({
       gasLimit: 1_000_000n,
-      gasPrice: 7n,
       data: DEPLOY_DATA,
     })
 
@@ -65,7 +64,6 @@ export class TestEvmCommand extends IronfishCommand {
       nonce: 1n,
       gasLimit: 100_000n,
       to: globalContractAddress,
-      gasPrice: 7n,
       data: data2,
     })
 

--- a/ironfish-cli/src/commands/test-evm.ts
+++ b/ironfish-cli/src/commands/test-evm.ts
@@ -4,7 +4,7 @@
 import { LegacyTransaction } from '@ethereumjs/tx'
 import { Account, Address } from '@ethereumjs/util'
 import { generateKey } from '@ironfish/rust-nodejs'
-import { IronfishEvm } from '@ironfish/sdk/src/evm'
+import { IronfishEvm } from '@ironfish/sdk'
 import { IronfishCommand } from '../command'
 import { LocalFlags } from '../flags'
 
@@ -44,7 +44,6 @@ export class TestEvmCommand extends IronfishCommand {
       to: recipientAddress,
       value: 200000n,
       gasLimit: 21000n,
-      gasPrice: 7n,
     })
 
     this.log(

--- a/ironfish/package.json
+++ b/ironfish/package.json
@@ -20,6 +20,7 @@
     "node": ">=18"
   },
   "dependencies": {
+    "@ethereumjs/block": "5.2.0",
     "@ethereumjs/common": "4.3.0",
     "@ethereumjs/evm": "3.0.0",
     "@ethereumjs/statemanager": "2.3.0",

--- a/ironfish/src/evm/evm.ts
+++ b/ironfish/src/evm/evm.ts
@@ -1,12 +1,12 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Block } from '@ethereumjs/block'
 import { EVM } from '@ethereumjs/evm'
 import { Address } from '@ethereumjs/util'
 import { RunTxOpts, RunTxResult, VM } from '@ethereumjs/vm'
 import { BlockchainDB } from '../blockchain/database/blockchaindb'
 import { EvmBlockchain } from './blockchain'
-import { Block } from '@ethereumjs/block'
 
 export class IronfishEvm {
   private vm: VM

--- a/ironfish/src/evm/evm.ts
+++ b/ironfish/src/evm/evm.ts
@@ -6,6 +6,7 @@ import { Address } from '@ethereumjs/util'
 import { RunTxOpts, RunTxResult, VM } from '@ethereumjs/vm'
 import { BlockchainDB } from '../blockchain/database/blockchaindb'
 import { EvmBlockchain } from './blockchain'
+import { Block } from '@ethereumjs/block'
 
 export class IronfishEvm {
   private vm: VM
@@ -25,6 +26,7 @@ export class IronfishEvm {
   }
 
   async runTx(opts: RunTxOpts): Promise<RunTxResult> {
+    opts.block = Block.fromBlockData({ header: { baseFeePerGas: 0n } })
     return this.vm.runTx(opts)
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -360,7 +360,7 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.56.0.tgz#ef20350fec605a7f7035a01764731b2de0f3782b"
   integrity sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==
 
-"@ethereumjs/block@^5.2.0":
+"@ethereumjs/block@5.2.0", "@ethereumjs/block@^5.2.0":
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/@ethereumjs/block/-/block-5.2.0.tgz#f6722dcce597150a7a8fc32803f5e8dcdfdeebeb"
   integrity sha512-NuVDtD58zyjm5lO3AKPaelzX9VywNwRpDF7WTCY0SKFlD5OeewK5Rdb6LWhwmdQ0ngiIg0Nh/36AQ/8W1nEhjw==


### PR DESCRIPTION
## Summary

sets block header in runTx to use a baseFeePerGas of 0, which makes gas free to use

## Testing Plan

modifies test-evm command to send transaction without gas price

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
