### PR TITLE
feat(cli): Return locked warning in wallet:accounts and wallet:which

### DIFF
--- a/ironfish-cli/src/commands/wallet/index.ts
+++ b/ironfish-cli/src/commands/wallet/index.ts
@@ -25,6 +25,11 @@ export class AccountsCommand extends IronfishCommand {
 
     const response = await client.wallet.getAccountsStatus()
 
+    if (response.content.locked) {
+      this.log('Your wallet is locked. Unlock the wallet to access your accounts')
+      this.exit(0)
+    }
+
     if (response.content.accounts.length === 0) {
       this.log('you have no accounts')
       return []

--- a/ironfish-cli/src/commands/wallet/which.ts
+++ b/ironfish-cli/src/commands/wallet/which.ts
@@ -25,6 +25,12 @@ export class WhichCommand extends IronfishCommand {
 
     const client = await this.connectRpc()
 
+    const response = await client.wallet.getAccountsStatus()
+    if (response.content.locked) {
+      this.log('Your wallet is locked. Unlock the wallet to access your accounts')
+      this.exit(0)
+    }
+
     const {
       content: {
         accounts: [accountName],


### PR DESCRIPTION
## Summary

Notify the user they have a locked wallet instead of no accounts

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
