### PR TITLE
feat(cli): Add `wallet:unlock`

### DIFF
--- a/ironfish-cli/src/commands/wallet/unlock.ts
+++ b/ironfish-cli/src/commands/wallet/unlock.ts
@@ -1,0 +1,67 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { DEFAULT_UNLOCK_TIMEOUT_MS, RpcRequestError } from '@ironfish/sdk'
+import { Flags } from '@oclif/core'
+import { IronfishCommand } from '../../command'
+import { RemoteFlags } from '../../flags'
+import { inputPrompt } from '../../ui'
+
+export class UnlockCommand extends IronfishCommand {
+  static hidden = true
+
+  static description = 'Unlock accounts in the wallet'
+
+  static flags = {
+    ...RemoteFlags,
+    passphrase: Flags.string({
+      description: 'Passphrase to unlock the wallet with',
+    }),
+    timeout: Flags.integer({
+      description:
+        'How long to unlock the wallet for in ms. Use -1 to keep the wallet unlocked until the process stops',
+    }),
+  }
+
+  async start(): Promise<void> {
+    const { flags } = await this.parse(UnlockCommand)
+
+    const client = await this.connectRpc()
+
+    const response = await client.wallet.getAccountsStatus()
+    if (!response.content.encrypted) {
+      this.log('Wallet is already decrypted')
+      this.exit(1)
+    }
+
+    let passphrase = flags.passphrase
+    if (!passphrase) {
+      passphrase = await inputPrompt('Enter a passphrase to unlock the wallet', true)
+    }
+
+    try {
+      await client.wallet.unlock({
+        passphrase,
+        timeout: flags.timeout,
+      })
+    } catch (e) {
+      if (e instanceof RpcRequestError) {
+        this.log('Wallet unlock failed')
+        this.exit(1)
+      }
+
+      throw e
+    }
+
+    const timeout = flags.timeout || DEFAULT_UNLOCK_TIMEOUT_MS
+    if (timeout === -1) {
+      this.log(
+        'Unlocked the wallet. Call wallet:lock or stop the node to lock the wallet again.',
+      )
+    } else {
+      this.log(`Unlocked the wallet for ${timeout}ms`)
+    }
+
+    this.exit(0)
+  }
+}

--- a/ironfish-cli/src/commands/wallet/unlock.ts
+++ b/ironfish-cli/src/commands/wallet/unlock.ts
@@ -10,7 +10,7 @@ import { inputPrompt } from '../../ui'
 export class UnlockCommand extends IronfishCommand {
   static hidden = true
 
-  static description = 'Unlock accounts in the wallet'
+  static description = 'unlock accounts in the wallet'
 
   static flags = {
     ...RemoteFlags,


### PR DESCRIPTION
## Summary

Add command to unlock the wallet

## Testing Plan

```sh
❯ f wallet:unlock -d ~/.ironfish-1 
yarn run v1.22.18
$ yarn build && yarn start:js wallet:unlock -d /home/rohan/.ironfish-1
$ tsc -b
? Enter a passphrase to unlock the wallet: passwer
Wallet unlock failed
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.

❯ f wallet:unlock -d ~/.ironfish-1
yarn run v1.22.18
$ yarn build && yarn start:js wallet:unlock -d /home/rohan/.ironfish-1
$ tsc -b
? Enter a passphrase to unlock the wallet: password
Unlocked the wallet for 300000ms
Done in 4.77s.

❯ f wallet:unlock -d ~/.ironfish-1 --timeout -1
yarn run v1.22.18
$ yarn build && yarn start:js wallet:unlock -d /home/rohan/.ironfish-1 --timeout -1
$ tsc -b
? Enter a passphrase to unlock the wallet: password
Unlocked the wallet. Call wallet:lock or stop the node to lock the wallet again.
```

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[x] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
