### PR TITLE
add eth transaction hash to hash store, for eth_getTransactionByHash

### DIFF
--- a/ironfish/src/blockchain/database/blockchaindb.ts
+++ b/ironfish/src/blockchain/database/blockchaindb.ts
@@ -24,6 +24,7 @@ import {
   AssetSchema,
   AssetToContractTokenSchema,
   ContractTokenToAssetSchema,
+  ethTransactionHashToTransactionHashSchema,
   HashToNextSchema,
   HeadersSchema,
   MetaSchema,
@@ -64,6 +65,8 @@ export class BlockchainDB extends TransactionalDatabase {
   contractTokenToAssetId: IDatabaseStore<ContractTokenToAssetSchema>
   // TransactionHash -> BlockHash
   transactionHashToBlockHash: IDatabaseStore<TransactionHashToBlockHashSchema>
+  // EthTransactionHash -> TransactionHash
+  ethTransactionHashToTransactionHash: IDatabaseStore<ethTransactionHashToTransactionHashSchema>
 
   stateManager: IronfishStateManager
 
@@ -134,6 +137,12 @@ export class BlockchainDB extends TransactionalDatabase {
 
     this.transactionHashToBlockHash = this.db.addStore({
       name: 'tb',
+      keyEncoding: BUFFER_ENCODING,
+      valueEncoding: BUFFER_ENCODING,
+    })
+
+    this.ethTransactionHashToTransactionHash = this.db.addStore({
+      name: 'ett',
       keyEncoding: BUFFER_ENCODING,
       valueEncoding: BUFFER_ENCODING,
     })
@@ -396,6 +405,21 @@ export class BlockchainDB extends TransactionalDatabase {
     tx?: IDatabaseTransaction,
   ): Promise<void> {
     return this.transactionHashToBlockHash.del(transactionHash, tx)
+  }
+
+  async putEthTransactionHashToTransactionHash(
+    ethTransactionHash: Buffer,
+    transactionHash: Buffer,
+    tx?: IDatabaseTransaction,
+  ): Promise<void> {
+    return this.ethTransactionHashToTransactionHash.put(ethTransactionHash, transactionHash, tx)
+  }
+
+  async deleteEthTransactionHashToTransactionHash(
+    ethTransactionHash: Buffer,
+    tx?: IDatabaseTransaction,
+  ): Promise<void> {
+    return this.ethTransactionHashToTransactionHash.del(ethTransactionHash, tx)
   }
 
   async compact(): Promise<void> {

--- a/ironfish/src/blockchain/schema.ts
+++ b/ironfish/src/blockchain/schema.ts
@@ -61,3 +61,8 @@ export interface TransactionHashToBlockHashSchema extends DatabaseSchema {
   key: TransactionHash
   value: BlockHash
 }
+
+export interface ethTransactionHashToTransactionHashSchema extends DatabaseSchema {
+  key: Buffer
+  value: TransactionHash
+}


### PR DESCRIPTION
## Summary

## Testing Plan
Will test with RPC addition of `eth_getTransactionByHash`
## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
