### PR TITLE
Add the ability to unset default account in CLI

### DIFF
--- a/ironfish-cli/src/commands/wallet/use.ts
+++ b/ironfish-cli/src/commands/wallet/use.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { Args } from '@oclif/core'
+import { Args, Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 
@@ -10,21 +10,32 @@ export class UseCommand extends IronfishCommand {
 
   static args = {
     account: Args.string({
-      required: true,
       description: 'Name of the account',
     }),
   }
 
   static flags = {
     ...RemoteFlags,
+    unset: Flags.boolean({
+      description: 'Clear the default account',
+    }),
   }
 
   async start(): Promise<void> {
-    const { args } = await this.parse(UseCommand)
+    const { args, flags } = await this.parse(UseCommand)
     const { account } = args
+    const { unset } = flags
+
+    if (!account && !unset) {
+      this.error('You must provide the name of an account')
+    }
 
     const client = await this.connectRpc()
     await client.wallet.useAccount({ account })
-    this.log(`The default account is now: ${account}`)
+    if (account == null) {
+      this.log('The default account has been unset')
+    } else {
+      this.log(`The default account is now: ${account}`)
+    }
   }
 }

--- a/ironfish/src/rpc/routes/wallet/useAccount.ts
+++ b/ironfish/src/rpc/routes/wallet/useAccount.ts
@@ -7,12 +7,12 @@ import { routes } from '../router'
 import { AssertHasRpcContext } from '../rpcContext'
 import { getAccount } from './utils'
 
-export type UseAccountRequest = { account: string }
+export type UseAccountRequest = { account?: string }
 export type UseAccountResponse = undefined
 
 export const UseAccountRequestSchema: yup.ObjectSchema<UseAccountRequest> = yup
   .object({
-    account: yup.string().defined(),
+    account: yup.string().optional(),
   })
   .defined()
 
@@ -26,8 +26,12 @@ routes.register<typeof UseAccountRequestSchema, UseAccountResponse>(
   async (request, context): Promise<void> => {
     AssertHasRpcContext(request, context, 'wallet')
 
-    const account = getAccount(context.wallet, request.data.account)
-    await context.wallet.setDefaultAccount(account.name)
+    let accountName = null
+    if (request.data.account) {
+      accountName = getAccount(context.wallet, request.data.account).name
+    }
+
+    await context.wallet.setDefaultAccount(accountName)
     request.end()
   },
 )


### PR DESCRIPTION

## Summary

You can now use `wallet:use --unset` to unset the default account

![image](https://github.com/user-attachments/assets/1b16bc63-4f8b-4990-bf14-54ab3f2f977e)


## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
