### PR TITLE
feat(ironfish,rust-nodejs): Add EncryptedAccount class

### DIFF
--- a/ironfish-rust-nodejs/index.d.ts
+++ b/ironfish-rust-nodejs/index.d.ts
@@ -47,7 +47,8 @@ export const TRANSACTION_EXPIRATION_LENGTH: number
 export const TRANSACTION_FEE_LENGTH: number
 export const LATEST_TRANSACTION_VERSION: number
 export function verifyTransactions(serializedTransactions: Array<Buffer>): boolean
-export function encrypt(plaintext: string, passphrase: string): string
+export function encrypt(plaintext: Buffer, passphrase: string): Buffer
+export function decrypt(encryptedBlob: Buffer, passphrase: string): Buffer
 export const enum LanguageCode {
   English = 0,
   ChineseSimplified = 1,

--- a/ironfish-rust-nodejs/index.js
+++ b/ironfish-rust-nodejs/index.js
@@ -252,7 +252,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { FishHashContext, KEY_LENGTH, NONCE_LENGTH, BoxKeyPair, randomBytes, boxMessage, unboxMessage, RollingFilter, initSignalHandler, triggerSegfault, ASSET_ID_LENGTH, ASSET_METADATA_LENGTH, ASSET_NAME_LENGTH, ASSET_LENGTH, Asset, NOTE_ENCRYPTION_KEY_LENGTH, MAC_LENGTH, ENCRYPTED_NOTE_PLAINTEXT_LENGTH, ENCRYPTED_NOTE_LENGTH, NoteEncrypted, PUBLIC_ADDRESS_LENGTH, RANDOMNESS_LENGTH, MEMO_LENGTH, AMOUNT_VALUE_LENGTH, DECRYPTED_NOTE_LENGTH, Note, PROOF_LENGTH, TRANSACTION_SIGNATURE_LENGTH, TRANSACTION_PUBLIC_KEY_RANDOMNESS_LENGTH, TRANSACTION_EXPIRATION_LENGTH, TRANSACTION_FEE_LENGTH, LATEST_TRANSACTION_VERSION, TransactionPosted, Transaction, verifyTransactions, UnsignedTransaction, encrypt, LanguageCode, generateKey, spendingKeyToWords, wordsToSpendingKey, generatePublicAddressFromIncomingViewKey, generateKeyFromPrivateKey, initializeSapling, FoundBlockResult, ThreadPoolHandler, isValidPublicAddress, CpuCount, getCpuCount, generateRandomizedPublicKey, multisig } = nativeBinding
+const { FishHashContext, KEY_LENGTH, NONCE_LENGTH, BoxKeyPair, randomBytes, boxMessage, unboxMessage, RollingFilter, initSignalHandler, triggerSegfault, ASSET_ID_LENGTH, ASSET_METADATA_LENGTH, ASSET_NAME_LENGTH, ASSET_LENGTH, Asset, NOTE_ENCRYPTION_KEY_LENGTH, MAC_LENGTH, ENCRYPTED_NOTE_PLAINTEXT_LENGTH, ENCRYPTED_NOTE_LENGTH, NoteEncrypted, PUBLIC_ADDRESS_LENGTH, RANDOMNESS_LENGTH, MEMO_LENGTH, AMOUNT_VALUE_LENGTH, DECRYPTED_NOTE_LENGTH, Note, PROOF_LENGTH, TRANSACTION_SIGNATURE_LENGTH, TRANSACTION_PUBLIC_KEY_RANDOMNESS_LENGTH, TRANSACTION_EXPIRATION_LENGTH, TRANSACTION_FEE_LENGTH, LATEST_TRANSACTION_VERSION, TransactionPosted, Transaction, verifyTransactions, UnsignedTransaction, encrypt, decrypt, LanguageCode, generateKey, spendingKeyToWords, wordsToSpendingKey, generatePublicAddressFromIncomingViewKey, generateKeyFromPrivateKey, initializeSapling, FoundBlockResult, ThreadPoolHandler, isValidPublicAddress, CpuCount, getCpuCount, generateRandomizedPublicKey, multisig } = nativeBinding
 
 module.exports.FishHashContext = FishHashContext
 module.exports.KEY_LENGTH = KEY_LENGTH
@@ -291,6 +291,7 @@ module.exports.Transaction = Transaction
 module.exports.verifyTransactions = verifyTransactions
 module.exports.UnsignedTransaction = UnsignedTransaction
 module.exports.encrypt = encrypt
+module.exports.decrypt = decrypt
 module.exports.LanguageCode = LanguageCode
 module.exports.generateKey = generateKey
 module.exports.spendingKeyToWords = spendingKeyToWords

--- a/ironfish-rust-nodejs/src/xchacha20poly1305.rs
+++ b/ironfish-rust-nodejs/src/xchacha20poly1305.rs
@@ -11,7 +11,7 @@ use crate::to_napi_err;
 #[napi]
 pub fn encrypt(plaintext: JsBuffer, passphrase: String) -> Result<Buffer> {
     let plaintext_bytes = plaintext.into_value()?;
-    let result = xchacha20poly1305::encrypt(&plaintext_bytes.as_ref(), &passphrase.as_bytes())
+    let result = xchacha20poly1305::encrypt(plaintext_bytes.as_ref(), passphrase.as_bytes())
         .map_err(to_napi_err)?;
 
     let mut vec: Vec<u8> = vec![];
@@ -25,8 +25,8 @@ pub fn decrypt(encrypted_blob: JsBuffer, passphrase: String) -> Result<Buffer> {
     let encrypted_bytes = encrypted_blob.into_value()?;
 
     let encrypted_output = EncryptOutput::read(encrypted_bytes.as_ref()).map_err(to_napi_err)?;
-    let result = xchacha20poly1305::decrypt(encrypted_output, &passphrase.as_bytes())
-        .map_err(to_napi_err)?;
+    let result =
+        xchacha20poly1305::decrypt(encrypted_output, passphrase.as_bytes()).map_err(to_napi_err)?;
 
     Ok(Buffer::from(&result[..]))
 }

--- a/ironfish-rust-nodejs/src/xchacha20poly1305.rs
+++ b/ironfish-rust-nodejs/src/xchacha20poly1305.rs
@@ -2,9 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use ironfish::{
-    xchacha20poly1305::{self, EncryptOutput},
-};
+use ironfish::xchacha20poly1305::{self, EncryptOutput};
 use napi::{bindgen_prelude::*, JsBuffer};
 use napi_derive::napi;
 
@@ -13,8 +11,8 @@ use crate::to_napi_err;
 #[napi]
 pub fn encrypt(plaintext: JsBuffer, passphrase: String) -> Result<Buffer> {
     let plaintext_bytes = plaintext.into_value()?;
-    let result =
-        xchacha20poly1305::encrypt(&plaintext_bytes.as_ref(), &passphrase.as_bytes()).map_err(to_napi_err)?;
+    let result = xchacha20poly1305::encrypt(&plaintext_bytes.as_ref(), &passphrase.as_bytes())
+        .map_err(to_napi_err)?;
 
     let mut vec: Vec<u8> = vec![];
     result.write(&mut vec).map_err(to_napi_err)?;
@@ -27,8 +25,8 @@ pub fn decrypt(encrypted_blob: JsBuffer, passphrase: String) -> Result<Buffer> {
     let encrypted_bytes = encrypted_blob.into_value()?;
 
     let encrypted_output = EncryptOutput::read(encrypted_bytes.as_ref()).map_err(to_napi_err)?;
-    let result =
-        xchacha20poly1305::decrypt(encrypted_output, &passphrase.as_bytes()).map_err(to_napi_err)?;
+    let result = xchacha20poly1305::decrypt(encrypted_output, &passphrase.as_bytes())
+        .map_err(to_napi_err)?;
 
     Ok(Buffer::from(&result[..]))
 }

--- a/ironfish-rust-nodejs/src/xchacha20poly1305.rs
+++ b/ironfish-rust-nodejs/src/xchacha20poly1305.rs
@@ -3,35 +3,32 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use ironfish::{
-    serializing::{bytes_to_hex, hex_to_vec_bytes},
     xchacha20poly1305::{self, EncryptOutput},
 };
-use napi::bindgen_prelude::*;
+use napi::{bindgen_prelude::*, JsBuffer};
 use napi_derive::napi;
 
 use crate::to_napi_err;
 
 #[napi]
-pub fn encrypt(plaintext: String, passphrase: String) -> Result<String> {
-    let plaintext_bytes = hex_to_vec_bytes(&plaintext).map_err(to_napi_err)?;
-    let passphrase_bytes = hex_to_vec_bytes(&passphrase).map_err(to_napi_err)?;
+pub fn encrypt(plaintext: JsBuffer, passphrase: String) -> Result<Buffer> {
+    let plaintext_bytes = plaintext.into_value()?;
     let result =
-        xchacha20poly1305::encrypt(&plaintext_bytes, &passphrase_bytes).map_err(to_napi_err)?;
+        xchacha20poly1305::encrypt(&plaintext_bytes.as_ref(), &passphrase.as_bytes()).map_err(to_napi_err)?;
 
     let mut vec: Vec<u8> = vec![];
     result.write(&mut vec).map_err(to_napi_err)?;
 
-    Ok(bytes_to_hex(&vec))
+    Ok(Buffer::from(&vec[..]))
 }
 
 #[napi]
-pub fn decrypt(encrypted_blob: String, passphrase: String) -> Result<String> {
-    let encrypted_blob_bytes = hex_to_vec_bytes(&encrypted_blob).map_err(to_napi_err)?;
-    let passphrase_bytes = hex_to_vec_bytes(&passphrase).map_err(to_napi_err)?;
+pub fn decrypt(encrypted_blob: JsBuffer, passphrase: String) -> Result<Buffer> {
+    let encrypted_bytes = encrypted_blob.into_value()?;
 
-    let encrypted_output = EncryptOutput::read(&encrypted_blob_bytes[..]).map_err(to_napi_err)?;
+    let encrypted_output = EncryptOutput::read(encrypted_bytes.as_ref()).map_err(to_napi_err)?;
     let result =
-        xchacha20poly1305::decrypt(encrypted_output, &passphrase_bytes).map_err(to_napi_err)?;
+        xchacha20poly1305::decrypt(encrypted_output, &passphrase.as_bytes()).map_err(to_napi_err)?;
 
-    Ok(bytes_to_hex(&result[..]))
+    Ok(Buffer::from(&result[..]))
 }

--- a/ironfish/src/testUtilities/fixtures/account.ts
+++ b/ironfish/src/testUtilities/fixtures/account.ts
@@ -2,7 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Blockchain } from '../../blockchain'
-import { AccountValue, AssertSpending, SpendingAccount, Wallet } from '../../wallet'
+import { AssertSpending, SpendingAccount, Wallet } from '../../wallet'
+import { DecryptedAccountValue } from '../../wallet/walletdb/accountValue'
 import { HeadValue } from '../../wallet/walletdb/headValue'
 import { useMinerBlockFixture } from './blocks'
 import { FixtureGenerate, useFixture } from './fixture'
@@ -26,7 +27,7 @@ export function useAccountFixture(
     serialize: async (
       account: SpendingAccount,
     ): Promise<{
-      value: AccountValue
+      value: DecryptedAccountValue
       head: HeadValue | null
     }> => {
       return {
@@ -39,7 +40,7 @@ export function useAccountFixture(
       value,
       head,
     }: {
-      value: AccountValue
+      value: DecryptedAccountValue
       head: HeadValue | null
     }): Promise<SpendingAccount> => {
       const createdAt = value.createdAt

--- a/ironfish/src/wallet/account/__fixtures__/encryptedAccount.test.ts.fixture
+++ b/ironfish/src/wallet/account/__fixtures__/encryptedAccount.test.ts.fixture
@@ -29,5 +29,36 @@
         "sequence": 1
       }
     }
+  ],
+  "EncryptedAccount throws an error when an invalid passphrase is used": [
+    {
+      "value": {
+        "encrypted": false,
+        "version": 4,
+        "id": "2710f42e-f848-4d67-b0a2-9e4eac56df7d",
+        "name": "test",
+        "spendingKey": "eb527038b1b452c2abb13c1c7135309d6acd9e4737a7f18aa75bb4363141e077",
+        "viewKey": "b05272abd89b4eb48435b336d638771e69854fd36947971d22b3bd9cde7a2a5c0d83d88ccc8ef8259693c1391eedc1a25e5fccdf554ff605b593c15a619aa851",
+        "incomingViewKey": "fd48d3ddf807a6d1a881af440f2b3b23fc670b70323ecbb08f8dd54ff9220401",
+        "outgoingViewKey": "62603f4717d3a7f7ab00887ad77c1567b103f06fc885aa4a000625cf4b278f81",
+        "publicAddress": "40fd3b67d0abeacda175781f1bb97d5a08dff7b3850cc94ce0b3c3dfee742a41",
+        "createdAt": {
+          "hash": {
+            "type": "Buffer",
+            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+          },
+          "sequence": 1
+        },
+        "scanningEnabled": true,
+        "proofAuthorizingKey": "c0159378c279f74958da06b63f3db79a85e84abf4919b1c9b321392de5be9a06"
+      },
+      "head": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+        },
+        "sequence": 1
+      }
+    }
   ]
 }

--- a/ironfish/src/wallet/account/__fixtures__/encryptedAccount.test.ts.fixture
+++ b/ironfish/src/wallet/account/__fixtures__/encryptedAccount.test.ts.fixture
@@ -1,0 +1,33 @@
+{
+  "EncryptedAccount can decrypt an encrypted account": [
+    {
+      "value": {
+        "encrypted": false,
+        "version": 4,
+        "id": "0332daf1-4ba3-42b3-9d72-6803529df295",
+        "name": "test",
+        "spendingKey": "f7bff5aabef137c1231d16fdaee2c0b7da61e81cebd08e8be35d0cd0dea1f015",
+        "viewKey": "c8ee06884cc6aa31002c058a511aeea219059579350cbe6deb07416ad049e7cfef7877b730dd1e4d982d5228e8badf0c7020b1d07ff0eb23b298d9c97b0d5e1c",
+        "incomingViewKey": "d9753f22ba723bdc381cd3dba675ef36247a6807e5c0d082f88948496f687601",
+        "outgoingViewKey": "03268cd3770209e043742554a83f6944a768980309ba2beec2bc8995fe446130",
+        "publicAddress": "7742fa58b9e1efc337b05d54dea06d1dabd89c78cd98c7656f667314da865d04",
+        "createdAt": {
+          "hash": {
+            "type": "Buffer",
+            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+          },
+          "sequence": 1
+        },
+        "scanningEnabled": true,
+        "proofAuthorizingKey": "67e962ba0d98e71f351534ad8d9bb8cfe01c76f291b06933b694b57b7808c10a"
+      },
+      "head": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+        },
+        "sequence": 1
+      }
+    }
+  ]
+}

