### PR TITLE
Add mining reward to chain:blocks:info

### DIFF
--- a/ironfish-cli/src/commands/chain/blocks/info.ts
+++ b/ironfish-cli/src/commands/chain/blocks/info.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { BufferUtils, TimeUtils } from '@ironfish/sdk'
+import { BufferUtils, CurrencyUtils, TimeUtils } from '@ironfish/sdk'
 import { Args } from '@oclif/core'
 import { IronfishCommand } from '../../../command'
 import * as ui from '../../../ui'
@@ -26,6 +26,8 @@ export default class BlockInfo extends IronfishCommand {
     const data = await client.chain.getBlock({ search })
     const blockData = data.content
 
+    const miningReward = blockData.block.transactions[0]
+
     this.log(
       ui.card({
         Hash: blockData.block.hash,
@@ -36,6 +38,7 @@ export default class BlockInfo extends IronfishCommand {
         Difficulty: blockData.block.difficulty,
         Timestamp: TimeUtils.renderString(blockData.block.timestamp),
         Graffiti: BufferUtils.toHuman(Buffer.from(blockData.block.graffiti, 'hex')),
+        'Mining Reward': CurrencyUtils.render((miningReward.fee * -1).toString(), true),
         'Transaction Count': blockData.block.transactions.length,
       }),
     )


### PR DESCRIPTION
## Summary

This shows the mining reward, which is derived from the first transaction's fee.
```
> ironfish chain:blocks:info 525600

Hash:                  00000000000035a4680ff1f59390a08ae686575a00a46243543dfbedaeee7d5a
Confirmed:             true
Fork:                  false
Sequence:              525600
Previous Block Hash:   00000000000108fbf92d8d8870b044cf1b39d0b8155596b58a8e3ac83286bbd7
Difficulty:            258980819860357
Timestamp:             4/17/2024 7:02:04 PM PDT
Graffiti:              pool.kryptex.com [1dce]
Mining Reward:         $IRON 19.00000000
Transaction Count:     1
```

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
