### PR TITLE
encodes to address as string in unshield

### DIFF
--- a/ironfish-cli/src/commands/evm/unshield.ts
+++ b/ironfish-cli/src/commands/evm/unshield.ts
@@ -7,6 +7,7 @@ import { GoldTokenJson } from '@ironfish/ironfish-contracts'
 import {
   ContractArtifact,
   EthSendTransactionRequest,
+  EthUtils,
   GLOBAL_CONTRACT_ADDRESS,
 } from '@ironfish/sdk'
 import { Flags, ux } from '@oclif/core'
@@ -110,10 +111,7 @@ export class UnshieldCommand extends IronfishCommand {
     let data: string
     if (isIron) {
       const globalContract = new ethers.Interface(ContractArtifact.abi)
-      data = globalContract.encodeFunctionData('unshield_iron', [
-        Buffer.from(to, 'hex'),
-        amount,
-      ])
+      data = globalContract.encodeFunctionData('unshield_iron', [EthUtils.prefix0x(to), amount])
     } else {
       const contract = new ethers.Interface(GoldTokenJson.abi)
       data = contract.encodeFunctionData('unshield', [amount])


### PR DESCRIPTION
## Summary

the function input in the global contract is an ethereum address, not a byte array

## Testing Plan

sent unshield transaction on evmnet after making changes

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
