### PR TITLE
adds db store for evm receipts

### DIFF
--- a/ironfish/src/blockchain/database/__fixtures__/evmReceiptValue.test.ts.fixture
+++ b/ironfish/src/blockchain/database/__fixtures__/evmReceiptValue.test.ts.fixture
@@ -1,0 +1,32 @@
+{
+  "EvmReceiptValueEncoding serializes the value into a buffer and deserializes to the original value": [
+    {
+      "value": {
+        "version": 4,
+        "id": "68205589-3a91-4466-be12-16cb1a9072be",
+        "name": "ifReceivingAccount",
+        "spendingKey": "7e79e63f44e3c4879fa297631768ef4de3355acb7fd47e4633b5a8aff718fc67",
+        "viewKey": "2e8cf0a06cc36a397aa36b4d5119a8addcc7e7bfdd4530079405cd59b70ba54028d8af1f21375c554c30a583047dcdc2f9044eb850b71062408e93caefdae655",
+        "incomingViewKey": "0c6b36a987e6be4059fa0facac0ae124e025e8f95e0137f2f78964d978f8d201",
+        "outgoingViewKey": "4d6ba8301fc5ffc49aafb04b80e3ebcbf022192a2d02dbab85f793cd0eb6f7e2",
+        "publicAddress": "13ac843bf793979dbb62e9eed1c4cdf0a617a8c2792b40f32c5c6c049b47000d",
+        "createdAt": {
+          "hash": {
+            "type": "Buffer",
+            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+          },
+          "sequence": 1
+        },
+        "scanningEnabled": true,
+        "proofAuthorizingKey": "37b422aa9c3b21eb2fe14ae7e8b99f3881558fa47e5b0a99e73f2595a7de3b0e"
+      },
+      "head": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+        },
+        "sequence": 1
+      }
+    }
+  ]
+}

--- a/ironfish/src/blockchain/database/blockchaindb.ts
+++ b/ironfish/src/blockchain/database/blockchaindb.ts
@@ -440,6 +440,13 @@ export class BlockchainDB extends TransactionalDatabase {
     return this.evmTransactionReceipts.put(ethTransactionHash, receipt, tx)
   }
 
+  async getEvmReceipt(
+    ethTransactionHash: Buffer,
+    tx?: IDatabaseTransaction,
+  ): Promise<EvmReceiptValue | undefined> {
+    return this.evmTransactionReceipts.get(ethTransactionHash, tx)
+  }
+
   async deleteEvmReceipt(ethTransactionHash: Buffer, tx?: IDatabaseTransaction): Promise<void> {
     return this.evmTransactionReceipts.del(ethTransactionHash, tx)
   }

--- a/ironfish/src/blockchain/database/evmReceiptValue.test.ts
+++ b/ironfish/src/blockchain/database/evmReceiptValue.test.ts
@@ -1,0 +1,64 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { LegacyTransaction } from '@ethereumjs/tx'
+import { Account as EthAccount, Address } from '@ethereumjs/util'
+import ContractArtifact from '@ironfish/ironfish-contracts'
+import { ethers } from 'ethers'
+import { Assert } from '../../assert'
+import { GLOBAL_CONTRACT_ADDRESS } from '../../evm'
+import { createNodeTest, useAccountFixture } from '../../testUtilities'
+import { EvmReceiptValueEncoding, runTxResultToEvmReceipt } from './evmReceiptValue'
+
+describe('EvmReceiptValueEncoding', () => {
+  const nodeTest = createNodeTest()
+
+  it('serializes the value into a buffer and deserializes to the original value', async () => {
+    const { chain, wallet } = nodeTest
+    nodeTest.network.consensus.parameters.enableEvmDescriptions = 1
+
+    const globalContract = new ethers.Interface(ContractArtifact.abi)
+
+    const evmAccount = ethers.HDNodeWallet.fromSeed(
+      Buffer.from('f92df72b4c3b1f4f29cfcb0874679b2154c1d686651dde2f3a72f9db54aced25', 'hex'),
+    )
+
+    const ifReceivingAccount = await useAccountFixture(wallet, 'ifReceivingAccount')
+
+    // Give a public account 500 ORE
+    await chain.blockchainDb.stateManager.checkpoint()
+    await chain.blockchainDb.stateManager.putAccount(
+      Address.fromString(evmAccount.address),
+      new EthAccount(BigInt(0), 10_000_000_000n),
+    )
+    await chain.blockchainDb.stateManager.commit()
+
+    const encodedFunctionData = globalContract.encodeFunctionData('shield_iron', [
+      Buffer.from(ifReceivingAccount.publicAddress, 'hex'),
+    ])
+
+    const tx = new LegacyTransaction({
+      nonce: 0n,
+      to: GLOBAL_CONTRACT_ADDRESS,
+      gasLimit: 1000000n,
+      gasPrice: 0n,
+      value: 500n,
+      data: encodedFunctionData,
+    })
+
+    const signed = tx.sign(Buffer.from(evmAccount.privateKey.replace(/0x/g, ''), 'hex'))
+
+    const result = await chain.evm.simulateTx({ tx: signed })
+
+    Assert.isNotUndefined(result.result)
+
+    const evmReceiptValue = runTxResultToEvmReceipt(result.result)
+
+    const encoder = new EvmReceiptValueEncoding()
+
+    const serialized = encoder.serialize(evmReceiptValue)
+    const deserialized = encoder.deserialize(serialized)
+
+    expect(deserialized).toEqual(evmReceiptValue)
+  })
+})

