### PR TITLE
feat(ironfish): Remove cached accounts when encrypting/decrypting

### DIFF
--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -1792,7 +1792,7 @@ export class Wallet {
     const unlock = await this.createTransactionMutex.lock()
 
     try {
-      await this.walletDb.encryptAccounts(this.accounts, passphrase, tx)
+      await this.walletDb.encryptAccounts(passphrase, tx)
       await this.load()
     } finally {
       unlock()
@@ -1803,7 +1803,7 @@ export class Wallet {
     const unlock = await this.createTransactionMutex.lock()
 
     try {
-      await this.walletDb.decryptAccounts(this.encryptedAccounts, passphrase, tx)
+      await this.walletDb.decryptAccounts(passphrase, tx)
       await this.load()
     } finally {
       unlock()

--- a/ironfish/src/wallet/walletdb/walletdb.test.ts
+++ b/ironfish/src/wallet/walletdb/walletdb.test.ts
@@ -469,7 +469,7 @@ describe('WalletDB', () => {
       const accountA = await useAccountFixture(node.wallet, 'A')
       const accountB = await useAccountFixture(node.wallet, 'B')
 
-      await walletDb.encryptAccounts([accountA, accountB], passphrase)
+      await walletDb.encryptAccounts(passphrase)
 
       const encryptedAccountById = new Map<string, EncryptedAccount>()
       for await (const [id, accountValue] of walletDb.loadAccounts()) {
@@ -503,7 +503,7 @@ describe('WalletDB', () => {
 
       const accountA = await useAccountFixture(node.wallet, 'A')
       const accountB = await useAccountFixture(node.wallet, 'B')
-      await walletDb.encryptAccounts([accountA, accountB], passphrase)
+      await walletDb.encryptAccounts(passphrase)
 
       const encryptedAccountById = new Map<string, EncryptedAccount>()
       for await (const [id, accountValue] of walletDb.loadAccounts()) {
@@ -522,7 +522,7 @@ describe('WalletDB', () => {
       const encryptedAccountB = encryptedAccountById.get(accountB.id)
       Assert.isNotUndefined(encryptedAccountB)
 
-      await walletDb.decryptAccounts([encryptedAccountA, encryptedAccountB], passphrase)
+      await walletDb.decryptAccounts(passphrase)
 
       const accountById = new Map<string, Account>()
       for await (const [id, accountValue] of walletDb.loadAccounts()) {
@@ -551,7 +551,7 @@ describe('WalletDB', () => {
       const accountA = await useAccountFixture(node.wallet, 'A')
       const accountB = await useAccountFixture(node.wallet, 'B')
 
-      await walletDb.encryptAccounts([accountA, accountB], passphrase)
+      await walletDb.encryptAccounts(passphrase)
 
       const encryptedAccountById = new Map<string, EncryptedAccount>()
       for await (const [id, accountValue] of walletDb.loadAccounts()) {
@@ -570,9 +570,9 @@ describe('WalletDB', () => {
       const encryptedAccountB = encryptedAccountById.get(accountB.id)
       Assert.isNotUndefined(encryptedAccountB)
 
-      await expect(
-        walletDb.decryptAccounts([encryptedAccountA, encryptedAccountB], invalidPassphrase),
-      ).rejects.toThrow(AccountDecryptionFailedError)
+      await expect(walletDb.decryptAccounts(invalidPassphrase)).rejects.toThrow(
+        AccountDecryptionFailedError,
+      )
     })
   })
 
@@ -595,9 +595,9 @@ describe('WalletDB', () => {
       const walletDb = node.wallet.walletDb
       const passphrase = 'test'
 
-      const accountA = await useAccountFixture(node.wallet, 'A')
-      const accountB = await useAccountFixture(node.wallet, 'B')
-      await walletDb.encryptAccounts([accountA, accountB], passphrase)
+      await useAccountFixture(node.wallet, 'A')
+      await useAccountFixture(node.wallet, 'B')
+      await walletDb.encryptAccounts(passphrase)
 
       expect(await walletDb.accountsEncrypted()).toBe(true)
     })


### PR DESCRIPTION
## Summary

Making the WalletDB interface a bit stricter to read all account values from the database and call the appropriate function instead of using cached values in the wallet. Also accepting an array of accounts seems like a foot-gun in case anyone accidentally doesn't pass in all of the accounts.

These cached accounts are reloaded after encrypt/decrypt so no updates are necessary there.

## Testing Plan

Refactored unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
