### PR TITLE
Add --json support to chain:transactions:info cmd

### DIFF
--- a/ironfish-cli/src/commands/chain/transactions/info.ts
+++ b/ironfish-cli/src/commands/chain/transactions/info.ts
@@ -5,14 +5,16 @@
 import { CurrencyUtils, FileUtils } from '@ironfish/sdk'
 import { Args } from '@oclif/core'
 import { IronfishCommand } from '../../../command'
-import { RemoteFlags } from '../../../flags'
+import { ColorFlag, ColorFlagKey, RemoteFlags } from '../../../flags'
 import * as ui from '../../../ui'
 
 export class TransactionInfo extends IronfishCommand {
   static description = 'show transaction information'
+  static enableJsonFlag = true
 
   static flags = {
     ...RemoteFlags,
+    [ColorFlagKey]: ColorFlag,
   }
 
   static args = {
@@ -22,7 +24,7 @@ export class TransactionInfo extends IronfishCommand {
     }),
   }
 
-  async start(): Promise<void> {
+  async start(): Promise<unknown> {
     const { args } = await this.parse(TransactionInfo)
 
     const client = await this.connectRpc()
@@ -46,5 +48,7 @@ export class TransactionInfo extends IronfishCommand {
         'Burn count': transaction.burns.length,
       }),
     )
+
+    return transaction
   }
 }


### PR DESCRIPTION
## Summary

this outputs the transaction here. We need to add --serialization support to the RPC.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
