### PR TITLE
Make chain:getTransaction use rpcSerializer

### DIFF
--- a/ironfish/src/rpc/routes/chain/getTransaction.ts
+++ b/ironfish/src/rpc/routes/chain/getTransaction.ts
@@ -3,13 +3,12 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
-import { getTransactionSize } from '../../../network/utils/serializers'
 import { FullNode } from '../../../node'
 import { BlockHashSerdeInstance } from '../../../serde'
-import { CurrencyUtils } from '../../../utils'
 import { RpcNotFoundError, RpcValidationError } from '../../adapters'
 import { ApiNamespace } from '../namespaces'
 import { routes } from '../router'
+import { serializeRpcTransaction } from './serializers'
 import { RpcTransaction, RpcTransactionSchema } from './types'
 
 export type GetTransactionRequest = { transactionHash: string; blockHash?: string }
@@ -82,57 +81,25 @@ routes.register<typeof GetTransactionRequestSchema, GetTransactionResponse>(
 
     const transactions = await context.chain.getBlockTransactions(blockHeader)
 
-    const foundTransaction = transactions.find(({ transaction }) =>
+    const chainTransaction = transactions.find(({ transaction }) =>
       transaction.hash().equals(transactionHashBuffer),
     )
 
-    if (!foundTransaction) {
+    if (!chainTransaction) {
       throw new RpcNotFoundError(
         `Transaction not found on block ${blockHashBuffer.toString('hex')}`,
       )
     }
 
-    const { transaction, initialNoteIndex } = foundTransaction
-
-    const rawTransaction: GetTransactionResponse = {
+    request.end({
+      ...serializeRpcTransaction(chainTransaction.transaction, true),
       blockHash: blockHashBuffer.toString('hex'),
-      fee: Number(transaction.fee()),
-      expiration: transaction.expiration(),
-      hash: transaction.hash().toString('hex'),
-      size: getTransactionSize(transaction),
-      noteSize: initialNoteIndex + transaction.notes.length,
-      notesCount: transaction.notes.length,
-      spendsCount: transaction.spends.length,
-      signature: transaction.transactionSignature().toString('hex'),
-      notesEncrypted: transaction.notes.map((note) => note.serialize().toString('hex')),
-      notes: transaction.notes.map((note) => ({
-        commitment: note.hash().toString('hex'),
-        hash: note.hash().toString('hex'),
-        serialized: note.serialize().toString('hex'),
-      })),
-      mints: transaction.mints.map((mint) => ({
-        assetId: mint.asset.id().toString('hex'),
-        id: mint.asset.id().toString('hex'),
-        assetName: mint.asset.name().toString('hex'),
-        value: CurrencyUtils.encode(mint.value),
-        name: mint.asset.name().toString('hex'),
-        metadata: mint.asset.metadata().toString('hex'),
-        creator: mint.asset.creator().toString('hex'),
-        transferOwnershipTo: mint.transferOwnershipTo?.toString('hex'),
-      })),
-      burns: transaction.burns.map((burn) => ({
-        assetId: burn.assetId.toString('hex'),
-        id: burn.assetId.toString('hex'),
-        assetName: '',
-        value: CurrencyUtils.encode(burn.value),
-      })),
-      spends: transaction.spends.map((spend) => ({
-        nullifier: spend.nullifier.toString('hex'),
-        commitment: spend.commitment.toString('hex'),
-        size: spend.size,
-      })),
-    }
-
-    request.end(rawTransaction)
+      noteSize: chainTransaction.initialNoteIndex + chainTransaction.transaction.notes.length,
+      notesCount: chainTransaction.transaction.notes.length,
+      spendsCount: chainTransaction.transaction.spends.length,
+      notesEncrypted: chainTransaction.transaction.notes.map((note) =>
+        note.serialize().toString('hex'),
+      ),
+    })
   },
 )


### PR DESCRIPTION
## Summary

It already returned RpcTransaction with extra fields, so we can just use the serializer and attach these extra fields.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
