### PR TITLE
adds StateManager method for reading at past state roots

### DIFF
--- a/ironfish/src/evm/evm.ts
+++ b/ironfish/src/evm/evm.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Block } from '@ethereumjs/block'
 import { EVM, Log } from '@ethereumjs/evm'
-import { Address, hexToBytes } from '@ethereumjs/util'
+import { Account, Address, hexToBytes } from '@ethereumjs/util'
 import { RunTxOpts, RunTxResult, VM } from '@ethereumjs/vm'
 import ContractArtifact from '@ironfish/ironfish-contracts'
 import { Asset, generateKeyFromPrivateKey } from '@ironfish/rust-nodejs'
@@ -152,6 +152,17 @@ export class IronfishEvm {
     const asset = new Asset(GLOBAL_IF_ACCOUNT.publicAddress, name, '')
 
     return asset.id()
+  }
+
+  async getAccount(address: Address, stateRoot?: Uint8Array): Promise<Account | undefined> {
+    return this.blockchainDb.stateManager.withStateRoot(stateRoot, async () => {
+      return this.blockchainDb.stateManager.getAccount(address)
+    })
+  }
+
+  async getBalance(address: Address, stateRoot?: Uint8Array): Promise<bigint | undefined> {
+    const account = await this.getAccount(address, stateRoot)
+    return account?.balance
   }
 }
 

--- a/ironfish/src/evm/evm.ts
+++ b/ironfish/src/evm/evm.ts
@@ -155,9 +155,8 @@ export class IronfishEvm {
   }
 
   async getAccount(address: Address, stateRoot?: Uint8Array): Promise<Account | undefined> {
-    return this.blockchainDb.stateManager.withStateRoot(stateRoot, async () => {
-      return this.blockchainDb.stateManager.getAccount(address)
-    })
+    const sm = await this.blockchainDb.stateManager.withStateRoot(stateRoot)
+    return sm.getAccount(address)
   }
 
   async getBalance(address: Address, stateRoot?: Uint8Array): Promise<bigint | undefined> {

--- a/ironfish/src/evm/stateManager.ts
+++ b/ironfish/src/evm/stateManager.ts
@@ -38,7 +38,7 @@ export class IronfishStateManager extends DefaultStateManager {
     }
 
     try {
-      return handler()
+      return await handler()
     } finally {
       await this.setStateRoot(currentRoot)
     }

--- a/ironfish/src/evm/stateManager.ts
+++ b/ironfish/src/evm/stateManager.ts
@@ -26,4 +26,21 @@ export class IronfishStateManager extends DefaultStateManager {
       common: this.common,
     })
   }
+
+  async withStateRoot<TResult>(
+    stateRoot: Uint8Array | undefined,
+    handler: () => Promise<TResult>,
+  ): Promise<TResult> {
+    const currentRoot = await this.getStateRoot()
+
+    if (stateRoot) {
+      await this.setStateRoot(stateRoot)
+    }
+
+    try {
+      return handler()
+    } finally {
+      await this.setStateRoot(currentRoot)
+    }
+  }
 }

--- a/ironfish/src/evm/stateManager.ts
+++ b/ironfish/src/evm/stateManager.ts
@@ -27,20 +27,11 @@ export class IronfishStateManager extends DefaultStateManager {
     })
   }
 
-  async withStateRoot<TResult>(
-    stateRoot: Uint8Array | undefined,
-    handler: () => Promise<TResult>,
-  ): Promise<TResult> {
-    const currentRoot = await this.getStateRoot()
-
+  async withStateRoot(stateRoot: Uint8Array | undefined): Promise<DefaultStateManager> {
+    const stateManager = this.shallowCopy()
     if (stateRoot) {
-      await this.setStateRoot(stateRoot)
+      await stateManager.setStateRoot(stateRoot)
     }
-
-    try {
-      return await handler()
-    } finally {
-      await this.setStateRoot(currentRoot)
-    }
+    return stateManager
   }
 }


### PR DESCRIPTION
## Summary

reading the confirmed balance (for any confirmation range) for an account will require reading from the state trie at a past state root

adds a function, withStateRoot, to make a copy of the stateManager, set the state root, and return the copy to the caller.

defines getAccount and getBalance on the IronfishEvm using withStateRoot

some RPC methods, like eth_getAccount and eth_getBalance, will require this functionality

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
