### PR TITLE
CLI command: replace unneeded type hacking with built-in ctor property

### DIFF
--- a/ironfish-cli/src/command.ts
+++ b/ironfish-cli/src/command.ts
@@ -109,10 +109,7 @@ export abstract class IronfishCommand extends Command {
   }
 
   async init(): Promise<void> {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
-    const commandClass = this.constructor as any
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-    const { flags } = await this.parse(commandClass)
+    const { flags } = await this.parse(this.ctor)
 
     // Get the flags from the flag object which is unknown
     const dataDirFlag = getFlag(flags, DataDirFlagKey)


### PR DESCRIPTION
## Summary

We can use the `this.ctor` property instead of relying on escaping from Typescript's system now.

https://github.com/oclif/core/blob/main/src/command.ts#L187-L189

## Testing Plan

Manual - run some commands, utilize the common/built-in flags like datadir

## Documentation

N/A

## Breaking Change

N/A