### PR TITLE
feat(cli): Add `wallet:lock`

### DIFF
--- a/ironfish-cli/src/commands/wallet/lock.ts
+++ b/ironfish-cli/src/commands/wallet/lock.ts
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { RpcRequestError } from '@ironfish/sdk'
+import { IronfishCommand } from '../../command'
+import { RemoteFlags } from '../../flags'
+
+export class LockCommand extends IronfishCommand {
+  static hidden = true
+
+  static description = 'lock accounts in the wallet'
+
+  static flags = {
+    ...RemoteFlags,
+  }
+
+  async start(): Promise<void> {
+    const client = await this.connectRpc()
+
+    const response = await client.wallet.getAccountsStatus()
+    if (!response.content.encrypted) {
+      this.log('Wallet is decrypted')
+      this.exit(1)
+    }
+
+    try {
+      await client.wallet.lock()
+    } catch (e) {
+      if (e instanceof RpcRequestError) {
+        this.log('Wallet lock failed')
+        this.exit(1)
+      }
+
+      throw e
+    }
+
+    this.log('Locked the wallet')
+    this.exit(0)
+  }
+}


### PR DESCRIPTION
## Summary

Add command to lock the wallet

## Testing Plan

```sh
❯ f wallet:lock -d ~/.ironfish-1
yarn run v1.22.18
$ yarn build && yarn start:js wallet:lock -d /home/rohan/.ironfish-1
$ tsc -b
Locked the wallet
```

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[x] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
