### PR TITLE
update config descriptions to match our new standard

### DIFF
--- a/ironfish-cli/src/commands/config/edit.ts
+++ b/ironfish-cli/src/commands/config/edit.ts
@@ -15,7 +15,7 @@ const writeFileAsync = promisify(writeFile)
 const readFileAsync = promisify(readFile)
 
 export class EditCommand extends IronfishCommand {
-  static description = `Edit the config in your configured editor
+  static description = `interactively edit your config
 
   Set the editor in either EDITOR environment variable, or set 'editor' in your ironfish config`
 

--- a/ironfish-cli/src/commands/config/get.ts
+++ b/ironfish-cli/src/commands/config/get.ts
@@ -8,7 +8,7 @@ import { JsonFlags, RemoteFlags } from '../../flags'
 import * as ui from '../../ui'
 
 export class GetCommand extends IronfishCommand {
-  static description = `Print out one config value`
+  static description = `show a single config value`
   static enableJsonFlag = true
 
   static args = {

--- a/ironfish-cli/src/commands/config/set.ts
+++ b/ironfish-cli/src/commands/config/set.ts
@@ -6,7 +6,7 @@ import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 
 export class SetCommand extends IronfishCommand {
-  static description = `Set a value in the config`
+  static description = `set a single value in the config`
 
   static args = {
     name: Args.string({

--- a/ironfish-cli/src/commands/config/unset.ts
+++ b/ironfish-cli/src/commands/config/unset.ts
@@ -6,7 +6,7 @@ import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 
 export class UnsetCommand extends IronfishCommand {
-  static description = `Unset a value in the config and fall back to default`
+  static description = `reset a config value to the default`
 
   static args = {
     name: Args.string({


### PR DESCRIPTION
## Summary

![image](https://github.com/user-attachments/assets/91a06df7-1cd2-4fdb-8f09-376a123a9ddc)


## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