--- a/ironfish/src/wallet/account/account.ts
+++ b/ironfish/src/wallet/account/account.ts
@@ -15,7 +15,7 @@ import { WithNonNull, WithRequired } from '../../utils'
 import { DecryptedNote } from '../../workerPool/tasks/decryptNotes'
 import { AssetBalances } from '../assetBalances'
 import { MultisigKeys, MultisigSigner } from '../interfaces/multisigKeys'
-import { AccountValue } from '../walletdb/accountValue'
+import { DecryptedAccountValue } from '../walletdb/accountValue'
 import { AssetValue } from '../walletdb/assetValue'
 import { BalanceValue } from '../walletdb/balanceValue'
 import { DecryptedNoteValue } from '../walletdb/decryptedNoteValue'
@@ -76,7 +76,13 @@ export class Account {
   readonly multisigKeys?: MultisigKeys
   readonly proofAuthorizingKey: string | null
 
-  constructor({ accountValue, walletDb }: { accountValue: AccountValue; walletDb: WalletDB }) {
+  constructor({
+    accountValue,
+    walletDb,
+  }: {
+    accountValue: DecryptedAccountValue
+    walletDb: WalletDB
+  }) {
     this.id = accountValue.id
     this.name = accountValue.name
     this.spendingKey = accountValue.spendingKey
@@ -102,8 +108,9 @@ export class Account {
     return this.spendingKey !== null
   }
 
-  serialize(): AccountValue {
+  serialize(): DecryptedAccountValue {
     return {
+      encrypted: false,
       version: this.version,
       id: this.id,
       name: this.name,

--- a/ironfish/src/wallet/account/encryptedAccount.test.ts
+++ b/ironfish/src/wallet/account/encryptedAccount.test.ts
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { encrypt } from '@ironfish/rust-nodejs'
+import { useAccountFixture } from '../../testUtilities/fixtures/account'
+import { createNodeTest } from '../../testUtilities/nodeTest'
+import { AccountValueEncoding } from '../walletdb/accountValue'
+import { EncryptedAccount } from './encryptedAccount'
+
+describe('EncryptedAccount', () => {
+  const nodeTest = createNodeTest()
+
+  it('can decrypt an encrypted account', async () => {
+    const passphrase = 'foobarbaz'
+    const { node } = nodeTest
+    const account = await useAccountFixture(node.wallet)
+
+    const encoder = new AccountValueEncoding()
+    const data = encoder.serialize(account.serialize())
+
+    const encryptedData = encrypt(data, passphrase)
+    const encryptedAccount = new EncryptedAccount({
+      data: encryptedData,
+      walletDb: node.wallet.walletDb,
+    })
+
+    const decryptedAccount = encryptedAccount.decrypt(passphrase)
+    const decryptedData = encoder.serialize(decryptedAccount.serialize())
+    expect(data.toString('hex')).toEqual(decryptedData.toString('hex'))
+  })
+})

--- a/ironfish/src/wallet/account/encryptedAccount.test.ts
+++ b/ironfish/src/wallet/account/encryptedAccount.test.ts
@@ -4,6 +4,7 @@
 import { encrypt } from '@ironfish/rust-nodejs'
 import { useAccountFixture } from '../../testUtilities/fixtures/account'
 import { createNodeTest } from '../../testUtilities/nodeTest'
+import { AccountDecryptionFailedError } from '../errors'
 import { AccountValueEncoding } from '../walletdb/accountValue'
 import { EncryptedAccount } from './encryptedAccount'
 
@@ -44,6 +45,8 @@ describe('EncryptedAccount', () => {
       walletDb: node.wallet.walletDb,
     })
 
-    expect(() => encryptedAccount.decrypt(invalidPassphrase)).toThrow()
+    expect(() => encryptedAccount.decrypt(invalidPassphrase)).toThrow(
+      AccountDecryptionFailedError,
+    )
   })
 })

--- a/ironfish/src/wallet/account/encryptedAccount.test.ts
+++ b/ironfish/src/wallet/account/encryptedAccount.test.ts
@@ -28,4 +28,22 @@ describe('EncryptedAccount', () => {
     const decryptedData = encoder.serialize(decryptedAccount.serialize())
     expect(data.toString('hex')).toEqual(decryptedData.toString('hex'))
   })
+
+  it('throws an error when an invalid passphrase is used', async () => {
+    const passphrase = 'foobarbaz'
+    const invalidPassphrase = 'fakepassphrase'
+    const { node } = nodeTest
+    const account = await useAccountFixture(node.wallet)
+
+    const encoder = new AccountValueEncoding()
+    const data = encoder.serialize(account.serialize())
+
+    const encryptedData = encrypt(data, passphrase)
+    const encryptedAccount = new EncryptedAccount({
+      data: encryptedData,
+      walletDb: node.wallet.walletDb,
+    })
+
+    expect(() => encryptedAccount.decrypt(invalidPassphrase)).toThrow()
+  })
 })

