### PR TITLE
feat(cli): Hide passphrases in encryption commands

### DIFF
--- a/ironfish-cli/src/commands/wallet/decrypt.ts
+++ b/ironfish-cli/src/commands/wallet/decrypt.ts
@@ -32,7 +32,9 @@ export class DecryptCommand extends IronfishCommand {
 
     let passphrase = flags.passphrase
     if (!passphrase) {
-      passphrase = await inputPrompt('Enter a passphrase to decrypt the wallet', true)
+      passphrase = await inputPrompt('Enter a passphrase to decrypt the wallet', true, {
+        password: true,
+      })
     }
 
     try {

--- a/ironfish-cli/src/commands/wallet/encrypt.ts
+++ b/ironfish-cli/src/commands/wallet/encrypt.ts
@@ -17,6 +17,9 @@ export class EncryptCommand extends IronfishCommand {
     passphrase: Flags.string({
       description: 'Passphrase to encrypt the wallet with',
     }),
+    confirm: Flags.boolean({
+      description: 'Suppress the passphrase confirmation prompt',
+    }),
   }
 
   async start(): Promise<void> {
@@ -32,7 +35,20 @@ export class EncryptCommand extends IronfishCommand {
 
     let passphrase = flags.passphrase
     if (!passphrase) {
-      passphrase = await inputPrompt('Enter a passphrase to encrypt the wallet', true)
+      passphrase = await inputPrompt('Enter a passphrase to encrypt the wallet', true, {
+        password: true,
+      })
+    }
+
+    if (!flags.confirm) {
+      const confirmedPassphrase = await inputPrompt('Confirm your passphrase', true, {
+        password: true,
+      })
+
+      if (confirmedPassphrase !== passphrase) {
+        this.log('Passphrases do not match')
+        this.exit(1)
+      }
     }
 
     try {

--- a/ironfish-cli/src/commands/wallet/unlock.ts
+++ b/ironfish-cli/src/commands/wallet/unlock.ts
@@ -36,7 +36,9 @@ export class UnlockCommand extends IronfishCommand {
 
     let passphrase = flags.passphrase
     if (!passphrase) {
-      passphrase = await inputPrompt('Enter a passphrase to unlock the wallet', true)
+      passphrase = await inputPrompt('Enter a passphrase to unlock the wallet', true, {
+        password: true,
+      })
     }
 
     try {

--- a/ironfish-cli/src/ui/prompt.ts
+++ b/ironfish-cli/src/ui/prompt.ts
@@ -5,24 +5,28 @@
 import { ux } from '@oclif/core'
 import inquirer from 'inquirer'
 
-async function _inputPrompt(message: string): Promise<string> {
+async function _inputPrompt(message: string, options?: { password: boolean }): Promise<string> {
   const result: { prompt: string } = await inquirer.prompt({
-    type: 'input',
+    type: options?.password ? 'password' : 'input',
     name: 'prompt',
     message: `${message}:`,
   })
   return result.prompt.trim()
 }
 
-export async function inputPrompt(message: string, required: boolean = false): Promise<string> {
+export async function inputPrompt(
+  message: string,
+  required: boolean = false,
+  options?: { password: boolean },
+): Promise<string> {
   let userInput: string = ''
 
   if (required) {
     while (!userInput) {
-      userInput = await _inputPrompt(message)
+      userInput = await _inputPrompt(message, options)
     }
   } else {
-    userInput = await _inputPrompt(message)
+    userInput = await _inputPrompt(message, options)
   }
 
   return userInput


### PR DESCRIPTION
## Summary

Hide passphrases when using encryption CLI commands

## Testing Plan

https://github.com/user-attachments/assets/24e758ab-aaa9-46be-96cc-25ccac45b341

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
