### PR TITLE
status command returns json

### DIFF
--- a/ironfish-cli/src/commands/status.ts
+++ b/ironfish-cli/src/commands/status.ts
@@ -12,14 +12,16 @@ import {
 import { Flags } from '@oclif/core'
 import blessed from 'blessed'
 import { IronfishCommand } from '../command'
-import { RemoteFlags } from '../flags'
+import { JsonFlags, RemoteFlags } from '../flags'
 import * as ui from '../ui'
 
 export default class Status extends IronfishCommand {
   static description = "show the node's status"
+  static enableJsonFlag = true
 
   static flags = {
     ...RemoteFlags,
+    ...JsonFlags,
     follow: Flags.boolean({
       char: 'f',
       default: false,
@@ -31,14 +33,15 @@ export default class Status extends IronfishCommand {
     }),
   }
 
-  async start(): Promise<void> {
+  async start(): Promise<unknown> {
     const { flags } = await this.parse(Status)
 
     if (!flags.follow) {
       const client = await this.connectRpc()
       const response = await client.node.getStatus()
       this.log(renderStatus(response.content, flags.all))
-      this.exit(0)
+
+      return response.content
     }
 
     // Console log will create display issues with Blessed
@@ -219,7 +222,7 @@ function renderStatus(content: GetNodeStatusResponse, debugOutput: boolean): str
     Version: `${content.node.version} @ ${content.node.git}`,
     Node: nodeStatus,
     'Node Name': content.node.nodeName,
-    'Peed ID': content.peerNetwork.publicIdentity,
+    'Peer ID': content.peerNetwork.publicIdentity,
     'Block Graffiti': blockGraffiti,
     Network: network,
     Memory: memoryStatus,


### PR DESCRIPTION
## Summary


```
> ironfish status --json
{
  "peerNetwork": {
    "peers": 8,
    "isReady": true,
    "inboundTraffic": 3.827089272106467,
    "outboundTraffic": 77.51846118445366,
    "publicIdentity": "2BRyL2XoCgk0SjCMg8DkOK/JefkUR+5s8YsClp0OM08="
  },
  "blockchain": {
    "synced": true,
    "head": {
      "hash": "00000186c16ce24d57584e54453ea2f2f3fded2f70500014e2a9beecf661f357",
      "sequence": 625446
    },
    "headTimestamp": 1723051770752,
    "newBlockSpeed": 0,
    "dbSizeBytes": 967838004
  },
  "node": {
    "status": "started",
    "version": "2.5.0",
    "git": "src",
    "nodeName": "",
    "networkId": 0
  },
  "cpu": {
    "cores": 10,
    "percentRollingAvg": 9.2734960340776,
    "percentCurrent": 0.9176352705410822
  },
  "memory": {
    "heapMax": 4292074584,
    "heapTotal": 54018048,
    "heapUsed": 50897496,
    "rss": 609730560,
    "memFree": 196640768,
    "memTotal": 34359738368
  },
  "miningDirector": {
    "status": "started",
    "miners": 0,
    "blocks": 0,
    "blockGraffiti": "",
    "newEmptyBlockTemplateSpeed": 0,
    "newBlockTemplateSpeed": 0,
    "newBlockTransactionsSpeed": 0
  },
  "memPool": {
    "size": 0,
    "sizeBytes": 0,
    "maxSizeBytes": 60000000,
    "evictions": 0,
    "recentlyEvictedCache": {
      "size": 0,
      "maxSize": 60000
    }
  },
  "blockSyncer": {
    "status": "idle",
    "syncing": {
      "blockSpeed": 29.96,
      "speed": 0.58,
      "downloadSpeed": 96.56,
      "progress": 1
    }
  },
  "telemetry": {
    "status": "stopped",
    "pending": 0,
    "submitted": 0
  },
  "workers": {
    "started": true,
    "workers": 9,
    "executing": 0,
    "queued": 0,
    "capacity": 9,
    "change": 0,
    "speed": 0.42
  },
  "accounts": {
    "enabled": true,
    "head": {
      "hash": "00000186c16ce24d57584e54453ea2f2f3fded2f70500014e2a9beecf661f357",
      "sequence": 625446
    }
  }
}
```

## Testing Plan

## Documentation



## Breaking Change

