### PR TITLE
feat(rust,rust-nodejs): Add napi `encrypt` function for xchacha20poly1305

### DIFF
--- a/ironfish-rust-nodejs/index.d.ts
+++ b/ironfish-rust-nodejs/index.d.ts
@@ -47,6 +47,7 @@ export const TRANSACTION_EXPIRATION_LENGTH: number
 export const TRANSACTION_FEE_LENGTH: number
 export const LATEST_TRANSACTION_VERSION: number
 export function verifyTransactions(serializedTransactions: Array<Buffer>): boolean
+export function encrypt(plaintext: string, passphrase: string): string
 export const enum LanguageCode {
   English = 0,
   ChineseSimplified = 1,

--- a/ironfish-rust-nodejs/index.js
+++ b/ironfish-rust-nodejs/index.js
@@ -252,7 +252,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { FishHashContext, KEY_LENGTH, NONCE_LENGTH, BoxKeyPair, randomBytes, boxMessage, unboxMessage, RollingFilter, initSignalHandler, triggerSegfault, ASSET_ID_LENGTH, ASSET_METADATA_LENGTH, ASSET_NAME_LENGTH, ASSET_LENGTH, Asset, NOTE_ENCRYPTION_KEY_LENGTH, MAC_LENGTH, ENCRYPTED_NOTE_PLAINTEXT_LENGTH, ENCRYPTED_NOTE_LENGTH, NoteEncrypted, PUBLIC_ADDRESS_LENGTH, RANDOMNESS_LENGTH, MEMO_LENGTH, AMOUNT_VALUE_LENGTH, DECRYPTED_NOTE_LENGTH, Note, PROOF_LENGTH, TRANSACTION_SIGNATURE_LENGTH, TRANSACTION_PUBLIC_KEY_RANDOMNESS_LENGTH, TRANSACTION_EXPIRATION_LENGTH, TRANSACTION_FEE_LENGTH, LATEST_TRANSACTION_VERSION, TransactionPosted, Transaction, verifyTransactions, UnsignedTransaction, LanguageCode, generateKey, spendingKeyToWords, wordsToSpendingKey, generatePublicAddressFromIncomingViewKey, generateKeyFromPrivateKey, initializeSapling, FoundBlockResult, ThreadPoolHandler, isValidPublicAddress, CpuCount, getCpuCount, generateRandomizedPublicKey, multisig } = nativeBinding
+const { FishHashContext, KEY_LENGTH, NONCE_LENGTH, BoxKeyPair, randomBytes, boxMessage, unboxMessage, RollingFilter, initSignalHandler, triggerSegfault, ASSET_ID_LENGTH, ASSET_METADATA_LENGTH, ASSET_NAME_LENGTH, ASSET_LENGTH, Asset, NOTE_ENCRYPTION_KEY_LENGTH, MAC_LENGTH, ENCRYPTED_NOTE_PLAINTEXT_LENGTH, ENCRYPTED_NOTE_LENGTH, NoteEncrypted, PUBLIC_ADDRESS_LENGTH, RANDOMNESS_LENGTH, MEMO_LENGTH, AMOUNT_VALUE_LENGTH, DECRYPTED_NOTE_LENGTH, Note, PROOF_LENGTH, TRANSACTION_SIGNATURE_LENGTH, TRANSACTION_PUBLIC_KEY_RANDOMNESS_LENGTH, TRANSACTION_EXPIRATION_LENGTH, TRANSACTION_FEE_LENGTH, LATEST_TRANSACTION_VERSION, TransactionPosted, Transaction, verifyTransactions, UnsignedTransaction, encrypt, LanguageCode, generateKey, spendingKeyToWords, wordsToSpendingKey, generatePublicAddressFromIncomingViewKey, generateKeyFromPrivateKey, initializeSapling, FoundBlockResult, ThreadPoolHandler, isValidPublicAddress, CpuCount, getCpuCount, generateRandomizedPublicKey, multisig } = nativeBinding
 
 module.exports.FishHashContext = FishHashContext
 module.exports.KEY_LENGTH = KEY_LENGTH
@@ -290,6 +290,7 @@ module.exports.TransactionPosted = TransactionPosted
 module.exports.Transaction = Transaction
 module.exports.verifyTransactions = verifyTransactions
 module.exports.UnsignedTransaction = UnsignedTransaction
+module.exports.encrypt = encrypt
 module.exports.LanguageCode = LanguageCode
 module.exports.generateKey = generateKey
 module.exports.spendingKeyToWords = spendingKeyToWords

--- a/ironfish-rust-nodejs/src/lib.rs
+++ b/ironfish-rust-nodejs/src/lib.rs
@@ -26,6 +26,7 @@ pub mod nacl;
 pub mod rolling_filter;
 pub mod signal_catcher;
 pub mod structs;
+pub mod xchacha20poly1305;
 
 #[cfg(feature = "stats")]
 pub mod stats;

--- a/ironfish-rust-nodejs/src/xchacha20poly1305.rs
+++ b/ironfish-rust-nodejs/src/xchacha20poly1305.rs
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use ironfish::{
+    serializing::{bytes_to_hex, hex_to_vec_bytes},
+    xchacha20poly1305,
+};
+use napi::bindgen_prelude::*;
+use napi_derive::napi;
+
+use crate::to_napi_err;
+
+#[napi]
+pub fn encrypt(plaintext: String, passphrase: String) -> Result<String> {
+    let plaintext_bytes = hex_to_vec_bytes(&plaintext).map_err(to_napi_err)?;
+    let passphrase_bytes = hex_to_vec_bytes(&passphrase).map_err(to_napi_err)?;
+    let result =
+        xchacha20poly1305::encrypt(&plaintext_bytes, &passphrase_bytes).map_err(to_napi_err)?;
+
+    let mut vec: Vec<u8> = vec![];
+    result.write(&mut vec).map_err(to_napi_err)?;
+
+    Ok(bytes_to_hex(&vec))
+}

--- a/ironfish-rust/src/xchacha20poly1305.rs
+++ b/ironfish-rust/src/xchacha20poly1305.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::io;
+
 use argon2::{password_hash::SaltString, Argon2};
 use chacha20poly1305::aead::Aead;
 use chacha20poly1305::{Key, KeyInit, XChaCha20Poly1305, XNonce};
@@ -12,12 +14,62 @@ use crate::errors::{IronfishError, IronfishErrorKind};
 const KEY_LENGTH: usize = 32;
 const NONCE_LENGTH: usize = 24;
 
+#[derive(Debug)]
 pub struct EncryptOutput {
-    pub salt: SaltString,
+    pub salt: Vec<u8>,
 
     pub nonce: [u8; NONCE_LENGTH],
 
     pub ciphertext: Vec<u8>,
+}
+
+impl EncryptOutput {
+    pub fn write<W: io::Write>(&self, mut writer: W) -> Result<(), IronfishError> {
+        let salt_len = u32::try_from(self.salt.len())?.to_le_bytes();
+        writer.write_all(&salt_len)?;
+        writer.write_all(&self.salt)?;
+
+        writer.write_all(&self.nonce)?;
+
+        let ciphertext_len = u32::try_from(self.ciphertext.len())?.to_le_bytes();
+        writer.write_all(&ciphertext_len)?;
+        writer.write_all(&self.ciphertext)?;
+
+        Ok(())
+    }
+
+    pub fn read<R: io::Read>(mut reader: R) -> Result<Self, IronfishError> {
+        let mut salt_len = [0u8; 4];
+        reader.read_exact(&mut salt_len)?;
+        let salt_len = u32::from_le_bytes(salt_len) as usize;
+
+        let mut salt = vec![0u8; salt_len];
+        reader.read_exact(&mut salt)?;
+
+        let mut nonce = [0u8; NONCE_LENGTH];
+        reader.read_exact(&mut nonce)?;
+
+        let mut ciphertext_len = [0u8; 4];
+        reader.read_exact(&mut ciphertext_len)?;
+        let ciphertext_len = u32::from_le_bytes(ciphertext_len) as usize;
+
+        let mut ciphertext = vec![0u8; ciphertext_len];
+        reader.read_exact(&mut ciphertext)?;
+
+        Ok(EncryptOutput {
+            salt,
+            nonce,
+            ciphertext,
+        })
+    }
+}
+
+impl PartialEq for EncryptOutput {
+    fn eq(&self, other: &EncryptOutput) -> bool {
+        self.salt == other.salt
+            && self.nonce == other.nonce
+            && self.ciphertext == other.ciphertext
+    }
 }
 
 fn derive_key(passphrase: &[u8], salt: &[u8]) -> Result<Key, IronfishError> {
@@ -33,7 +85,9 @@ fn derive_key(passphrase: &[u8], salt: &[u8]) -> Result<Key, IronfishError> {
 
 pub fn encrypt(plaintext: &[u8], passphrase: &[u8]) -> Result<EncryptOutput, IronfishError> {
     let salt = SaltString::generate(&mut thread_rng());
-    let key = derive_key(passphrase, salt.to_string().as_bytes())?;
+    let salt_str = salt.to_string();
+    let salt_bytes = salt_str.as_bytes();
+    let key = derive_key(passphrase, salt_bytes)?;
 
     let cipher = XChaCha20Poly1305::new(&key);
     let mut nonce_bytes = [0u8; NONCE_LENGTH];
@@ -45,7 +99,7 @@ pub fn encrypt(plaintext: &[u8], passphrase: &[u8]) -> Result<EncryptOutput, Iro
         .map_err(|_| IronfishError::new(IronfishErrorKind::FailedXChaCha20Poly1305Encryption))?;
 
     Ok(EncryptOutput {
-        salt,
+        salt: salt_bytes.to_vec(),
         nonce: nonce_bytes,
         ciphertext,
     })
@@ -57,7 +111,7 @@ pub fn decrypt(
 ) -> Result<Vec<u8>, IronfishError> {
     let nonce = XNonce::from_slice(&encrypted_output.nonce);
 
-    let key = derive_key(passphrase, encrypted_output.salt.to_string().as_bytes())?;
+    let key = derive_key(passphrase, &encrypted_output.salt[..])?;
     let cipher = XChaCha20Poly1305::new(&key);
 
     cipher
@@ -68,6 +122,8 @@ pub fn decrypt(
 #[cfg(test)]
 mod test {
     use crate::xchacha20poly1305::{decrypt, encrypt};
+
+    use super::EncryptOutput;
 
     #[test]
     fn test_valid_passphrase() {
@@ -93,5 +149,21 @@ mod test {
 
         decrypt(encrypted_output, incorrect_passphrase.as_bytes())
             .expect_err("should fail decryption");
+    }
+
+    #[test]
+    fn test_encrypt_output_serialization() {
+        let plaintext = "thisissensitivedata";
+        let passphrase = "supersecretpassword";
+
+        let encrypted_output = encrypt(plaintext.as_bytes(), passphrase.as_bytes())
+            .expect("should successfully encrypt");
+
+        let mut vec: Vec<u8> = vec![];
+        encrypted_output.write(&mut vec).expect("should serialize successfully");
+
+        let deserialized = EncryptOutput::read(&vec[..]).expect("should deserialize successfully");
+
+        assert_eq!(encrypted_output, deserialized);
     }
 }

--- a/ironfish-rust/src/xchacha20poly1305.rs
+++ b/ironfish-rust/src/xchacha20poly1305.rs
@@ -66,9 +66,7 @@ impl EncryptOutput {
 
 impl PartialEq for EncryptOutput {
     fn eq(&self, other: &EncryptOutput) -> bool {
-        self.salt == other.salt
-            && self.nonce == other.nonce
-            && self.ciphertext == other.ciphertext
+        self.salt == other.salt && self.nonce == other.nonce && self.ciphertext == other.ciphertext
     }
 }
 
@@ -160,7 +158,9 @@ mod test {
             .expect("should successfully encrypt");
 
         let mut vec: Vec<u8> = vec![];
-        encrypted_output.write(&mut vec).expect("should serialize successfully");
+        encrypted_output
+            .write(&mut vec)
+            .expect("should serialize successfully");
 
         let deserialized = EncryptOutput::read(&vec[..]).expect("should deserialize successfully");
 


### PR DESCRIPTION
## Summary

* Updates `salt` on `EncryptOutput` to be `Vec<u8>`
* Adds serialization for `EncryptOutput`
* Adds napi wrapper function for `encrypt`

## Testing Plan

Unit test for serialization

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
