### PR TITLE
eth rpc wrapper

### DIFF
--- a/ironfish/src/rpc/clients/client.ts
+++ b/ironfish/src/rpc/clients/client.ts
@@ -43,6 +43,8 @@ import type {
   EstimateFeeRateResponse,
   EstimateFeeRatesRequest,
   EstimateFeeRatesResponse,
+  EthRequest,
+  EthResponse,
   ExportAccountRequest,
   ExportAccountResponse,
   ExportChainStreamRequest,
@@ -1013,6 +1015,9 @@ export abstract class RpcClient {
   }
 
   eth = {
+    ethRouter: (params: EthRequest): Promise<RpcResponseEnded<EthResponse>> => {
+      return this.request<EthResponse>(`${ApiNamespace.eth}/ethRouter`, params).waitForEnd()
+    },
     getAccount: (params: GetAccountRequest): Promise<RpcResponseEnded<GetAccountResponse>> => {
       return this.request<GetAccountResponse>(
         `${ApiNamespace.eth}/getAccount`,

--- a/ironfish/src/rpc/routes/eth/__fixtures__/ethRouter.test.ts.fixture
+++ b/ironfish/src/rpc/routes/eth/__fixtures__/ethRouter.test.ts.fixture
@@ -1,0 +1,32 @@
+{
+  "Route eth/ethRouter should handle eth_sendTransaction successfully": [
+    {
+      "value": {
+        "version": 4,
+        "id": "3499a534-0784-4079-a2ae-b2bbb7a9b129",
+        "name": "test",
+        "spendingKey": "db05cfb895e4e76d452850ff6a2bf9d5c79c143f300319f5bb73bbaa69758d26",
+        "viewKey": "90ee08101ef8a5ebb2b262cfc832c5802d4c48df5ef10bb4cb023478da1609c20ceb883f46597d50790898e781b3fc017f5b691593cba6359fe1e099300a71a3",
+        "incomingViewKey": "28a151f4592df9569a0d8ed9ca606973a08acc01a378fed57c537759dc9f6000",
+        "outgoingViewKey": "cc5e0c0cadd798c413b9dffac5baac20ab76944e25f5e00705d39c36f959b978",
+        "publicAddress": "71e30f5a92d7c419ba6de6b23d427e687405fe51de22282bb130c1b1b550c596",
+        "createdAt": {
+          "hash": {
+            "type": "Buffer",
+            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+          },
+          "sequence": 1
+        },
+        "scanningEnabled": true,
+        "proofAuthorizingKey": "48ea19104afb42099882254130f6cbf02e6554055217211c3216b25a78386f01"
+      },
+      "head": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+        },
+        "sequence": 1
+      }
+    }
+  ]
+}

--- a/ironfish/src/rpc/routes/eth/ethRouter.test.ts
+++ b/ironfish/src/rpc/routes/eth/ethRouter.test.ts
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Address } from '@ethereumjs/util'
+import { useAccountFixture } from '../../../testUtilities'
+import { createRouteTest } from '../../../testUtilities/routeTest'
+
+describe('Route eth/ethRouter', () => {
+  const routeTest = createRouteTest(false)
+
+  it('should handle eth_sendTransaction successfully', async () => {
+    const { node } = routeTest
+    const account = await useAccountFixture(node.wallet, 'test')
+    const address = Address.fromPrivateKey(Buffer.from(account.spendingKey, 'hex'))
+
+    const transactionRequest = {
+      jsonrpc: '2.0' as const,
+      id: 1,
+      method: 'eth_sendTransaction' as const,
+      params: [
+        {
+          from: address.toString(),
+          to: address.toString(),
+          gas: '0x5208',
+          gasPrice: '0x0',
+          value: '0x0',
+          data: '0x',
+        },
+      ],
+    }
+
+    const response = await routeTest.client.eth.ethRouter(transactionRequest)
+
+    expect(response.status).toEqual(200)
+  })
+})

--- a/ironfish/src/rpc/routes/eth/ethRouter.test.ts
+++ b/ironfish/src/rpc/routes/eth/ethRouter.test.ts
@@ -32,5 +32,10 @@ describe('Route eth/ethRouter', () => {
     const response = await routeTest.client.eth.ethRouter(transactionRequest)
 
     expect(response.status).toEqual(200)
+    expect(response.content).toMatchObject({
+      jsonrpc: '2.0',
+      id: 1,
+      result: expect.anything(),
+    })
   })
 })

