### PR TITLE
update mempool descriptions and add json support to status

### DIFF
--- a/ironfish-cli/src/commands/mempool/status.ts
+++ b/ironfish-cli/src/commands/mempool/status.ts
@@ -6,14 +6,16 @@ import { GetMempoolStatusResponse } from '@ironfish/sdk'
 import { Flags } from '@oclif/core'
 import blessed from 'blessed'
 import { IronfishCommand } from '../../command'
-import { RemoteFlags } from '../../flags'
+import { JsonFlags, RemoteFlags } from '../../flags'
 import * as ui from '../../ui'
 
 export default class Status extends IronfishCommand {
-  static description = 'Show the status of the Mempool'
+  static description = "show the mempool's status"
+  static enableJsonFlag = true
 
   static flags = {
     ...RemoteFlags,
+    ...JsonFlags,
     follow: Flags.boolean({
       char: 'f',
       default: false,
@@ -21,14 +23,15 @@ export default class Status extends IronfishCommand {
     }),
   }
 
-  async start(): Promise<void> {
+  async start(): Promise<unknown> {
     const { flags } = await this.parse(Status)
 
     if (!flags.follow) {
       const client = await this.connectRpc()
       const response = await client.mempool.getMempoolStatus()
       this.log(renderStatus(response.content))
-      this.exit(0)
+
+      return response.content
     }
 
     // Console log will create display issues with Blessed

--- a/ironfish-cli/src/commands/mempool/transactions.ts
+++ b/ironfish-cli/src/commands/mempool/transactions.ts
@@ -31,7 +31,7 @@ const parseMinMax = (input: string): MinMax | undefined => {
 }
 
 export class TransactionsCommand extends IronfishCommand {
-  static description = `List transactions in the mempool`
+  static description = `list mempool transactions`
 
   static flags = {
     ...RemoteFlags,


### PR DESCRIPTION
## Summary

`mempool --help`
![image](https://github.com/user-attachments/assets/be65410a-8e13-4552-ba13-e0a864e54b55)


`mempool:status --json`
```
{
  "size": 0,
  "sizeBytes": 0,
  "maxSizeBytes": 60000000,
  "headSequence": 0,
  "evictions": 0,
  "recentlyEvictedCache": {
    "size": 0,
    "maxSize": 60000,
    "saturation": 0
  }
}
```

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
