### PR TITLE
feat(cli,ironfish): Check if the wallet is locked before fetching accounts

### DIFF
--- a/ironfish-cli/src/utils/account.ts
+++ b/ironfish-cli/src/utils/account.ts
@@ -14,6 +14,11 @@ export async function useAccount(
     return account
   }
 
+  const status = await client.wallet.getAccountsStatus()
+  if (status.content.locked) {
+    throw new Error('Wallet is locked. Unlock the wallet to fetch accounts')
+  }
+
   const defaultAccount = await client.wallet.getAccounts({ default: true })
 
   if (defaultAccount.content.accounts.length) {

--- a/ironfish/src/rpc/routes/wallet/utils.ts
+++ b/ironfish/src/rpc/routes/wallet/utils.ts
@@ -12,6 +12,10 @@ import { serializeRpcWalletNote } from './serializers'
 import { RpcWalletNote } from './types'
 
 export function getAccount(wallet: Wallet, name?: string): Account {
+  if (wallet.locked) {
+    throw new RpcValidationError('Wallet is locked. Unlock the wallet to fetch accounts')
+  }
+
   if (name) {
     const account = wallet.getAccountByName(name)
     if (account) {


### PR DESCRIPTION
## Summary

Check the wallet is unlocked before returning account(s)

## Testing Plan

```sh
❯ f wallet:balances -d ~/.ironfish-testnet
yarn run v1.22.21

Error: Wallet is locked. Unlock the wallet to fetch accounts
    at useAccount (/Users/rohan/git/ironfish/ironfish-cli/src/utils/account.ts:19:11)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at BalancesCommand.start (/Users/rohan/git/ironfish/ironfish-cli/src/commands/wallet/balances.ts:36:21)
    at BalancesCommand.run (/Users/rohan/git/ironfish/ironfish-cli/src/command.ts:92:14)
    at async BalancesCommand._run (/Users/rohan/git/ironfish/node_modules/@oclif/core/lib/command.js:301:22)
    at async Config.runCommand (/Users/rohan/git/ironfish/node_modules/@oclif/core/lib/config/config.js:424:25)
    at async run (/Users/rohan/git/ironfish/node_modules/@oclif/core/lib/main.js:95:16)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.

❯ f wallet:unlock -d ~/.ironfish-testnet
yarn run v1.22.21

? Enter a passphrase to unlock the wallet: foobar
Unlocked the wallet for 300000ms
✨  Done in 3.24s.

❯ f wallet:balances -d ~/.ironfish-testnet
yarn run v1.22.21

Account: default
 Asset  Balance   
 ────── ──────────
 $IRON✓ 0.00000000
✨  Done in 1.34s.

❯ f wallet:lock -d ~/.ironfish-testnet
yarn run v1.22.21

Locked the wallet
✨  Done in 1.37s.

❯ f wallet:balances -d ~/.ironfish-testnet
yarn run v1.22.21

Error: Wallet is locked. Unlock the wallet to fetch accounts
    at useAccount (/Users/rohan/git/ironfish/ironfish-cli/src/utils/account.ts:19:11)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at BalancesCommand.start (/Users/rohan/git/ironfish/ironfish-cli/src/commands/wallet/balances.ts:36:21)
    at BalancesCommand.run (/Users/rohan/git/ironfish/ironfish-cli/src/command.ts:92:14)
    at async BalancesCommand._run (/Users/rohan/git/ironfish/node_modules/@oclif/core/lib/command.js:301:22)
    at async Config.runCommand (/Users/rohan/git/ironfish/node_modules/@oclif/core/lib/config/config.js:424:25)
    at async run (/Users/rohan/git/ironfish/node_modules/@oclif/core/lib/main.js:95:16)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
