### PR TITLE
eth_sendRawTransaction RPC

### DIFF
--- a/ironfish/src/rpc/clients/client.ts
+++ b/ironfish/src/rpc/clients/client.ts
@@ -171,7 +171,12 @@ import type {
   UseAccountRequest,
   UseAccountResponse,
 } from '../routes'
-import { GetAccountRequest, GetAccountResponse } from '../routes/eth'
+import {
+  GetAccountRequest,
+  GetAccountResponse,
+  SendRawTransactionRequest,
+  SendRawTransactionResponse,
+} from '../routes/eth'
 import { ApiNamespace } from '../routes/namespaces'
 
 export abstract class RpcClient {
@@ -1007,6 +1012,14 @@ export abstract class RpcClient {
     getAccount: (params: GetAccountRequest): Promise<RpcResponseEnded<GetAccountResponse>> => {
       return this.request<GetAccountResponse>(
         `${ApiNamespace.eth}/getAccount`,
+        params,
+      ).waitForEnd()
+    },
+    sendRawTransaction: (
+      params: SendRawTransactionRequest,
+    ): Promise<RpcResponseEnded<SendRawTransactionResponse>> => {
+      return this.request<SendRawTransactionResponse>(
+        `${ApiNamespace.eth}/sendRawTransaction`,
         params,
       ).waitForEnd()
     },

--- a/ironfish/src/rpc/routes/eth/__fixtures__/sendRawTransaction.test.ts.fixture
+++ b/ironfish/src/rpc/routes/eth/__fixtures__/sendRawTransaction.test.ts.fixture
@@ -1,0 +1,32 @@
+{
+  "Route eth/sendRawTransaction should construct evm transaction and submit to node": [
+    {
+      "value": {
+        "version": 4,
+        "id": "f1e2bcf7-dc4b-4b21-ae85-be96dc90891a",
+        "name": "sender",
+        "spendingKey": "c94e9a20b662c9fbdecd29453c9df7920d848e20557d7b4978a6040e1997f90e",
+        "viewKey": "916b84878dde5afcc39c0884db4f6276d91bcda54122e06c7833babec131bba1a1302365c506a091870ea6550cb06dedb16b203d7af1027381a005384e331d20",
+        "incomingViewKey": "6631574519f2c28b7a946626b3dc1fdc4af024488686e436601aed5b41a6e806",
+        "outgoingViewKey": "c2c5ca0ac4e1ae89293b5dc28854aa76253a5824c9f36572c8715701d52fb694",
+        "publicAddress": "2c2dda8b68514072b3693a75ea8c5eff98c04282d343a70a15342e31d3270cee",
+        "createdAt": {
+          "hash": {
+            "type": "Buffer",
+            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+          },
+          "sequence": 1
+        },
+        "scanningEnabled": true,
+        "proofAuthorizingKey": "44598e8914292b31ef2ddcf8553655a8774a54eb21935c4c77fddcea80d3a50d"
+      },
+      "head": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+        },
+        "sequence": 1
+      }
+    }
+  ]
+}

--- a/ironfish/src/rpc/routes/eth/index.ts
+++ b/ironfish/src/rpc/routes/eth/index.ts
@@ -2,3 +2,4 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 export * from './getAccount'
+export * from './sendRawTransaction'

