### PR TITLE
Have chain:power support --json flag

### DIFF
--- a/ironfish-cli/src/commands/chain/power.ts
+++ b/ironfish-cli/src/commands/chain/power.ts
@@ -4,11 +4,14 @@
 import { FileUtils } from '@ironfish/sdk'
 import { Args, Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
+import { ColorFlag, ColorFlagKey } from '../../flags'
 
 export default class Power extends IronfishCommand {
   static description = "show the network's mining power"
+  static enableJsonFlag = true
 
   static flags = {
+    [ColorFlagKey]: ColorFlag,
     history: Flags.integer({
       required: false,
       description:
@@ -23,14 +26,13 @@ export default class Power extends IronfishCommand {
     }),
   }
 
-  async start(): Promise<void> {
+  async start(): Promise<unknown> {
     const { flags, args } = await this.parse(Power)
-    const { block } = args
 
     const client = await this.connectRpc()
 
     const data = await client.chain.getNetworkHashPower({
-      sequence: block,
+      sequence: args.block,
       blocks: flags.history,
     })
 
@@ -39,5 +41,7 @@ export default class Power extends IronfishCommand {
     this.log(
       `The network power for block ${data.content.sequence} was ${formattedHashesPerSecond} averaged over ${data.content.blocks} previous blocks.`,
     )
+
+    return data.content
   }
 }


### PR DESCRIPTION
## Summary

This makes chain:power standard and return JSON when you pass in --json flag and adds the --color flag support as well.

```
> ironfish chain:power --json

{
  "hashesPerSecond": 2662751897683.1084,
  "blocks": 120,
  "sequence": 665609
}
```

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
