### PR TITLE
Standardize account flags to char 'a'

### DIFF
--- a/ironfish-cli/src/commands/wallet/burn.ts
+++ b/ironfish-cli/src/commands/wallet/burn.ts
@@ -35,28 +35,24 @@ This will destroy tokens and decrease supply for a given asset.`
   static flags = {
     ...RemoteFlags,
     account: Flags.string({
-      char: 'f',
+      char: 'a',
       description: 'Name of the account to burn from',
     }),
     fee: IronFlag({
-      char: 'o',
       description: 'The fee amount in IRON',
       minimum: 1n,
       flagName: 'fee',
     }),
     feeRate: IronFlag({
-      char: 'r',
       description: 'The fee rate amount in IRON/Kilobyte',
       minimum: 1n,
       flagName: 'fee rate',
     }),
     amount: ValueFlag({
-      char: 'a',
       description: 'Amount of coins to burn in the major denomination',
       flagName: 'amount',
     }),
     assetId: Flags.string({
-      char: 'i',
       description: 'Identifier for the asset',
     }),
     confirm: Flags.boolean({
@@ -64,7 +60,6 @@ This will destroy tokens and decrease supply for a given asset.`
       description: 'Confirm without asking',
     }),
     confirmations: Flags.integer({
-      char: 'c',
       description:
         'Minimum number of block confirmations needed to include a note. Set to 0 to include all blocks.',
       required: false,

--- a/ironfish-cli/src/commands/wallet/chainport/send.ts
+++ b/ironfish-cli/src/commands/wallet/chainport/send.ts
@@ -43,36 +43,30 @@ export class BridgeCommand extends IronfishCommand {
       description: 'Wait for the transaction to be confirmed on Ironfish',
     }),
     account: Flags.string({
-      char: 'f',
+      char: 'a',
       description: 'Name of the account to send the asset from',
     }),
     to: Flags.string({
-      char: 't',
       description: 'The Ethereum public address of the recipient',
     }),
     amount: ValueFlag({
-      char: 'a',
       description: 'The amount of the asset in the major denomination',
       flagName: 'amount',
     }),
     assetId: HexFlag({
-      char: 'i',
       description: 'The identifier for the asset to use when bridging',
     }),
     fee: IronFlag({
-      char: 'o',
       description: 'The fee amount in IRON',
       minimum: 1n,
       flagName: 'fee',
     }),
     feeRate: IronFlag({
-      char: 'r',
       description: 'The fee rate amount in IRON/Kilobyte',
       minimum: 1n,
       flagName: 'fee rate',
     }),
     expiration: Flags.integer({
-      char: 'e',
       description:
         'The block sequence after which the transaction will be removed from the mempool. Set to 0 for no expiration.',
     }),

--- a/ironfish-cli/src/commands/wallet/mint.ts
+++ b/ironfish-cli/src/commands/wallet/mint.ts
@@ -41,38 +41,32 @@ This will create tokens and increase supply for a given asset.`
   static flags = {
     ...RemoteFlags,
     account: Flags.string({
-      char: 'f',
+      char: 'a',
       description: 'Name of the account to mint from',
     }),
     fee: IronFlag({
-      char: 'o',
       description: 'The fee amount in IRON',
       minimum: 1n,
       flagName: 'fee',
     }),
     feeRate: IronFlag({
-      char: 'r',
       description: 'The fee rate amount in IRON/Kilobyte',
       minimum: 1n,
       flagName: 'fee rate',
     }),
     amount: ValueFlag({
-      char: 'a',
       description: 'Amount of coins to mint in the major denomination',
       flagName: 'amount',
     }),
     assetId: Flags.string({
-      char: 'i',
       description: 'Identifier for the asset',
       required: false,
     }),
     metadata: Flags.string({
-      char: 'm',
       description: 'Metadata for the asset',
       required: false,
     }),
     name: Flags.string({
-      char: 'n',
       description: 'Name for the asset',
       required: false,
     }),
@@ -81,7 +75,6 @@ This will create tokens and increase supply for a given asset.`
       description: 'Confirm without asking',
     }),
     confirmations: Flags.integer({
-      char: 'c',
       description:
         'Minimum number of block confirmations needed to include a note. Set to 0 to include all blocks.',
       required: false,

--- a/ironfish-cli/src/commands/wallet/multisig/account/participants.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/account/participants.ts
@@ -11,7 +11,7 @@ export class MultisigAccountParticipants extends IronfishCommand {
   static flags = {
     ...RemoteFlags,
     account: Flags.string({
-      char: 'f',
+      char: 'a',
       description: 'Name of the account to list group identities for',
     }),
   }

--- a/ironfish-cli/src/commands/wallet/multisig/commitment/aggregate.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/commitment/aggregate.ts
@@ -14,7 +14,7 @@ export class CreateSigningPackage extends IronfishCommand {
   static flags = {
     ...RemoteFlags,
     account: Flags.string({
-      char: 'f',
+      char: 'a',
       description: 'Name of the account to use when creating the signing package',
       required: false,
     }),

--- a/ironfish-cli/src/commands/wallet/multisig/commitment/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/commitment/create.ts
@@ -15,7 +15,7 @@ export class CreateSigningCommitmentCommand extends IronfishCommand {
   static flags = {
     ...RemoteFlags,
     account: Flags.string({
-      char: 'f',
+      char: 'a',
       description:
         'Name of the account to use for generating the commitment, must be a multisig participant account',
       required: false,

--- a/ironfish-cli/src/commands/wallet/multisig/signature/aggregate.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/signature/aggregate.ts
@@ -15,7 +15,7 @@ export class MultisigSign extends IronfishCommand {
   static flags = {
     ...RemoteFlags,
     account: Flags.string({
-      char: 'f',
+      char: 'a',
       description: 'Name of the account to use when aggregating signature shares',
       required: false,
     }),

--- a/ironfish-cli/src/commands/wallet/multisig/signature/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/signature/create.ts
@@ -16,7 +16,7 @@ export class CreateSignatureShareCommand extends IronfishCommand {
   static flags = {
     ...RemoteFlags,
     account: Flags.string({
-      char: 'f',
+      char: 'a',
       description: 'Name of the account from which the signature share will be created',
       required: false,
     }),

--- a/ironfish-cli/src/commands/wallet/send.ts
+++ b/ironfish-cli/src/commands/wallet/send.ts
@@ -41,32 +41,27 @@ export class Send extends IronfishCommand {
   static flags = {
     ...RemoteFlags,
     account: Flags.string({
-      char: 'f',
+      char: 'a',
       description: 'Name of the account to send money from',
     }),
     amount: ValueFlag({
-      char: 'a',
       description: 'The amount to send in the major denomination',
       flagName: 'amount',
     }),
     to: Flags.string({
-      char: 't',
       description: 'The public address of the recipient',
     }),
     fee: IronFlag({
-      char: 'o',
       description: 'The fee amount in IRON',
       minimum: 1n,
       flagName: 'fee',
     }),
     feeRate: IronFlag({
-      char: 'r',
       description: 'The fee rate amount in IRON/Kilobyte',
       minimum: 1n,
       flagName: 'fee rate',
     }),
     memo: Flags.string({
-      char: 'm',
       description: 'The memo of transaction',
     }),
     confirm: Flags.boolean({
@@ -83,7 +78,6 @@ export class Send extends IronfishCommand {
         'The block sequence after which the transaction will be removed from the mempool. Set to 0 for no expiration.',
     }),
     confirmations: Flags.integer({
-      char: 'c',
       description:
         'Minimum number of block confirmations needed to include a note. Set to 0 to include all blocks.',
       required: false,


### PR DESCRIPTION
## Summary

And rename or delete command specific competing flags. These command flags had chars that were not consistent across commands like "confirmations". It's best not to have command specific single letter char shortcuts. User's should be explicit when sending transactions.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
