### PR TITLE
feat(ironfish): Add serialization for encrypted accounts

### DIFF
--- a/ironfish/src/wallet/account/encryptedAccount.ts
+++ b/ironfish/src/wallet/account/encryptedAccount.ts
@@ -20,7 +20,7 @@ export class EncryptedAccount {
     try {
       const decryptedAccountValue = decrypt(this.data, passphrase)
       const encoder = new AccountValueEncoding()
-      const accountValue = encoder.deserialize(decryptedAccountValue)
+      const accountValue = encoder.deserializeDecrypted(decryptedAccountValue)
 
       return new Account({ accountValue, walletDb: this.walletDb })
     } catch {

--- a/ironfish/src/wallet/walletdb/accountValue.test.ts
+++ b/ironfish/src/wallet/walletdb/accountValue.test.ts
@@ -1,8 +1,12 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { generateKey } from '@ironfish/rust-nodejs'
-import { AccountValueEncoding, DecryptedAccountValue } from './accountValue'
+import { encrypt, generateKey } from '@ironfish/rust-nodejs'
+import {
+  AccountValueEncoding,
+  DecryptedAccountValue,
+  EncryptedAccountValue,
+} from './accountValue'
 
 describe('AccountValueEncoding', () => {
   it('serializes the object into a buffer and deserializes to the original object', () => {
@@ -58,5 +62,43 @@ describe('AccountValueEncoding', () => {
     const buffer = encoder.serialize(value)
     const deserializedValue = encoder.deserialize(buffer)
     expect(deserializedValue).toEqual(value)
+  })
+
+  it('serializes an object encrypted account data into a buffer and deserializes to the original object', () => {
+    const encoder = new AccountValueEncoding()
+
+    const key = generateKey()
+    const value: DecryptedAccountValue = {
+      encrypted: false,
+      id: 'id',
+      name: 'foobar👁️🏃🐟',
+      incomingViewKey: key.incomingViewKey,
+      outgoingViewKey: key.outgoingViewKey,
+      publicAddress: key.publicAddress,
+      spendingKey: null,
+      viewKey: key.viewKey,
+      version: 1,
+      createdAt: null,
+      scanningEnabled: true,
+      multisigKeys: {
+        publicKeyPackage: 'cccc',
+        secret: 'deaf',
+        keyPackage: 'beef',
+      },
+      proofAuthorizingKey: key.proofAuthorizingKey,
+    }
+
+    const passphrase = 'foobarbaz'
+    const data = encoder.serialize(value)
+    const encryptedData = encrypt(data, passphrase)
+
+    const encryptedValue: EncryptedAccountValue = {
+      encrypted: true,
+      data: encryptedData,
+    }
+
+    const buffer = encoder.serialize(encryptedValue)
+    const deserializedValue = encoder.deserializeEncrypted(buffer)
+    expect(encryptedValue).toEqual(deserializedValue)
   })
 })

--- a/ironfish/src/wallet/walletdb/walletdb.ts
+++ b/ironfish/src/wallet/walletdb/walletdb.ts
@@ -32,7 +32,7 @@ import { BufferUtils } from '../../utils'
 import { BloomFilter } from '../../utils/bloomFilter'
 import { WorkerPool } from '../../workerPool'
 import { Account, calculateAccountPrefix } from '../account/account'
-import { AccountValueEncoding, DecryptedAccountValue } from './accountValue'
+import { AccountValue, AccountValueEncoding, DecryptedAccountValue } from './accountValue'
 import { AssetValue, AssetValueEncoding } from './assetValue'
 import { BalanceValue, BalanceValueEncoding } from './balanceValue'
 import { DecryptedNoteValue, DecryptedNoteValueEncoding } from './decryptedNoteValue'
@@ -54,7 +54,7 @@ export class WalletDB {
   location: string
   files: FileSystem
 
-  accounts: IDatabaseStore<{ key: string; value: DecryptedAccountValue }>
+  accounts: IDatabaseStore<{ key: string; value: AccountValue }>
 
   meta: IDatabaseStore<{
     key: keyof AccountsDBMeta
@@ -395,7 +395,10 @@ export class WalletDB {
     tx?: IDatabaseTransaction,
   ): AsyncGenerator<DecryptedAccountValue, void, unknown> {
     for await (const account of this.accounts.getAllValuesIter(tx)) {
-      yield account
+      // TODO(rohanjadvani): Remove this when encrypted accounts are managed in the wallet
+      if (!account.encrypted) {
+        yield account
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

* Expands AccountValueEncoding to support both encrypted and decrypted accounts
* Only return decrypted accounts from the walletdb generator (will be fixed when the wallet can store encrypted accounts)

## Testing Plan

Unit test for serialization round trip

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
