### PR TITLE
Add Config, DataDir and Verbose flags as base flags to all commands

### DIFF
--- a/ironfish-cli/src/command.ts
+++ b/ironfish-cli/src/command.ts
@@ -15,7 +15,9 @@ import {
 import { Command, Config, ux } from '@oclif/core'
 import { CLIError, ExitError } from '@oclif/core/errors'
 import {
+  ConfigFlag,
   ConfigFlagKey,
+  DataDirFlag,
   DataDirFlagKey,
   RpcAuthFlagKey,
   RpcHttpHostFlagKey,
@@ -71,6 +73,12 @@ export abstract class IronfishCommand extends Command {
   closing = false
 
   client: RpcClient | null = null
+
+  public static baseFlags = {
+    [VerboseFlagKey]: VerboseFlag,
+    [ConfigFlagKey]: ConfigFlag,
+    [DataDirFlagKey]: DataDirFlag,
+  }
 
   constructor(argv: string[], config: Config) {
     super(argv, config)

--- a/ironfish-cli/src/commands/browse.ts
+++ b/ironfish-cli/src/commands/browse.ts
@@ -4,15 +4,12 @@
 import { Platform } from '@ironfish/sdk'
 import { Flags } from '@oclif/core'
 import { IronfishCommand } from '../command'
-import { ConfigFlag, ConfigFlagKey, DataDirFlag, DataDirFlagKey } from '../flags'
 import { PlatformUtils } from '../utils'
 
 export class BrowseCommand extends IronfishCommand {
   static description = `Browse to your data directory`
 
   static flags = {
-    [ConfigFlagKey]: ConfigFlag,
-    [DataDirFlagKey]: DataDirFlag,
     cd: Flags.boolean({
       default: false,
       description: 'print the directory where the data directory is',

--- a/ironfish-cli/src/commands/chain/benchmark.ts
+++ b/ironfish-cli/src/commands/chain/benchmark.ts
@@ -7,7 +7,6 @@ import blessed from 'blessed'
 import fs from 'fs/promises'
 import path from 'path'
 import { IronfishCommand } from '../../command'
-import { LocalFlags } from '../../flags'
 import { IronfishCliPKG } from '../../package'
 import * as ui from '../../ui'
 
@@ -18,7 +17,6 @@ export default class Benchmark extends IronfishCommand {
   static hidden = true
 
   static flags = {
-    ...LocalFlags,
     targetdir: Flags.string({
       char: 't',
       required: false,

--- a/ironfish-cli/src/commands/chain/blocks/info.ts
+++ b/ironfish-cli/src/commands/chain/blocks/info.ts
@@ -4,7 +4,6 @@
 import { BufferUtils, TimeUtils } from '@ironfish/sdk'
 import { Args } from '@oclif/core'
 import { IronfishCommand } from '../../../command'
-import { LocalFlags } from '../../../flags'
 import * as ui from '../../../ui'
 
 export default class BlockInfo extends IronfishCommand {
@@ -15,10 +14,6 @@ export default class BlockInfo extends IronfishCommand {
       required: true,
       description: 'The hash or sequence of the block to look at',
     }),
-  }
-
-  static flags = {
-    ...LocalFlags,
   }
 
   static enableJsonFlag: boolean = true

--- a/ironfish-cli/src/commands/chain/download.ts
+++ b/ironfish-cli/src/commands/chain/download.ts
@@ -5,7 +5,6 @@ import { ErrorUtils, FileUtils, NodeUtils } from '@ironfish/sdk'
 import { Flags, ux } from '@oclif/core'
 import fsAsync from 'fs/promises'
 import { IronfishCommand } from '../../command'
-import { LocalFlags } from '../../flags'
 import { DownloadedSnapshot, getDefaultManifestUrl, SnapshotDownloader } from '../../snapshot'
 import { confirmOrQuit, ProgressBar, ProgressBarPresets } from '../../ui'
 
@@ -13,7 +12,6 @@ export default class Download extends IronfishCommand {
   static description = 'download the chain'
 
   static flags = {
-    ...LocalFlags,
     manifestUrl: Flags.string({
       char: 'm',
       description: 'Manifest url to download snapshot from',

--- a/ironfish-cli/src/commands/chain/genesisadd.ts
+++ b/ironfish-cli/src/commands/chain/genesisadd.ts
@@ -13,14 +13,12 @@ import {
 import { Flags } from '@oclif/core'
 import fs from 'fs/promises'
 import { IronfishCommand } from '../../command'
-import { LocalFlags } from '../../flags'
 import { confirmOrQuit, table, TableColumns } from '../../ui'
 
 export default class GenesisAddCommand extends IronfishCommand {
   static hidden = true
 
   static flags = {
-    ...LocalFlags,
     account: Flags.string({
       char: 'a',
       required: true,

--- a/ironfish-cli/src/commands/chain/genesisblock.ts
+++ b/ironfish-cli/src/commands/chain/genesisblock.ts
@@ -15,7 +15,6 @@ import {
 import { Flags } from '@oclif/core'
 import fs from 'fs/promises'
 import { IronfishCommand } from '../../command'
-import { LocalFlags } from '../../flags'
 import { confirmOrQuit, table, TableColumns } from '../../ui'
 
 export default class GenesisBlockCommand extends IronfishCommand {
@@ -24,7 +23,6 @@ export default class GenesisBlockCommand extends IronfishCommand {
   static hidden = true
 
   static flags = {
-    ...LocalFlags,
     account: Flags.string({
       char: 'a',
       required: false,

--- a/ironfish-cli/src/commands/chain/power.ts
+++ b/ironfish-cli/src/commands/chain/power.ts
@@ -4,13 +4,11 @@
 import { FileUtils } from '@ironfish/sdk'
 import { Args, Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
-import { LocalFlags } from '../../flags'
 
 export default class Power extends IronfishCommand {
   static description = "show the network's mining power"
 
   static flags = {
-    ...LocalFlags,
     history: Flags.integer({
       required: false,
       description:

--- a/ironfish-cli/src/commands/chain/prune.ts
+++ b/ironfish-cli/src/commands/chain/prune.ts
@@ -4,13 +4,11 @@
 import { BlockchainUtils } from '@ironfish/sdk'
 import { Flags, ux } from '@oclif/core'
 import { IronfishCommand } from '../../command'
-import { LocalFlags } from '../../flags'
 
 export default class Prune extends IronfishCommand {
   static description = 'remove unused blocks from the chain'
 
   static flags = {
-    ...LocalFlags,
     dry: Flags.boolean({
       default: false,
       description: 'Dry run prune first',

--- a/ironfish-cli/src/commands/chain/repair.ts
+++ b/ironfish-cli/src/commands/chain/repair.ts
@@ -4,7 +4,6 @@
 import { Assert, BlockHeader, FullNode, IDatabaseTransaction, TimeUtils } from '@ironfish/sdk'
 import { Flags, ux } from '@oclif/core'
 import { IronfishCommand } from '../../command'
-import { LocalFlags } from '../../flags'
 import { confirmOrQuit, ProgressBar, ProgressBarPresets } from '../../ui'
 
 const TREE_BATCH = 1000
@@ -20,7 +19,6 @@ export default class RepairChain extends IronfishCommand {
   static hidden = true
 
   static flags = {
-    ...LocalFlags,
     confirm: Flags.boolean({
       char: 'c',
       default: false,

--- a/ironfish-cli/src/commands/chain/rewind.ts
+++ b/ironfish-cli/src/commands/chain/rewind.ts
@@ -4,7 +4,6 @@
 import { Assert, Blockchain, BlockchainUtils, FullNode, NodeUtils, Wallet } from '@ironfish/sdk'
 import { Args, Command, Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
-import { LocalFlags } from '../../flags'
 import { ProgressBar, ProgressBarPresets } from '../../ui'
 
 export default class Rewind extends IronfishCommand {
@@ -24,7 +23,6 @@ export default class Rewind extends IronfishCommand {
   }
 
   static flags = {
-    ...LocalFlags,
     wallet: Flags.boolean({
       default: true,
       allowNo: true,

--- a/ironfish-cli/src/commands/chain/status.ts
+++ b/ironfish-cli/src/commands/chain/status.ts
@@ -3,15 +3,10 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { FileUtils, renderNetworkName } from '@ironfish/sdk'
 import { IronfishCommand } from '../../command'
-import { LocalFlags } from '../../flags'
 import * as ui from '../../ui'
 
 export default class ChainStatus extends IronfishCommand {
   static description = 'show chain information'
-
-  static flags = {
-    ...LocalFlags,
-  }
 
   async start(): Promise<void> {
     const client = await this.connectRpc()

--- a/ironfish-cli/src/commands/config/edit.ts
+++ b/ironfish-cli/src/commands/config/edit.ts
@@ -8,7 +8,6 @@ import os from 'os'
 import path from 'path'
 import { promisify } from 'util'
 import { IronfishCommand } from '../../command'
-import { ConfigFlag, ConfigFlagKey, DataDirFlag, DataDirFlagKey } from '../../flags'
 import { launchEditor } from '../../utils'
 
 const mkdtempAsync = promisify(mkdtemp)
@@ -21,8 +20,6 @@ export class EditCommand extends IronfishCommand {
   Set the editor in either EDITOR environment variable, or set 'editor' in your ironfish config`
 
   static flags = {
-    [ConfigFlagKey]: ConfigFlag,
-    [DataDirFlagKey]: DataDirFlag,
     remote: Flags.boolean({
       default: false,
       description: 'Connect to the node when editing the config',

--- a/ironfish-cli/src/commands/debug.ts
+++ b/ironfish-cli/src/commands/debug.ts
@@ -13,17 +13,12 @@ import { execSync } from 'child_process'
 import os from 'os'
 import { getHeapStatistics } from 'v8'
 import { IronfishCommand } from '../command'
-import { LocalFlags } from '../flags'
 
 const SPACE_BUFFER = 8
 
 export default class Debug extends IronfishCommand {
   static description = 'Show debug information to help locate issues'
   static hidden = true
-
-  static flags = {
-    ...LocalFlags,
-  }
 
   async start(): Promise<void> {
     const node = await this.sdk.node({ autoSeed: false })

--- a/ironfish-cli/src/commands/migrations/index.ts
+++ b/ironfish-cli/src/commands/migrations/index.ts
@@ -2,15 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { IronfishCommand } from '../../command'
-import { ConfigFlag, ConfigFlagKey, DataDirFlag, DataDirFlagKey } from '../../flags'
 
 export class StatusCommand extends IronfishCommand {
   static description = `List all the migration statuses`
-
-  static flags = {
-    [ConfigFlagKey]: ConfigFlag,
-    [DataDirFlagKey]: DataDirFlag,
-  }
 
   async start(): Promise<void> {
     await this.parse(StatusCommand)

--- a/ironfish-cli/src/commands/migrations/revert.ts
+++ b/ironfish-cli/src/commands/migrations/revert.ts
@@ -2,17 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { IronfishCommand } from '../../command'
-import { ConfigFlag, ConfigFlagKey, DataDirFlag, DataDirFlagKey } from '../../flags'
 
 export class RevertCommand extends IronfishCommand {
   static description = `Revert the last run migration`
 
   static hidden = true
-
-  static flags = {
-    [ConfigFlagKey]: ConfigFlag,
-    [DataDirFlagKey]: DataDirFlag,
-  }
 
   async start(): Promise<void> {
     await this.parse(RevertCommand)

--- a/ironfish-cli/src/commands/migrations/start.ts
+++ b/ironfish-cli/src/commands/migrations/start.ts
@@ -3,15 +3,11 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
-import { ConfigFlag, ConfigFlagKey, DataDirFlag, DataDirFlagKey, LocalFlags } from '../../flags'
 
 export class StartCommand extends IronfishCommand {
   static description = `Run migrations`
 
   static flags = {
-    ...LocalFlags,
-    [ConfigFlagKey]: ConfigFlag,
-    [DataDirFlagKey]: DataDirFlag,
     dry: Flags.boolean({
       default: false,
       description: 'Dry run migrations first',

--- a/ironfish-cli/src/commands/repl.ts
+++ b/ironfish-cli/src/commands/repl.ts
@@ -8,22 +8,11 @@ import fs from 'fs/promises'
 import repl from 'node:repl'
 import path from 'path'
 import { IronfishCommand } from '../command'
-import {
-  ConfigFlag,
-  ConfigFlagKey,
-  DataDirFlag,
-  DataDirFlagKey,
-  VerboseFlag,
-  VerboseFlagKey,
-} from '../flags'
 
 export default class Repl extends IronfishCommand {
   static description = 'An interactive terminal to the node'
 
   static flags = {
-    [VerboseFlagKey]: VerboseFlag,
-    [ConfigFlagKey]: ConfigFlag,
-    [DataDirFlagKey]: DataDirFlag,
     opendb: Flags.boolean({
       description: 'open the databases',
       allowNo: true,

--- a/ironfish-cli/src/commands/reset.ts
+++ b/ironfish-cli/src/commands/reset.ts
@@ -5,23 +5,12 @@ import { FullNode, PEER_STORE_FILE_NAME } from '@ironfish/sdk'
 import { Flags, ux } from '@oclif/core'
 import fsAsync from 'fs/promises'
 import { IronfishCommand } from '../command'
-import {
-  ConfigFlag,
-  ConfigFlagKey,
-  DataDirFlag,
-  DataDirFlagKey,
-  VerboseFlag,
-  VerboseFlagKey,
-} from '../flags'
 import { confirmOrQuit } from '../ui'
 
 export default class Reset extends IronfishCommand {
   static description = 'Reset the node to its initial state'
 
   static flags = {
-    [VerboseFlagKey]: VerboseFlag,
-    [ConfigFlagKey]: ConfigFlag,
-    [DataDirFlagKey]: DataDirFlag,
     networkId: Flags.integer({
       char: 'i',
       default: undefined,

--- a/ironfish-cli/src/commands/rpc/token.ts
+++ b/ironfish-cli/src/commands/rpc/token.ts
@@ -3,13 +3,11 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
-import { LocalFlags } from '../../flags'
 
 export default class Token extends IronfishCommand {
   static description = 'Get or set the RPC auth token'
 
   static flags = {
-    ...LocalFlags,
     token: Flags.string({
       required: false,
       description: 'Set the RPC auth token to <value>',

--- a/ironfish-cli/src/commands/start.ts
+++ b/ironfish-cli/src/commands/start.ts
@@ -7,10 +7,6 @@ import inspector from 'node:inspector'
 import { v4 as uuid } from 'uuid'
 import { IronfishCommand, SIGNALS } from '../command'
 import {
-  ConfigFlag,
-  ConfigFlagKey,
-  DataDirFlag,
-  DataDirFlagKey,
   RpcAuthFlag,
   RpcAuthFlagKey,
   RpcHttpHostFlag,
@@ -29,8 +25,6 @@ import {
   RpcUseIpcFlagKey,
   RpcUseTcpFlag,
   RpcUseTcpFlagKey,
-  VerboseFlag,
-  VerboseFlagKey,
 } from '../flags'
 import { ONE_FISH_IMAGE } from '../images'
 
@@ -41,9 +35,6 @@ export default class Start extends IronfishCommand {
   static description = 'Start the node'
 
   static flags = {
-    [VerboseFlagKey]: VerboseFlag,
-    [ConfigFlagKey]: ConfigFlag,
-    [DataDirFlagKey]: DataDirFlag,
     [RpcUseIpcFlagKey]: { ...RpcUseIpcFlag, allowNo: true } as typeof RpcUseIpcFlag,
     [RpcUseTcpFlagKey]: { ...RpcUseTcpFlag, allowNo: true } as typeof RpcUseTcpFlag,
     [RpcUseHttpFlagKey]: { ...RpcUseHttpFlag, allowNo: true } as typeof RpcUseHttpFlag,

--- a/ironfish-cli/src/commands/wallet/prune.ts
+++ b/ironfish-cli/src/commands/wallet/prune.ts
@@ -4,13 +4,11 @@
 import { NodeUtils, TransactionStatus } from '@ironfish/sdk'
 import { Flags, ux } from '@oclif/core'
 import { IronfishCommand } from '../../command'
-import { LocalFlags } from '../../flags'
 
 export default class PruneCommand extends IronfishCommand {
   static description = 'Removes expired transactions from the wallet'
 
   static flags = {
-    ...LocalFlags,
     dryrun: Flags.boolean({
       default: false,
       description: 'Dry run prune first',

--- a/ironfish-cli/src/flags.ts
+++ b/ironfish-cli/src/flags.ts
@@ -97,23 +97,10 @@ export const RpcUseHttpFlag = Flags.boolean({
 })
 
 /**
- * These flags should usually be used on any command that starts a node,
- * or uses a database to execute the command
- */
-export const LocalFlags = {
-  [VerboseFlagKey]: VerboseFlag,
-  [ConfigFlagKey]: ConfigFlag,
-  [DataDirFlagKey]: DataDirFlag,
-}
-
-/**
  * These flags should usually be used on any command that uses an
  * RPC client to connect to a node to run the command
  */
 export const RemoteFlags = {
-  [VerboseFlagKey]: VerboseFlag,
-  [ConfigFlagKey]: ConfigFlag,
-  [DataDirFlagKey]: DataDirFlag,
   [RpcUseTcpFlagKey]: RpcUseTcpFlag,
   [RpcUseIpcFlagKey]: RpcUseIpcFlag,
   [RpcTcpHostFlagKey]: RpcTcpHostFlag,


### PR DESCRIPTION
## Summary

This removes LocalFlags entirely, as well as removing these 3 flags from RemoteFlags.

Only 2 or 3 non-hidden commands didn't utilize all 3 of these, and it was mostly the verbose flag, so there are scenarios where verbose will be listed as an argument but doesn't do anything, which I think is an okay trade-off. It's not ideal, but ensuring these flags are present seems very beneficial. 

This has the added benefit of throwing compile errors if a command tries to use a flag it hasn't defined. For some reason, if baseFlags is undefined/empty object, it seems to break the strict typing of flags. Closes IFL-2826

## Testing Plan

## Documentation

N/A

## Breaking Change

N/A