### PR TITLE
Dont serialize rpc notes if not passed in

### DIFF
--- a/ironfish/src/rpc/routes/chain/__fixtures__/serializers.test.ts.fixture
+++ b/ironfish/src/rpc/routes/chain/__fixtures__/serializers.test.ts.fixture
@@ -1,0 +1,36 @@
+{
+  "Rpc Chain Serializers should optionally return serialized": [
+    {
+      "value": {
+        "version": 4,
+        "id": "92879eb0-acc6-432f-be27-4086746a8f81",
+        "name": "test",
+        "spendingKey": "13ae2b816c006b1ca439bb3f1f34ad5c560418ab9b7127e6b35ac15586e6a7dc",
+        "viewKey": "3a2fded7a277601345c41ceee3582457beac30e2fc698c0a780e0151c4485decd57749d0e52cc41c0804ff5e97901b551e5f642216b2fe7e75af95e51c0a4ee0",
+        "incomingViewKey": "d18c6bbd9fcd1fa9902e3981a0cbbe80f0b12eb6bf53860041bb334e38766606",
+        "outgoingViewKey": "d585ac8112192346000cba3a17cdf1e931cefd669d18c969ebfdda5620d8047a",
+        "publicAddress": "9a56d5900d757ac4837f2fc800c7426a43d6e1d69c829c11f3c17af52e870757",
+        "createdAt": {
+          "hash": {
+            "type": "Buffer",
+            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+          },
+          "sequence": 1
+        },
+        "scanningEnabled": true,
+        "proofAuthorizingKey": "438afe1b8a45c98ccc426857103a5c1c20a3cd0d13292fb40f790ed5f956a90b"
+      },
+      "head": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAszlMYP6jllK6GdKJuvklyEInkCA5L3y9zzcwbVpFhpiDRbRF0zL/rSRpqORJjsL3Aj02X8BFcx8a8aB7I1ri2/Nw5DofvDmQirYEQtli/cGLH71rd22qcT3WTsjL+G6Lsjgoif3L2nmuwkNo+dCEOBUmbUC50s8TXmBdxvc9D/wTzC5l8SFrle869DI0Lk9eTMzyGZnPxr9fDUG8Io0RaIdIFE+e9JCY85yiRR4PT5ukitq4bW2LPqCOyi0tdxGPtO0b2/iUxxYgXYJy5zklqIoHNUm09bTy91+n7Ey61WjzMy27WZ3PUqpG0oupHPvGYMBoR/OljUGwhg3p4o9yCve3+EkzQHNwNkExgq9AIQQ+XvWkp62iRR0nqtxwWtZeeJ752sZ2P7f5/LZic+LxmQMrARFWP59e9iyx4O0eNs49QHMUs9vxSG28U6CDd0kDvlWv6hfx++asQTuONFLNOGLKqOjmcKv/ZJAOxyTWMqz//OSVTj3rkz0uuwVYs4R2Qa69FRmaoadlAe5KTpTBiL83yY1rDaAKfjyC4hGLm5EzfE29qz1Z2aeHXZXsAMBVL+HoAEN9uLl25jqOCVq3JWWRCnhgfGV/G8YjEfu873eiZTy43HHdwklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwL4g+FyQGz8rRXCWSBRk+7I2l9plAKoyFyA573OzGWMVTno00WAQlRaBDu9wkH/fqF/WhxRSIUkFdcP78NOp+DA=="
+    }
+  ]
+}

--- a/ironfish/src/rpc/routes/chain/serializers.test.ts
+++ b/ironfish/src/rpc/routes/chain/serializers.test.ts
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { useMinersTxFixture } from '../../../testUtilities/fixtures'
+import { createNodeTest } from '../../../testUtilities/nodeTest'
+import { serializeRpcTransaction } from './serializers'
+
+describe('Rpc Chain Serializers', () => {
+  const nodeTest = createNodeTest()
+
+  it('should optionally return serialized', async () => {
+    const transaction = await useMinersTxFixture(nodeTest.node)
+
+    // Should include serialized formats
+    let serialized = serializeRpcTransaction(transaction, true)
+    expect(serialized.serialized).toBe(transaction.serialize().toString('hex'))
+    expect(serialized.notes[0].serialized).toBe(
+      transaction.notes[0].serialize().toString('hex'),
+    )
+
+    // Now should not include them
+    serialized = serializeRpcTransaction(transaction, false)
+    expect(serialized.serialized).not.toBeDefined()
+    expect(serialized.notes[0].serialized).not.toBeDefined()
+  })
+})

--- a/ironfish/src/rpc/routes/chain/serializers.ts
+++ b/ironfish/src/rpc/routes/chain/serializers.ts
@@ -4,8 +4,9 @@
 
 import { getBlockSize, getTransactionSize } from '../../../network/utils/serializers'
 import { Block, BlockHeader, Target, Transaction } from '../../../primitives'
+import { NoteEncrypted } from '../../../primitives/noteEncrypted'
 import { BufferUtils } from '../../../utils'
-import { RpcBlock, RpcBlockHeader, RpcTransaction } from './types'
+import { RpcBlock, RpcBlockHeader, RpcEncryptedNote, RpcTransaction } from './types'
 
 export function serializeRpcBlockHeader(header: BlockHeader): RpcBlockHeader {
   return {
@@ -57,6 +58,17 @@ export const serializeRpcBlock = (block: Block, serialized?: boolean): RpcBlock 
   }
 }
 
+export const serializeRpcEncryptedNote = (
+  note: NoteEncrypted,
+  serialized?: boolean,
+): RpcEncryptedNote => {
+  return {
+    commitment: note.hash().toString('hex'),
+    hash: note.hash().toString('hex'),
+    ...(serialized ? { serialized: note.serialize().toString('hex') } : undefined),
+  }
+}
+
 export const serializeRpcTransaction = (
   tx: Transaction,
   serialized?: boolean,
@@ -66,11 +78,9 @@ export const serializeRpcTransaction = (
     size: getTransactionSize(tx),
     fee: Number(tx.fee()),
     expiration: tx.expiration(),
-    notes: tx.notes.map((note) => ({
-      commitment: note.hash().toString('hex'),
-      hash: note.hash().toString('hex'),
-      serialized: note.serialize().toString('hex'),
-    })),
+    notes: tx.notes.map((note) => {
+      return serializeRpcEncryptedNote(note, serialized)
+    }),
     spends: tx.spends.map((spend) => ({
       nullifier: spend.nullifier.toString('hex'),
       commitment: spend.commitment.toString('hex'),

--- a/ironfish/src/rpc/routes/chain/types.ts
+++ b/ironfish/src/rpc/routes/chain/types.ts
@@ -21,7 +21,7 @@ export const RpcSpendSchema: yup.ObjectSchema<RpcSpend> = yup
 
 export type RpcEncryptedNote = {
   hash: string
-  serialized: string
+  serialized?: string
   /**
    * @deprecated Please use hash instead
    */
@@ -32,7 +32,7 @@ export const RpcEncryptedNoteSchema: yup.ObjectSchema<RpcEncryptedNote> = yup
   .object({
     commitment: yup.string().defined(),
     hash: yup.string().defined(),
-    serialized: yup.string().defined(),
+    serialized: yup.string().optional(),
   })
   .defined()
 


### PR DESCRIPTION
## Summary

This makes it so if you tell the RpcTransaction serializer not to include the serialized format, the notes will also not be included.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[X] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