--- a/ironfish/src/blockchain/database/evmReceiptValue.test.ts
+++ b/ironfish/src/blockchain/database/evmReceiptValue.test.ts
@@ -8,6 +8,7 @@ import { ethers } from 'ethers'
 import { Assert } from '../../assert'
 import { GLOBAL_CONTRACT_ADDRESS } from '../../evm'
 import { createNodeTest, useAccountFixture } from '../../testUtilities'
+import { EthUtils } from '../../utils'
 import { EvmReceiptValueEncoding, runTxResultToEvmReceipt } from './evmReceiptValue'
 
 describe('EvmReceiptValueEncoding', () => {
@@ -46,7 +47,7 @@ describe('EvmReceiptValueEncoding', () => {
       data: encodedFunctionData,
     })
 
-    const signed = tx.sign(Buffer.from(evmAccount.privateKey.replace(/0x/g, ''), 'hex'))
+    const signed = tx.sign(Buffer.from(EthUtils.remove0x(evmAccount.privateKey), 'hex'))
 
     const result = await chain.evm.simulateTx({ tx: signed })
 

--- a/ironfish/src/blockchain/database/evmReceiptValue.ts
+++ b/ironfish/src/blockchain/database/evmReceiptValue.ts
@@ -1,0 +1,141 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import type { IDatabaseEncoding } from '../../storage/database/types'
+import { Log } from '@ethereumjs/evm'
+import { RunTxResult } from '@ethereumjs/vm'
+import bufio from 'bufio'
+
+export interface EvmReceiptValue {
+  type: number
+  status: number
+  contractAddress?: Buffer
+  logsBloom: Buffer
+  logs: Log[]
+  gasUsed: bigint
+  cumulativeGasUsed: bigint
+
+  // fields below are included in Geth serialization, but we may not need them
+
+  // effectiveGasPrice: bigint
+  // postState: Buffer
+  // TxHash: Buffer
+  // blobGasUsed: bigint
+  // blobGasPrice: bigint
+  // blockHash: Buffer
+  // blockNumber: number
+  // transactionIndex: number
+}
+
+export function runTxResultToEvmReceipt(result: RunTxResult): EvmReceiptValue {
+  return {
+    type: 0, // hardcoded for LegacyTransaction
+    status: result.execResult.exceptionError !== undefined ? 0 : 1,
+    contractAddress: result.createdAddress
+      ? Buffer.from(result.createdAddress.bytes)
+      : undefined,
+    logsBloom: Buffer.from(result.receipt.bitvector),
+    logs: result.receipt.logs ?? [],
+    gasUsed: result.execResult.executionGasUsed,
+    cumulativeGasUsed: result.receipt.cumulativeBlockGasUsed,
+  }
+}
+
+export class EvmReceiptValueEncoding implements IDatabaseEncoding<EvmReceiptValue> {
+  serialize(value: EvmReceiptValue): Buffer {
+    const bw = bufio.write(this.getSize(value))
+
+    let flags = 0
+    flags |= Number(!!value.contractAddress) << 0
+
+    bw.writeU8(flags)
+    bw.writeU8(value.type)
+    bw.writeU8(value.status)
+
+    if (value.contractAddress) {
+      bw.writeBytes(value.contractAddress)
+    }
+
+    bw.writeBytes(value.logsBloom)
+
+    bw.writeU32(value.logs.length)
+    for (const [address, topics, data] of value.logs) {
+      bw.writeBytes(Buffer.from(address))
+      bw.writeU32(topics.length)
+      for (const topic of topics) {
+        bw.writeBytes(Buffer.from(topic))
+      }
+      bw.writeVarBytes(Buffer.from(data))
+    }
+
+    bw.writeBigU64(value.gasUsed)
+    bw.writeBigU64(value.cumulativeGasUsed)
+
+    return bw.render()
+  }
+
+  deserialize(buffer: Buffer): EvmReceiptValue {
+    const reader = bufio.read(buffer, true)
+    const flags = reader.readU8()
+    const type = reader.readU8()
+    const status = reader.readU8()
+
+    let contractAddress = undefined
+    if (flags & (1 << 0)) {
+      contractAddress = reader.readBytes(20)
+    }
+
+    const logsBloom = reader.readBytes(256)
+
+    const logs = []
+    const logsLength = reader.readU32()
+    for (let i = 0; i < logsLength; i++) {
+      const address = reader.readBytes(20)
+      const topics = []
+      const topicsLength = reader.readU32()
+      for (let j = 0; j < topicsLength; j++) {
+        const topic = reader.readBytes(32)
+        topics.push(Uint8Array.from(topic))
+      }
+      const data = reader.readVarBytes()
+      logs.push([Uint8Array.from(address), topics, Uint8Array.from(data)] as Log)
+    }
+
+    const gasUsed = reader.readBigU64()
+    const cumulativeGasUsed = reader.readBigU64()
+
+    return {
+      type,
+      status,
+      contractAddress,
+      logsBloom,
+      logs,
+      gasUsed,
+      cumulativeGasUsed,
+    }
+  }
+
+  getSize(value: EvmReceiptValue): number {
+    let size = 1 // flags
+    size += 1 // type
+    size += 1 // status
+    if (value.contractAddress) {
+      size += 20
+    }
+
+    size += 256 // logsBloom bitvector
+
+    size += 4 // logs length
+    for (const [_, topics, data] of value.logs) {
+      size += 20 // address
+      size += 4 // topics length
+      size += 32 * topics.length // topics
+      size += bufio.sizeVarBytes(Buffer.from(data)) // data
+    }
+
+    size += 8 // gasUsed
+    size += 8 // cumulativeGasUsed
+
+    return size
+  }
+}

--- a/ironfish/src/blockchain/schema.ts
+++ b/ironfish/src/blockchain/schema.ts
@@ -6,6 +6,7 @@ import { BlockHash } from '../primitives/blockheader'
 import { TransactionHash } from '../primitives/transaction'
 import { DatabaseSchema } from '../storage'
 import { AssetValue } from './database/assetValue'
+import { EvmReceiptValue } from './database/evmReceiptValue'
 import { HeaderValue } from './database/headers'
 import { SequenceToHashesValue } from './database/sequenceToHashes'
 import { TransactionsValue } from './database/transactions'
@@ -65,4 +66,9 @@ export interface TransactionHashToBlockHashSchema extends DatabaseSchema {
 export interface ethTransactionHashToTransactionHashSchema extends DatabaseSchema {
   key: Buffer
   value: TransactionHash
+}
+
+export interface EvmReceiptSchema extends DatabaseSchema {
+  key: Buffer
+  value: EvmReceiptValue
 }


### PR DESCRIPTION
## Summary

stores most of the same fields as geth, but excludes fields that we can obtain from the transaction or block and excludes blob-related fields because we haven't addressed blobs

defines a separate interface for the values stored in the db store since the RunTxResult has many nested fields

updates the store in tandem with the ethTransactionHashToTransactionHash store

TODO: we don't accurately track cumulativeGasUsed right yet

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
