### PR TITLE
Add command chain:status

### DIFF
--- a/ironfish-cli/src/commands/chain/status.ts
+++ b/ironfish-cli/src/commands/chain/status.ts
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { FileUtils, renderNetworkName } from '@ironfish/sdk'
+import { IronfishCommand } from '../../command'
+import { LocalFlags } from '../../flags'
+import * as ui from '../../ui'
+
+export default class ChainStatus extends IronfishCommand {
+  static description = 'show the status of the chain'
+
+  static flags = {
+    ...LocalFlags,
+  }
+
+  async start(): Promise<void> {
+    const client = await this.sdk.connectRpc()
+
+    const [status, difficulty, power] = await Promise.all([
+      client.node.getStatus(),
+      client.chain.getDifficulty(),
+      client.chain.getNetworkHashPower(),
+    ])
+
+    this.log(
+      ui.card({
+        Network: renderNetworkName(status.content.node.networkId),
+        Blocks: status.content.blockchain.head.sequence,
+        Hash: status.content.blockchain.head.hash,
+        Time: new Date(status.content.blockchain.headTimestamp).toLocaleString(),
+        Synced: status.content.blockchain.synced,
+        Difficulty: difficulty.content.difficulty,
+        Size: FileUtils.formatFileSize(status.content.blockchain.dbSizeBytes),
+        Work: status.content.blockchain.dbSizeBytes,
+        Power: FileUtils.formatHashRate(power.content.hashesPerSecond),
+      }),
+    )
+  }
+}


### PR DESCRIPTION
## Summary

```
> ironfish chain:status

Network:      Mainnet
Blocks:       656880
Hash:         000000000000fd9c207f0c91f45ed1aac0413af20c87b4a9bc70cc7cfb5e8ecc
Time:         7/17/2024, 3:59:39 PM
Synced:       false
Difficulty:   178062303183912
Size:         15.41 GB
Work:         15411118322
Power:        2.69 TH
```

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[x] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
