### PR TITLE
feat(ironfish): Return if the wallet is locked in getStatus

### DIFF
--- a/ironfish/src/rpc/routes/node/getStatus.test.ts
+++ b/ironfish/src/rpc/routes/node/getStatus.test.ts
@@ -25,6 +25,9 @@ describe('Route node/getStatus', () => {
       blockSyncer: {
         status: 'stopped',
       },
+      accounts: {
+        locked: expect.any(Boolean),
+      },
     })
   })
 })

--- a/ironfish/src/rpc/routes/node/getStatus.ts
+++ b/ironfish/src/rpc/routes/node/getStatus.ts
@@ -97,6 +97,7 @@ export type GetNodeStatusResponse = {
   }
   accounts: {
     enabled: boolean
+    locked: boolean
     scanning?: {
       hash: string
       sequence: number
@@ -236,6 +237,7 @@ export const GetStatusResponseSchema: yup.ObjectSchema<GetNodeStatusResponse> = 
           })
           .defined(),
         enabled: yup.boolean().defined(),
+        locked: yup.boolean().defined(),
         scanning: yup
           .object({
             hash: yup.string().defined(),
@@ -366,6 +368,7 @@ async function getStatus(node: FullNode): Promise<GetNodeStatusResponse> {
     },
     accounts: {
       enabled: node.config.get('enableWallet'),
+      locked: node.wallet.locked,
       head: {
         hash: walletHead?.hash.toString('hex') ?? '',
         sequence: walletHead?.sequence ?? -1,


### PR DESCRIPTION
## Summary

Return if the wallet is locked in `node/getStatus`

## Testing Plan

Unit test

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[x] Yes
```

https://github.com/iron-fish/website/pull/719

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
