### PR TITLE
supports deploying branch-named Docker images to AWS

### DIFF
--- a/.github/workflows/deploy-node-docker-image.yml
+++ b/.github/workflows/deploy-node-docker-image.yml
@@ -25,6 +25,10 @@ on:
         description: 'AWS:{GIT_SHA}'
         type: boolean
         default: false
+      aws_tag_git_branch:
+        description: 'AWS:{BRANCH}'
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -112,6 +116,13 @@ jobs:
       # This is only executed when deploying a new release to mainnet
       - name: Deploy Node Image to AWS:${{ github.ref_name }}
         if: ${{ inputs.aws_tag_mainnet && github.event.ref_type == 'tag'}}
+        run: |
+          docker tag ironfish ${{ secrets.AWS_NODE_REGISTRY_URL }}/ironfish:${{ github.ref_name }}
+          docker push ${{ secrets.AWS_NODE_REGISTRY_URL }}/ironfish:${{ github.ref_name }}
+
+      # Used to deploy images for specific branches
+      - name: Deploy Node Image to AWS:${{ github.ref_name }}
+        if: ${{ inputs.aws_tag_git_branch && github.ref_type == 'branch' }}
         run: |
           docker tag ironfish ${{ secrets.AWS_NODE_REGISTRY_URL }}/ironfish:${{ github.ref_name }}
           docker push ${{ secrets.AWS_NODE_REGISTRY_URL }}/ironfish:${{ github.ref_name }}


### PR DESCRIPTION
## Summary

adds a workflow input for `AWS:{BRANCH}` and adds a deploy step for deploying the branch-named image to our AWS ECR repository

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
