### PR TITLE
fix `wallet:which --displayName` output

### DIFF
--- a/ironfish/src/rpc/routes/wallet/getAccounts.ts
+++ b/ironfish/src/rpc/routes/wallet/getAccounts.ts
@@ -14,6 +14,7 @@ export type GetAccountsResponse = { accounts: string[] }
 export const GetAccountsRequestSchema: yup.ObjectSchema<GetAccountsRequest> = yup
   .object({
     default: yup.boolean().optional(),
+    displayName: yup.boolean().optional(),
   })
   .notRequired()
   .default({})


### PR DESCRIPTION
## Summary

Previously, the RPC wasn't receiving this parameter properly due to it being left out of the yup schema. Add it to the schema so that the flag is properly passed through.

![image](https://github.com/user-attachments/assets/a68577a9-c38d-4e4f-a97e-d65771f4abd0)


## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
