### PR TITLE
Add new useAccount helper an upgrade commands

### DIFF
--- a/ironfish-cli/src/commands/wallet/assets.ts
+++ b/ironfish-cli/src/commands/wallet/assets.ts
@@ -9,11 +9,11 @@ import {
   PUBLIC_ADDRESS_LENGTH,
 } from '@ironfish/rust-nodejs'
 import { BufferUtils } from '@ironfish/sdk'
-import { Args, Flags } from '@oclif/core'
+import { Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 import { table, TableFlags } from '../../ui'
-import { renderAssetWithVerificationStatus } from '../../utils'
+import { renderAssetWithVerificationStatus, useAccount } from '../../utils'
 import { TableCols } from '../../utils/table'
 
 const MAX_ASSET_METADATA_COLUMN_WIDTH = ASSET_METADATA_LENGTH + 1
@@ -25,13 +25,6 @@ const MIN_ASSET_NAME_COLUMN_WIDTH = ASSET_NAME_LENGTH / 2 + 1
 export class AssetsCommand extends IronfishCommand {
   static description = `list the account's assets`
 
-  static args = {
-    account: Args.string({
-      required: false,
-      description: 'Name of the account. DEPRECATED: use --account flag',
-    }),
-  }
-
   static flags = {
     ...RemoteFlags,
     ...TableFlags,
@@ -42,11 +35,12 @@ export class AssetsCommand extends IronfishCommand {
   }
 
   async start(): Promise<void> {
-    const { flags, args } = await this.parse(AssetsCommand)
-    // TODO: remove account arg
-    const account = flags.account ? flags.account : args.account
+    const { flags } = await this.parse(AssetsCommand)
 
     const client = await this.connectRpc()
+
+    const account = await useAccount(client, flags.account)
+
     const response = client.wallet.getAssets({
       account,
     })

--- a/ironfish-cli/src/commands/wallet/balance.ts
+++ b/ironfish-cli/src/commands/wallet/balance.ts
@@ -2,11 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { CurrencyUtils, GetBalanceResponse, isNativeIdentifier, RpcAsset } from '@ironfish/sdk'
-import { Args, Flags } from '@oclif/core'
+import { Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 import * as ui from '../../ui'
-import { renderAssetWithVerificationStatus } from '../../utils'
+import { renderAssetWithVerificationStatus, useAccount } from '../../utils'
 
 export class BalanceCommand extends IronfishCommand {
   static description = `show the account's balance for an asset
@@ -26,13 +26,6 @@ Balance is your coins from all of your transactions, even if they are on forks o
         'ironfish wallet:balance --assetId 51f33a2f14f92735e562dc658a5639279ddca3d5079a6d1242b2a588a9cbf44c',
     },
   ]
-
-  static args = {
-    account: Args.string({
-      required: false,
-      description: 'Name of the account to get balance for. DEPRECATED: use --account flag',
-    }),
-  }
 
   static flags = {
     ...RemoteFlags,
@@ -59,11 +52,11 @@ Balance is your coins from all of your transactions, even if they are on forks o
   }
 
   async start(): Promise<void> {
-    const { flags, args } = await this.parse(BalanceCommand)
-    // TODO: remove account arg
-    const account = flags.account ? flags.account : args.account
+    const { flags } = await this.parse(BalanceCommand)
 
     const client = await this.connectRpc()
+
+    const account = await useAccount(client, flags.account)
 
     const response = await client.wallet.getAccountBalance({
       account,

--- a/ironfish-cli/src/commands/wallet/balances.ts
+++ b/ironfish-cli/src/commands/wallet/balances.ts
@@ -2,23 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { BufferUtils, CurrencyUtils, GetBalancesResponse, RpcAsset } from '@ironfish/sdk'
-import { Args, Flags } from '@oclif/core'
+import { Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 import { table, TableColumns, TableFlags } from '../../ui'
-import { compareAssets, renderAssetWithVerificationStatus } from '../../utils'
+import { compareAssets, renderAssetWithVerificationStatus, useAccount } from '../../utils'
 
 type AssetBalancePairs = { asset: RpcAsset; balance: GetBalancesResponse['balances'][number] }
 
 export class BalancesCommand extends IronfishCommand {
   static description = `show the account's balance for all assets`
-
-  static args = {
-    account: Args.string({
-      required: false,
-      description: 'Name of the account to get balances for. DEPRECATED: use --account flag',
-    }),
-  }
 
   static flags = {
     ...RemoteFlags,
@@ -38,11 +31,11 @@ export class BalancesCommand extends IronfishCommand {
   }
 
   async start(): Promise<void> {
-    const { flags, args } = await this.parse(BalancesCommand)
+    const { flags } = await this.parse(BalancesCommand)
     const client = await this.connectRpc()
 
-    // TODO: remove account arg
-    const account = flags.account ? flags.account : args.account
+    const account = await useAccount(client, flags.account)
+
     const response = await client.wallet.getAccountBalances({
       account,
       confirmations: flags.confirmations,

--- a/ironfish-cli/src/commands/wallet/burn.ts
+++ b/ironfish-cli/src/commands/wallet/burn.ts
@@ -14,6 +14,7 @@ import { Flags, ux } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { IronFlag, RemoteFlags, ValueFlag } from '../../flags'
 import * as ui from '../../ui'
+import { useAccount } from '../../utils'
 import { promptCurrency } from '../../utils/currency'
 import { promptExpiration } from '../../utils/expiration'
 import { getExplorer } from '../../utils/explorer'
@@ -108,19 +109,7 @@ This will destroy tokens and decrease supply for a given asset.`
       }
     }
 
-    let account = flags.account
-    if (!account) {
-      const response = await client.wallet.getDefaultAccount()
-
-      if (!response.content.account) {
-        this.error(
-          `No account is currently active.
-           Use ironfish wallet:create <name> to first create an account`,
-        )
-      }
-
-      account = response.content.account.name
-    }
+    const account = await useAccount(client, flags.account)
 
     let assetId = flags.assetId
 

--- a/ironfish-cli/src/commands/wallet/export.ts
+++ b/ironfish-cli/src/commands/wallet/export.ts
@@ -2,27 +2,25 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { AccountFormat, ErrorUtils, LanguageUtils } from '@ironfish/sdk'
-import { Args, Flags } from '@oclif/core'
+import { Flags } from '@oclif/core'
 import fs from 'fs'
 import path from 'path'
 import { IronfishCommand } from '../../command'
 import { EnumLanguageKeyFlag, JsonFlags, RemoteFlags } from '../../flags'
 import { confirmOrQuit } from '../../ui'
+import { useAccount } from '../../utils'
 
 export class ExportCommand extends IronfishCommand {
   static description = `export an account`
   static enableJsonFlag = true
 
-  static args = {
-    account: Args.string({
-      required: false,
-      description: 'Name of the account to export',
-    }),
-  }
-
   static flags = {
     ...RemoteFlags,
     ...JsonFlags,
+    account: Flags.string({
+      char: 'a',
+      description: 'Name of the account to export',
+    }),
     local: Flags.boolean({
       default: false,
       description: 'Export an account without an online node',
@@ -47,9 +45,8 @@ export class ExportCommand extends IronfishCommand {
   }
 
   async start(): Promise<unknown> {
-    const { flags, args } = await this.parse(ExportCommand)
+    const { flags } = await this.parse(ExportCommand)
     const { local, path: exportPath, viewonly: viewOnly } = flags
-    const { account } = args
 
     if (flags.language) {
       flags.mnemonic = true
@@ -62,6 +59,9 @@ export class ExportCommand extends IronfishCommand {
       : AccountFormat.Base64Json
 
     const client = await this.connectRpc(local)
+
+    const account = await useAccount(client, flags.account)
+
     const response = await client.wallet.exportAccount({
       account,
       viewOnly,

--- a/ironfish-cli/src/commands/wallet/mint.ts
+++ b/ironfish-cli/src/commands/wallet/mint.ts
@@ -18,6 +18,7 @@ import { Flags, ux } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { IronFlag, RemoteFlags, ValueFlag } from '../../flags'
 import * as ui from '../../ui'
+import { useAccount } from '../../utils'
 import { promptCurrency } from '../../utils/currency'
 import { promptExpiration } from '../../utils/expiration'
 import { getExplorer } from '../../utils/explorer'
@@ -129,19 +130,7 @@ This will create tokens and increase supply for a given asset.`
       }
     }
 
-    let account = flags.account
-    if (!account) {
-      const response = await client.wallet.getDefaultAccount()
-
-      if (!response.content.account) {
-        this.error(
-          `No account is currently active.
-           Use ironfish wallet:create <name> to first create an account`,
-        )
-      }
-
-      account = response.content.account.name
-    }
+    const account = await useAccount(client, flags.account)
 
     const publicKeyResponse = await client.wallet.getAccountPublicKey({ account })
     const accountPublicKey = publicKeyResponse.content.publicKey

--- a/ironfish-cli/src/commands/wallet/notes/index.ts
+++ b/ironfish-cli/src/commands/wallet/notes/index.ts
@@ -2,22 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { CurrencyUtils, RpcAsset } from '@ironfish/sdk'
-import { Args, Flags } from '@oclif/core'
+import { Flags } from '@oclif/core'
 import { IronfishCommand } from '../../../command'
 import { RemoteFlags } from '../../../flags'
 import { table, TableFlags } from '../../../ui'
+import { useAccount } from '../../../utils'
 import { TableCols } from '../../../utils/table'
 
 const { sort: _, ...tableFlags } = TableFlags
 export class NotesCommand extends IronfishCommand {
   static description = `list the account's notes`
-
-  static args = {
-    account: Args.string({
-      required: false,
-      description: 'Name of the account to get notes for. DEPRECATED: use --account flag',
-    }),
-  }
 
   static flags = {
     ...RemoteFlags,
@@ -29,13 +23,13 @@ export class NotesCommand extends IronfishCommand {
   }
 
   async start(): Promise<void> {
-    const { flags, args } = await this.parse(NotesCommand)
-    // TODO: remove account arg
-    const account = flags.account ? flags.account : args.account
+    const { flags } = await this.parse(NotesCommand)
 
     const assetLookup: Map<string, RpcAsset> = new Map()
 
     const client = await this.connectRpc()
+
+    const account = await useAccount(client, flags.account)
 
     const response = client.wallet.getAccountNotesStream({ account })
 

--- a/ironfish-cli/src/commands/wallet/reset.ts
+++ b/ironfish-cli/src/commands/wallet/reset.ts
@@ -2,23 +2,21 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { Args, Flags } from '@oclif/core'
+import { Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 import { confirmOrQuit } from '../../ui'
+import { useAccount } from '../../utils'
 
 export class ResetCommand extends IronfishCommand {
   static description = `resets an account's balance and rescans`
 
-  static args = {
-    account: Args.string({
-      required: true,
-      description: 'Name of the account to reset',
-    }),
-  }
-
   static flags = {
     ...RemoteFlags,
+    account: Flags.string({
+      char: 'a',
+      description: 'Name of the account to reset',
+    }),
     resetCreated: Flags.boolean({
       default: false,
       description: 'Reset the accounts birthday',
@@ -34,8 +32,11 @@ export class ResetCommand extends IronfishCommand {
   }
 
   async start(): Promise<void> {
-    const { args, flags } = await this.parse(ResetCommand)
-    const { account } = args
+    const { flags } = await this.parse(ResetCommand)
+
+    const client = await this.connectRpc()
+
+    const account = await useAccount(client, flags.account)
 
     await confirmOrQuit(
       `Are you sure you want to reset the account '${account}'?` +
@@ -44,8 +45,6 @@ export class ResetCommand extends IronfishCommand {
         `\nAre you sure?`,
       flags.confirm,
     )
-
-    const client = await this.connectRpc()
 
     await client.wallet.resetAccount({
       account,

--- a/ironfish-cli/src/commands/wallet/send.ts
+++ b/ironfish-cli/src/commands/wallet/send.ts
@@ -16,6 +16,7 @@ import { Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { HexFlag, IronFlag, RemoteFlags, ValueFlag } from '../../flags'
 import * as ui from '../../ui'
+import { useAccount } from '../../utils'
 import { promptCurrency } from '../../utils/currency'
 import { promptExpiration } from '../../utils/expiration'
 import { getExplorer } from '../../utils/explorer'
@@ -121,7 +122,6 @@ export class Send extends IronfishCommand {
     const { flags } = await this.parse(Send)
     let assetId = flags.assetId
     let to = flags.to
-    let from = flags.account
 
     const client = await this.connectRpc()
 
@@ -134,6 +134,8 @@ export class Send extends IronfishCommand {
         )
       }
     }
+
+    const from = await useAccount(client, flags.account, 'Select an account to send from')
 
     if (assetId == null) {
       const asset = await ui.assetPrompt(client, from, {
@@ -188,19 +190,6 @@ export class Send extends IronfishCommand {
           confirmations: flags.confirmations,
         },
       })
-    }
-
-    if (!from) {
-      const response = await client.wallet.getDefaultAccount()
-
-      if (!response.content.account) {
-        this.error(
-          `No account is currently active.
-           Use ironfish wallet:create <name> to first create an account`,
-        )
-      }
-
-      from = response.content.account.name
     }
 
     if (!to) {

--- a/ironfish-cli/src/commands/wallet/transactions.ts
+++ b/ironfish-cli/src/commands/wallet/transactions.ts
@@ -10,24 +10,17 @@ import {
   RpcAsset,
   TransactionType,
 } from '@ironfish/sdk'
-import { Args, Flags } from '@oclif/core'
+import { Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 import { table, TableColumns, TableFlags } from '../../ui'
-import { getAssetsByIDs } from '../../utils'
+import { getAssetsByIDs, useAccount } from '../../utils'
 import { extractChainportDataFromTransaction } from '../../utils/chainport'
 import { Format, TableCols } from '../../utils/table'
 
 const { sort: _, ...tableFlags } = TableFlags
 export class TransactionsCommand extends IronfishCommand {
   static description = `list the account's transactions`
-
-  static args = {
-    account: Args.string({
-      required: false,
-      description: 'Name of the account. DEPRECATED: use --account flag',
-    }),
-  }
 
   static flags = {
     ...RemoteFlags,
@@ -61,9 +54,7 @@ export class TransactionsCommand extends IronfishCommand {
   }
 
   async start(): Promise<void> {
-    const { flags, args } = await this.parse(TransactionsCommand)
-    // TODO: remove account arg
-    const account = flags.account ? flags.account : args.account
+    const { flags } = await this.parse(TransactionsCommand)
 
     const format: Format =
       flags.csv || flags.output === 'csv'
@@ -73,6 +64,8 @@ export class TransactionsCommand extends IronfishCommand {
         : Format.cli
 
     const client = await this.connectRpc()
+
+    const account = await useAccount(client, flags.account)
 
     const networkId = (await client.chain.getNetworkInfo()).content.networkId
 

--- a/ironfish-cli/src/commands/wallet/transactions/info.ts
+++ b/ironfish-cli/src/commands/wallet/transactions/info.ts
@@ -18,6 +18,7 @@ import {
   extractChainportDataFromTransaction,
   fetchChainportNetworkMap,
   getAssetsByIDs,
+  useAccount,
 } from '../../../utils'
 import { getExplorer } from '../../../utils/explorer'
 
@@ -30,10 +31,6 @@ export class TransactionInfoCommand extends IronfishCommand {
     transaction: Args.string({
       required: true,
       description: 'Hash of the transaction',
-    }),
-    account: Args.string({
-      required: false,
-      description: 'Name of the account. DEPRECATED: use --account flag',
     }),
   }
 
@@ -48,10 +45,11 @@ export class TransactionInfoCommand extends IronfishCommand {
   async start(): Promise<void> {
     const { flags, args } = await this.parse(TransactionInfoCommand)
     const { transaction: hash } = args
-    // TODO: remove account arg
-    const account = flags.account ? flags.account : args.account
 
     const client = await this.connectRpc()
+
+    const account = await useAccount(client, flags.account)
+
     const networkId = (await client.chain.getNetworkInfo()).content.networkId
 
     const response = await client.wallet.getAccountTransaction({

--- a/ironfish-cli/src/ui/prompts.ts
+++ b/ironfish-cli/src/ui/prompts.ts
@@ -8,9 +8,12 @@ import inquirer from 'inquirer'
 import { getAssetsByIDs, renderAssetWithVerificationStatus } from '../utils'
 import { listPrompt } from './prompt'
 
-export async function accountPrompt(client: Pick<RpcClient, 'wallet'>): Promise<string> {
+export async function accountPrompt(
+  client: Pick<RpcClient, 'wallet'>,
+  message: string = 'Select account',
+): Promise<string> {
   const accountsResponse = await client.wallet.getAccounts()
-  return listPrompt('Select account', accountsResponse.content.accounts, (a) => a)
+  return listPrompt(message, accountsResponse.content.accounts, (a) => a)
 }
 
 export async function multisigSecretPrompt(client: Pick<RpcClient, 'wallet'>): Promise<string> {

--- a/ironfish-cli/src/utils/account.ts
+++ b/ironfish-cli/src/utils/account.ts
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { RpcClient } from '@ironfish/sdk'
+import * as ui from '../ui'
+
+export async function useAccount(
+  client: RpcClient,
+  account: string | undefined,
+): Promise<string> {
+  if (account !== undefined) {
+    return account
+  }
+
+  const defaultAccount = await client.wallet.getAccounts({ default: true })
+
+  if (defaultAccount.content.accounts.length) {
+    return defaultAccount.content.accounts[0]
+  }
+
+  return ui.accountPrompt(client)
+}

--- a/ironfish-cli/src/utils/account.ts
+++ b/ironfish-cli/src/utils/account.ts
@@ -8,6 +8,7 @@ import * as ui from '../ui'
 export async function useAccount(
   client: RpcClient,
   account: string | undefined,
+  message?: string,
 ): Promise<string> {
   if (account !== undefined) {
     return account
@@ -19,5 +20,5 @@ export async function useAccount(
     return defaultAccount.content.accounts[0]
   }
 
-  return ui.accountPrompt(client)
+  return ui.accountPrompt(client, message)
 }

--- a/ironfish-cli/src/utils/index.ts
+++ b/ironfish-cli/src/utils/index.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 export * from './asset'
+export * from './account'
 export * from './chainport'
 export * from './editor'
 export * from './platform'


### PR DESCRIPTION
## Summary

- This deprecates arg flags in account context commands
- Prompts users for an account top use if no account was provided and there is no default account

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
