### PR TITLE
Add the ability for CLI commands to track and close an RPC client

### DIFF
--- a/ironfish-cli/src/command.ts
+++ b/ironfish-cli/src/command.ts
@@ -81,9 +81,7 @@ export abstract class IronfishCommand extends Command {
 
   async run(): Promise<unknown> {
     try {
-      const json = await this.start()
-      this.client?.close()
-      return json
+      return await this.start()
     } catch (error: unknown) {
       if (hasUserResponseError(error)) {
         this.log(error.codeMessage)
@@ -109,6 +107,8 @@ export abstract class IronfishCommand extends Command {
       } else {
         throw error
       }
+    } finally {
+      this.client?.close()
     }
 
     this.exit(0)

--- a/ironfish-cli/src/commands/chain/assets/info.ts
+++ b/ironfish-cli/src/commands/chain/assets/info.ts
@@ -25,7 +25,7 @@ export default class AssetInfo extends IronfishCommand {
     const { args } = await this.parse(AssetInfo)
     const { id: assetId } = args
 
-    const client = await this.sdk.connectRpc()
+    const client = await this.connectRpc()
     const data = await client.chain.getAsset({ id: assetId })
 
     this.log(

--- a/ironfish-cli/src/commands/chain/blocks/info.ts
+++ b/ironfish-cli/src/commands/chain/blocks/info.ts
@@ -27,7 +27,7 @@ export default class BlockInfo extends IronfishCommand {
     const { args } = await this.parse(BlockInfo)
     const { search } = args
 
-    const client = await this.sdk.connectRpc()
+    const client = await this.connectRpc()
     const data = await client.chain.getBlock({ search })
     const blockData = data.content
 

--- a/ironfish-cli/src/commands/chain/broadcast.ts
+++ b/ironfish-cli/src/commands/chain/broadcast.ts
@@ -24,7 +24,7 @@ export class BroadcastCommand extends IronfishCommand {
     const { transaction } = args
 
     ux.action.start(`Broadcasting transaction`)
-    const client = await this.sdk.connectRpc()
+    const client = await this.connectRpc()
     const response = await client.chain.broadcastTransaction({ transaction })
     if (response.content) {
       ux.action.stop(`Transaction broadcasted: ${response.content.hash}`)

--- a/ironfish-cli/src/commands/chain/export.ts
+++ b/ironfish-cli/src/commands/chain/export.ts
@@ -41,7 +41,7 @@ export default class Export extends IronfishCommand {
 
     const exportPath = this.sdk.fileSystem.join(exportDir, 'data.json')
 
-    const client = await this.sdk.connectRpc()
+    const client = await this.connectRpc()
 
     const stream = client.chain.exportChainStream({
       start: args.start,

--- a/ironfish-cli/src/commands/chain/power.ts
+++ b/ironfish-cli/src/commands/chain/power.ts
@@ -29,7 +29,7 @@ export default class Power extends IronfishCommand {
     const { flags, args } = await this.parse(Power)
     const { block } = args
 
-    const client = await this.sdk.connectRpc()
+    const client = await this.connectRpc()
 
     const data = await client.chain.getNetworkHashPower({
       sequence: block,

--- a/ironfish-cli/src/commands/chain/status.ts
+++ b/ironfish-cli/src/commands/chain/status.ts
@@ -14,7 +14,7 @@ export default class ChainStatus extends IronfishCommand {
   }
 
   async start(): Promise<void> {
-    const client = await this.sdk.connectRpc()
+    const client = await this.connectRpc()
 
     const [status, difficulty, power] = await Promise.all([
       client.node.getStatus(),

--- a/ironfish-cli/src/commands/chain/transactions/info.ts
+++ b/ironfish-cli/src/commands/chain/transactions/info.ts
@@ -25,7 +25,7 @@ export class TransactionInfo extends IronfishCommand {
   async start(): Promise<void> {
     const { args } = await this.parse(TransactionInfo)
 
-    const client = await this.sdk.connectRpc()
+    const client = await this.connectRpc()
 
     const response = await client.chain.getTransaction({
       transactionHash: args.hash,

--- a/ironfish-cli/src/commands/config/edit.ts
+++ b/ironfish-cli/src/commands/config/edit.ts
@@ -39,7 +39,7 @@ export class EditCommand extends IronfishCommand {
       this.exit(code || undefined)
     }
 
-    const client = await this.sdk.connectRpc(!flags.remote)
+    const client = await this.connectRpc(!flags.remote)
     const response = await client.config.getConfig({ user: true })
     const output = JSON.stringify(response.content, undefined, '   ')
 

--- a/ironfish-cli/src/commands/config/get.ts
+++ b/ironfish-cli/src/commands/config/get.ts
@@ -42,7 +42,7 @@ export class GetCommand extends IronfishCommand {
     const { args, flags } = await this.parse(GetCommand)
     const { name } = args
 
-    const client = await this.sdk.connectRpc(flags.local)
+    const client = await this.connectRpc(flags.local)
 
     const response = await client.config.getConfig({
       user: flags.user,

--- a/ironfish-cli/src/commands/config/index.ts
+++ b/ironfish-cli/src/commands/config/index.ts
@@ -25,7 +25,7 @@ export class ShowCommand extends IronfishCommand {
   async start(): Promise<void> {
     const { flags } = await this.parse(ShowCommand)
 
-    const client = await this.sdk.connectRpc(flags.local)
+    const client = await this.connectRpc(flags.local)
     const response = await client.config.getConfig({ user: flags.user })
 
     let output = JSON.stringify(response.content, undefined, '   ')

--- a/ironfish-cli/src/commands/config/set.ts
+++ b/ironfish-cli/src/commands/config/set.ts
@@ -35,7 +35,7 @@ export class SetCommand extends IronfishCommand {
     const { args, flags } = await this.parse(SetCommand)
     const { name, value } = args
 
-    const client = await this.sdk.connectRpc(flags.local)
+    const client = await this.connectRpc(flags.local)
     await client.config.setConfig({ name, value })
 
     this.exit(0)

--- a/ironfish-cli/src/commands/config/unset.ts
+++ b/ironfish-cli/src/commands/config/unset.ts
@@ -29,7 +29,7 @@ export class UnsetCommand extends IronfishCommand {
     const { args, flags } = await this.parse(UnsetCommand)
     const { name } = args
 
-    const client = await this.sdk.connectRpc(flags.local)
+    const client = await this.connectRpc(flags.local)
     await client.config.unsetConfig({ name })
 
     this.exit(0)

--- a/ironfish-cli/src/commands/faucet.ts
+++ b/ironfish-cli/src/commands/faucet.ts
@@ -34,7 +34,7 @@ export class FaucetCommand extends IronfishCommand {
       this.exit(1)
     }
 
-    const client = await this.sdk.connectRpc()
+    const client = await this.connectRpc()
     const networkInfoResponse = await client.chain.getNetworkInfo()
 
     if (networkInfoResponse.content === null || networkInfoResponse.content.networkId !== 0) {

--- a/ironfish-cli/src/commands/fees.ts
+++ b/ironfish-cli/src/commands/fees.ts
@@ -26,7 +26,7 @@ export class FeeCommand extends IronfishCommand {
   async start(): Promise<void> {
     const { flags } = await this.parse(FeeCommand)
 
-    const client = await this.sdk.connectRpc()
+    const client = await this.connectRpc()
 
     if (flags.explain) {
       await this.explainFeeRates(client)

--- a/ironfish-cli/src/commands/mempool/status.ts
+++ b/ironfish-cli/src/commands/mempool/status.ts
@@ -25,7 +25,7 @@ export default class Status extends IronfishCommand {
     const { flags } = await this.parse(Status)
 
     if (!flags.follow) {
-      const client = await this.sdk.connectRpc()
+      const client = await this.connectRpc()
       const response = await client.mempool.getMempoolStatus()
       this.log(renderStatus(response.content))
       this.exit(0)

--- a/ironfish-cli/src/commands/miners/start.ts
+++ b/ironfish-cli/src/commands/miners/start.ts
@@ -81,7 +81,7 @@ export class Miner extends IronfishCommand {
       let publicAddress = flags.address
 
       if (publicAddress == null) {
-        const client = await this.sdk.connectRpc()
+        const client = await this.connectRpc()
         const publicKeyResponse = await client.wallet.getAccountPublicKey()
 
         publicAddress = publicKeyResponse.content.publicKey

--- a/ironfish-cli/src/commands/rpc/status.ts
+++ b/ironfish-cli/src/commands/rpc/status.ts
@@ -24,7 +24,7 @@ export default class Status extends IronfishCommand {
     const { flags } = await this.parse(Status)
 
     if (!flags.follow) {
-      const client = await this.sdk.connectRpc()
+      const client = await this.connectRpc()
       const response = await client.rpc.getRpcStatus()
       this.log(renderStatus(response.content))
       this.exit(0)

--- a/ironfish-cli/src/commands/status.ts
+++ b/ironfish-cli/src/commands/status.ts
@@ -35,7 +35,7 @@ export default class Status extends IronfishCommand {
     const { flags } = await this.parse(Status)
 
     if (!flags.follow) {
-      const client = await this.sdk.connectRpc()
+      const client = await this.connectRpc()
       const response = await client.node.getStatus()
       this.log(renderStatus(response.content, flags.all))
       this.exit(0)

--- a/ironfish-cli/src/commands/wallet/accounts.ts
+++ b/ironfish-cli/src/commands/wallet/accounts.ts
@@ -19,7 +19,7 @@ export class AccountsCommand extends IronfishCommand {
   async start(): Promise<void> {
     const { flags } = await this.parse(AccountsCommand)
 
-    const client = await this.sdk.connectRpc()
+    const client = await this.connectRpc()
 
     const response = await client.wallet.getAccounts({ displayName: flags.displayName })
 

--- a/ironfish-cli/src/commands/wallet/address.ts
+++ b/ironfish-cli/src/commands/wallet/address.ts
@@ -25,7 +25,7 @@ export class AddressCommand extends IronfishCommand {
     const { args } = await this.parse(AddressCommand)
     const { account } = args
 
-    const client = await this.sdk.connectRpc()
+    const client = await this.connectRpc()
 
     const response = await client.wallet.getAccountPublicKey({
       account: account,

--- a/ironfish-cli/src/commands/wallet/assets.ts
+++ b/ironfish-cli/src/commands/wallet/assets.ts
@@ -46,7 +46,7 @@ export class AssetsCommand extends IronfishCommand {
     // TODO: remove account arg
     const account = flags.account ? flags.account : args.account
 
-    const client = await this.sdk.connectRpc()
+    const client = await this.connectRpc()
     const response = client.wallet.getAssets({
       account,
     })

--- a/ironfish-cli/src/commands/wallet/balance.ts
+++ b/ironfish-cli/src/commands/wallet/balance.ts
@@ -51,7 +51,7 @@ export class BalanceCommand extends IronfishCommand {
     // TODO: remove account arg
     const account = flags.account ? flags.account : args.account
 
-    const client = await this.sdk.connectRpc()
+    const client = await this.connectRpc()
 
     const response = await client.wallet.getAccountBalance({
       account,

--- a/ironfish-cli/src/commands/wallet/balances.ts
+++ b/ironfish-cli/src/commands/wallet/balances.ts
@@ -39,7 +39,7 @@ export class BalancesCommand extends IronfishCommand {
 
   async start(): Promise<void> {
     const { flags, args } = await this.parse(BalancesCommand)
-    const client = await this.sdk.connectRpc()
+    const client = await this.connectRpc()
 
     // TODO: remove account arg
     const account = flags.account ? flags.account : args.account

--- a/ironfish-cli/src/commands/wallet/burn.ts
+++ b/ironfish-cli/src/commands/wallet/burn.ts
@@ -95,7 +95,7 @@ export class Burn extends IronfishCommand {
 
   async start(): Promise<void> {
     const { flags } = await this.parse(Burn)
-    const client = await this.sdk.connectRpc()
+    const client = await this.connectRpc()
 
     if (!flags.offline) {
       const status = await client.wallet.getNodeStatus()

--- a/ironfish-cli/src/commands/wallet/chainport/send.ts
+++ b/ironfish-cli/src/commands/wallet/chainport/send.ts
@@ -86,7 +86,7 @@ export class BridgeCommand extends IronfishCommand {
   async start(): Promise<void> {
     const { flags } = await this.parse(BridgeCommand)
 
-    const client = await this.sdk.connectRpc()
+    const client = await this.connectRpc()
 
     const networkId = (await client.chain.getNetworkInfo()).content.networkId
 

--- a/ironfish-cli/src/commands/wallet/create.ts
+++ b/ironfish-cli/src/commands/wallet/create.ts
@@ -29,7 +29,7 @@ export class CreateCommand extends IronfishCommand {
       name = await inputPrompt('Enter the name of the account', true)
     }
 
-    const client = await this.sdk.connectRpc()
+    const client = await this.connectRpc()
 
     this.log(`Creating account ${name}`)
     const result = await client.wallet.createAccount({ name })

--- a/ironfish-cli/src/commands/wallet/delete.ts
+++ b/ironfish-cli/src/commands/wallet/delete.ts
@@ -33,7 +33,7 @@ export class DeleteCommand extends IronfishCommand {
     const { confirm, wait } = flags
     const { account } = args
 
-    const client = await this.sdk.connectRpc()
+    const client = await this.connectRpc()
 
     ux.action.start(`Deleting account '${account}'`)
     const response = await client.wallet.removeAccount({ account, confirm, wait })

--- a/ironfish-cli/src/commands/wallet/export.ts
+++ b/ironfish-cli/src/commands/wallet/export.ts
@@ -65,7 +65,7 @@ export class ExportCommand extends IronfishCommand {
       ? AccountFormat.JSON
       : AccountFormat.Base64Json
 
-    const client = await this.sdk.connectRpc(local)
+    const client = await this.connectRpc(local)
     const response = await client.wallet.exportAccount({
       account,
       viewOnly,

--- a/ironfish-cli/src/commands/wallet/import.ts
+++ b/ironfish-cli/src/commands/wallet/import.ts
@@ -51,7 +51,7 @@ export class ImportCommand extends IronfishCommand {
     const { flags, args } = await this.parse(ImportCommand)
     const { blob } = args
 
-    const client = await this.sdk.connectRpc()
+    const client = await this.connectRpc()
 
     let account: string
 

--- a/ironfish-cli/src/commands/wallet/mint.ts
+++ b/ironfish-cli/src/commands/wallet/mint.ts
@@ -116,7 +116,7 @@ export class Mint extends IronfishCommand {
 
   async start(): Promise<void> {
     const { flags } = await this.parse(Mint)
-    const client = await this.sdk.connectRpc()
+    const client = await this.connectRpc()
 
     if (!flags.offline) {
       const status = await client.wallet.getNodeStatus()

--- a/ironfish-cli/src/commands/wallet/multisig/account/participants.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/account/participants.ts
@@ -19,7 +19,7 @@ export class MultisigAccountParticipants extends IronfishCommand {
   async start(): Promise<void> {
     const { flags } = await this.parse(MultisigAccountParticipants)
 
-    const client = await this.sdk.connectRpc()
+    const client = await this.connectRpc()
 
     const response = await client.wallet.multisig.getAccountIdentities({
       account: flags.account,

--- a/ironfish-cli/src/commands/wallet/multisig/commitment/aggregate.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/commitment/aggregate.ts
@@ -55,7 +55,7 @@ export class CreateSigningPackage extends IronfishCommand {
     }
     commitments = commitments.map((s) => s.trim())
 
-    const client = await this.sdk.connectRpc()
+    const client = await this.connectRpc()
 
     const signingPackageResponse = await client.wallet.multisig.createSigningPackage({
       account: flags.account,

--- a/ironfish-cli/src/commands/wallet/multisig/commitment/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/commitment/create.ts
@@ -69,7 +69,7 @@ export class CreateSigningCommitmentCommand extends IronfishCommand {
       })
     }
 
-    const client = await this.sdk.connectRpc()
+    const client = await this.connectRpc()
     const unsignedTransaction = new UnsignedTransaction(
       Buffer.from(unsignedTransactionInput, 'hex'),
     )

--- a/ironfish-cli/src/commands/wallet/multisig/dealer/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dealer/create.ts
@@ -62,7 +62,7 @@ export class MultisigCreateDealer extends IronfishCommand {
       }
     }
 
-    const client = await this.sdk.connectRpc()
+    const client = await this.connectRpc()
 
     const name = await this.getCoordinatorName(client, flags.name?.trim())
 

--- a/ironfish-cli/src/commands/wallet/multisig/dkg/round1.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/round1.ts
@@ -33,7 +33,7 @@ export class DkgRound1Command extends IronfishCommand {
   async start(): Promise<void> {
     const { flags } = await this.parse(DkgRound1Command)
 
-    const client = await this.sdk.connectRpc()
+    const client = await this.connectRpc()
 
     let participantName = flags.participantName
     if (!participantName) {

--- a/ironfish-cli/src/commands/wallet/multisig/dkg/round2.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/round2.ts
@@ -33,7 +33,7 @@ export class DkgRound2Command extends IronfishCommand {
   async start(): Promise<void> {
     const { flags } = await this.parse(DkgRound2Command)
 
-    const client = await this.sdk.connectRpc()
+    const client = await this.connectRpc()
 
     let participantName = flags.participantName
     if (!participantName) {

--- a/ironfish-cli/src/commands/wallet/multisig/dkg/round3.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/round3.ts
@@ -43,7 +43,7 @@ export class DkgRound3Command extends IronfishCommand {
   async start(): Promise<void> {
     const { flags } = await this.parse(DkgRound3Command)
 
-    const client = await this.sdk.connectRpc()
+    const client = await this.connectRpc()
 
     let participantName = flags.participantName
     if (!participantName) {

--- a/ironfish-cli/src/commands/wallet/multisig/participant/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/participant/create.ts
@@ -25,7 +25,7 @@ export class MultisigIdentityCreate extends IronfishCommand {
       name = await inputPrompt('Enter a name for the identity', true)
     }
 
-    const client = await this.sdk.connectRpc()
+    const client = await this.connectRpc()
     let response
     while (!response) {
       try {

--- a/ironfish-cli/src/commands/wallet/multisig/participant/index.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/participant/index.ts
@@ -20,7 +20,7 @@ export class MultisigIdentity extends IronfishCommand {
   async start(): Promise<void> {
     const { flags } = await this.parse(MultisigIdentity)
 
-    const client = await this.sdk.connectRpc()
+    const client = await this.connectRpc()
 
     if (flags.name) {
       const response = await client.wallet.multisig.getIdentity({ name: flags.name })

--- a/ironfish-cli/src/commands/wallet/multisig/participants/index.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/participants/index.ts
@@ -13,7 +13,7 @@ export class MultisigParticipants extends IronfishCommand {
   }
 
   async start(): Promise<void> {
-    const client = await this.sdk.connectRpc()
+    const client = await this.connectRpc()
     const response = await client.wallet.multisig.getIdentities()
 
     const participants = []

--- a/ironfish-cli/src/commands/wallet/multisig/signature/aggregate.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/signature/aggregate.ts
@@ -64,7 +64,7 @@ export class MultisigSign extends IronfishCommand {
 
     ux.action.start('Signing the multisig transaction')
 
-    const client = await this.sdk.connectRpc()
+    const client = await this.connectRpc()
 
     const response = await client.wallet.multisig.aggregateSignatureShares({
       account: flags.account,

--- a/ironfish-cli/src/commands/wallet/multisig/signature/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/signature/create.ts
@@ -46,7 +46,7 @@ export class CreateSignatureShareCommand extends IronfishCommand {
       signingPackageString = await longPrompt('Enter the signing package')
     }
 
-    const client = await this.sdk.connectRpc()
+    const client = await this.connectRpc()
 
     const signingPackage = new multisig.SigningPackage(Buffer.from(signingPackageString, 'hex'))
     const unsignedTransaction = new UnsignedTransaction(

--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -218,7 +218,7 @@ export class CombineNotesCommand extends IronfishCommand {
   async start(): Promise<void> {
     const { flags } = await this.parse(CombineNotesCommand)
 
-    const client = await this.sdk.connectRpc()
+    const client = await this.connectRpc()
 
     let to = flags.to
     let from = flags.account

--- a/ironfish-cli/src/commands/wallet/notes/index.ts
+++ b/ironfish-cli/src/commands/wallet/notes/index.ts
@@ -35,7 +35,7 @@ export class NotesCommand extends IronfishCommand {
 
     const assetLookup: Map<string, RpcAsset> = new Map()
 
-    const client = await this.sdk.connectRpc()
+    const client = await this.connectRpc()
 
     const response = client.wallet.getAccountNotesStream({ account })
 

--- a/ironfish-cli/src/commands/wallet/post.ts
+++ b/ironfish-cli/src/commands/wallet/post.ts
@@ -57,7 +57,7 @@ export class PostCommand extends IronfishCommand {
     const serialized = Buffer.from(transaction, 'hex')
     const raw = RawTransactionSerde.deserialize(serialized)
 
-    const client = await this.sdk.connectRpc()
+    const client = await this.connectRpc()
 
     const senderAddress = raw.sender()
     if (!senderAddress) {

--- a/ironfish-cli/src/commands/wallet/rename.ts
+++ b/ironfish-cli/src/commands/wallet/rename.ts
@@ -27,7 +27,7 @@ export class RenameCommand extends IronfishCommand {
     const { args } = await this.parse(RenameCommand)
     const { account, newName } = args
 
-    const client = await this.sdk.connectRpc()
+    const client = await this.connectRpc()
     await client.wallet.renameAccount({ account, newName })
     this.log(`Account ${account} renamed to ${newName}`)
   }

--- a/ironfish-cli/src/commands/wallet/rescan.ts
+++ b/ironfish-cli/src/commands/wallet/rescan.ts
@@ -34,7 +34,7 @@ export class RescanCommand extends IronfishCommand {
       this.error('You cannot pass both --local and --no-follow')
     }
 
-    const client = await this.sdk.connectRpc(local)
+    const client = await this.connectRpc(local)
 
     ux.action.start('Asking node to start scanning', undefined, {
       stdout: true,

--- a/ironfish-cli/src/commands/wallet/reset.ts
+++ b/ironfish-cli/src/commands/wallet/reset.ts
@@ -45,7 +45,7 @@ export class ResetCommand extends IronfishCommand {
       flags.confirm,
     )
 
-    const client = await this.sdk.connectRpc()
+    const client = await this.connectRpc()
 
     await client.wallet.resetAccount({
       account,

--- a/ironfish-cli/src/commands/wallet/scanning/off.ts
+++ b/ironfish-cli/src/commands/wallet/scanning/off.ts
@@ -23,7 +23,7 @@ export class ScanningOffCommand extends IronfishCommand {
     const { args } = await this.parse(ScanningOffCommand)
     const { account } = args
 
-    const client = await this.sdk.connectRpc()
+    const client = await this.connectRpc()
 
     await client.wallet.setScanning({
       account: account,

--- a/ironfish-cli/src/commands/wallet/scanning/on.ts
+++ b/ironfish-cli/src/commands/wallet/scanning/on.ts
@@ -23,7 +23,7 @@ export class ScanningOnCommand extends IronfishCommand {
     const { args } = await this.parse(ScanningOnCommand)
     const { account } = args
 
-    const client = await this.sdk.connectRpc()
+    const client = await this.connectRpc()
 
     await client.wallet.setScanning({
       account: account,

--- a/ironfish-cli/src/commands/wallet/send.ts
+++ b/ironfish-cli/src/commands/wallet/send.ts
@@ -124,7 +124,7 @@ export class Send extends IronfishCommand {
     let to = flags.to
     let from = flags.account
 
-    const client = await this.sdk.connectRpc()
+    const client = await this.connectRpc()
 
     if (!flags.offline) {
       const status = await client.wallet.getNodeStatus()

--- a/ironfish-cli/src/commands/wallet/sign.ts
+++ b/ironfish-cli/src/commands/wallet/sign.ts
@@ -35,7 +35,7 @@ export class SignTransaction extends IronfishCommand {
 
   async start(): Promise<void> {
     const { flags } = await this.parse(SignTransaction)
-    const client = await this.sdk.connectRpc()
+    const client = await this.connectRpc()
 
     if (!flags.broadcast && flags.watch) {
       this.error('Cannot use --watch without --broadcast')

--- a/ironfish-cli/src/commands/wallet/status.ts
+++ b/ironfish-cli/src/commands/wallet/status.ts
@@ -17,7 +17,7 @@ export class StatusCommand extends IronfishCommand {
   async start(): Promise<void> {
     const { flags } = await this.parse(StatusCommand)
 
-    const client = await this.sdk.connectRpc()
+    const client = await this.connectRpc()
 
     const response = await client.wallet.getAccountsStatus()
 

--- a/ironfish-cli/src/commands/wallet/transaction/import.ts
+++ b/ironfish-cli/src/commands/wallet/transaction/import.ts
@@ -57,7 +57,7 @@ export class TransactionImportCommand extends IronfishCommand {
     }
 
     ux.action.start(`Importing transaction`)
-    const client = await this.sdk.connectRpc()
+    const client = await this.connectRpc()
     const response = await client.wallet.addTransaction({
       transaction,
       broadcast: flags.broadcast,

--- a/ironfish-cli/src/commands/wallet/transaction/index.ts
+++ b/ironfish-cli/src/commands/wallet/transaction/index.ts
@@ -49,7 +49,7 @@ export class TransactionCommand extends IronfishCommand {
     // TODO: remove account arg
     const account = flags.account ? flags.account : args.account
 
-    const client = await this.sdk.connectRpc()
+    const client = await this.connectRpc()
     const networkId = (await client.chain.getNetworkInfo()).content.networkId
 
     const response = await client.wallet.getAccountTransaction({

--- a/ironfish-cli/src/commands/wallet/transaction/view.ts
+++ b/ironfish-cli/src/commands/wallet/transaction/view.ts
@@ -39,7 +39,7 @@ export class TransactionViewCommand extends IronfishCommand {
   async start(): Promise<void> {
     const { flags } = await this.parse(TransactionViewCommand)
 
-    const client = await this.sdk.connectRpc()
+    const client = await this.connectRpc()
 
     const account = flags.account ?? (await this.selectAccount(client))
 

--- a/ironfish-cli/src/commands/wallet/transaction/watch.ts
+++ b/ironfish-cli/src/commands/wallet/transaction/watch.ts
@@ -38,7 +38,7 @@ export class WatchTxCommand extends IronfishCommand {
     // TODO: remove account arg
     const account = flags.account ? flags.account : args.account
 
-    const client = await this.sdk.connectRpc()
+    const client = await this.connectRpc()
 
     await watchTransaction({
       client,

--- a/ironfish-cli/src/commands/wallet/transactions.ts
+++ b/ironfish-cli/src/commands/wallet/transactions.ts
@@ -71,7 +71,7 @@ export class TransactionsCommand extends IronfishCommand {
         ? Format.json
         : Format.cli
 
-    const client = await this.sdk.connectRpc()
+    const client = await this.connectRpc()
 
     const networkId = (await client.chain.getNetworkInfo()).content.networkId
 

--- a/ironfish-cli/src/commands/wallet/use.ts
+++ b/ironfish-cli/src/commands/wallet/use.ts
@@ -23,7 +23,7 @@ export class UseCommand extends IronfishCommand {
     const { args } = await this.parse(UseCommand)
     const { account } = args
 
-    const client = await this.sdk.connectRpc()
+    const client = await this.connectRpc()
     await client.wallet.useAccount({ account })
     this.log(`The default account is now: ${account}`)
   }

--- a/ironfish-cli/src/commands/wallet/which.ts
+++ b/ironfish-cli/src/commands/wallet/which.ts
@@ -23,7 +23,7 @@ export class WhichCommand extends IronfishCommand {
   async start(): Promise<void> {
     const { flags } = await this.parse(WhichCommand)
 
-    const client = await this.sdk.connectRpc()
+    const client = await this.connectRpc()
 
     const {
       content: {

--- a/ironfish-cli/src/commands/workers/status.ts
+++ b/ironfish-cli/src/commands/workers/status.ts
@@ -23,7 +23,7 @@ export default class Status extends IronfishCommand {
     const { flags } = await this.parse(Status)
 
     if (!flags.follow) {
-      const client = await this.sdk.connectRpc()
+      const client = await this.connectRpc()
       const response = await client.worker.getWorkersStatus()
       this.log(renderStatus(response.content))
       this.exit(0)

--- a/ironfish/src/rpc/clients/client.ts
+++ b/ironfish/src/rpc/clients/client.ts
@@ -176,6 +176,8 @@ import type {
 import { ApiNamespace } from '../routes/namespaces'
 
 export abstract class RpcClient {
+  abstract close(): void
+
   abstract request<TEnd = unknown, TStream = unknown>(
     route: string,
     data?: unknown,

--- a/ironfish/src/rpc/clients/memoryClient.ts
+++ b/ironfish/src/rpc/clients/memoryClient.ts
@@ -30,7 +30,5 @@ export class RpcMemoryClient extends RpcClient {
     return RpcMemoryAdapter.requestStream<TEnd, TStream>(this.router, route, data)
   }
 
-  close(): void {
-    return
-  }
+  close(): void {}
 }

--- a/ironfish/src/rpc/clients/memoryClient.ts
+++ b/ironfish/src/rpc/clients/memoryClient.ts
@@ -29,4 +29,8 @@ export class RpcMemoryClient extends RpcClient {
 
     return RpcMemoryAdapter.requestStream<TEnd, TStream>(this.router, route, data)
   }
+
+  close(): void {
+    return
+  }
 }


### PR DESCRIPTION
## Summary

With the addition of the JSON changes, which requires us to await on the start command in the IronfishCommand, commands that used `this.sdk.connectRpc()` were hanging because the clients were not being closed. This change allows us to fetch a client from the IronfishCommand directly, which gives the IronfishCommand the ability to track the client, and close it when the code is done being ran/executed.

Closes IFL-2823

## Testing Plan

## Documentation

N/A

## Breaking Change

N/A