### PR TITLE
Add missing offline flag

### DIFF
--- a/ironfish-cli/src/commands/wallet/chainport/send.ts
+++ b/ironfish-cli/src/commands/wallet/chainport/send.ts
@@ -77,6 +77,10 @@ export class BridgeCommand extends IronfishCommand {
       description:
         'The block sequence after which the transaction will be removed from the mempool. Set to 0 for no expiration.',
     }),
+    offline: Flags.boolean({
+      default: false,
+      description: 'Allow offline transaction creation',
+    }),
   }
 
   async start(): Promise<void> {


### PR DESCRIPTION
## Summary

This flag doesn't quite work as intended, but having missing flags can sometimes throw compilation errors in certain scenarios. It should throw errors in all scenarios, but that will be tackled soon.

## Testing Plan

## Documentation

N/A

## Breaking Change

N/A