### PR TITLE
Add an asset info example

### DIFF
--- a/ironfish-cli/src/commands/chain/assets/info.ts
+++ b/ironfish-cli/src/commands/chain/assets/info.ts
@@ -11,6 +11,14 @@ export default class AssetInfo extends IronfishCommand {
   static description = 'show asset information'
   static enableJsonFlag = true
 
+  static examples = [
+    {
+      description: 'show the native $IRON asset info',
+      command:
+        'ironfish chain:assets:info 51f33a2f14f92735e562dc658a5639279ddca3d5079a6d1242b2a588a9cbf44c',
+    },
+  ]
+
   static args = {
     id: Args.string({
       required: true,


### PR DESCRIPTION
## Summary

It will show an example to see the native currency information

```
> ironfish chain:assets:info --help
show asset information

USAGE
  $ ironfish chain:assets:info ID [--json] [-v] [--config <value>] [-d <value>] [--rpc.tcp] [--rpc.ipc] [--rpc.tcp.host <value>] [--rpc.tcp.port <value>] [--rpc.http.host <value>] [--rpc.http.port <value>] [--rpc.http] [--rpc.tcp.tls] [--rpc.auth <value>] [--color]

ARGUMENTS
  ID  The identifier of the asset

GLOBAL FLAGS
  -d, --datadir=<value>  [default: ~/.ironfish] The path to the data dir
  -v, --verbose          Set logging level to verbose
      --config=<value>   [default: config.json] The name of the config file to use

OUTPUT FLAGS
  --[no-]color  Should colorize the output
  --json        format output as json

DESCRIPTION
  show asset information

EXAMPLES
  get the native IRON asset info

    $ ironfish chain:assets:info 51f33a2f14f92735e562dc658a5639279ddca3d5079a6d1242b2a588a9cbf44c
```

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