--- a/ironfish/src/rpc/routes/eth/ethRouter.ts
+++ b/ironfish/src/rpc/routes/eth/ethRouter.ts
@@ -1,0 +1,106 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { id } from 'ethers'
+import * as yup from 'yup'
+import { Assert } from '../../../assert'
+import { FullNode } from '../../../node'
+import { RpcRequest } from '../../request'
+import { ApiNamespace } from '../namespaces'
+import { routes } from '../router'
+import {
+  sendRawTransaction,
+  SendRawTransactionRequest,
+  SendRawTransactionResponse,
+} from './sendRawTransaction'
+import {
+  EthSendTransactionRequest,
+  EthSendTransactionResponse,
+  sendTransaction,
+} from './sendTransaction'
+
+export type SendRequest = {
+  jsonrpc: '2.0'
+  id: number | string
+  method: 'eth_sendTransaction'
+  params: EthSendTransactionRequest[]
+}
+
+export type SendRawRequest = {
+  jsonrpc: '2.0'
+  id: number | string
+  method: 'eth_sendRawTransaction'
+  params: SendRawTransactionRequest[]
+}
+
+export type RouterRequest = SendRequest | SendRawRequest
+
+export type RouterResponse = {
+  result: string
+}
+
+const SendRequestSchema: yup.ObjectSchema<SendRequest> = yup
+  .object({
+    jsonrpc: yup.string<'2.0'>().required().equals(['2.0']),
+    id: yup.mixed<number | string>().required(),
+    method: yup.string<'eth_sendTransaction'>().required(),
+    params: yup.mixed<EthSendTransactionRequest[]>().required(),
+  })
+  .defined()
+const router: yup.MixedSchema<
+const SendRawRequestSchema: yup.ObjectSchema<SendRawRequest> = yup
+  .object({
+    jsonrpc: yup.string<'2.0'>().required().equals(['2.0']),
+    id: yup.mixed<number | string>().required(),
+    method: yup.string<'eth_sendRawTransaction'>().required(),
+    params: yup
+      .array()
+      .of(
+        yup.object().shape({
+          // Define the shape of SendRawTransactionRequest
+        }),
+      )
+      .required(),
+  })
+  .defined()
+
+export const RouterRequestSchema: yup.MixedSchema<RouterRequest> = yup
+  .mixed<RouterRequest>()
+  .test('is-send-request', 'Invalid SendRequest', (value) =>
+    SendRequestSchema.isValidSync(value),
+  )
+  .test('is-send-raw-request', 'Invalid SendRawRequest', (value) =>
+    SendRawRequestSchema.isValidSync(value),
+  )
+  .defined()
+export const RouterResponseSchema: yup.ObjectSchema<RouterResponse> = yup
+  .object({
+    result: yup.string().required(),
+  })
+  .defined()
+
+routes.register<typeof RouterRequestSchema, RouterRequest>(
+  `${ApiNamespace.eth}/ethRouter`,
+  RouterRequestSchema,
+  async (request, node): Promise<void> => {
+    Assert.isInstanceOf(node, FullNode)
+
+    if (request.data.method === 'eth_sendTransaction') {
+      const req = new RpcRequest<EthSendTransactionRequest, EthSendTransactionResponse>(
+        request.data.params[0],
+        '',
+        request.onEnd as (status: number, data?: unknown) => void,
+        request.onStream as (data: unknown) => void,
+      )
+      await sendTransaction(req, node)
+    } else if (request.data.method === 'eth_sendRawTransaction') {
+      const req = new RpcRequest<SendRawTransactionRequest, SendRawTransactionResponse>(
+        request.data.params[0],
+        '',
+        request.onEnd as (status: number, data?: unknown) => void,
+        request.onStream as (data: unknown) => void,
+      )
+      await sendRawTransaction(req, node)
+    }
+  },
+)

