### PR TITLE
CLI commands: use built-in JSON functionality instead of re-implementing it as needed

### DIFF
--- a/ironfish-cli/src/commands/chain/blocks/info.ts
+++ b/ironfish-cli/src/commands/chain/blocks/info.ts
@@ -8,6 +8,7 @@ import * as ui from '../../../ui'
 
 export default class BlockInfo extends IronfishCommand {
   static description = 'Show the block header of a requested hash or sequence'
+  static enableJsonFlag = true
 
   static args = {
     search: Args.string({
@@ -15,8 +16,6 @@ export default class BlockInfo extends IronfishCommand {
       description: 'The hash or sequence of the block to look at',
     }),
   }
-
-  static enableJsonFlag: boolean = true
 
   async start(): Promise<unknown> {
     const { args } = await this.parse(BlockInfo)

--- a/ironfish-cli/src/commands/config/get.ts
+++ b/ironfish-cli/src/commands/config/get.ts
@@ -3,12 +3,13 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { ConfigOptions } from '@ironfish/sdk'
 import { Args, Flags } from '@oclif/core'
-import jsonColorizer from 'json-colorizer'
 import { IronfishCommand } from '../../command'
-import { RemoteFlags } from '../../flags'
+import { ColorFlag, ColorFlagKey, RemoteFlags } from '../../flags'
+import * as ui from '../../ui'
 
 export class GetCommand extends IronfishCommand {
   static description = `Print out one config value`
+  static enableJsonFlag = true
 
   static args = {
     name: Args.string({
@@ -19,6 +20,7 @@ export class GetCommand extends IronfishCommand {
 
   static flags = {
     ...RemoteFlags,
+    [ColorFlagKey]: ColorFlag,
     user: Flags.boolean({
       description: 'Only show config from the users datadir and not overrides',
     }),
@@ -26,19 +28,9 @@ export class GetCommand extends IronfishCommand {
       default: false,
       description: 'Dont connect to the node when displaying the config',
     }),
-    color: Flags.boolean({
-      default: true,
-      allowNo: true,
-      description: 'Should colorize the output',
-    }),
-    json: Flags.boolean({
-      default: false,
-      allowNo: true,
-      description: 'Output the config value as json',
-    }),
   }
 
-  async start(): Promise<void> {
+  async start(): Promise<unknown> {
     const { args, flags } = await this.parse(GetCommand)
     const { name } = args
 
@@ -54,19 +46,10 @@ export class GetCommand extends IronfishCommand {
       this.exit(0)
     }
 
-    let output = ''
+    const config = { [key]: response.content[key] }
 
-    if (flags.json) {
-      output = JSON.stringify(response.content[key], undefined, '   ')
+    this.log(ui.card(config))
 
-      if (flags.color) {
-        output = jsonColorizer(output)
-      }
-    } else {
-      output = String(response.content[key])
-    }
-
-    this.log(output)
-    this.exit(0)
+    return config
   }
 }

--- a/ironfish-cli/src/commands/config/index.ts
+++ b/ironfish-cli/src/commands/config/index.ts
@@ -2,13 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Flags } from '@oclif/core'
-import jsonColorizer from 'json-colorizer'
 import { IronfishCommand } from '../../command'
 import { ColorFlag, ColorFlagKey } from '../../flags'
 import { RemoteFlags } from '../../flags'
+import * as ui from '../../ui'
 
 export class ShowCommand extends IronfishCommand {
   static description = `Print out the entire config`
+  static enableJsonFlag = true
 
   static flags = {
     ...RemoteFlags,
@@ -22,16 +23,15 @@ export class ShowCommand extends IronfishCommand {
     }),
   }
 
-  async start(): Promise<void> {
+  async start(): Promise<unknown> {
     const { flags } = await this.parse(ShowCommand)
 
     const client = await this.connectRpc(flags.local)
     const response = await client.config.getConfig({ user: flags.user })
+    const config = response.content
 
-    let output = JSON.stringify(response.content, undefined, '   ')
-    if (flags.color) {
-      output = jsonColorizer(output)
-    }
-    this.log(output)
+    this.log(ui.card(config))
+
+    return config
   }
 }

--- a/ironfish-cli/src/commands/wallet/export.ts
+++ b/ironfish-cli/src/commands/wallet/export.ts
@@ -4,7 +4,6 @@
 import { AccountFormat, ErrorUtils, LanguageUtils } from '@ironfish/sdk'
 import { Args, Flags } from '@oclif/core'
 import fs from 'fs'
-import jsonColorizer from 'json-colorizer'
 import path from 'path'
 import { IronfishCommand } from '../../command'
 import { ColorFlag, ColorFlagKey, EnumLanguageKeyFlag, RemoteFlags } from '../../flags'
@@ -12,6 +11,7 @@ import { confirmOrQuit } from '../../ui'
 
 export class ExportCommand extends IronfishCommand {
   static description = `Export an account`
+  static enableJsonFlag = true
 
   static flags = {
     ...RemoteFlags,
@@ -28,10 +28,6 @@ export class ExportCommand extends IronfishCommand {
       description: 'Language to use for mnemonic export',
       required: false,
       choices: LanguageUtils.LANGUAGE_KEYS,
-    }),
-    json: Flags.boolean({
-      default: false,
-      description: 'Output the account as JSON, rather than the default bech32',
     }),
     path: Flags.string({
       description: 'The path to export the account to',
@@ -50,9 +46,9 @@ export class ExportCommand extends IronfishCommand {
     }),
   }
 
-  async start(): Promise<void> {
+  async start(): Promise<unknown> {
     const { flags, args } = await this.parse(ExportCommand)
-    const { color, local, path: exportPath, viewonly: viewOnly } = flags
+    const { local, path: exportPath, viewonly: viewOnly } = flags
     const { account } = args
 
     if (flags.language) {
@@ -73,10 +69,7 @@ export class ExportCommand extends IronfishCommand {
       language: flags.language,
     })
 
-    let output = response.content.account
-    if (color && flags.json && !exportPath) {
-      output = jsonColorizer(output)
-    }
+    const output = response.content.account
 
     if (exportPath) {
       let resolved = this.sdk.fileSystem.resolve(exportPath)
@@ -110,5 +103,9 @@ export class ExportCommand extends IronfishCommand {
     }
 
     this.log(output)
+
+    if (flags.json) {
+      return output
+    }
   }
 }

--- a/ironfish-cli/src/ui/json.ts
+++ b/ironfish-cli/src/ui/json.ts
@@ -5,5 +5,12 @@
 import jsonColorizer from 'json-colorizer'
 
 export function json(data: unknown): string {
-  return jsonColorizer(JSON.stringify(data, undefined, '  '))
+  let output = data
+
+  // Only try to stringify JSON output if it is not already a string
+  if (typeof data !== 'string') {
+    output = JSON.stringify(data, undefined, '  ')
+  }
+
+  return jsonColorizer(output)
 }


### PR DESCRIPTION
## Summary

We had a few commands that manually added JSON output. This change moves them to use the ui.json function instead. 

I modified ui.json to only attempt stringification of the input if it isn't already a string. The reason this was added is because the wallet:export/import flow would require a lot more substantial changes to work with pretty-printed JSON, and the wallet export RPC already exports the stringified JSON. I would prefer if this wasn't the case, but don't think the effort is worth tackling at this point.

I also slightly modified the output of some of the commands to be more valid JSON or clearer output.

`config:get` - added the config name so its a little easier to read
<img width="1109" alt="image" src="https://github.com/user-attachments/assets/ec2b1019-0b29-4479-a2a9-5f62620abe9c">

`config:get --json`
<img width="1164" alt="image" src="https://github.com/user-attachments/assets/378f5c53-9574-48aa-b279-4743c6de0f32">

`config` - use the ui.card for normal display
<img width="956" alt="image" src="https://github.com/user-attachments/assets/2f995e87-c585-460e-a7be-51d7d8a56a35">

Closes IFL-2820

## Testing Plan

## Documentation

N/A

## Breaking Change

N/A
