### PR TITLE
Change wallet:delete to use new confirmInput

### DIFF
--- a/ironfish-cli/src/commands/wallet/delete.ts
+++ b/ironfish-cli/src/commands/wallet/delete.ts
@@ -5,7 +5,7 @@
 import { Args, Flags, ux } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
-import { inputPrompt } from '../../ui'
+import * as ui from '../../ui'
 
 export class DeleteCommand extends IronfishCommand {
   static description = `delete an account`
@@ -40,12 +40,11 @@ export class DeleteCommand extends IronfishCommand {
     ux.action.stop()
 
     if (response.content.needsConfirm) {
-      const value = await inputPrompt(`Are you sure? Type ${account} to confirm`)
-
-      if (value !== account) {
-        this.log(`Aborting: ${value} did not match ${account}`)
-        this.exit(1)
-      }
+      await ui.confirmInputOrQuit(
+        account,
+        `Are you sure you want to delete "${account}"?\nType ${account} to confirm`,
+        flags.confirm,
+      )
 
       ux.action.start(`Deleting account '${account}'`)
       await client.wallet.removeAccount({ account, confirm: true, wait })

--- a/ironfish-cli/src/ui/prompt.ts
+++ b/ironfish-cli/src/ui/prompt.ts
@@ -28,6 +28,27 @@ export async function inputPrompt(message: string, required: boolean = false): P
   return userInput
 }
 
+export async function confirmInputOrQuit(
+  input: string,
+  message?: string,
+  confirm?: boolean,
+): Promise<void> {
+  if (confirm) {
+    return
+  }
+
+  if (!message) {
+    message = `Are you sure? Type ${input} to confirm.`
+  }
+
+  const entered = await inputPrompt(message, true)
+
+  if (entered !== input) {
+    ux.stdout('Operation aborted.')
+    ux.exit(0)
+  }
+}
+
 export async function confirmPrompt(message: string): Promise<boolean> {
   const result: { prompt: boolean } = await inquirer.prompt({
     type: 'confirm',


### PR DESCRIPTION
## Summary

This makes the user type in the account name they are trying to delete

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
