### PR TITLE
allows pre-signed evm descriptions in Iron Fish transactions

### DIFF
--- a/ironfish-rust-nodejs/index.d.ts
+++ b/ironfish-rust-nodejs/index.d.ts
@@ -193,7 +193,7 @@ export class Transaction {
   mint(asset: Asset, value: bigint, transferOwnershipTo?: string | undefined | null): void
   /** Burn some supply of a given asset and value as part of this transaction. */
   burn(assetIdJsBytes: Buffer, value: bigint): void
-  evm(nonce: bigint, gasPrice: bigint, gasLimit: bigint, to: Buffer, value: bigint, data: Buffer, privateIron: bigint, publicIron: bigint): void
+  evm(nonce: bigint, gasPrice: bigint, gasLimit: bigint, to: Buffer, value: bigint, data: Buffer, privateIron: bigint, publicIron: bigint, v?: bigint | undefined | null, r?: Buffer | undefined | null, s?: Buffer | undefined | null): void
   /**
    * Special case for posting a miners fee transaction. Miner fee transactions
    * are unique in that they generate currency. They do not have any spends

--- a/ironfish-rust-nodejs/src/structs/transaction.rs
+++ b/ironfish-rust-nodejs/src/structs/transaction.rs
@@ -288,7 +288,7 @@ impl NativeTransaction {
             Some(to_bytes)
         };
 
-        let v = v.map_or(None, |v| Some(v.get_u64().1));
+        let v = v.map(|v| v.get_u64().1);
 
         let r = match r {
             None => None,

--- a/ironfish-rust-nodejs/src/structs/transaction.rs
+++ b/ironfish-rust-nodejs/src/structs/transaction.rs
@@ -15,7 +15,7 @@ use ironfish::frost_utils::signing_package::SigningPackage;
 use ironfish::serializing::bytes_to_hex;
 use ironfish::serializing::fr::FrSerializable;
 use ironfish::serializing::hex_to_vec_bytes;
-use ironfish::transaction::evm::UnsignedEvmDescription;
+use ironfish::transaction::evm::WrappedEvmDescription;
 use ironfish::transaction::unsigned::UnsignedTransaction;
 use ironfish::transaction::{
     batch_verify_transactions, TransactionVersion, TRANSACTION_EXPIRATION_SIZE,
@@ -267,6 +267,9 @@ impl NativeTransaction {
         data: JsBuffer,
         private_iron: BigInt,
         public_iron: BigInt,
+        v: Option<BigInt>,
+        r: Option<JsBuffer>,
+        s: Option<JsBuffer>,
     ) -> Result<()> {
         // if to length is 0, return none, else set the address
         let to_vec = to.into_value()?.to_vec();
@@ -285,7 +288,35 @@ impl NativeTransaction {
             Some(to_bytes)
         };
 
-        let evm_description = UnsignedEvmDescription::new(
+        let v = v.map_or(None, |v| Some(v.get_u64().1));
+
+        let r = match r {
+            None => None,
+            Some(r) => {
+                let r_vec = r.into_value()?.to_vec();
+                if r_vec.len() != 32 {
+                    return Err(to_napi_err("EVM r must be 32 bytes"));
+                }
+                let mut r = [0u8; 32];
+                r.copy_from_slice(&r_vec);
+                Some(r)
+            }
+        };
+
+        let s = match s {
+            None => None,
+            Some(s) => {
+                let s_vec = s.into_value()?.to_vec();
+                if s_vec.len() != 32 {
+                    return Err(to_napi_err("EVM s must be 32 bytes"));
+                }
+                let mut s = [0u8; 32];
+                s.copy_from_slice(&s_vec);
+                Some(s)
+            }
+        };
+
+        let evm_description = WrappedEvmDescription::new(
             nonce.get_u64().1,
             gas_price.get_u64().1,
             gas_limit.get_u64().1,
@@ -294,7 +325,11 @@ impl NativeTransaction {
             data.into_value()?.to_vec(),
             private_iron.get_u64().1,
             public_iron.get_u64().1,
+            v,
+            r,
+            s,
         );
+
         self.transaction
             .add_evm(evm_description)
             .map_err(to_napi_err)?;

--- a/ironfish-rust/src/transaction/mod.rs
+++ b/ironfish-rust/src/transaction/mod.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use blstrs::Bls12;
-use evm::{EvmDescription, UnsignedEvmDescription};
+use evm::{EvmDescription, WrappedEvmDescription};
 use ff::Field;
 use outputs::OutputBuilder;
 use spends::{SpendBuilder, UnsignedSpendDescription};
@@ -106,7 +106,7 @@ pub struct ProposedTransaction {
     burns: Vec<BurnBuilder>,
 
     // can attach arbitrary data to transaction, will initially be used for EVM transactions
-    evm: Option<UnsignedEvmDescription>,
+    evm: Option<WrappedEvmDescription>,
 
     /// The balance of all the spends minus all the outputs. The difference
     /// is the fee paid to the miner for mining the transaction.
@@ -174,10 +174,7 @@ impl ProposedTransaction {
         Ok(())
     }
 
-    pub fn add_evm(
-        &mut self,
-        evm_description: UnsignedEvmDescription,
-    ) -> Result<(), IronfishError> {
+    pub fn add_evm(&mut self, evm_description: WrappedEvmDescription) -> Result<(), IronfishError> {
         self.value_balances.add(
             &NATIVE_ASSET,
             evm_description.description.private_iron.try_into()?,
@@ -509,7 +506,7 @@ impl ProposedTransaction {
         &self,
         mints: &[UnsignedMintDescription],
         burns: &[BurnDescription],
-        evm: &Option<UnsignedEvmDescription>,
+        evm: &Option<WrappedEvmDescription>,
     ) -> Result<(redjubjub::PrivateKey, redjubjub::PublicKey), IronfishError> {
         // A "private key" manufactured from a bunch of randomness added for each
         // spend and output.
@@ -552,7 +549,7 @@ impl ProposedTransaction {
         binding_verification_key: &ExtendedPoint,
         mints: &[UnsignedMintDescription],
         burns: &[BurnDescription],
-        evm: &Option<UnsignedEvmDescription>,
+        evm: &Option<WrappedEvmDescription>,
     ) -> Result<ExtendedPoint, IronfishError> {
         let mints_descriptions: Vec<MintDescription> =
             mints.iter().map(|m| m.description.clone()).collect();

--- a/ironfish-rust/src/transaction/tests.rs
+++ b/ironfish-rust/src/transaction/tests.rs
@@ -8,7 +8,7 @@ use std::collections::{BTreeMap, HashMap};
 use super::internal_batch_verify_transactions;
 use super::{ProposedTransaction, Transaction};
 use crate::test_util::create_multisig_identities;
-use crate::transaction::evm::UnsignedEvmDescription;
+use crate::transaction::evm::WrappedEvmDescription;
 use crate::transaction::tests::split_spender_key::split_spender_key;
 use crate::{
     assets::{asset::Asset, asset_identifier::NATIVE_ASSET},
@@ -231,7 +231,7 @@ fn test_evm_transaction() {
     );
     let witness = make_fake_witness(&in_note);
 
-    let evm = UnsignedEvmDescription::new(
+    let evm = WrappedEvmDescription::new(
         9,
         1,
         2_000_000,
@@ -240,6 +240,9 @@ fn test_evm_transaction() {
         vec![],
         0,
         0,
+        None,
+        None,
+        None,
     );
 
     let mut transaction = ProposedTransaction::new(TransactionVersion::latest());
@@ -286,7 +289,7 @@ fn test_evm_transaction_public_iron() {
     );
     let witness = make_fake_witness(&in_note);
 
-    let evm = UnsignedEvmDescription::new(
+    let evm = WrappedEvmDescription::new(
         9,
         1,
         2_000_000,
@@ -295,6 +298,9 @@ fn test_evm_transaction_public_iron() {
         vec![],
         0,
         41,
+        None,
+        None,
+        None,
     );
     let evm_clone = evm.clone();
 
@@ -345,7 +351,7 @@ fn test_evm_transaction_private_iron() {
         spender_key.public_address(),
     );
 
-    let evm = UnsignedEvmDescription::new(
+    let evm = WrappedEvmDescription::new(
         9,
         1,
         2_000_000,
@@ -354,6 +360,9 @@ fn test_evm_transaction_private_iron() {
         vec![],
         42,
         0,
+        None,
+        None,
+        None,
     );
     let evm_clone = evm.clone();
 

--- a/ironfish-rust/src/transaction/unsigned.rs
+++ b/ironfish-rust/src/transaction/unsigned.rs
@@ -28,7 +28,7 @@ use crate::{
 };
 
 use super::{
-    burns::BurnDescription, evm::UnsignedEvmDescription, mints::UnsignedMintDescription,
+    burns::BurnDescription, evm::WrappedEvmDescription, mints::UnsignedMintDescription,
     spends::UnsignedSpendDescription, TransactionVersion, SIGNATURE_HASH_PERSONALIZATION,
     TRANSACTION_SIGNATURE_VERSION,
 };
@@ -52,7 +52,7 @@ pub struct UnsignedTransaction {
     pub(crate) burns: Vec<BurnDescription>,
 
     /// List of data
-    pub(crate) evm: Option<UnsignedEvmDescription>,
+    pub(crate) evm: Option<WrappedEvmDescription>,
 
     /// Signature calculated from accumulating randomness with all the spends
     /// and outputs when the transaction was created.
@@ -114,7 +114,7 @@ impl UnsignedTransaction {
         }
 
         let evm = if version.has_evm() && reader.read_u8()? == 1 {
-            Some(UnsignedEvmDescription::read(&mut reader)?)
+            Some(WrappedEvmDescription::read(&mut reader)?)
         } else {
             None
         };

--- a/ironfish/src/consensus/__fixtures__/verifier.evm.test.slow.ts.fixture
+++ b/ironfish/src/consensus/__fixtures__/verifier.evm.test.slow.ts.fixture
@@ -212,5 +212,35 @@
         }
       ]
     }
+  ],
+  "Verifier EVM Transaction allows presigned evm descriptions": [
+    {
+      "value": {
+        "version": 4,
+        "id": "b471d748-668c-424e-a2ed-aa4b2ba6df1c",
+        "name": "recipient",
+        "spendingKey": "fa62ae4191d339b42ce8ffdf782e2864baca49cfb784d37b5f52cde929b75c44",
+        "viewKey": "9571dd99d15960829b9a36648231fa0024638c0ccf4d9be71add1ce2e8dfe0d3f3233c705d133ea979ec900ad7b86482cc3afe18f33f1e01fa4ec5f9feed95e7",
+        "incomingViewKey": "21f009a8ae855ead16bc29ac03b61bdd2887ae4f67b1270278a5e90296732902",
+        "outgoingViewKey": "a85b159ae6e5ea2f21d67cdae606963ec145f4d7b50839bff29c98b3ebf9b31f",
+        "publicAddress": "6b9d550c91ec3773f69b17bff605bb9fce871e4a7435ac6da3786f96679f9156",
+        "createdAt": {
+          "hash": {
+            "type": "Buffer",
+            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+          },
+          "sequence": 1
+        },
+        "scanningEnabled": true,
+        "proofAuthorizingKey": "d3a021e7a8d7ed31d9fc7c667c093211b6b0f10b4c604ffc86fb1e71dede3801"
+      },
+      "head": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+        },
+        "sequence": 1
+      }
+    }
   ]
 }

--- a/ironfish/src/primitives/evmDescription.ts
+++ b/ironfish/src/primitives/evmDescription.ts
@@ -4,7 +4,7 @@
 import { LegacyTransaction } from '@ethereumjs/tx'
 import { bigIntToBytes, bytesToBigInt } from '@ethereumjs/util'
 
-export interface UnsignedEvmDescription {
+export interface EvmDescription {
   nonce: bigint
   gasPrice: bigint
   gasLimit: bigint
@@ -13,12 +13,9 @@ export interface UnsignedEvmDescription {
   data: Buffer
   privateIron: bigint
   publicIron: bigint
-}
-
-export interface EvmDescription extends UnsignedEvmDescription {
-  v: number
-  r: Buffer
-  s: Buffer
+  v?: bigint
+  r?: Buffer
+  s?: Buffer
 }
 
 export function legacyTransactionToEvmDescription(tx: LegacyTransaction): EvmDescription {
@@ -29,9 +26,9 @@ export function legacyTransactionToEvmDescription(tx: LegacyTransaction): EvmDes
     to: tx.to ? Buffer.from(tx.to.bytes) : Buffer.alloc(0),
     value: BigInt(tx.value),
     data: Buffer.from(tx.data),
-    v: Number(tx.v),
-    r: tx.r ? Buffer.from(bigIntToBytes(tx.r)) : Buffer.alloc(0),
-    s: tx.s ? Buffer.from(bigIntToBytes(tx.s)) : Buffer.alloc(0),
+    v: tx.v,
+    r: tx.r ? Buffer.from(bigIntToBytes(tx.r)) : undefined,
+    s: tx.s ? Buffer.from(bigIntToBytes(tx.s)) : undefined,
     privateIron: BigInt(0),
     publicIron: BigInt(0),
   }
@@ -43,9 +40,9 @@ export function evmDescriptionToLegacyTransaction(desc: EvmDescription): LegacyT
     to: desc.to.length > 0 ? desc.to : undefined,
     value: desc.value,
     data: desc.data,
-    v: BigInt(desc.v),
-    r: desc.r.length > 0 ? bytesToBigInt(desc.r) : undefined,
-    s: desc.s.length > 0 ? bytesToBigInt(desc.s) : undefined,
+    v: desc.v,
+    r: desc.r ? bytesToBigInt(desc.r) : undefined,
+    s: desc.s ? bytesToBigInt(desc.s) : undefined,
     // TODO(jwp) gas constants are hardcoded
     gasLimit: desc.gasLimit,
     gasPrice: desc.gasPrice,

--- a/ironfish/src/primitives/rawTransaction.ts
+++ b/ironfish/src/primitives/rawTransaction.ts
@@ -24,7 +24,7 @@ import { Side } from '../merkletree/merkletree'
 import { CurrencyUtils } from '../utils/currency'
 import { AssetBalances } from '../wallet/assetBalances'
 import { BurnDescription } from './burnDescription'
-import { UnsignedEvmDescription } from './evmDescription'
+import { EvmDescription } from './evmDescription'
 import { Note } from './note'
 import { NoteEncrypted, NoteEncryptedHash, SerializedNoteEncryptedHash } from './noteEncrypted'
 import { SPEND_SERIALIZED_SIZE_IN_BYTE } from './spend'
@@ -49,7 +49,7 @@ export class RawTransaction {
   mints: MintData[] = []
   burns: BurnDescription[] = []
   outputs: { note: Note }[] = []
-  evm: UnsignedEvmDescription | null = null
+  evm: EvmDescription | null = null
 
   spends: {
     note: Note
@@ -191,6 +191,9 @@ export class RawTransaction {
         this.evm.data,
         this.evm.privateIron,
         this.evm.publicIron,
+        this.evm.v,
+        this.evm.r,
+        this.evm.s,
       )
     }
 
@@ -238,7 +241,6 @@ export class RawTransaction {
   }
 }
 
-// TODO update serde to include evm data
 export class RawTransactionSerde {
   static serialize(raw: RawTransaction): Buffer {
     const bw = bufio.write(this.getSize(raw))

--- a/ironfish/src/primitives/transaction.ts
+++ b/ironfish/src/primitives/transaction.ts
@@ -167,7 +167,7 @@ export class Transaction {
         const privateIron = reader.readBigU64()
         const publicIron = reader.readBigU64()
 
-        const v = reader.readU64()
+        const v = reader.readBigU64()
         const r = reader.readBytes(32)
         const s = reader.readBytes(32)
 


### PR DESCRIPTION
## Summary

supports use cases like the eth_sendRawTransaction RPC where we might have an evm transaction that the user has already signed that we then wrap with an Iron Fish transaction without access to the user's keys

this could also support a shielding RPC where uses submit signed evm transactions that shield assets that are then wrapped in Iron Fish transactions

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
