### PR TITLE
pays gas fees to miners in minersFee transactions

### DIFF
--- a/ironfish-cli/src/commands/evm/sendTransaction.ts
+++ b/ironfish-cli/src/commands/evm/sendTransaction.ts
@@ -51,6 +51,7 @@ export class SendTransactionTestEvmCommand extends IronfishCommand {
       value: BigInt(flags.value),
       gasLimit: 21000n,
       nonce: flags.nonce,
+      gasPrice: 1n,
     })
 
     const rawTransaction = new RawTransaction(TransactionVersion.V3)

--- a/ironfish-cli/src/commands/evm/shield-custom-asset.ts
+++ b/ironfish-cli/src/commands/evm/shield-custom-asset.ts
@@ -57,7 +57,10 @@ export class TestEvmCommand extends IronfishCommand {
       data: data,
     })
 
-    const result = await evm.runTx({ tx: tx.sign(senderPrivateKey) })
+    const { result, error } = await evm.runTx({ tx: tx.sign(senderPrivateKey) })
+    if (error) {
+      throw error
+    }
 
     Assert.isEqual(result.receipt.logs.length, 1)
 

--- a/ironfish-cli/src/commands/evm/shield-iron.ts
+++ b/ironfish-cli/src/commands/evm/shield-iron.ts
@@ -64,6 +64,7 @@ export class TestEvmCommand extends IronfishCommand {
 
     const { events } = await evm.runTx({ tx: tx.sign(senderPrivateKey) })
 
+    Assert.isNotUndefined(events)
     Assert.isEqual(events.length, 1)
     const log = events[0] as EvmShield
 

--- a/ironfish-cli/src/commands/evm/shield-iron.ts
+++ b/ironfish-cli/src/commands/evm/shield-iron.ts
@@ -62,12 +62,10 @@ export class TestEvmCommand extends IronfishCommand {
       data: data,
     })
 
-    const result = await evm.runTx({ tx: tx.sign(senderPrivateKey) })
+    const { events } = await evm.runTx({ tx: tx.sign(senderPrivateKey) })
 
-    const logEvents = evm.decodeLogs(result.receipt.logs)
-
-    Assert.isEqual(logEvents.length, 1)
-    const log = logEvents[0] as EvmShield
+    Assert.isEqual(events.length, 1)
+    const log = events[0] as EvmShield
 
     this.log('Contract Address')
     this.log(log.caller.toString())

