### PR TITLE
Added missing RemoteFlags on commands

### DIFF
--- a/ironfish-cli/src/commands/chain/blocks/info.ts
+++ b/ironfish-cli/src/commands/chain/blocks/info.ts
@@ -4,7 +4,7 @@
 import { BufferUtils, CurrencyUtils, TimeUtils } from '@ironfish/sdk'
 import { Args } from '@oclif/core'
 import { IronfishCommand } from '../../../command'
-import { ColorFlag, ColorFlagKey } from '../../../flags'
+import { ColorFlag, ColorFlagKey, RemoteFlags } from '../../../flags'
 import * as ui from '../../../ui'
 
 export default class BlockInfo extends IronfishCommand {
@@ -19,6 +19,7 @@ export default class BlockInfo extends IronfishCommand {
   }
 
   static flags = {
+    ...RemoteFlags,
     [ColorFlagKey]: ColorFlag,
   }
 

--- a/ironfish-cli/src/commands/chain/power.ts
+++ b/ironfish-cli/src/commands/chain/power.ts
@@ -4,13 +4,14 @@
 import { FileUtils } from '@ironfish/sdk'
 import { Args, Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
-import { ColorFlag, ColorFlagKey } from '../../flags'
+import { ColorFlag, ColorFlagKey, RemoteFlags } from '../../flags'
 
 export default class Power extends IronfishCommand {
   static description = "show the network's mining power"
   static enableJsonFlag = true
 
   static flags = {
+    ...RemoteFlags,
     [ColorFlagKey]: ColorFlag,
     history: Flags.integer({
       required: false,

--- a/ironfish-cli/src/commands/chain/status.ts
+++ b/ironfish-cli/src/commands/chain/status.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { FileUtils, renderNetworkName } from '@ironfish/sdk'
 import { IronfishCommand } from '../../command'
-import { JsonFlags } from '../../flags'
+import { JsonFlags, RemoteFlags } from '../../flags'
 import * as ui from '../../ui'
 
 export default class ChainStatus extends IronfishCommand {
@@ -12,6 +12,7 @@ export default class ChainStatus extends IronfishCommand {
 
   static flags = {
     ...JsonFlags,
+    ...RemoteFlags,
   }
 
   async start(): Promise<unknown> {


### PR DESCRIPTION
## Summary

These commands were all missing RemoteFlags.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
