### PR TITLE
Abstract out rendering network name

### DIFF
--- a/ironfish/src/networks/network.ts
+++ b/ironfish/src/networks/network.ts
@@ -1,11 +1,10 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { Assert } from '../assert'
 import { Consensus } from '../consensus'
 import { SerializedBlock } from '../primitives/block'
 import { MathUtils } from '../utils'
-import { defaultNetworkName, isDefaultNetworkId, NetworkDefinition } from './networkDefinition'
+import { isDefaultNetworkId, NetworkDefinition, renderNetworkName } from './networkDefinition'
 
 export class Network {
   readonly default: boolean
@@ -23,14 +22,7 @@ export class Network {
     this.consensus = new Consensus({ ...definition.consensus })
     this.genesis = definition.genesis
     this.bootstrapNodes = definition.bootstrapNodes
-
-    if (this.default) {
-      const defaultName = defaultNetworkName(definition.id)
-      Assert.isNotUndefined(defaultName)
-      this.name = defaultName
-    } else {
-      this.name = `Custom Network ${definition.id}`
-    }
+    this.name = renderNetworkName(definition.id)
   }
 
   /**

--- a/ironfish/src/networks/networkDefinition.ts
+++ b/ironfish/src/networks/networkDefinition.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
+import { Assert } from '../assert'
 import { ActivationSequence, Checkpoint, ConsensusParameters } from '../consensus'
 import { Config, InternalStore } from '../fileStores'
 import { FileSystem } from '../fileSystems'
@@ -80,6 +81,16 @@ export function defaultNetworkName(networkId: number): string | undefined {
       return 'Mainnet'
     case 2:
       return 'Devnet'
+  }
+}
+
+export function renderNetworkName(networkId: number): string {
+  if (isDefaultNetworkId(networkId)) {
+    const defaultName = defaultNetworkName(networkId)
+    Assert.isNotUndefined(defaultName)
+    return defaultName
+  } else {
+    return `Custom Network ${networkId}`
   }
 }
 


### PR DESCRIPTION
## Summary

So we can reuse this in the CLI and make this consistent everywhere.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
