### PR TITLE
moves evm tx execution to verifyBlock

### DIFF
--- a/ironfish/src/consensus/verifier.ts
+++ b/ironfish/src/consensus/verifier.ts
@@ -52,7 +52,13 @@ export class Verifier {
    */
   async verifyBlock(
     block: Block,
-    options: { verifyTarget?: boolean } = { verifyTarget: true },
+    options: {
+      verifyTarget?: boolean
+      verifyEvm?: boolean
+    } = {
+      verifyTarget: true,
+      verifyEvm: true,
+    },
   ): Promise<VerificationResult> {
     if (getBlockSize(block) > this.chain.consensus.parameters.maxBlockSizeBytes) {
       return { valid: false, reason: VerificationResultReason.MAX_BLOCK_SIZE_EXCEEDED }
@@ -128,11 +134,12 @@ export class Verifier {
           return noMints
         }
       } else {
-        // TODO(hughy): do not verify evm transactions again because they are verified during block construction
-        // const evmVerify = await this.verifyEvm(transaction, vm)
-        // if (!evmVerify.valid) {
-        //   return evmVerify
-        // }
+        if (options.verifyEvm) {
+          const evmVerify = await this.verifyEvm(transaction)
+          if (!evmVerify.valid) {
+            return evmVerify
+          }
+        }
       }
 
       transactionBatch.push(transaction)


### PR DESCRIPTION
## Summary

we will need to use the result of evm transaction execution to calculate miner fees (including gas from evm transactions) in verifyBlock

executes evm transactions in verifyBlock instead of saveConnect and newBlock

makes evm transaction verification in verifyBlock optional so that mining manager does not execute evm transactions more than once when creating block templates and verifying them

makes evm transaction execution in block template creation commit state to the stateManager (i.e., removes use of withCopy)

## Testing Plan

- manual testing to ensure that we can still mine blocks with evm transactions

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
