### PR TITLE
allows deploying branch-named docker images to AWS

### DIFF
--- a/.github/workflows/deploy-node-docker-image.yml
+++ b/.github/workflows/deploy-node-docker-image.yml
@@ -116,6 +116,13 @@ jobs:
           docker tag ironfish ${{ secrets.AWS_NODE_REGISTRY_URL }}/ironfish:${{ github.ref_name }}
           docker push ${{ secrets.AWS_NODE_REGISTRY_URL }}/ironfish:${{ github.ref_name }}
 
+      # Used to deploy a new 'evm' image to AWS
+      - name: Deploy Node Image to AWS:${{ github.ref_name }}
+        if: ${{ github.event.ref_type == 'branch'}}
+        run: |
+          docker tag ironfish ${{ secrets.AWS_NODE_REGISTRY_URL }}/ironfish:${{ github.ref_name }}
+          docker push ${{ secrets.AWS_NODE_REGISTRY_URL }}/ironfish:${{ github.ref_name }}
+
       - name: Deploy Node Image to AWS:testnet
         if: ${{ inputs.aws_tag_testnet }}
         run: |


### PR DESCRIPTION
## Summary

this will allow us to deploy a docker image to AWS named for the 'evm' branch or any branch that includes this change

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
