### PR TITLE
Add UI card element to CLI

### DIFF
--- a/ironfish-cli/src/ui/card.ts
+++ b/ironfish-cli/src/ui/card.ts
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+export function card(items: Record<string, unknown>, extraPadding: number = 2): string {
+  const keys = Object.keys(items)
+  const longestKey = keys.reduce((p, c) => Math.max(p, c.length), 0)
+
+  const result = []
+
+  for (const key of keys) {
+    const keyPadded = (key + ':').padEnd(longestKey + 1 + extraPadding)
+    const value = String(items[key])
+    result.push(`${keyPadded} ${value}`)
+  }
+
+  return result.join('\n')
+}

--- a/ironfish-cli/src/ui/index.ts
+++ b/ironfish-cli/src/ui/index.ts
@@ -5,3 +5,4 @@
 export * from './prompt'
 export * from './progressBar'
 export * from './table'
+export * from './card'


### PR DESCRIPTION
## Summary

So we can render these horizontal cards more easily.

Example
```
Network:      Mainnet (1)
Blocks:       656880
Synced:       false
Difficulty:   0
Size:         15.41 GB
Work:         15411118322
Power:        0 H
Hash:         000000000000fd9c207f0c91f45ed1aac0413af20c87b4a9bc70cc7cfb5e8ecc
Time:         1721257179702
```

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
