### PR TITLE
Upgrade commands to use JsonFlags

### DIFF
--- a/ironfish-cli/src/commands/chain/assets/info.ts
+++ b/ironfish-cli/src/commands/chain/assets/info.ts
@@ -4,7 +4,7 @@
 import { BufferUtils } from '@ironfish/sdk'
 import { Args } from '@oclif/core'
 import { IronfishCommand } from '../../../command'
-import { ColorFlag, ColorFlagKey, RemoteFlags } from '../../../flags'
+import { JsonFlags, RemoteFlags } from '../../../flags'
 import * as ui from '../../../ui'
 
 export default class AssetInfo extends IronfishCommand {
@@ -20,7 +20,7 @@ export default class AssetInfo extends IronfishCommand {
 
   static flags = {
     ...RemoteFlags,
-    [ColorFlagKey]: ColorFlag,
+    ...JsonFlags,
   }
 
   async start(): Promise<unknown> {

--- a/ironfish-cli/src/commands/chain/blocks/info.ts
+++ b/ironfish-cli/src/commands/chain/blocks/info.ts
@@ -4,7 +4,7 @@
 import { BufferUtils, CurrencyUtils, TimeUtils } from '@ironfish/sdk'
 import { Args } from '@oclif/core'
 import { IronfishCommand } from '../../../command'
-import { ColorFlag, ColorFlagKey, RemoteFlags } from '../../../flags'
+import { JsonFlags, RemoteFlags } from '../../../flags'
 import * as ui from '../../../ui'
 
 export default class BlockInfo extends IronfishCommand {
@@ -20,7 +20,7 @@ export default class BlockInfo extends IronfishCommand {
 
   static flags = {
     ...RemoteFlags,
-    [ColorFlagKey]: ColorFlag,
+    ...JsonFlags,
   }
 
   async start(): Promise<unknown> {

--- a/ironfish-cli/src/commands/chain/power.ts
+++ b/ironfish-cli/src/commands/chain/power.ts
@@ -4,7 +4,7 @@
 import { FileUtils } from '@ironfish/sdk'
 import { Args, Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
-import { ColorFlag, ColorFlagKey, RemoteFlags } from '../../flags'
+import { JsonFlags, RemoteFlags } from '../../flags'
 
 export default class Power extends IronfishCommand {
   static description = "show the network's mining power"
@@ -12,7 +12,7 @@ export default class Power extends IronfishCommand {
 
   static flags = {
     ...RemoteFlags,
-    [ColorFlagKey]: ColorFlag,
+    ...JsonFlags,
     history: Flags.integer({
       required: false,
       description:

--- a/ironfish-cli/src/commands/chain/transactions/info.ts
+++ b/ironfish-cli/src/commands/chain/transactions/info.ts
@@ -5,7 +5,7 @@
 import { CurrencyUtils, FileUtils } from '@ironfish/sdk'
 import { Args } from '@oclif/core'
 import { IronfishCommand } from '../../../command'
-import { ColorFlag, ColorFlagKey, RemoteFlags } from '../../../flags'
+import { JsonFlags, RemoteFlags } from '../../../flags'
 import * as ui from '../../../ui'
 
 export class TransactionInfo extends IronfishCommand {
@@ -14,7 +14,7 @@ export class TransactionInfo extends IronfishCommand {
 
   static flags = {
     ...RemoteFlags,
-    [ColorFlagKey]: ColorFlag,
+    ...JsonFlags,
   }
 
   static args = {

--- a/ironfish-cli/src/commands/config/get.ts
+++ b/ironfish-cli/src/commands/config/get.ts
@@ -4,7 +4,7 @@
 import { ConfigOptions } from '@ironfish/sdk'
 import { Args, Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
-import { ColorFlag, ColorFlagKey, RemoteFlags } from '../../flags'
+import { JsonFlags, RemoteFlags } from '../../flags'
 import * as ui from '../../ui'
 
 export class GetCommand extends IronfishCommand {
@@ -20,7 +20,7 @@ export class GetCommand extends IronfishCommand {
 
   static flags = {
     ...RemoteFlags,
-    [ColorFlagKey]: ColorFlag,
+    ...JsonFlags,
     user: Flags.boolean({
       description: 'Only show config from the users datadir and not overrides',
     }),

--- a/ironfish-cli/src/commands/config/index.ts
+++ b/ironfish-cli/src/commands/config/index.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
-import { ColorFlag, ColorFlagKey } from '../../flags'
+import { JsonFlags } from '../../flags'
 import { RemoteFlags } from '../../flags'
 import * as ui from '../../ui'
 
@@ -13,7 +13,7 @@ export class ShowCommand extends IronfishCommand {
 
   static flags = {
     ...RemoteFlags,
-    [ColorFlagKey]: ColorFlag,
+    ...JsonFlags,
     user: Flags.boolean({
       description: 'Only show config from the users datadir and not overrides',
     }),

--- a/ironfish-cli/src/commands/wallet/export.ts
+++ b/ironfish-cli/src/commands/wallet/export.ts
@@ -6,7 +6,7 @@ import { Args, Flags } from '@oclif/core'
 import fs from 'fs'
 import path from 'path'
 import { IronfishCommand } from '../../command'
-import { ColorFlag, ColorFlagKey, EnumLanguageKeyFlag, RemoteFlags } from '../../flags'
+import { EnumLanguageKeyFlag, JsonFlags, RemoteFlags } from '../../flags'
 import { confirmOrQuit } from '../../ui'
 
 export class ExportCommand extends IronfishCommand {
@@ -15,7 +15,7 @@ export class ExportCommand extends IronfishCommand {
 
   static flags = {
     ...RemoteFlags,
-    [ColorFlagKey]: ColorFlag,
+    ...JsonFlags,
     local: Flags.boolean({
       default: false,
       description: 'Export an account without an online node',


### PR DESCRIPTION
## Summary

This will automatically pull in color and the right json flag with the correct help groups.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
