### PR TITLE
Changes how EVM is instantiated.

### DIFF
--- a/ironfish-cli/src/commands/evm/deploy-contract.ts
+++ b/ironfish-cli/src/commands/evm/deploy-contract.ts
@@ -18,7 +18,8 @@ export class TestEvmCommand extends IronfishCommand {
     const node = await this.sdk.node()
     await node.openDB()
 
-    const evm = await IronfishEvm.create(node.chain.blockchainDb)
+    const evm = new IronfishEvm(node.chain.blockchainDb)
+    await evm.open()
 
     const senderKey = generateKey()
 

--- a/ironfish-cli/src/commands/test-evm.ts
+++ b/ironfish-cli/src/commands/test-evm.ts
@@ -17,7 +17,8 @@ export class TestEvmCommand extends IronfishCommand {
     const node = await this.sdk.node()
     await node.openDB()
 
-    const evm = await IronfishEvm.create(node.chain.blockchainDb)
+    const evm = new IronfishEvm(node.chain.blockchainDb)
+    await evm.open()
 
     const senderKey = generateKey()
     const receipientKey = generateKey()

--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -63,7 +63,7 @@ export class Blockchain {
   files: FileSystem
   consensus: Consensus
   // TODO: the EVM creation is async, so this has to be optional for the constructor
-  evm?: IronfishEvm
+  evm: IronfishEvm
   seedGenesisBlock: SerializedBlock
   config: Config
   blockHasher: BlockHasher
@@ -197,6 +197,7 @@ export class Blockchain {
       defaultValue: Buffer.alloc(32),
     })
 
+    this.evm = new IronfishEvm(this.blockchainDb)
     this.nullifiers = new NullifierSet({ db: this.blockchainDb.db, name: 'u' })
   }
 
@@ -239,9 +240,9 @@ export class Blockchain {
     }
 
     this.opened = true
-    await this.blockchainDb.open()
-    this.evm = await IronfishEvm.create(this.blockchainDb)
 
+    await this.blockchainDb.open()
+    await this.evm.open()
     await this.load()
   }
 

--- a/ironfish/src/consensus/verifier.ts
+++ b/ironfish/src/consensus/verifier.ts
@@ -239,7 +239,7 @@ export class Verifier {
       if (
         current.timestamp.getTime() <
         previousHeader.timestamp.getTime() -
-          this.chain.consensus.parameters.allowedBlockFutureSeconds * 1000
+        this.chain.consensus.parameters.allowedBlockFutureSeconds * 1000
       ) {
         return { valid: false, reason: VerificationResultReason.BLOCK_TOO_OLD }
       }
@@ -279,7 +279,6 @@ export class Verifier {
         return noMints
       }
     } else {
-      Assert.isNotUndefined(this.chain.evm)
       const evmVerify = await this.chain.evm.withCopy(async (vm) => {
         return this.verifyEvm(transaction, vm)
       })
@@ -617,7 +616,7 @@ export class Verifier {
     // tx?: BlockchainDBTransaction,
   ): Promise<VerificationResult> {
     // TODO(jwp): handle these more cleanly after hughs changes
-    if (!transaction.evm || !this.chain.evm) {
+    if (!transaction.evm) {
       return { valid: true }
     }
 

--- a/ironfish/src/consensus/verifier.ts
+++ b/ironfish/src/consensus/verifier.ts
@@ -239,7 +239,7 @@ export class Verifier {
       if (
         current.timestamp.getTime() <
         previousHeader.timestamp.getTime() -
-        this.chain.consensus.parameters.allowedBlockFutureSeconds * 1000
+          this.chain.consensus.parameters.allowedBlockFutureSeconds * 1000
       ) {
         return { valid: false, reason: VerificationResultReason.BLOCK_TOO_OLD }
       }


### PR DESCRIPTION
Previously, we needed to check whether the EVM on the blockchain object was instantiated. There shouldn't be a case where EVM is not instantiated. We should always have an EVM instance.

That change was made because instantiating EVM requires async code because of the VM instantiation.

This change changes that pattern to a synchronous instantiation. The VM instantiation now happens in the open function that is no longer static. We check whether the object has been instantiated in the sub functions of the EVM class.

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
