### PR TITLE
Make rpc get network power request optional

### DIFF
--- a/ironfish/src/rpc/clients/client.ts
+++ b/ironfish/src/rpc/clients/client.ts
@@ -907,7 +907,7 @@ export abstract class RpcClient {
     },
 
     getNetworkHashPower: (
-      params: GetNetworkHashPowerRequest,
+      params: GetNetworkHashPowerRequest = undefined,
     ): Promise<RpcResponseEnded<GetNetworkHashPowerResponse>> => {
       return this.request<GetNetworkHashPowerResponse>(
         `${ApiNamespace.chain}/getNetworkHashPower`,

--- a/ironfish/src/rpc/routes/chain/getNetworkHashPower.test.ts
+++ b/ironfish/src/rpc/routes/chain/getNetworkHashPower.test.ts
@@ -26,7 +26,8 @@ describe('Route chain/getNetworkHashPower', () => {
       await Promise.all([expect(routeTest.node.chain).toAddBlock(block)])
       await Promise.all([routeTest.node.wallet.scan()])
     }
-    const response = await routeTest.client.chain.getNetworkHashPower({})
+    const response = await routeTest.client.chain.getNetworkHashPower()
+
     expect(response.content).toEqual(
       expect.objectContaining({
         hashesPerSecond: expect.any(Number),

--- a/ironfish/src/rpc/routes/chain/getNetworkHashPower.ts
+++ b/ironfish/src/rpc/routes/chain/getNetworkHashPower.ts
@@ -9,10 +9,12 @@ import { RpcValidationError } from '../../adapters'
 import { ApiNamespace } from '../namespaces'
 import { routes } from '../router'
 
-export type GetNetworkHashPowerRequest = {
-  blocks?: number | null // number of blocks to look back
-  sequence?: number | null // the sequence of the latest block from when to estimate the network speed
-}
+export type GetNetworkHashPowerRequest =
+  | {
+      blocks?: number | null // number of blocks to look back
+      sequence?: number | null // the sequence of the latest block from when to estimate the network speed
+    }
+  | undefined
 
 export type GetNetworkHashPowerResponse = {
   hashesPerSecond: number
@@ -26,7 +28,7 @@ export const GetNetworkHashPowerRequestSchema: yup.ObjectSchema<GetNetworkHashPo
       blocks: yup.number().nullable().optional(),
       sequence: yup.number().nullable().optional(),
     })
-    .defined()
+    .optional()
 
 export const GetNetworkHashPowerResponseSchema: yup.ObjectSchema<GetNetworkHashPowerResponse> =
   yup


### PR DESCRIPTION
## Summary

This makes the usability nicer because there are no mandatory arguments.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