--- a/ironfish-cli/src/commands/test-evm.ts
+++ b/ironfish-cli/src/commands/test-evm.ts
@@ -50,7 +50,10 @@ export class TestEvmCommand extends IronfishCommand {
     this.log(
       `Sending ${tx.value} from ${senderAddress.toString()} to ${recipientAddress.toString()}`,
     )
-    const result = await evm.runTx({ tx: tx.sign(senderPrivateKey) })
+    const { result, error } = await evm.runTx({ tx: tx.sign(senderPrivateKey) })
+    if (error) {
+      throw error
+    }
     this.log(`Amount spent for gas: ${result.amountSpent}`)
 
     senderBalance =

--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -1010,7 +1010,8 @@ export class Blockchain {
           blockNotes.push(note)
         }
         if (transaction.evm) {
-          const evmVerify = await this.verifier.verifyEvm(transaction)
+          const evmResult = await this.evm.runDesc(transaction.evm)
+          const evmVerify = this.verifier.verifyEvm(transaction, evmResult)
           if (!evmVerify.valid) {
             throw Error(evmVerify.reason)
           }
@@ -1315,7 +1316,8 @@ export class Blockchain {
       await this.saveConnectedEvmMints(transaction, tx)
 
       if (transaction.evm) {
-        const evmVerify = await this.verifier.verifyEvm(transaction)
+        const evmResult = await this.evm.runDesc(transaction.evm)
+        const evmVerify = this.verifier.verifyEvm(transaction, evmResult)
         if (!evmVerify.valid) {
           throw Error(evmVerify.reason)
         }

--- a/ironfish/src/consensus/verifier.evm.test.slow.ts
+++ b/ironfish/src/consensus/verifier.evm.test.slow.ts
@@ -214,6 +214,7 @@ describe('Verifier', () => {
 
       const evmResult = await node.chain.evm.runTx({ tx: signed })
 
+      Assert.isNotUndefined(evmResult.events)
       const shieldEvents = evmResult.events.filter(
         (event) => event.name === 'shield',
       ) as EvmShield[]
@@ -341,6 +342,7 @@ describe('Verifier', () => {
         ],
       } as unknown as EvmResult
 
+      Assert.isNotUndefined(evmResult.events)
       const result = Verifier.verifyEvmBurns(transaction, evmResult.events)
       expect(result).toEqual({ valid: true })
     })

--- a/ironfish/src/consensus/verifier.evm.test.slow.ts
+++ b/ironfish/src/consensus/verifier.evm.test.slow.ts
@@ -143,8 +143,12 @@ describe('Verifier', () => {
 
       Assert.isNotUndefined(node.chain.evm)
 
-      const result = await node.chain.evm.runTx({ tx: tx.sign(evmPrivateKey) })
-      const globalContractAddress = result?.createdAddress
+      const { result, error } = await node.chain.evm.runTx({ tx: tx.sign(evmPrivateKey) })
+      if (error) {
+        throw error
+      }
+
+      const globalContractAddress = result.createdAddress
 
       Assert.isNotUndefined(globalContractAddress)
 
@@ -208,7 +212,7 @@ describe('Verifier', () => {
 
       signed = tx.sign(evmPrivateKey)
 
-      const evmResult = await node.chain.evm.verifyTx({ tx: signed })
+      const evmResult = await node.chain.evm.runTx({ tx: signed })
 
       const shieldEvents = evmResult.events.filter(
         (event) => event.name === 'shield',
@@ -337,7 +341,7 @@ describe('Verifier', () => {
         ],
       } as unknown as EvmResult
 
-      const result = Verifier.verifyEvmBurns(transaction, evmResult)
+      const result = Verifier.verifyEvmBurns(transaction, evmResult.events)
       expect(result).toEqual({ valid: true })
     })
   })

--- a/ironfish/src/evm/__fixtures__/evm.test.ts.fixture
+++ b/ironfish/src/evm/__fixtures__/evm.test.ts.fixture
@@ -1,5 +1,5 @@
 {
-  "IronfishEvm simulateTx does not modify database": [
+  "IronfishEvm withCopy does not modify database": [
     {
       "value": {
         "version": 4,

--- a/ironfish/src/evm/evm.test.ts
+++ b/ironfish/src/evm/evm.test.ts
@@ -9,7 +9,7 @@ import { createNodeTest, useAccountFixture } from '../testUtilities'
 import { EvmStateEncoding, HexStringEncoding } from './database'
 
 describe('IronfishEvm', () => {
-  describe('simulateTx', () => {
+  describe('withCopy', () => {
     const nodeTest = createNodeTest()
 
     it('does not modify database', async () => {
@@ -54,9 +54,11 @@ describe('IronfishEvm', () => {
 
       Assert.isNotUndefined(nodeTest.chain.evm)
 
-      const result = await nodeTest.chain.evm.simulateTx({ tx: signed })
+      const result = await nodeTest.chain.evm.withCopy((vm) => {
+        return nodeTest.chain.evm.runTx({ tx: signed }, vm)
+      })
 
-      expect(result.totalGasSpent).toEqual(21000n)
+      expect(result?.result?.totalGasSpent).toEqual(21000n)
 
       const senderAccountAfter = await nodeTest.chain.blockchainDb.stateManager.getAccount(
         senderAddress,

--- a/ironfish/src/evm/evm.ts
+++ b/ironfish/src/evm/evm.ts
@@ -97,6 +97,10 @@ export class IronfishEvm {
     }
   }
 
+  async simulateTx(opts: RunTxOpts): Promise<EvmResult> {
+    return this.withCopy(async (vm) => this.runTx(opts, vm))
+  }
+
   async withCopy<TResult>(handler: (copy: VM) => Promise<TResult>): Promise<TResult> {
     Assert.isNotNull(this.vm, 'EVM not initialized')
     const vm = await this.vm.shallowCopy()

--- a/ironfish/src/evm/evm.ts
+++ b/ironfish/src/evm/evm.ts
@@ -85,13 +85,13 @@ export class IronfishEvm {
       if (e instanceof Error) {
         return {
           result: undefined,
-          events: [],
+          events: undefined,
           error: new EvmError(e.message),
         }
       }
       return {
         result: undefined,
-        events: [],
+        events: undefined,
         error: new EvmError('unknown evm execution error'),
       }
     }
@@ -199,7 +199,7 @@ export type EvmResult =
   | {
       result: undefined
       error: EvmError
-      events: UTXOEvent[]
+      events: undefined
     }
 
 export class EvmError extends Error {

--- a/ironfish/src/mining/manager.ts
+++ b/ironfish/src/mining/manager.ts
@@ -292,11 +292,13 @@ export class MiningManager {
 
         // verify that EVM transactions are valid
         if (transaction.evm) {
-          Assert.isNotUndefined(this.chain.evm)
-          const evmVerify = await this.chain.verifier.verifyEvm(transaction, vm)
+          const evmResult = await this.chain.evm.runDesc(transaction.evm, vm)
+          const evmVerify = this.chain.verifier.verifyEvm(transaction, evmResult)
           if (!evmVerify.valid) {
             continue
           }
+
+          totalTransactionFees += evmResult.result?.minerValue ?? 0n
         }
 
         currBlockSize += transactionSize


### PR DESCRIPTION
## Summary

moves evm tx execution out of verifyEvm

consolidates IronfishEvm methods runTx and verifyTx into a single method that returns a result and events decoded from logs or an error if exeuction fails

removes redundant simulateTx method

refactors verifyEvm to take an EvmResult instead of executing the transaction itself. allows us to use evm transaction execution results outside of verification, e.g., for summing miner fees from gas

adds runDesc method for convenience to wrap conversion from EvmDescription to evm transaction

## Testing Plan

manual testing to see miners fee includes gas:

- apply attached diff: [miner_fee_gas_test.diff.txt](https://github.com/user-attachments/files/16532152/miner_fee_gas_test.diff.txt)
- start node with `--networkId=2` and `--forceMining`
- start miner
- use `evm:sendTransaction` with the spending key from the diff to send an evm transaction
- use `wallet:transactions` to see miners fee transaction that includes 21000 ORE from gas

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```


## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
