### PR TITLE
merge verify block logic into one entry point

### DIFF
--- a/ironfish/src/blockchain/blockchain.test.ts
+++ b/ironfish/src/blockchain/blockchain.test.ts
@@ -729,7 +729,7 @@ describe('Blockchain', () => {
     const { node } = await nodeTest.createSetup()
     const block = await useMinerBlockFixture(node.chain)
 
-    let result = await node.chain.verifier.verifyBlockAdd(block, node.chain.genesis)
+    let result = await node.chain.verifier.verifyBlock(block, { prev: node.chain.genesis })
     expect(result).toMatchObject({
       valid: true,
     })
@@ -742,7 +742,7 @@ describe('Blockchain', () => {
       transactions: block.transactions,
     })
 
-    result = await node.chain.verifier.verifyBlockAdd(invalidBlock, node.chain.genesis)
+    result = await node.chain.verifier.verifyBlock(invalidBlock, { prev: node.chain.genesis })
     expect(result).toMatchObject({
       valid: false,
       reason: VerificationResultReason.BLOCK_TOO_OLD,
@@ -834,7 +834,7 @@ describe('Blockchain', () => {
     const { node } = await nodeTest.createSetup()
     const block = await useMinerBlockFixture(node.chain)
 
-    const result = await node.chain.verifier.verifyBlockAdd(block, null)
+    const result = await node.chain.verifier.verifyBlock(block, { prev: null })
     expect(result).toMatchObject({
       valid: false,
       reason: VerificationResultReason.PREV_HASH_NULL,
@@ -850,7 +850,7 @@ describe('Blockchain', () => {
     //Force one byte of the hash to not match the previous hash of the block.
     node.chain.genesis.hash[0] = node.chain.genesis.hash[0] ^ 0xff
 
-    const result = await node.chain.verifier.verifyBlockAdd(block, node.chain.genesis)
+    const result = await node.chain.verifier.verifyBlock(block, { prev: node.chain.genesis })
     expect(result).toMatchObject({
       valid: false,
       reason: VerificationResultReason.PREV_HASH_MISMATCH,

--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -646,7 +646,7 @@ export class Blockchain {
     prev: BlockHeader | null,
     tx: IDatabaseTransaction,
   ): Promise<void> {
-    const verifyBlockAdd = this.verifier.verifyBlockAdd(block, prev).catch((_) => {
+    const verifyBlockAdd = this.verifier.verifyBlock(block, { prev }).catch((_) => {
       return { valid: false, reason: VerificationResultReason.ERROR }
     })
 
@@ -707,7 +707,7 @@ export class Blockchain {
       await this.reorganizeChain(prev, tx)
     }
 
-    const verifyBlockAdd = this.verifier.verifyBlockAdd(block, prev).catch((_) => {
+    const verifyBlockAdd = this.verifier.verifyBlock(block, { prev }).catch((_) => {
       return { valid: false, reason: VerificationResultReason.ERROR }
     })
 

--- a/ironfish/src/consensus/verifier.test.ts
+++ b/ironfish/src/consensus/verifier.test.ts
@@ -702,7 +702,7 @@ describe('Verifier', () => {
 
         const invalidBlock = new Block(invalidHeader, block.transactions)
 
-        expect(await verifier.verifyBlockAdd(invalidBlock, prevHeader)).toMatchObject({
+        expect(await verifier.verifyBlock(invalidBlock, { prev: prevHeader })).toMatchObject({
           reason: VerificationResultReason.BLOCK_TOO_OLD,
           valid: false,
         })
@@ -723,7 +723,7 @@ describe('Verifier', () => {
 
         const invalidBlock = new Block(invalidHeader, block.transactions)
 
-        expect(await verifier.verifyBlockAdd(invalidBlock, prevHeader)).toMatchObject({
+        expect(await verifier.verifyBlock(invalidBlock, { prev: prevHeader })).toMatchObject({
           reason: VerificationResultReason.TOO_FAR_IN_FUTURE,
           valid: false,
         })
@@ -741,7 +741,7 @@ describe('Verifier', () => {
 
         const invalidBlock = new Block(invalidHeader, block.transactions)
 
-        expect(await verifier.verifyBlockAdd(invalidBlock, prevHeader)).toMatchObject({
+        expect(await verifier.verifyBlock(invalidBlock, { prev: prevHeader })).toMatchObject({
           valid: true,
         })
       })
@@ -758,7 +758,7 @@ describe('Verifier', () => {
 
         const invalidBlock = new Block(invalidHeader, block.transactions)
 
-        expect(await verifier.verifyBlockAdd(invalidBlock, prevHeader)).toMatchObject({
+        expect(await verifier.verifyBlock(invalidBlock, { prev: prevHeader })).toMatchObject({
           valid: true,
         })
       })
@@ -802,7 +802,7 @@ describe('Verifier', () => {
 
         const invalidBlock = new Block(invalidHeader, currentBlock.transactions)
 
-        expect(await verifier.verifyBlockAdd(invalidBlock, prevHeader)).toMatchObject({
+        expect(await verifier.verifyBlock(invalidBlock, { prev: prevHeader })).toMatchObject({
           reason: VerificationResultReason.BLOCK_TOO_OLD,
           valid: false,
         })
@@ -823,7 +823,7 @@ describe('Verifier', () => {
 
         const invalidBlock = new Block(invalidHeader, currentBlock.transactions)
 
-        expect(await verifier.verifyBlockAdd(invalidBlock, prevHeader)).toMatchObject({
+        expect(await verifier.verifyBlock(invalidBlock, { prev: prevHeader })).toMatchObject({
           reason: VerificationResultReason.TOO_FAR_IN_FUTURE,
           valid: false,
         })
@@ -837,7 +837,7 @@ describe('Verifier', () => {
 
         const invalidBlock = new Block(invalidHeader, currentBlock.transactions)
 
-        expect(await verifier.verifyBlockAdd(invalidBlock, prevHeader)).toMatchObject({
+        expect(await verifier.verifyBlock(invalidBlock, { prev: prevHeader })).toMatchObject({
           reason: VerificationResultReason.BLOCK_TOO_OLD,
           valid: false,
         })
@@ -851,7 +851,7 @@ describe('Verifier', () => {
 
         const invalidBlock = new Block(invalidHeader, currentBlock.transactions)
 
-        expect(await verifier.verifyBlockAdd(invalidBlock, prevHeader)).toMatchObject({
+        expect(await verifier.verifyBlock(invalidBlock, { prev: prevHeader })).toMatchObject({
           reason: VerificationResultReason.BLOCK_TOO_OLD,
           valid: false,
         })
@@ -869,7 +869,7 @@ describe('Verifier', () => {
 
         const invalidBlock = new Block(invalidHeader, currentBlock.transactions)
 
-        expect(await verifier.verifyBlockAdd(invalidBlock, prevHeader)).toMatchObject({
+        expect(await verifier.verifyBlock(invalidBlock, { prev: prevHeader })).toMatchObject({
           valid: true,
         })
       })

--- a/ironfish/src/consensus/verifier.ts
+++ b/ironfish/src/consensus/verifier.ts
@@ -44,7 +44,7 @@ export class Verifier {
    *  *  All transaction proofs are valid
    *  *  Miner's fee is transaction list fees + miner's reward
    */
-  async verifyBlock(
+  private async _verifyBlock(
     block: Block,
     options: { verifyTarget?: boolean } = { verifyTarget: true },
   ): Promise<VerificationResult> {
@@ -392,22 +392,29 @@ export class Verifier {
     return header.target.targetValue === expectedTarget.targetValue
   }
 
-  // TODO: Rename to verifyBlock but merge verifyBlock into this
-  async verifyBlockAdd(block: Block, prev: BlockHeader | null): Promise<VerificationResult> {
+  async verifyBlock(
+    block: Block,
+    options: {
+      prev?: BlockHeader | null
+      verifyTarget?: boolean
+    } = { verifyTarget: true },
+  ): Promise<VerificationResult> {
     if (block.header.sequence === GENESIS_BLOCK_SEQUENCE) {
       return { valid: true }
     }
 
-    if (!prev) {
+    if (options.prev === null) {
       return { valid: false, reason: VerificationResultReason.PREV_HASH_NULL }
     }
 
-    let verification = this.verifyBlockHeaderContextual(block.header, prev)
-    if (!verification.valid) {
-      return verification
+    if (options.prev) {
+      const verification = this.verifyBlockHeaderContextual(block.header, options.prev)
+      if (!verification.valid) {
+        return verification
+      }
     }
 
-    verification = await this.verifyBlock(block, {})
+    const verification = await this._verifyBlock(block, options)
     if (!verification.valid) {
       return verification
     }

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -1216,11 +1216,7 @@ export class PeerNetwork {
     await this.onNewFullBlock(peer, block, prevHeader)
   }
 
-  private async onNewFullBlock(
-    peer: Peer,
-    block: Block,
-    prevHeader: BlockHeader,
-  ): Promise<void> {
+  private async onNewFullBlock(peer: Peer, block: Block, prev: BlockHeader): Promise<void> {
     if (!this.shouldProcessNewBlocks()) {
       return
     }
@@ -1235,7 +1231,8 @@ export class PeerNetwork {
     this.telemetry.submitNewBlockSeen(block, new Date(), firstPeer)
 
     // verify the full block
-    const verified = await this.chain.verifier.verifyBlockAdd(block, prevHeader)
+    const verified = await this.chain.verifier.verifyBlock(block, { prev })
+
     if (!verified.valid) {
       this.chain.addInvalid(
         block.header.hash,


### PR DESCRIPTION
## Summary

Creates 1 entry point for verifying blocks. Addresses the comment left in our codebase over 3 years ago. 

Side note: This refactor will be helpful in optimizing performance for EVM. It seems like we verify blocks twice when we receive them, once when we get it and once when we add it to the chain. This should help consolidate that logic. 

## Testing Plan

Ensure all of our tests pass

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
