### PR TITLE
ChainProcessor returns when head is not found

### DIFF
--- a/ironfish/src/chainProcessor.test.ts
+++ b/ironfish/src/chainProcessor.test.ts
@@ -198,4 +198,18 @@ describe('ChainProcessor', () => {
     expect(processor.hash).toEqualBuffer(block.header.hash)
     expect(onEvent).toHaveBeenCalledTimes(0)
   })
+
+  it('should not crash if head not found', async () => {
+    const MISSING_HEAD = Buffer.alloc(32, 'helloworld')
+    const processor = new ChainProcessor({ chain: nodeTest.chain, head: MISSING_HEAD })
+
+    const onEvent: Mock<(header: BlockHeader, event: 'add' | 'remove') => void> = jest.fn()
+    processor.onAdd.on((block) => onEvent(block, 'add'))
+    processor.onRemove.on((block) => onEvent(block, 'remove'))
+
+    let result = await processor.update()
+    expect(result.hashChanged).toBe(false)
+    expect(processor.hash).toEqualBuffer(MISSING_HEAD)
+    expect(onEvent).toHaveBeenCalledTimes(0)
+  })
 })

--- a/ironfish/src/chainProcessor.test.ts
+++ b/ironfish/src/chainProcessor.test.ts
@@ -207,7 +207,7 @@ describe('ChainProcessor', () => {
     processor.onAdd.on((block) => onEvent(block, 'add'))
     processor.onRemove.on((block) => onEvent(block, 'remove'))
 
-    let result = await processor.update()
+    const result = await processor.update()
     expect(result.hashChanged).toBe(false)
     expect(processor.hash).toEqualBuffer(MISSING_HEAD)
     expect(onEvent).toHaveBeenCalledTimes(0)

--- a/ironfish/src/chainProcessor.ts
+++ b/ironfish/src/chainProcessor.ts
@@ -3,7 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import type { Blockchain } from './blockchain'
 import type { BlockHeader } from './primitives'
-import { Assert } from './assert'
 import { Event } from './event'
 import { createRootLogger, Logger } from './logger'
 
@@ -73,13 +72,13 @@ export class ChainProcessor {
 
     const head = await this.chain.getHeader(this.hash)
 
-    Assert.isNotNull(
-      head,
-      `Chain processor head not found in chain: ${this.hash.toString('hex')}`,
-    )
-
     let blockCount = 0
     let hashChanged = false
+
+    if (!head) {
+      this.logger.warn('ChainProcessor could not find head in blockchain.')
+      return { hashChanged }
+    }
 
     const fork = await this.chain.findFork(head, chainHead)
 


### PR DESCRIPTION
## Summary

This is experimenting with a fix for a problem i've seen. If the wallet gets ahead of the chain, the node will no longer start with this error.

```
Error: Chain processor head not found in chain: 0000000000012f4aca795fe01d3823b6d2b01a581fb7b4d41e78c09e68f477ba
    at Function.isNotNull (/ironfish/src/assert.ts:26:13)
    at ChainProcessor.update (/ironfish/src/chainProcessor.ts:76:12)
    at <anonymous> (/ironfish/src/wallet/scanner/walletScanner.ts:132:26)
```

You can reproduce this by running
- `ironfish chain:rewind  665566 // use a sequence 1 behind the head`
- `ironfish start`

The problem is that the ChainProcessor crashes if it cannot find the head in the chain. After looking at all the usages of ChainProcessor, I think instead it should just return having not processed any blocks.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
