### PR TITLE
Add custom help category for RPC flags

### DIFF
--- a/ironfish-cli/src/flags.ts
+++ b/ironfish-cli/src/flags.ts
@@ -60,43 +60,52 @@ export const DataDirFlag = Flags.string({
 export const RpcUseIpcFlag = Flags.boolean({
   default: DEFAULT_USE_RPC_IPC,
   description: 'Connect to the RPC over IPC (default)',
+  helpGroup: 'RPC',
 })
 
 export const RpcUseTcpFlag = Flags.boolean({
   default: DEFAULT_USE_RPC_TCP,
   description: 'Connect to the RPC over TCP',
+  helpGroup: 'RPC',
 })
 
 export const RpcTcpHostFlag = Flags.string({
   description: 'The TCP host to listen for connections on',
+  helpGroup: 'RPC',
 })
 
 export const RpcTcpPortFlag = Flags.integer({
   description: 'The TCP port to listen for connections on',
+  helpGroup: 'RPC',
 })
 
 export const RpcTcpTlsFlag = Flags.boolean({
   default: DEFAULT_USE_RPC_TLS,
   description: 'Encrypt TCP connection to the RPC over TLS',
   allowNo: true,
+  helpGroup: 'RPC',
 })
 
 export const RpcAuthFlag = Flags.string({
   description: 'The RPC auth token',
+  helpGroup: 'RPC',
 })
 
 export const RpcHttpHostFlag = Flags.string({
   description: 'The HTTP host to listen for connections on',
+  helpGroup: 'RPC',
 })
 
 export const RpcHttpPortFlag = Flags.integer({
   description: 'The HTTP port to listen for connections on',
+  helpGroup: 'RPC',
 })
 
 export const RpcUseHttpFlag = Flags.boolean({
   default: DEFAULT_USE_RPC_HTTP,
   description: 'Connect to the RPC over HTTP',
   allowNo: true,
+  helpGroup: 'RPC',
 })
 
 /**


### PR DESCRIPTION
## Summary

This should make all the RPC flags show up in their own section in --help now.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