--- a/ironfish/src/wallet/account/encryptedAccount.ts
+++ b/ironfish/src/wallet/account/encryptedAccount.ts
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { decrypt } from '@ironfish/rust-nodejs'
+import { AccountValueEncoding, EncryptedAccountValue } from '../walletdb/accountValue'
+import { WalletDB } from '../walletdb/walletdb'
+import { Account } from './account'
+
+export class EncryptedAccount {
+  private readonly walletDb: WalletDB
+  readonly data: Buffer
+
+  constructor({ data, walletDb }: { data: Buffer; walletDb: WalletDB }) {
+    this.data = data
+    this.walletDb = walletDb
+  }
+
+  decrypt(passphrase: string): Account {
+    const decryptedAccountValue = decrypt(this.data, passphrase)
+    if (!decryptedAccountValue) {
+      throw new Error('Failed to decrypt payload')
+    }
+
+    const encoder = new AccountValueEncoding()
+    const accountValue = encoder.deserialize(decryptedAccountValue)
+    return new Account({ accountValue, walletDb: this.walletDb })
+  }
+
+  serialize(): EncryptedAccountValue {
+    return {
+      encrypted: true,
+      data: this.data,
+    }
+  }
+}

--- a/ironfish/src/wallet/errors.ts
+++ b/ironfish/src/wallet/errors.ts
@@ -60,3 +60,12 @@ export class DuplicateMultisigSecretNameError extends Error {
     this.message = `Multisig secret already exists with the name ${name}`
   }
 }
