### PR TITLE
feat(cli): Add `wallet:decrypt`

### DIFF
--- a/ironfish-cli/src/commands/wallet/decrypt.ts
+++ b/ironfish-cli/src/commands/wallet/decrypt.ts
@@ -1,0 +1,53 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { RpcRequestError } from '@ironfish/sdk'
+import { Flags } from '@oclif/core'
+import { IronfishCommand } from '../../command'
+import { RemoteFlags } from '../../flags'
+import { inputPrompt } from '../../ui'
+
+export class DecryptCommand extends IronfishCommand {
+  static hidden = true
+
+  static description = 'Decrypt accounts in the wallet'
+
+  static flags = {
+    ...RemoteFlags,
+    passphrase: Flags.string({
+      description: 'Passphrase to decrypt the wallet with',
+    }),
+  }
+
+  async start(): Promise<void> {
+    const { flags } = await this.parse(DecryptCommand)
+
+    const client = await this.connectRpc()
+
+    const response = await client.wallet.getAccountsStatus()
+    if (!response.content.encrypted) {
+      this.log('Wallet is already decrypted')
+      this.exit(1)
+    }
+
+    let passphrase = flags.passphrase
+    if (!passphrase) {
+      passphrase = await inputPrompt('Enter a passphrase to decrypt the wallet', true)
+    }
+
+    try {
+      await client.wallet.decrypt({
+        passphrase,
+      })
+    } catch (e) {
+      if (e instanceof RpcRequestError) {
+        this.log('Wallet decryption failed')
+        this.exit(1)
+      }
+
+      throw e
+    }
+
+    this.log('Decrypted the wallet')
+  }
+}

--- a/ironfish-cli/src/commands/wallet/decrypt.ts
+++ b/ironfish-cli/src/commands/wallet/decrypt.ts
@@ -10,7 +10,7 @@ import { inputPrompt } from '../../ui'
 export class DecryptCommand extends IronfishCommand {
   static hidden = true
 
-  static description = 'Decrypt accounts in the wallet'
+  static description = 'decrypt accounts in the wallet'
 
   static flags = {
     ...RemoteFlags,


### PR DESCRIPTION
## Summary

Add CLI command to encrypt the wallet

## Testing Plan

```fish
❯ f wallet:decrypt -d ~/.ironfish-1
yarn run v1.22.18
$ yarn build && yarn start:js wallet:decrypt -d /home/rohan/.ironfish-1
$ tsc -b
? Enter a passphrase to decrypt the wallet: invalid
Wallet decryption failed

❯ f wallet:decrypt -d ~/.ironfish-1
yarn run v1.22.18
$ yarn build && yarn start:js wallet:decrypt -d /home/rohan/.ironfish-1
$ tsc -b
? Enter a passphrase to decrypt the wallet: foobar
Decrypted the wallet
Done in 2.58s.
```

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
