### PR TITLE
replaces withCopy with copy of IronfishEvm

### DIFF
--- a/ironfish/src/evm/__fixtures__/evm.test.ts.fixture
+++ b/ironfish/src/evm/__fixtures__/evm.test.ts.fixture
@@ -1,5 +1,5 @@
 {
-  "IronfishEvm withCopy does not modify database": [
+  "IronfishEvm copy does not modify database": [
     {
       "value": {
         "version": 4,

--- a/ironfish/src/evm/evm.test.ts
+++ b/ironfish/src/evm/evm.test.ts
@@ -9,7 +9,7 @@ import { createNodeTest, useAccountFixture } from '../testUtilities'
 import { EvmStateEncoding, HexStringEncoding } from './database'
 
 describe('IronfishEvm', () => {
-  describe('withCopy', () => {
+  describe('copy', () => {
     const nodeTest = createNodeTest()
 
     it('does not modify database', async () => {
@@ -54,9 +54,8 @@ describe('IronfishEvm', () => {
 
       Assert.isNotUndefined(nodeTest.chain.evm)
 
-      const result = await nodeTest.chain.evm.withCopy((vm) => {
-        return nodeTest.chain.evm.runTx({ tx: signed }, vm)
-      })
+      const evmCopy = await nodeTest.chain.evm.copy()
+      const result = await evmCopy.runTx({ tx: signed })
 
       expect(result?.result?.totalGasSpent).toEqual(21000n)
 

--- a/ironfish/src/mining/manager.ts
+++ b/ironfish/src/mining/manager.ts
@@ -236,76 +236,70 @@ export class MiningManager {
     const assetOwners = new BufferMap<Buffer>()
     let totalTransactionFees = BigInt(0)
 
-    Assert.isNotUndefined(this.chain.evm)
-    await this.chain.evm.withCopy(async (vm) => {
-      for (const transaction of this.memPool.orderedTransactions()) {
-        if (transaction.version() !== transactionVersion) {
-          continue
-        }
+    const evmCopy = await this.chain.evm.copy()
 
-        // Skip transactions that would cause the block to exceed the max size
-        const transactionSize = getTransactionSize(transaction)
-        if (
-          currBlockSize + transactionSize >
-          this.chain.consensus.parameters.maxBlockSizeBytes
-        ) {
-          continue
-        }
-
-        if (isExpiredSequence(transaction.expiration(), sequence)) {
-          continue
-        }
-
-        const isConflicted = transaction.spends.find((spend) => nullifiers.has(spend.nullifier))
-        if (isConflicted) {
-          continue
-        }
-
-        const { valid: isValid } = await this.chain.verifier.verifyTransactionSpends(
-          transaction,
-        )
-        if (!isValid) {
-          continue
-        }
-
-        for (const spend of transaction.spends) {
-          nullifiers.add(spend.nullifier)
-        }
-
-        if (transaction.mints.length) {
-          const mintOwnerResult = await this.chain.verifier.verifyMintOwnersIncremental(
-            transaction.mints,
-            assetOwners,
-          )
-
-          // If the transaction is valid with the state of this new block
-          // template, we need to update the assetOwners map with the latest state
-          // of the owners, accounting for new mints and ownership transfer
-          if (mintOwnerResult.valid) {
-            for (const [assetId, assetOwner] of mintOwnerResult.assetOwners.entries()) {
-              assetOwners.set(assetId, assetOwner)
-            }
-          } else {
-            continue
-          }
-        }
-
-        // verify that EVM transactions are valid
-        if (transaction.evm) {
-          const evmResult = await this.chain.evm.runDesc(transaction.evm, vm)
-          const evmVerify = this.chain.verifier.verifyEvm(transaction, evmResult)
-          if (!evmVerify.valid) {
-            continue
-          }
-
-          totalTransactionFees += evmResult.result?.minerValue ?? 0n
-        }
-
-        currBlockSize += transactionSize
-        totalTransactionFees += transaction.fee()
-        blockTransactions.push(transaction)
+    for (const transaction of this.memPool.orderedTransactions()) {
+      if (transaction.version() !== transactionVersion) {
+        continue
       }
-    })
+
+      // Skip transactions that would cause the block to exceed the max size
+      const transactionSize = getTransactionSize(transaction)
+      if (currBlockSize + transactionSize > this.chain.consensus.parameters.maxBlockSizeBytes) {
+        continue
+      }
+
+      if (isExpiredSequence(transaction.expiration(), sequence)) {
+        continue
+      }
+
+      const isConflicted = transaction.spends.find((spend) => nullifiers.has(spend.nullifier))
+      if (isConflicted) {
+        continue
+      }
+
+      const { valid: isValid } = await this.chain.verifier.verifyTransactionSpends(transaction)
+      if (!isValid) {
+        continue
+      }
+
+      for (const spend of transaction.spends) {
+        nullifiers.add(spend.nullifier)
+      }
+
+      if (transaction.mints.length) {
+        const mintOwnerResult = await this.chain.verifier.verifyMintOwnersIncremental(
+          transaction.mints,
+          assetOwners,
+        )
+
+        // If the transaction is valid with the state of this new block
+        // template, we need to update the assetOwners map with the latest state
+        // of the owners, accounting for new mints and ownership transfer
+        if (mintOwnerResult.valid) {
+          for (const [assetId, assetOwner] of mintOwnerResult.assetOwners.entries()) {
+            assetOwners.set(assetId, assetOwner)
+          }
+        } else {
+          continue
+        }
+      }
+
+      // verify that EVM transactions are valid
+      if (transaction.evm) {
+        const evmResult = await evmCopy.runDesc(transaction.evm)
+        const evmVerify = this.chain.verifier.verifyEvm(transaction, evmResult)
+        if (!evmVerify.valid) {
+          continue
+        }
+
+        totalTransactionFees += evmResult.result?.minerValue ?? 0n
+      }
+
+      currBlockSize += transactionSize
+      totalTransactionFees += transaction.fee()
+      blockTransactions.push(transaction)
+    }
 
     this.metrics.mining_newBlockTransactions.add(BenchUtils.end(startTime))
 


### PR DESCRIPTION
## Summary

the wrapper pattern of withCopy was proving cumbersome to use when verifying evm transactions in blocks because we needed to wrap verification of all transactions in the block

making a copy of the IronfishEvm instance is more straightforward and still has the benefit of not committing changes to the db if we set a checkpoint on the stateManager

removes the optional vm argument to runTx and runDesc since we can now use these on the copy of the IronfishEvm instead of using a copy of only the vm

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
