### PR TITLE
feat(ironfish): Notify via logger when the wallet locks

### DIFF
--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -1875,6 +1875,10 @@ export class Wallet {
       this.stopUnlockTimeout()
       this.accountById.clear()
       this.locked = true
+
+      this.logger.info(
+        'Wallet locked. Unlock the wallet to view your accounts and create transactions',
+      )
     } finally {
       unlock()
     }


### PR DESCRIPTION
## Summary

Small UX improvement to notify the user when the wallet automatically locks so they know to unlock it.

## Testing Plan

Manually tested

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
