### PR TITLE
Fix start command wallet flag over-riding config

### DIFF
--- a/ironfish-cli/src/commands/start.ts
+++ b/ironfish-cli/src/commands/start.ts
@@ -105,7 +105,7 @@ export default class Start extends IronfishCommand {
     }),
     wallet: Flags.boolean({
       allowNo: true,
-      default: true,
+      default: undefined,
       description: `Enable the node's wallet to scan transactions and decrypt notes from the blockchain`,
     }),
   }


### PR DESCRIPTION
## Summary

Because it defaulted to true instead of undefined.

## Testing Plan

```
ironfish config:set enableWallet false
ironfish start
// See that the wallet is still started before the change and not after
ironfish status
```

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
