### PR TITLE
update miners command descriptions, add json to pool status

### DIFF
--- a/ironfish-cli/src/commands/miners/pools/start.ts
+++ b/ironfish-cli/src/commands/miners/pools/start.ts
@@ -19,7 +19,7 @@ import { RemoteFlags } from '../../../flags'
 import { getExplorer } from '../../../utils/explorer'
 
 export class StartPool extends IronfishCommand {
-  static description = `Start a mining pool that connects to a node`
+  static description = `start a mining pool`
 
   static flags = {
     ...RemoteFlags,

--- a/ironfish-cli/src/commands/miners/start.ts
+++ b/ironfish-cli/src/commands/miners/start.ts
@@ -19,7 +19,7 @@ import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 
 export class Miner extends IronfishCommand {
-  static description = `Start a miner and subscribe to new blocks for the node`
+  static description = `start a miner`
 
   updateInterval: SetIntervalToken | null = null
 

--- a/ironfish/src/mining/stratum/clients/tcpClient.ts
+++ b/ironfish/src/mining/stratum/clients/tcpClient.ts
@@ -19,7 +19,7 @@ export class StratumTcpClient extends StratumClient {
 
   protected onSocketDisconnect = (): void => {
     this.client?.off('error', this.onError)
-    this.client?.off('close', this.onDisconnect)
+    this.client?.off('close', this.onSocketDisconnect)
     this.client?.off('data', this.onSocketData)
     this.onDisconnect()
   }


### PR DESCRIPTION
## Summary

Required some changes to the stratum client to properly end. Before this PR, the 'close' immediately kicked off the reconnect logic, so there was no actual way to close a client. This adds the ability to manually close a stratum client connection.

## Testing Plan

## Documentation

N/A

## Breaking Change

N/A