### PR TITLE
refreshes WalletScanner scanningAccounts on disconnect

### DIFF
--- a/ironfish/src/wallet/__fixtures__/wallet.test.slow.ts.fixture
+++ b/ironfish/src/wallet/__fixtures__/wallet.test.slow.ts.fixture
@@ -351,118 +351,6 @@
       ]
     }
   ],
-  "Wallet Removes notes when rolling back a fork": [
-    {
-      "value": {
-        "version": 4,
-        "id": "7c33400f-4467-4ca2-9fe8-753ec9b990e9",
-        "name": "testA",
-        "spendingKey": "8819793463a99aa9bb8054a9947d8963887af88c117d76f3afe8794857338031",
-        "viewKey": "9369194732ba2e85c96597feb003bcd1f5bbea96cf281f2b4ce602b592e75184aecd8034da8e4b86c006b1fb9fe3b0fca55757c3ad5f2a6221de50c5039b2441",
-        "incomingViewKey": "9cbf9085d17168e11796f7c7f6f8521293b5f21ca491a9eeb8212c6c0dc9d004",
-        "outgoingViewKey": "aa3070df98bff103850a048b079a4fb0fa084423585fd94655472710e50b3a4c",
-        "publicAddress": "4d1ffb1e38788f1d5ef3978d9680d08a4f402b40b43a7faabde3e3fbe544dc40",
-        "createdAt": null,
-        "scanningEnabled": true,
-        "proofAuthorizingKey": "b785af62a34f29e9080590f00a517fe3a73a66da2a39f5907731946f44ea2103"
-      },
-      "head": null
-    },
-    {
-      "value": {
-        "version": 4,
-        "id": "4729cfd4-1db0-4aca-94f8-45801c8edd58",
-        "name": "testB",
-        "spendingKey": "7dfa306dc31b259cfb933b09a4fe637a2afa459e35d5727c99bfe2ed42cfbbe7",
-        "viewKey": "ef97818417b95aca5234ba933b69ba76754ca35b897d15d977d20597aa0b70d808a6002dbef6140c092c212f1750df973cd2815041369abb8798f442822cce67",
-        "incomingViewKey": "dba7925a07a584b375b2d85182e68e595034ecb8839aacd6fbfb05b7bf9f1606",
-        "outgoingViewKey": "a5999a8e17629cbe4758bcd70edb21adf9e7ec675c092a0f4844b82ddc8aaf8f",
-        "publicAddress": "b244bd095c6c835d11f1f833af36984bf1589c2d842141077b609ce559d24f0b",
-        "createdAt": null,
-        "scanningEnabled": true,
-        "proofAuthorizingKey": "6325e463f2330133da4dd139d7c6e3c9b54001fce7f8cb42d3b9ac63af8bbd00"
-      },
-      "head": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "4791D7AE9F97DF100EF1558E84772D6A09B43762388283F75C6F20A32A88AA86",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:eTeIzsrYB3NQ6RX5Sf5ubtb2ZK0xwSRoZscdD2xknGI="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:BYxTG09lEE7p6FfekOb2/seCpBW0+1qCTEW456REE0E="
-        },
-        "target": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
-        "randomness": "0",
-        "timestamp": 1717545209094,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAXP/k0xped3BqaHPSSnDHj0dKjf/i0RAy5syReq74xma3c5VwfJrKlc9as6Np9Xw7b7uuEZnP3xcWXPGRUvup20+H+NnvsLMqJDo0iYTdH8y1URnQkJ+oSLvsJoK0LdFtyY16+HIC6Y18iM/kTecU6k3vZf8i6dcV4vQ2bhskft8Ipwv072ieMzxZgqXSfsPYRY42CqSDEwuDQBRtiZEm9drFyn1W4QaxdiorVLmv0gyMw1zA04U0DTJLNQEdzEDb1heJ0JQMBu1Mlg5LmW0CdqNB8NO/oXgvJUVN5i88LHXWxw9wmUb0lm5Usvv9RSk7m5rfqOOJcLaf+xT69h22UD1MpxrDU2L+zO8cmV5+PYl7q0fORpNX884sgzrPPnQwbqEIfAS6dSlocejA9WsGWc/4QyV9zH3QYeF8lh9SXgI2EA+D0pMH0TDuksLnV1e+cdnAXc4AajmYdSNQeUjYTWVruLbHSXdPp0TMGqev6lnPr2k9w65pXBH42ha9HTOtHwPUqjZWm7qKs7MrQy4y0ccSneBnUldJwByapdAUIdzFV50jkg05FXKxEOubQbQl36X1sTCDeuK1FOeYsqHhD7bsct+6Z3Woct50a5N5jUO2OfAqu8uJwUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwgqpdDC1NdQYtnnnL1ZAe1EEKRp9SgXpaa/p3zzRG6DoWeR6A9wDIPF2Vkfppuh74kb6m45DaxisEzHl4WyDBAg=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "4791D7AE9F97DF100EF1558E84772D6A09B43762388283F75C6F20A32A88AA86",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:/WHpUNJk1ZUbIs9RmVwBANo73YJmHzse6c2WIjwCggM="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:jGpU0dGtO0Bv/Rs9czI9bhcsdkJ76iq/Geu1OBr97k4="
-        },
-        "target": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
-        "randomness": "0",
-        "timestamp": 1717545210192,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAARGfwAf6MqHGgnUk0FzqI9e8HmtQMst5vC6Cq2itpQZ+l4DlJjn/FnTFHpvGkX4PpdLRamZExTYynMZhd5YIr3MZaKXRaergW1ZHwTfK6FoWxPDhbQa8Y2K5ZlR0t3X3lx/XYWBvKNKxKass6OmNV6Q5CHWhCmFiLXQUtHlOUIyoPzm5qTYVl6rYbfoJxR/fisyLLiek7Kisf8+nU0EHA5xZ3xLP8RKt3U/AbjgT3MrOnSShG4SHj66KUcGbhbQWWpT1KAeI6qChxJJEY/JiAxQu2HaNb8lT6UozXGZQ2TLU5reigPE3skC0lfqphfkpt39P+Is7kQwuKEcR2aOw4IVH+oiy4g/Ti13/sbG3q1673fplAOFjanoUKtwWpPdVHZM9DCJkHx8myWn3M1bIawpeshjJaEcafq8NwMkbEBDBYcnucWnoy9I675oSM9TCJNfbFZwNbmAXdBIMRI+D215CUpPcVWYne1DzX9QzvpdgFhkA+4q18jk1FnkM26zG+q85Y0sktDWqpc1wQ3u4qzwMDLM4XD8C9Hj9t4B37Z/fSHN25WgE+BiP6wuw1A9OEEqatunY+kdfSPxlHxSqFdNVFBzCdSD1mzU0tprl0B9TTskHH1Oqni0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwOOQ+TS2zMKSq3CQeJ9eCEXhAbCJrgKWnyW76HEWZHLkGtJlGlhFcZBEFr6vag4vTnx0aADytG9cnCsrzMQyHAw=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "9F3001E47620F2F57BC58E64B3B7F543EB9BBEE131796BD8A9961AEF2B5CEA7F",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:JN9o1LxRZiNJVsVVw3g53baaD2a3XsH9OR5v1WrWqgg="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:HABCNl1jrXBk8rNSQy+5IJ7ZEBEy44XMAQshq9pqX2E="
-        },
-        "target": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
-        "randomness": "0",
-        "timestamp": 1717545211266,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 5,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAC/xvrQ8NmY9V6PGSvqsqVsnw3u+FzuLk4Pls+LAWdlWHr/T4eJ+7Xm4dfqEjQR88kTGJlZZDhlCGB6J8bgo9HmIvW5imOBncG+nJjDMxEwyjeDQVe2xT4X0hxNbJ5eFXNKcGa80TZbC5e7hS/MrL0FYZoFZLWlHN9LrjairOBqAWIySKYRYwt9RwtMHEFc/TH9WiOTkdoV6ap7UwjMFEleYoAJr1Jxy2pwxxe8mrt9awf+sKF62vFrRdH6IlLX1mWB3kMjTbC1SOLAvfJxDWxoobVILziYJbeR/og/PyMSJx4nJ1Jo7tjXBY0KgsWKDyXkDHj0BFDoCcwzLZCkCDjOEtbVGJTcPddC1ADiDUk5Jd9UxbqTbRsRLGDrDZxqU5Q3VWFkBl8SScLO9CeSNT4EEzsaBjeejOGw1GTQ6nEIxcmR09O6RCDx3suZyCCXOINYrTv4cNuIzsdYnUbI1y+sWy5UuLc00HP66rYp3rVGeLQhBblxdOF5nURJHTfQfiFw7ubRsZg1sziSsrAEFFJvengDqP2+Wfvs1ckYJ/efHO6moKUIYaR2mGEuOUFicH/+XLiNDaNPUV/Wq99wfRDBYVT0xS7HKp0q+29Dbsb+QZ4qdLYwx7z0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwRWufRkwB7yAOVut2pYODDLbUVTLWIDiPnRanuCx2IzE10cHMe+bJvGKaUZx9reho0OBn3O2irqD/LHXyw2D7BA=="
-        }
-      ]
-    }
-  ],
   "Wallet View only accounts can observe received and spent notes": [
     {
       "value": {
@@ -1349,6 +1237,118 @@
         {
           "type": "Buffer",
           "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAdok7wQJnVgDj60zguzccUQOadRNNKOQCM9FWx0+Eb2K5l5D66TIRafgCHINZuofsI+YFUA8oT2c1q/1D1qKwcfhuLlgoQFlEaXEZja2HZ2CSHVJi7/tYj3N4HLtgACFaEEYxwr0OrESCam64QnACrVRpoa2Cq9iyb1ArD1JNGN8MLfko9ecHmArK7QL2cNmHxjsunkrg+aSD4qeeMNco5+e0XXqqhdexae1AT9s71kuuGQfd/Gc7LDTn0Tt6EJnUdWlcj9ILztFjI8TCcuYNM96vIbiWBC3Najqw2BpAMewagAIeaHHDSOul4Evxhsub8xfG2X7gun/qVoIVkPzQYtHQu6AM/7NqDQyj1VuAz/wmTQ6uf4wgKIf1dTkpqBo08/w/wRimb7W/vzpveC0pb7AF2Au39czFelPSnryrvgh8iDbib7MXwYcU1sbs4QQbACiWNoosEhUlbDvkN/kCfFLCMifm2fBO/3OTJ3QXtDnhIfUhhF6LIZJb0dMMxLnAczPfzJZVZnlIt1Tq9r8EKS1hSVy/C699hS6/AXz43x1GOciXrrjgUOz5YLicG0wVmrxd2d0ouL8jndqFJ5qaVwQQGHfaRoF6BMYbkXak88l5+fyNDMSdPUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw+ScgXfN6rSSKhBNVhqKT1GmEiFLaluHT0bSgZnwr7OJsLO2gRlF6ut6I6Dr6xPZpoBBcEuum4MVyySdZMeZiCQ=="
+        }
+      ]
+    }
+  ],
+  "Wallet Removes notes when rolling back a fork": [
+    {
+      "value": {
+        "version": 4,
+        "id": "cd32d3ae-a3f0-41e5-952c-ba430eac0a9d",
+        "name": "testA",
+        "spendingKey": "d1404bbc1140886f7f7be312029e254ea93369d59ffdefa45b9c5e96833bbb8a",
+        "viewKey": "9c9b854e1290ad846e75c8f747abedfcce7d68e41547157fc257afdccc429fec46b5aab2c46089bdd09c7fff38d8ae0f0faa699f97732c72b626853a5923e422",
+        "incomingViewKey": "a00560ae0c138fd4c2ae75ac8cb7b1869b4e90a8a7fa58728970547b6f721505",
+        "outgoingViewKey": "08e5fb5edc5eb8416cf151dc02812bb577d2ff2c96a7bbdac4ad10006b720553",
+        "publicAddress": "64cf78e2c1d923ca24a38863cd0a42f5f4bb42f3849375ba493a68d92a38401d",
+        "createdAt": null,
+        "scanningEnabled": true,
+        "proofAuthorizingKey": "dd370d899192be20a26816e195f6fce8651a3d501532198837d9d754e3d11c00"
+      },
+      "head": null
+    },
+    {
+      "value": {
+        "version": 4,
+        "id": "3c2f7db4-883c-4081-8ebe-dc1ddc9d6963",
+        "name": "testB",
+        "spendingKey": "9f8d5c3b61940b21e32279b68615b04e98f57953836761bb80e96ec19a902686",
+        "viewKey": "3bb41a4af34b71f766b6c17c154ef23b1b53d5bf22b13d34670f73c32722ef7099e33d5c888d843e865f66d6ea2518b2470110382c60b502f1edb70365385c89",
+        "incomingViewKey": "ba7298cad95c6b055576d38d901d3c29b5e4ba907351a29764c146e936d17800",
+        "outgoingViewKey": "1da9a40b0a70b2de121ae5c216d9a53efc3c565f7140154d98f5806cc3f8b7bc",
+        "publicAddress": "f00a99aa4bfe52a5749e36972bed4448575964eea74682f2759c4c9c225dda0f",
+        "createdAt": null,
+        "scanningEnabled": true,
+        "proofAuthorizingKey": "96b16ddb9f813186aff04cf38cf71fb13d25bbdf8ed9b79caa891552048e4709"
+      },
+      "head": null
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "4791D7AE9F97DF100EF1558E84772D6A09B43762388283F75C6F20A32A88AA86",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:qt+/GjSXOiZu6QmwE195NyB23lGgdtqg9kZWVOTtg2g="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:vX9z4YThMKURqgF8vNiEuESHN1wVSc0SepIvDXo/TaE="
+        },
+        "target": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+        "randomness": "0",
+        "timestamp": 1721686869438,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAArOIj6Wspm7vCIidTO9qd1gJBx+4OeOv961aNVztPOW2Kfv0kXVY/L53XzzaqhCvwsbChwT5W86t1f8vzAcizi5GhpZ2ipF8d8b96bc3kBhKi9NdjtpNGPmCeu3sTpiSybM1xFys+3LdqrBHfDc1iZE5pnBvNLHiwMrxgup/lJOILp3EYnlz6nVlE/eZrhxCKLBK2OwXzW78iQp/qjQcxUTFE4eNO9fL1f3GaO74VWteJAOjE8c2F2wqtPWkK/arJA7SSE+IgXoCstpIiRe3Yst3NO24PiaXh6oLCuLiWo2dmIzqV2idl7oAHF4Rs/YM1FnCdx2cI9c4Em+jsPVk4DOECB/M1tMHwjEwMxc1urLIDJFHonBW38MgH1Dp53tVyzLHpQVOaluWsb35WgCQb0AgwrdQ8WuiAay5fghvflVE+vcgvwY07R32z1cFsi7XjPvT1Kh2y4PP19j+59a22W6xQ+X0LmP06Y1YDl376FvTOi4K3/KQsPhzKeE/vP/cmC8YVEs45plMDmzBb59TFRnu2ivnad6wcGuvydzbrwUTWQ3CP89N9Vkv+O1p0W0abpqsXDkS7YqAUeWwlzQt9U3hJTsjtf3nzORrWfZug+PJw1GnF6u3B9klyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwV4BR4lfi4N/WjRCzYHINT7ZXN8hTXghOFY2gKCrBEcdULviK7GAfh2w9PYCaBDrQ7lV/OUQd6YmRtxS7x2n9CQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "4791D7AE9F97DF100EF1558E84772D6A09B43762388283F75C6F20A32A88AA86",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:CpSqkYHSG127MKJzBUwaQ5R3TyDDyWqgoqru0i0yoQg="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:3IwtFPxx+aQVediOcvQFqhRFznoqXnqFwUriKIPLEQ0="
+        },
+        "target": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+        "randomness": "0",
+        "timestamp": 1721686870002,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAATBxQ0f5eSmAyq9GWCNaKVVjDJ2Wzo2gOY6BbsQoV5EaRTBIgVLLMG0XNxyFEdlXL+UNes0xfg1GpJzaDqK62Me+JDIgH5HCtjG6RT0ArFuGZlvDCK6CQYoZjFIpIJpNgmlBoRNgtzumF7P7rIc/GPKREIsL8HJrBDktJ1raBGToAmXuyJBWYk3Lumei8obOWqjzzS4nq5Wx78BYTZvQM85EXDFXru8mLk3wS/6KLxBuuXgFbMSdnnev6ifSaN0t14T51ihDKrYX3OKRp7LjvdD9cEmiKV1wNqG5KKFy0LkVdIzqYmnaFtNP3Lp1jzcR8KKZtRNJXTQ63yFPP1rDpKjQxA0n1YWEF9hIKJvcY1tHgZesWcY7FdwJsbC98fn9Z+1DJYq2LmppBb6+7JlgjNQhGNlcmsiZrgPbDD7iQYhUe+EWooR9OyLf1ujft2wGroIT4wO3M4p9cteMICS++INl2Y6zhsVnlNdwVghJLD0Kd0AQVkA6jxEB/beaSXOWdoOBWfhzPr+DC3A6JUeTfKTnjKvOrfTvf3WKfcJi83d0d07LymqWv2lZ+MmdaWrZ2k1xj9dSaLc/YFSYE+8gLwE8ZN5H2g5sbdVry4CpiIaQjX+nwCOScRklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwY20OS3MMRoRF0edV7MAYEiAI5WpkyFjofregIiLjmbMr0Q4VIHV8WrZjqSTiDrGBj3ygqruDvBIct8GPFLb1BA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "AE8E39C81597A1C79984FC014137C09B70877A247B4390842A0884B495DD4258",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:PySdNCFehP11kb0hAHQG3yDASM2Ix95MGccF0yxnlkk="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:todu4D6yQZzV64lY1jA6qdA0t4CMmsQ0yrX8a0y13AM="
+        },
+        "target": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+        "randomness": "0",
+        "timestamp": 1721686870593,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAgjt4hfdcl/SHkDp2RESBhIWuTLaeXFVziFX6/6KCvKuF0mH+j4LlEQXGwyidBrOkqqYUapkpCMEGhLblIBZpq9HLd2JeOCcUyTvBgpuUc4ai+HNwuU6RQi6rjr9+ezH1lT1Jc5/AQoW2xjpgytpkTl+rjh5/l3JRl0K6UmjX3yIYOuuqVRDvZVXZ5PSEAvfnQgvaJ93N5FnM4YbxlimarF/f402E5jAQBKMn53Fv3OOK1MdU/AK5x7Hk6VHHa5DI1AM5Qi0kfPsfFw/rld66SLhX9jAhJtwnAizUIjnd0PK3oDFgo9aUOiaU3o4VXm6Xy7oERAaUukwyw876ApeQg0CdIEZM0YjzIzd18OlA/p/wkLnzSNA+YhmK6s6xcMJAiyY4ae231CH4K3GGc/eshZEcDU9Lb3MRpLYZB6fZwJMT4/Hv1SzkBQvoUvCNKNtDbN5HfSuBYY99oIXSZbEQ/DZ90IQ+8Ul6LK7HLZ626PhmtUZEn38Kss9DDWHKSnJIQ5kmX8IumJXDMfjOCIxkm0Y19JQX33i89xlSDebKVhH3zdhncFqaxPEJSSL7BLJIpQzN2pGEw+bLY6KA3Gzy2VPj1cK25D7uPNgXT/wR8h06ELjfClWItElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwKzXYdWoIVvs+eqBNNKdebAaImfAwueJBhVjohtuDDKwx+j4U/Mub0mIVhPQ+3En2wbFMLX/Z+vO4fqosUv0AAQ=="
         }
       ]
     }

--- a/ironfish/src/wallet/scanner/walletScanner.ts
+++ b/ironfish/src/wallet/scanner/walletScanner.ts
@@ -234,6 +234,12 @@ export class WalletScanner {
       }
       await this.wallet.disconnectBlockForAccount(account, header, transactions)
     }
+
+    for (const account of this.scanningAccounts) {
+      if (account.scanFrom && BufferUtils.equalsNullable(account.scanFrom.hash, header.hash)) {
+        account.scanFrom = null
+      }
+    }
   }
 
   getChainProcessor(


### PR DESCRIPTION
## Summary

the WalletScanner uses a hash, 'scanFrom', for each account in its scanningAccounts list to check whether it should decrypt notes for the account. if scanFrom is null or equal to the previous block hash then notes are decrypted when connecting a block.

scanFrom is set to the account head when calling refreshScanningAccounts and set to null when connecting a block if scanFrom is equal to the previous hash.

however, when blocks are disconnected scanFrom is not currently changed. in the event of a reorg, decryption is skipped when connecting blocks from the fork if 'scanFrom' is still set to the hash of a disconnected block.

regenerates fixtures for test of this behavior and updates disconnectBlock to set scanFrom to null for all accounts where it is equal to the disconnected block hash.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
