### PR TITLE
Make balance output consistent

### DIFF
--- a/ironfish-cli/src/commands/wallet/balance.ts
+++ b/ironfish-cli/src/commands/wallet/balance.ts
@@ -102,9 +102,7 @@ Balance is your coins from all of your transactions, even if they are on forks o
       this.log(
         ui.card({
           Account: response.content.account,
-          'Head Hash': response.content.blockHash || 'NULL',
-          'Head Sequence': response.content.sequence || 'NULL',
-          Available: renderedAvailable,
+          Balance: renderedAvailable,
           Confirmed: renderedConfirmed,
           Unconfirmed: renderedUnconfirmed,
           Pending: renderedPending,
@@ -116,7 +114,7 @@ Balance is your coins from all of your transactions, even if they are on forks o
     this.log(
       ui.card({
         Account: response.content.account,
-        'Available Balance': renderedAvailable,
+        Balance: renderedAvailable,
       }),
     )
   }

--- a/ironfish-cli/src/commands/wallet/balances.ts
+++ b/ironfish-cli/src/commands/wallet/balances.ts
@@ -66,7 +66,7 @@ export class BalancesCommand extends IronfishCommand {
 
     let columns: TableColumns<AssetBalancePairs> = {
       assetName: {
-        header: 'Asset Name',
+        header: 'Asset',
         get: ({ asset }) =>
           renderAssetWithVerificationStatus(
             BufferUtils.toHuman(Buffer.from(asset.name, 'hex')),
@@ -76,12 +76,8 @@ export class BalancesCommand extends IronfishCommand {
             },
           ),
       },
-      'asset.id': {
-        header: 'Asset Id',
-        get: ({ asset }) => asset.id,
-      },
       available: {
-        header: 'Available Balance',
+        header: 'Balance',
         get: ({ asset, balance }) =>
           CurrencyUtils.render(balance.available, false, asset.id, asset.verification),
       },
@@ -90,32 +86,28 @@ export class BalancesCommand extends IronfishCommand {
     if (flags.all) {
       columns = {
         ...columns,
-        availableNotes: {
-          header: 'Available Notes',
-          get: ({ balance }) => balance.availableNoteCount,
-        },
         confirmed: {
-          header: 'Confirmed Balance',
+          header: 'Confirmed',
           get: ({ asset, balance }) =>
             CurrencyUtils.render(balance.confirmed, false, asset.id, asset.verification),
         },
         unconfirmed: {
-          header: 'Unconfirmed Balance',
+          header: 'Unconfirmed',
           get: ({ asset, balance }) =>
             CurrencyUtils.render(balance.unconfirmed, false, asset.id, asset.verification),
         },
         pending: {
-          header: 'Pending Balance',
+          header: 'Pending',
           get: ({ asset, balance }) =>
             CurrencyUtils.render(balance.pending, false, asset.id, asset.verification),
         },
-        blockHash: {
-          header: 'Head Hash',
-          get: ({ balance }) => balance.blockHash || 'NULL',
+        availableNotes: {
+          header: 'Notes',
+          get: ({ balance }) => balance.availableNoteCount,
         },
-        sequence: {
-          header: 'Head Sequence',
-          get: ({ balance }) => balance.sequence || 'NULL',
+        'asset.id': {
+          header: 'Asset Id',
+          get: ({ asset }) => asset.id,
         },
       }
     }


### PR DESCRIPTION
## Summary

Also remove things that are not visible in `wallet:status`

```
> ironfish wallet:balance --all

Account:       foobar
Balance:       $IRON✓ 0.00000000
Confirmed:     $IRON✓ 0.00000000
Unconfirmed:   $IRON✓ 0.00000000
Pending:       $IRON✓ 0.00000000
```

```
> ironfish wallet:balances --all

Account: foobar
 Asset  Balance    Confirmed  Unconfirmed Pending    Notes Asset Id
 ────── ────────── ────────── ─────────── ────────── ───── ────────────────────────────────────────────────────────────────
 $IRON✓ 0.00000000 0.00000000 0.00000000  0.00000000 0     51f33a2f14f92735e562dc658a5639279ddca3d5079a6d1242b2a588a9cbf44c
```

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