+
+export class AccountDecryptionFailedError extends Error {
+  name = this.constructor.name
+
+  constructor() {
+    super()
+    this.message = 'Failed to decrypt account'
+  }
+}

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -1288,6 +1288,7 @@ export class Wallet {
 
     const account = new Account({
       accountValue: {
+        encrypted: false,
         version: ACCOUNT_SCHEMA_VERSION,
         id: uuid(),
         name,
@@ -1389,6 +1390,7 @@ export class Wallet {
         name,
         multisigKeys,
         scanningEnabled: true,
+        encrypted: false,
       },
       walletDb: this.walletDb,
     })
@@ -1441,6 +1443,7 @@ export class Wallet {
         createdAt: options?.resetCreatedAt ? null : account.createdAt,
         scanningEnabled: options?.resetScanningEnabled ? true : account.scanningEnabled,
         id: uuid(),
+        encrypted: false,
       },
       walletDb: this.walletDb,
     })

--- a/ironfish/src/wallet/walletdb/accountValue.test.ts
+++ b/ironfish/src/wallet/walletdb/accountValue.test.ts
@@ -2,14 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { generateKey } from '@ironfish/rust-nodejs'
-import { AccountValue, AccountValueEncoding } from './accountValue'
+import { AccountValueEncoding, DecryptedAccountValue } from './accountValue'
 
 describe('AccountValueEncoding', () => {
   it('serializes the object into a buffer and deserializes to the original object', () => {
     const encoder = new AccountValueEncoding()
 
     const key = generateKey()
-    const value: AccountValue = {
+    const value: DecryptedAccountValue = {
+      encrypted: false,
       id: 'id',
       name: 'foobar👁️🏃🐟',
       incomingViewKey: key.incomingViewKey,
@@ -34,7 +35,8 @@ describe('AccountValueEncoding', () => {
     const encoder = new AccountValueEncoding()
 
     const key = generateKey()
-    const value: AccountValue = {
+    const value: DecryptedAccountValue = {
+      encrypted: false,
       id: 'id',
       name: 'foobar👁️🏃🐟',
       incomingViewKey: key.incomingViewKey,

--- a/ironfish/src/wallet/walletdb/walletdb.ts
+++ b/ironfish/src/wallet/walletdb/walletdb.ts
@@ -32,7 +32,7 @@ import { BufferUtils } from '../../utils'
 import { BloomFilter } from '../../utils/bloomFilter'
 import { WorkerPool } from '../../workerPool'
 import { Account, calculateAccountPrefix } from '../account/account'
-import { AccountValue, AccountValueEncoding } from './accountValue'
+import { AccountValueEncoding, DecryptedAccountValue } from './accountValue'
 import { AssetValue, AssetValueEncoding } from './assetValue'
 import { BalanceValue, BalanceValueEncoding } from './balanceValue'
 import { DecryptedNoteValue, DecryptedNoteValueEncoding } from './decryptedNoteValue'
@@ -54,7 +54,7 @@ export class WalletDB {
   location: string
   files: FileSystem
 
-  accounts: IDatabaseStore<{ key: string; value: AccountValue }>
+  accounts: IDatabaseStore<{ key: string; value: DecryptedAccountValue }>
 
   meta: IDatabaseStore<{
     key: keyof AccountsDBMeta
@@ -391,7 +391,9 @@ export class WalletDB {
     return meta
   }
 
-  async *loadAccounts(tx?: IDatabaseTransaction): AsyncGenerator<AccountValue, void, unknown> {
+  async *loadAccounts(
+    tx?: IDatabaseTransaction,
+  ): AsyncGenerator<DecryptedAccountValue, void, unknown> {
     for await (const account of this.accounts.getAllValuesIter(tx)) {
       yield account
     }


### PR DESCRIPTION
## Summary

* Update Napi `encrypt` / `decrypt` to accept and return JS buffers
* Remove hex conversion from Napi functions and pass raw bytes
* Refactor `AccountValue` to `DecryptedAccountValue`
* Adds `encrypted` property to be used as a type guard in subsequent PRs
* Introduce `EncryptedAccountValue` to represent encrypted accounts in the database

## Testing Plan

Unit test

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
