### PR TITLE
Add --json support for chain:status

### DIFF
--- a/ironfish-cli/src/commands/chain/status.ts
+++ b/ironfish-cli/src/commands/chain/status.ts
@@ -3,12 +3,18 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { FileUtils, renderNetworkName } from '@ironfish/sdk'
 import { IronfishCommand } from '../../command'
+import { ColorFlag, ColorFlagKey } from '../../flags'
 import * as ui from '../../ui'
 
 export default class ChainStatus extends IronfishCommand {
   static description = 'show chain information'
+  static enableJsonFlag = true
 
-  async start(): Promise<void> {
+  static flags = {
+    [ColorFlagKey]: ColorFlag,
+  }
+
+  async start(): Promise<unknown> {
     const client = await this.connectRpc()
 
     const [status, difficulty, power] = await Promise.all([
@@ -30,5 +36,15 @@ export default class ChainStatus extends IronfishCommand {
         Power: FileUtils.formatHashRate(power.content.hashesPerSecond),
       }),
     )
+
+    return {
+      blockchain: status.content.blockchain,
+      difficulty: difficulty.content,
+      power: power.content,
+      node: {
+        network: renderNetworkName(status.content.node.networkId),
+        networkId: status.content.node.networkId,
+      },
+    }
   }
 }


### PR DESCRIPTION
## Summary

```
> ironfish chain:status

{
  "blockchain": {
    "synced": false,
    "head": {
      "hash": "0000000000011bb1a02f5109657dd7b8ffba5129795f1565b05918a6a12b0c38",
      "sequence": 665610
    },
    "headTimestamp": 1721778372512,
    "newBlockSpeed": 0,
    "dbSizeBytes": 15589950684
  },
  "difficulty": {
    "sequence": 665610,
    "hash": "0000000000011bb1a02f5109657dd7b8ffba5129795f1565b05918a6a12b0c38",
    "difficulty": "181728058513479"
  },
  "power": {
    "hashesPerSecond": 2662751897683.1084,
    "blocks": 120,
    "sequence": 665609
  },
  "node": {
    "network": "Mainnet",
    "networkId": 1
  }
}
```

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
