### PR TITLE
Add json support for chain:assets:info

### DIFF
--- a/ironfish-cli/src/commands/chain/assets/info.ts
+++ b/ironfish-cli/src/commands/chain/assets/info.ts
@@ -4,11 +4,12 @@
 import { BufferUtils } from '@ironfish/sdk'
 import { Args } from '@oclif/core'
 import { IronfishCommand } from '../../../command'
-import { RemoteFlags } from '../../../flags'
+import { ColorFlag, ColorFlagKey, RemoteFlags } from '../../../flags'
 import * as ui from '../../../ui'
 
 export default class AssetInfo extends IronfishCommand {
   static description = 'show asset information'
+  static enableJsonFlag = true
 
   static args = {
     id: Args.string({
@@ -19,9 +20,10 @@ export default class AssetInfo extends IronfishCommand {
 
   static flags = {
     ...RemoteFlags,
+    [ColorFlagKey]: ColorFlag,
   }
 
-  async start(): Promise<void> {
+  async start(): Promise<unknown> {
     const { args } = await this.parse(AssetInfo)
     const { id: assetId } = args
 
@@ -39,5 +41,7 @@ export default class AssetInfo extends IronfishCommand {
         'Transaction Created': data.content.createdTransactionHash,
       }),
     )
+
+    return data.content
   }
 }

--- a/ironfish-cli/src/commands/chain/blocks/info.ts
+++ b/ironfish-cli/src/commands/chain/blocks/info.ts
@@ -4,6 +4,7 @@
 import { BufferUtils, CurrencyUtils, TimeUtils } from '@ironfish/sdk'
 import { Args } from '@oclif/core'
 import { IronfishCommand } from '../../../command'
+import { ColorFlag, ColorFlagKey } from '../../../flags'
 import * as ui from '../../../ui'
 
 export default class BlockInfo extends IronfishCommand {
@@ -15,6 +16,10 @@ export default class BlockInfo extends IronfishCommand {
       required: true,
       description: 'The hash or sequence of the block to look at',
     }),
+  }
+
+  static flags = {
+    [ColorFlagKey]: ColorFlag,
   }
 
   async start(): Promise<unknown> {


### PR DESCRIPTION
## Summary

<img width="1082" alt="image" src="https://github.com/user-attachments/assets/471fad12-b1f6-4476-9905-15735e479d63">


## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