--- a/ironfish/src/rpc/routes/eth/sendRawTransaction.test.ts
+++ b/ironfish/src/rpc/routes/eth/sendRawTransaction.test.ts
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { LegacyTransaction } from '@ethereumjs/tx'
+import { Account as EthAccount, Address } from '@ethereumjs/util'
+import { Assert } from '../../../assert'
+import { useAccountFixture } from '../../../testUtilities'
+import { createRouteTest } from '../../../testUtilities/routeTest'
+
+describe('Route eth/sendRawTransaction', () => {
+  const routeTest = createRouteTest(false)
+
+  it('should construct evm transaction and submit to node', async () => {
+    const senderIf = await useAccountFixture(routeTest.node.wallet, 'sender')
+
+    const evmPrivateKey = Uint8Array.from(Buffer.from(senderIf.spendingKey || '', 'hex'))
+
+    const evmSenderAddress = Address.fromPrivateKey(evmPrivateKey)
+    const senderAccount = new EthAccount(BigInt(0), 500_000_000n)
+
+    await routeTest.node.chain.blockchainDb.stateManager.checkpoint()
+    await routeTest.node.chain.blockchainDb.stateManager.putAccount(
+      evmSenderAddress,
+      senderAccount,
+    )
+    await routeTest.node.chain.blockchainDb.stateManager.commit()
+
+    const evmAccount = await routeTest.node.chain.blockchainDb.stateManager.getAccount(
+      evmSenderAddress,
+    )
+    Assert.isNotUndefined(evmAccount)
+    const tx = new LegacyTransaction({
+      nonce: 0n,
+      to: evmSenderAddress,
+      value: evmAccount.balance / 2n,
+      gasLimit: 21000n,
+      gasPrice: 7n,
+    })
+    const signed = tx.sign(evmPrivateKey)
+    const response = await routeTest.client.eth.sendRawTransaction({
+      transaction: Buffer.from(signed.serialize()).toString('hex'),
+    })
+
+    expect(response.status).toEqual(200)
+    expect(response.content.hash).toEqual(Buffer.from(signed.hash()).toString('hex'))
+    expect(response.content.ifHash).toBeDefined()
+    expect(response.content.accepted).toEqual(true)
+  })
+})

--- a/ironfish/src/rpc/routes/eth/sendRawTransaction.ts
+++ b/ironfish/src/rpc/routes/eth/sendRawTransaction.ts
@@ -1,0 +1,66 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { LegacyTransaction } from '@ethereumjs/tx'
+import * as yup from 'yup'
+import { Assert } from '../../../assert'
+import { GLOBAL_IF_ACCOUNT } from '../../../evm'
+import { FullNode } from '../../../node'
+import { legacyTransactionToEvmDescription } from '../../../primitives'
+import { ApiNamespace } from '../namespaces'
+import { routes } from '../router'
+
+export type SendRawTransactionRequest = {
+  transaction: string
+}
+
+export type SendRawTransactionResponse = {
+  hash: string
+  ifHash: string
+  accepted?: boolean
+  broadcasted?: boolean
+}
+
+export const SendRawTransactionRequestSchema: yup.ObjectSchema<SendRawTransactionRequest> = yup
+  .object({
+    transaction: yup.string().defined().trim(),
+  })
+  .defined()
+
+export const SendRawTransactionResponseSchema: yup.ObjectSchema<SendRawTransactionResponse> =
+  yup
+    .object({
+      hash: yup.string().defined(),
+      ifHash: yup.string().defined(),
+      accepted: yup.boolean().optional(),
+      broadcasted: yup.boolean().optional(),
+    })
+    .defined()
+
+routes.register<typeof SendRawTransactionRequestSchema, SendRawTransactionResponse>(
+  `${ApiNamespace.eth}/sendRawTransaction`,
+  SendRawTransactionRequestSchema,
+  async (request, node): Promise<void> => {
+    Assert.isInstanceOf(node, FullNode)
+
+    const bytes = Buffer.from(request.data.transaction, 'hex')
+    const ethTransaction = LegacyTransaction.fromSerializedTx(bytes)
+    const evmDescription = legacyTransactionToEvmDescription(ethTransaction)
+    const raw = await node.wallet.createEvmTransaction({
+      evm: evmDescription,
+      evmEvents: [],
+    })
+
+    const transaction = await node.wallet.post({
+      transaction: raw,
+      spendingKey: GLOBAL_IF_ACCOUNT.spendingKey,
+    })
+
+    request.end({
+      hash: Buffer.from(ethTransaction.hash()).toString('hex'),
+      ifHash: transaction.transaction.hash().toString('hex'),
+      accepted: transaction.accepted,
+      broadcasted: transaction.broadcasted,
+    })
+  },
+)


### PR DESCRIPTION
## Summary
Send Raw Transaction that will take standard eth transactions and submit them to the network.
## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
