### PR TITLE
Move JSON flags into flags module

### DIFF
--- a/ironfish-cli/src/commands/chain/status.ts
+++ b/ironfish-cli/src/commands/chain/status.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { FileUtils, renderNetworkName } from '@ironfish/sdk'
 import { IronfishCommand } from '../../command'
-import { ColorFlag, ColorFlagKey } from '../../flags'
+import { JsonFlags } from '../../flags'
 import * as ui from '../../ui'
 
 export default class ChainStatus extends IronfishCommand {
@@ -11,7 +11,7 @@ export default class ChainStatus extends IronfishCommand {
   static enableJsonFlag = true
 
   static flags = {
-    [ColorFlagKey]: ColorFlag,
+    ...JsonFlags,
   }
 
   async start(): Promise<unknown> {

--- a/ironfish-cli/src/flags.ts
+++ b/ironfish-cli/src/flags.ts
@@ -18,6 +18,7 @@ import { Flags } from '@oclif/core'
 
 export const VerboseFlagKey = 'verbose'
 export const ConfigFlagKey = 'config'
+export const JsonFlagKey = 'json'
 export const ColorFlagKey = 'color'
 export const DataDirFlagKey = 'datadir'
 export const RpcUseIpcFlagKey = 'rpc.ipc'
@@ -37,10 +38,17 @@ export const VerboseFlag = Flags.boolean({
   helpGroup: 'GLOBAL',
 })
 
+export const JsonFlag = Flags.boolean({
+  default: false,
+  description: 'format output as json',
+  helpGroup: 'OUTPUT',
+})
+
 export const ColorFlag = Flags.boolean({
   default: true,
   allowNo: true,
   description: 'Should colorize the output',
+  helpGroup: 'OUTPUT',
 })
 
 export const ConfigFlag = Flags.string({
@@ -113,6 +121,15 @@ export const RemoteFlags = {
   [RpcUseHttpFlagKey]: RpcUseHttpFlag,
   [RpcTcpTlsFlagKey]: RpcTcpTlsFlag,
   [RpcAuthFlagKey]: RpcAuthFlag,
+}
+
+/**
+ * Flags to include if your command returns JSON
+ * you must also use enableJsonFlag = true
+ */
+export const JsonFlags = {
+  [JsonFlagKey]: JsonFlag,
+  [ColorFlagKey]: ColorFlag,
 }
 
 export type IronOpts = { minimum?: bigint; flagName: string }


### PR DESCRIPTION
## Summary

This allows us to over-ride the built in OCLIF JSON flag group which exists at https://github.com/oclif/core/blob/213e9203fd7f0f5aaffdcc9eb28d2828f7679373/src/util/aggregate-flags.ts#L4C1-L7C3

## Testing Plan

`ironfish chain:status --help`

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