--- a/ironfish/src/rpc/routes/eth/getAccount.ts
+++ b/ironfish/src/rpc/routes/eth/getAccount.ts
@@ -8,7 +8,7 @@ import { FullNode } from '../../../node'
 import { CurrencyUtils } from '../../../utils'
 import { RpcNotFoundError } from '../../adapters'
 import { ApiNamespace } from '../namespaces'
-import { routes } from '../router'
+import { registerEthRoute } from './ethRouter'
 
 export type GetAccountRequest = {
   address: string
@@ -38,7 +38,8 @@ export const GetAccountResponseSchema: yup.ObjectSchema<GetAccountResponse> = yu
   })
   .defined()
 
-routes.register<typeof GetAccountRequestSchema, GetAccountResponse>(
+registerEthRoute<typeof GetAccountRequestSchema, GetAccountResponse>(
+  'eth_getAccount',
   `${ApiNamespace.eth}/getAccount`,
   GetAccountRequestSchema,
   async (request, node): Promise<void> => {

--- a/ironfish/src/rpc/routes/eth/index.ts
+++ b/ironfish/src/rpc/routes/eth/index.ts
@@ -4,3 +4,4 @@
 export * from './getAccount'
 export * from './sendRawTransaction'
 export * from './sendTransaction'
+export * from './ethRouter'

--- a/ironfish/src/rpc/routes/eth/sendRawTransaction.ts
+++ b/ironfish/src/rpc/routes/eth/sendRawTransaction.ts
@@ -7,8 +7,10 @@ import { Assert } from '../../../assert'
 import { GLOBAL_IF_ACCOUNT } from '../../../evm'
 import { FullNode } from '../../../node'
 import { legacyTransactionToEvmDescription } from '../../../primitives'
+import { RpcRequest } from '../../request'
 import { ApiNamespace } from '../namespaces'
 import { routes } from '../router'
+import { RpcContext } from '../rpcContext'
 
 export type SendRawTransactionRequest = {
   transaction: string
@@ -40,31 +42,36 @@ export const SendRawTransactionResponseSchema: yup.ObjectSchema<SendRawTransacti
 routes.register<typeof SendRawTransactionRequestSchema, SendRawTransactionResponse>(
   `${ApiNamespace.eth}/sendRawTransaction`,
   SendRawTransactionRequestSchema,
-  async (request, node): Promise<void> => {
-    Assert.isInstanceOf(node, FullNode)
-
-    const bytes = Buffer.from(request.data.transaction, 'hex')
-    const ethTransaction = LegacyTransaction.fromSerializedTx(bytes)
-    const evmDescription = legacyTransactionToEvmDescription(ethTransaction)
-
-    const { events } = await node.chain.evm.simulateTx({ tx: ethTransaction })
-    Assert.isNotUndefined(events, "No events returned from 'simulateTx'")
-
-    const raw = await node.wallet.createEvmTransaction({
-      evm: evmDescription,
-      evmEvents: events,
-    })
-
-    const transaction = await node.wallet.post({
-      transaction: raw,
-      spendingKey: GLOBAL_IF_ACCOUNT.spendingKey,
-    })
-
-    request.end({
-      hash: Buffer.from(ethTransaction.hash()).toString('hex'),
-      ifHash: transaction.transaction.hash().toString('hex'),
-      accepted: transaction.accepted,
-      broadcasted: transaction.broadcasted,
-    })
-  },
+  sendRawTransaction,
 )
+
+export async function sendRawTransaction(
+  request: RpcRequest<SendRawTransactionRequest, SendRawTransactionResponse>,
+  node: RpcContext,
+): Promise<void> {
+  Assert.isInstanceOf(node, FullNode)
+
+  const bytes = Buffer.from(request.data.transaction, 'hex')
+  const ethTransaction = LegacyTransaction.fromSerializedTx(bytes)
+  const evmDescription = legacyTransactionToEvmDescription(ethTransaction)
+
+  const { events } = await node.chain.evm.simulateTx({ tx: ethTransaction })
+  Assert.isNotUndefined(events, "No events returned from 'simulateTx'")
+
+  const raw = await node.wallet.createEvmTransaction({
+    evm: evmDescription,
+    evmEvents: events,
+  })
+
+  const transaction = await node.wallet.post({
+    transaction: raw,
+    spendingKey: GLOBAL_IF_ACCOUNT.spendingKey,
+  })
+
+  request.end({
+    hash: Buffer.from(ethTransaction.hash()).toString('hex'),
+    ifHash: transaction.transaction.hash().toString('hex'),
+    accepted: transaction.accepted,
+    broadcasted: transaction.broadcasted,
+  })
+}

--- a/ironfish/src/rpc/routes/eth/sendRawTransaction.ts
+++ b/ironfish/src/rpc/routes/eth/sendRawTransaction.ts
@@ -7,10 +7,8 @@ import { Assert } from '../../../assert'
 import { GLOBAL_IF_ACCOUNT } from '../../../evm'
 import { FullNode } from '../../../node'
 import { legacyTransactionToEvmDescription } from '../../../primitives'
-import { RpcRequest } from '../../request'
 import { ApiNamespace } from '../namespaces'
-import { routes } from '../router'
-import { RpcContext } from '../rpcContext'
+import { registerEthRoute } from './ethRouter'
 
 export type SendRawTransactionRequest = {
   transaction: string
@@ -39,39 +37,35 @@ export const SendRawTransactionResponseSchema: yup.ObjectSchema<SendRawTransacti
     })
     .defined()
 
-routes.register<typeof SendRawTransactionRequestSchema, SendRawTransactionResponse>(
+registerEthRoute<typeof SendRawTransactionRequestSchema, SendRawTransactionResponse>(
+  `eth_sendRawTransaction`,
   `${ApiNamespace.eth}/sendRawTransaction`,
   SendRawTransactionRequestSchema,
-  sendRawTransaction,
+  async (request, node): Promise<void> => {
+    Assert.isInstanceOf(node, FullNode)
+
+    const bytes = Buffer.from(request.data.transaction, 'hex')
+    const ethTransaction = LegacyTransaction.fromSerializedTx(bytes)
+    const evmDescription = legacyTransactionToEvmDescription(ethTransaction)
+
+    const { events } = await node.chain.evm.simulateTx({ tx: ethTransaction })
+    Assert.isNotUndefined(events, "No events returned from 'simulateTx'")
+
+    const raw = await node.wallet.createEvmTransaction({
+      evm: evmDescription,
+      evmEvents: events,
+    })
+
+    const transaction = await node.wallet.post({
+      transaction: raw,
+      spendingKey: GLOBAL_IF_ACCOUNT.spendingKey,
+    })
+
+    request.end({
+      hash: Buffer.from(ethTransaction.hash()).toString('hex'),
+      ifHash: transaction.transaction.hash().toString('hex'),
+      accepted: transaction.accepted,
+      broadcasted: transaction.broadcasted,
+    })
+  },
 )
-
-export async function sendRawTransaction(
-  request: RpcRequest<SendRawTransactionRequest, SendRawTransactionResponse>,
-  node: RpcContext,
-): Promise<void> {
-  Assert.isInstanceOf(node, FullNode)
-
-  const bytes = Buffer.from(request.data.transaction, 'hex')
-  const ethTransaction = LegacyTransaction.fromSerializedTx(bytes)
-  const evmDescription = legacyTransactionToEvmDescription(ethTransaction)
-
-  const { events } = await node.chain.evm.simulateTx({ tx: ethTransaction })
-  Assert.isNotUndefined(events, "No events returned from 'simulateTx'")
-
-  const raw = await node.wallet.createEvmTransaction({
-    evm: evmDescription,
-    evmEvents: events,
-  })
-
-  const transaction = await node.wallet.post({
-    transaction: raw,
-    spendingKey: GLOBAL_IF_ACCOUNT.spendingKey,
-  })
-
-  request.end({
-    hash: Buffer.from(ethTransaction.hash()).toString('hex'),
-    ifHash: transaction.transaction.hash().toString('hex'),
-    accepted: transaction.accepted,
-    broadcasted: transaction.broadcasted,
-  })
-}

--- a/ironfish/src/rpc/routes/eth/sendTransaction.ts
+++ b/ironfish/src/rpc/routes/eth/sendTransaction.ts
@@ -10,10 +10,8 @@ import { FullNode } from '../../../node'
 import { legacyTransactionToEvmDescription } from '../../../primitives'
 import { EthUtils } from '../../../utils/eth'
 import { AssertSpending } from '../../../wallet/account/account'
-import { RpcRequest } from '../../request'
 import { ApiNamespace } from '../namespaces'
-import { routes } from '../router'
-import { RpcContext } from '../rpcContext'
+import { registerEthRoute } from './ethRouter'
 
 export type EthSendTransactionRequest = {
   from: string
@@ -48,65 +46,66 @@ export const EthSendTransactionResponseSchema: yup.ObjectSchema<EthSendTransacti
     })
     .defined()
 
-routes.register<typeof EthSendTransactionRequestSchema, EthSendTransactionResponse>(
+registerEthRoute<typeof EthSendTransactionRequestSchema, EthSendTransactionResponse>(
+  'eth_sendTransaction',
   `${ApiNamespace.eth}/sendTransaction`,
   EthSendTransactionRequestSchema,
-  sendTransaction,
+  async (request, node): Promise<void> => {
+    Assert.isInstanceOf(node, FullNode)
+
+    const account = node.wallet.listAccounts().find((a) => a.ethAddress === request.data.from)
+    Assert.isNotUndefined(account, 'Account not found')
+    AssertSpending(account)
+
+    const ethAccount = account.ethAddress
+      ? await node.chain.evm.getAccount(
+          Address.fromString(EthUtils.prefix0x(account.ethAddress)),
+        )
+      : undefined
+
+    const nonce = request.data.nonce
+      ? BigInt(request.data.nonce)
+      : ethAccount?.nonce ?? BigInt(0)
+
+    const gas = request.data.gas ? BigInt(request.data.gas) : 1000000n
+    const gasPrice = request.data.gasPrice ? BigInt(request.data.gasPrice) : 0n
+    const value = request.data.value ? BigInt(request.data.value) : undefined
+
+    const ethTransaction = new LegacyTransaction({
+      nonce: nonce,
+      to: request.data.to,
+      gasLimit: gas,
+      gasPrice: gasPrice,
+      value: value,
+      data: request.data.data,
+    })
+
+    const signed = ethTransaction.sign(Buffer.from(account.spendingKey, 'hex'))
+
+    const evmDescription = legacyTransactionToEvmDescription(signed)
+    const result = await node.chain.evm.simulateTx({ tx: signed })
+
+    const events = result.events
+    Assert.isUndefined(result.error, `Error simulating transaction ${result.error?.message}`)
+
+    const raw = await node.wallet.createEvmTransaction({
+      evm: evmDescription,
+      evmEvents: events,
+      account: account,
+    })
+
+    // TODO: This is pretty hacky to figure out which key to post with
+    const unshields = events ? events.filter((e) => e.name === 'unshield') : []
+    const spendingKey =
+      unshields.length > 0 ? account.spendingKey : GLOBAL_IF_ACCOUNT.spendingKey
+
+    const { transaction } = await node.wallet.post({
+      transaction: raw,
+      spendingKey: spendingKey,
+    })
+
+    request.end({
+      result: Buffer.from(transaction.hash()).toString('hex'),
+    })
+  },
 )
-
-export async function sendTransaction(
-  request: RpcRequest<EthSendTransactionRequest, EthSendTransactionResponse>,
-  node: RpcContext,
-): Promise<void> {
-  Assert.isInstanceOf(node, FullNode)
-
-  const account = node.wallet.listAccounts().find((a) => a.ethAddress === request.data.from)
-  Assert.isNotUndefined(account, 'Account not found')
-  AssertSpending(account)
-
-  const ethAccount = account.ethAddress
-    ? await node.chain.evm.getAccount(Address.fromString(EthUtils.prefix0x(account.ethAddress)))
-    : undefined
-
-  const nonce = request.data.nonce ? BigInt(request.data.nonce) : ethAccount?.nonce ?? BigInt(0)
-
-  const gas = request.data.gas ? BigInt(request.data.gas) : 1000000n
-  const gasPrice = request.data.gasPrice ? BigInt(request.data.gasPrice) : 0n
-  const value = request.data.value ? BigInt(request.data.value) : undefined
-
-  const ethTransaction = new LegacyTransaction({
-    nonce: nonce,
-    to: request.data.to,
-    gasLimit: gas,
-    gasPrice: gasPrice,
-    value: value,
-    data: request.data.data,
-  })
-
-  const signed = ethTransaction.sign(Buffer.from(account.spendingKey, 'hex'))
-
-  const evmDescription = legacyTransactionToEvmDescription(signed)
-  const result = await node.chain.evm.simulateTx({ tx: signed })
-
-  const events = result.events
-  Assert.isUndefined(result.error, `Error simulating transaction ${result.error?.message}`)
-
-  const raw = await node.wallet.createEvmTransaction({
-    evm: evmDescription,
-    evmEvents: events,
-    account: account,
-  })
-
-  // TODO: This is pretty hacky to figure out which key to post with
-  const unshields = events ? events.filter((e) => e.name === 'unshield') : []
-  const spendingKey = unshields.length > 0 ? account.spendingKey : GLOBAL_IF_ACCOUNT.spendingKey
-
-  const { transaction } = await node.wallet.post({
-    transaction: raw,
-    spendingKey: spendingKey,
-  })
-
-  request.end({
-    result: Buffer.from(transaction.hash()).toString('hex'),
-  })
-}

--- a/ironfish/src/rpc/routes/eth/sendTransaction.ts
+++ b/ironfish/src/rpc/routes/eth/sendTransaction.ts
@@ -10,8 +10,10 @@ import { FullNode } from '../../../node'
 import { legacyTransactionToEvmDescription } from '../../../primitives'
 import { EthUtils } from '../../../utils/eth'
 import { AssertSpending } from '../../../wallet/account/account'
+import { RpcRequest } from '../../request'
 import { ApiNamespace } from '../namespaces'
 import { routes } from '../router'
+import { RpcContext } from '../rpcContext'
 
 export type EthSendTransactionRequest = {
   from: string
@@ -49,62 +51,62 @@ export const EthSendTransactionResponseSchema: yup.ObjectSchema<EthSendTransacti
 routes.register<typeof EthSendTransactionRequestSchema, EthSendTransactionResponse>(
   `${ApiNamespace.eth}/sendTransaction`,
   EthSendTransactionRequestSchema,
-  async (request, node): Promise<void> => {
-    Assert.isInstanceOf(node, FullNode)
-
-    const account = node.wallet.listAccounts().find((a) => a.ethAddress === request.data.from)
-    Assert.isNotUndefined(account, 'Account not found')
-    AssertSpending(account)
-
-    const ethAccount = account.ethAddress
-      ? await node.chain.evm.getAccount(
-          Address.fromString(EthUtils.prefix0x(account.ethAddress)),
-        )
-      : undefined
-
-    const nonce = request.data.nonce
-      ? BigInt(request.data.nonce)
-      : ethAccount?.nonce ?? BigInt(0)
-
-    const gas = request.data.gas ? BigInt(request.data.gas) : 1000000n
-    const gasPrice = request.data.gasPrice ? BigInt(request.data.gasPrice) : 0n
-    const value = request.data.value ? BigInt(request.data.value) : undefined
-
-    const ethTransaction = new LegacyTransaction({
-      nonce: nonce,
-      to: request.data.to,
-      gasLimit: gas,
-      gasPrice: gasPrice,
-      value: value,
-      data: request.data.data,
-    })
-
-    const signed = ethTransaction.sign(Buffer.from(account.spendingKey, 'hex'))
-
-    const evmDescription = legacyTransactionToEvmDescription(signed)
-    const result = await node.chain.evm.simulateTx({ tx: signed })
-
-    const events = result.events
-    Assert.isUndefined(result.error, `Error simulating transaction ${result.error?.message}`)
-
-    const raw = await node.wallet.createEvmTransaction({
-      evm: evmDescription,
-      evmEvents: events,
-      account: account,
-    })
-
-    // TODO: This is pretty hacky to figure out which key to post with
-    const unshields = events ? events.filter((e) => e.name === 'unshield') : []
-    const spendingKey =
-      unshields.length > 0 ? account.spendingKey : GLOBAL_IF_ACCOUNT.spendingKey
-
-    const { transaction } = await node.wallet.post({
-      transaction: raw,
-      spendingKey: spendingKey,
-    })
-
-    request.end({
-      result: Buffer.from(transaction.hash()).toString('hex'),
-    })
-  },
+  sendTransaction,
 )
+
+export async function sendTransaction(
+  request: RpcRequest<EthSendTransactionRequest, EthSendTransactionResponse>,
+  node: RpcContext,
+): Promise<void> {
+  Assert.isInstanceOf(node, FullNode)
+
+  const account = node.wallet.listAccounts().find((a) => a.ethAddress === request.data.from)
+  Assert.isNotUndefined(account, 'Account not found')
+  AssertSpending(account)
+
+  const ethAccount = account.ethAddress
+    ? await node.chain.evm.getAccount(Address.fromString(EthUtils.prefix0x(account.ethAddress)))
+    : undefined
+
+  const nonce = request.data.nonce ? BigInt(request.data.nonce) : ethAccount?.nonce ?? BigInt(0)
+
+  const gas = request.data.gas ? BigInt(request.data.gas) : 1000000n
+  const gasPrice = request.data.gasPrice ? BigInt(request.data.gasPrice) : 0n
+  const value = request.data.value ? BigInt(request.data.value) : undefined
+
+  const ethTransaction = new LegacyTransaction({
+    nonce: nonce,
+    to: request.data.to,
+    gasLimit: gas,
+    gasPrice: gasPrice,
+    value: value,
+    data: request.data.data,
+  })
+
+  const signed = ethTransaction.sign(Buffer.from(account.spendingKey, 'hex'))
+
+  const evmDescription = legacyTransactionToEvmDescription(signed)
+  const result = await node.chain.evm.simulateTx({ tx: signed })
+
+  const events = result.events
+  Assert.isUndefined(result.error, `Error simulating transaction ${result.error?.message}`)
+
+  const raw = await node.wallet.createEvmTransaction({
+    evm: evmDescription,
+    evmEvents: events,
+    account: account,
+  })
+
+  // TODO: This is pretty hacky to figure out which key to post with
+  const unshields = events ? events.filter((e) => e.name === 'unshield') : []
+  const spendingKey = unshields.length > 0 ? account.spendingKey : GLOBAL_IF_ACCOUNT.spendingKey
+
+  const { transaction } = await node.wallet.post({
+    transaction: raw,
+    spendingKey: spendingKey,
+  })
+
+  request.end({
+    result: Buffer.from(transaction.hash()).toString('hex'),
+  })
+}


### PR DESCRIPTION
## Summary
For registering RPCs for integration with external systems, but maintain our own api specification, I created this wrapper. It will make the endpoints registered available via the standardized JSON rpc system of eth nodes, but also with our typesafe client.

For example, an endpoint can hit:

`rpc/ethRouter` with request body:
```
{
  jsonrpc: '2.0'
  id: 1
  method: 'eth_sendRawTransaction`
  params: [{transaction: '0x....']
}
```

Which is the same as using our client at
`client.eth.sendRawTransaction({transaction: '0x....'})`
or
`rpc/eth/sendTransaction`

## Testing Plan
Test Passes.

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
