### PR TITLE
Shield cli

### DIFF
--- a/ironfish-cli/src/commands/evm/shield.ts
+++ b/ironfish-cli/src/commands/evm/shield.ts
@@ -1,0 +1,99 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { GoldTokenJson } from '@ironfish/ironfish-contracts'
+import { ContractArtifact, GLOBAL_CONTRACT_ADDRESS } from '@ironfish/sdk'
+import { Flags, ux } from '@oclif/core'
+import { ethers } from 'ethers'
+import { IronfishCommand } from '../../command'
+import { LocalFlags } from '../../flags'
+import { promptCurrency } from '../../utils/currency'
+
+export class ShieldCommand extends IronfishCommand {
+  static description = `Shield token from EVM to private asset`
+
+  static flags = {
+    ...LocalFlags,
+    amount: Flags.integer({
+      char: 'a',
+      description: 'The amount of the asset to shield',
+    }),
+    contractAddress: Flags.string({
+      char: 'c',
+      description: 'The EVM contract address of the asset to shield',
+    }),
+    nonce: Flags.integer({
+      char: 'n',
+      description: 'The nonce of the EVM transaction',
+    }),
+    to: Flags.string({
+      char: 't',
+      description: 'The Ironfish public address of the recipient',
+    }),
+    from: Flags.string({
+      char: 'f',
+      description: 'The account name of the sender',
+    }),
+  }
+
+  async start(): Promise<void> {
+    const { flags } = await this.parse(ShieldCommand)
+    const { nonce } = flags
+    let { amount, contractAddress, to, from } = flags
+    const client = await this.sdk.connectRpc()
+
+    if (!amount) {
+      amount = Number(
+        await promptCurrency({
+          client: client,
+          required: true,
+          text: 'Enter the amount of the token you want to shield',
+          minimum: 1n,
+          logger: this.logger,
+        }),
+      )
+    }
+
+    if (!to) {
+      const input = await ux.prompt('Enter recipient address: ', {
+        required: true,
+      })
+      to = input
+    }
+
+    if (!from) {
+      const defaultAccount = await client.wallet.getDefaultAccount()
+      from = defaultAccount.content.account?.name
+    }
+
+    if (!contractAddress) {
+      contractAddress = GLOBAL_CONTRACT_ADDRESS.toString()
+    }
+    const isIron = contractAddress === GLOBAL_CONTRACT_ADDRESS.toString()
+    const response = await client.wallet.getAccountPublicKey({ account: from })
+    const publicAddress = response.content.evmPublicAddress
+    if (!publicAddress) {
+      this.error(`Account ${from} does not have an EVM public address`)
+    }
+
+    let data: string
+    if (isIron) {
+      const globalContract = new ethers.Interface(ContractArtifact.abi)
+      data = globalContract.encodeFunctionData('shield_iron', [Buffer.from(to, 'hex')])
+    } else {
+      const contract = new ethers.Interface(GoldTokenJson.abi)
+      data = contract.encodeFunctionData('shield', [Buffer.from(to, 'hex'), amount])
+    }
+    // TODO: should we unhardcode gas limit and gas price?
+    const hash = await client.eth.sendTransaction({
+      to: contractAddress,
+      from: publicAddress,
+      value: isIron ? String(amount) : undefined,
+      nonce: String(nonce),
+      gas: String(1000000),
+      gasPrice: String(0),
+      data,
+    })
+    this.log('Transaction hash:', hash.content.result)
+  }
+}

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -815,7 +815,6 @@ export class Wallet {
     expiration?: number
     expirationDelta?: number
     confirmations?: number
-    fund?: boolean
   }): Promise<RawTransaction> {
     const heaviestHead = await this.getChainHead()
     if (heaviestHead === null) {
@@ -894,13 +893,12 @@ export class Wallet {
       if (options.evm) {
         raw.evm = options.evm
       }
-      if (options.fund) {
-        await this.fund(raw, {
-          account: options.account,
-          notes: options.notes,
-          confirmations: confirmations,
-        })
-      }
+
+      await this.fund(raw, {
+        account: options.account,
+        notes: options.notes,
+        confirmations: confirmations,
+      })
 
       if (options.feeRate) {
         raw.fee = getFee(options.feeRate, raw.postedSize(options.account.publicAddress))

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -815,6 +815,7 @@ export class Wallet {
     expiration?: number
     expirationDelta?: number
     confirmations?: number
+    fund?: boolean
   }): Promise<RawTransaction> {
     const heaviestHead = await this.getChainHead()
     if (heaviestHead === null) {
@@ -893,12 +894,13 @@ export class Wallet {
       if (options.evm) {
         raw.evm = options.evm
       }
-
-      await this.fund(raw, {
-        account: options.account,
-        notes: options.notes,
-        confirmations: confirmations,
-      })
+      if (options.fund) {
+        await this.fund(raw, {
+          account: options.account,
+          notes: options.notes,
+          confirmations: confirmations,
+        })
+      }
 
       if (options.feeRate) {
         raw.fee = getFee(options.feeRate, raw.postedSize(options.account.publicAddress))


### PR DESCRIPTION
## Summary

Requires user to input ethereum spending key during shielding, alternative is that we store as account, pass account name, retrieve account in RPC and then sign in RPC and submit transaction.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
