### PR TITLE
Reorder chain commands so args are before flags

### DIFF
--- a/ironfish-cli/src/commands/chain/broadcast.ts
+++ b/ironfish-cli/src/commands/chain/broadcast.ts
@@ -8,15 +8,15 @@ import { RemoteFlags } from '../../flags'
 export class BroadcastCommand extends IronfishCommand {
   static description = 'broadcast a transaction to the network'
 
-  static flags = {
-    ...RemoteFlags,
-  }
-
   static args = {
     transaction: Args.string({
       required: true,
       description: 'The transaction in hex encoding',
     }),
+  }
+
+  static flags = {
+    ...RemoteFlags,
   }
 
   async start(): Promise<void> {

--- a/ironfish-cli/src/commands/chain/export.ts
+++ b/ironfish-cli/src/commands/chain/export.ts
@@ -11,15 +11,6 @@ import { ProgressBar } from '../../ui'
 export default class Export extends IronfishCommand {
   static description = 'export the chain to a file'
 
-  static flags = {
-    ...RemoteFlags,
-    path: Flags.string({
-      char: 'p',
-      required: false,
-      description: 'The path to export the chain to',
-    }),
-  }
-
   static args = {
     start: Args.integer({
       default: Number(GENESIS_BLOCK_SEQUENCE),
@@ -29,6 +20,15 @@ export default class Export extends IronfishCommand {
     stop: Args.integer({
       required: false,
       description: 'The sequence to end at (inclusive)',
+    }),
+  }
+
+  static flags = {
+    ...RemoteFlags,
+    path: Flags.string({
+      char: 'p',
+      required: false,
+      description: 'The path to export the chain to',
     }),
   }
 

--- a/ironfish-cli/src/commands/chain/power.ts
+++ b/ironfish-cli/src/commands/chain/power.ts
@@ -10,6 +10,13 @@ export default class Power extends IronfishCommand {
   static description = "show the network's mining power"
   static enableJsonFlag = true
 
+  static args = {
+    block: Args.integer({
+      required: false,
+      description: 'The sequence of the block to estimate network speed for',
+    }),
+  }
+
   static flags = {
     ...RemoteFlags,
     ...JsonFlags,
@@ -17,13 +24,6 @@ export default class Power extends IronfishCommand {
       required: false,
       description:
         'The number of blocks to look back to calculate the network hashes per second',
-    }),
-  }
-
-  static args = {
-    block: Args.integer({
-      required: false,
-      description: 'The sequence of the block to estimate network speed for',
     }),
   }
 

--- a/ironfish-cli/src/commands/chain/transactions/info.ts
+++ b/ironfish-cli/src/commands/chain/transactions/info.ts
@@ -12,16 +12,16 @@ export class TransactionInfo extends IronfishCommand {
   static description = 'show transaction information'
   static enableJsonFlag = true
 
-  static flags = {
-    ...RemoteFlags,
-    ...JsonFlags,
-  }
-
   static args = {
     hash: Args.string({
       required: true,
       description: 'Hash of the transaction',
     }),
+  }
+
+  static flags = {
+    ...RemoteFlags,
+    ...JsonFlags,
   }
 
   async start(): Promise<unknown> {


### PR DESCRIPTION
## Summary

This creates a standard in laying our command code.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
