### PR TITLE
Move `blocks:show` to `chain:blocks:info`

### DIFF
--- a/ironfish-cli/src/commands/chain/blocks/info.ts
+++ b/ironfish-cli/src/commands/chain/blocks/info.ts
@@ -2,10 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Args } from '@oclif/core'
-import { IronfishCommand } from '../../command'
-import { LocalFlags } from '../../flags'
+import { IronfishCommand } from '../../../command'
+import { LocalFlags } from '../../../flags'
 
-export default class ShowBlock extends IronfishCommand {
+export default class BlockInfo extends IronfishCommand {
   static description = 'Show the block header of a requested hash or sequence'
 
   static args = {
@@ -20,7 +20,7 @@ export default class ShowBlock extends IronfishCommand {
   }
 
   async start(): Promise<void> {
-    const { args } = await this.parse(ShowBlock)
+    const { args } = await this.parse(BlockInfo)
     const { search } = args
 
     const client = await this.sdk.connectRpc()


### PR DESCRIPTION
## Summary

Closes IFL-2773

## Testing Plan

## Documentation

N/A

## Breaking Change

Removes the CLI command `ironfish blocks:show`. The command is now `ironfish chain:blocks:info`.
