### PR TITLE
eth_accounts

### DIFF
--- a/ironfish/src/rpc/clients/client.ts
+++ b/ironfish/src/rpc/clients/client.ts
@@ -5,6 +5,8 @@ import type { RpcResponse, RpcResponseEnded } from '../response'
 import type {
   AcceptTransactionRequest,
   AcceptTransactionResponse,
+  AccountsRequest,
+  AccountsResponse,
   AddPeerRequest,
   AddPeerResponse,
   AddTransactionRequest,
@@ -1025,6 +1027,9 @@ export abstract class RpcClient {
   }
 
   eth = {
+    accounts: (params: AccountsRequest): Promise<RpcResponseEnded<AccountsResponse>> => {
+      return this.request<AccountsResponse>(`${ApiNamespace.eth}/accounts`, params).waitForEnd()
+    },
     ethRouter: (params: EthRequest): Promise<RpcResponseEnded<EthResponse>> => {
       return this.request<EthResponse>(`${ApiNamespace.eth}/ethRouter`, params).waitForEnd()
     },

--- a/ironfish/src/rpc/routes/eth/__fixtures__/accounts.test.ts.fixture
+++ b/ironfish/src/rpc/routes/eth/__fixtures__/accounts.test.ts.fixture
@@ -1,0 +1,32 @@
+{
+  "Route eth/accounts should fetch account addresses on the node": [
+    {
+      "value": {
+        "version": 4,
+        "id": "7ec28e97-bb6b-4bd8-b940-e4429b721c5f",
+        "name": "test",
+        "spendingKey": "3c2f8839eb562dd732a89e57d369956c40c8b657597c7514d81250fcfa5626a2",
+        "viewKey": "1888843c8c0eeef7cf1a404da7f00a0003aea5765e356a8101d5f179c27be7039d9f92c56ab51ddd74f40e3c3c0825659d3d355ed8c32504ffe61dfe43d2354d",
+        "incomingViewKey": "865e20c2635b03282117cc030dd49c5c542ad815dc05c1a34438113bdc91f600",
+        "outgoingViewKey": "54e025a54cd9960031da6a900a89e50f97ef290f8600bf4df60b8035f03811ee",
+        "publicAddress": "341a56ef8572d51e0505997ca366bde4f0e0e27e772bcd8d51fc62c5ac62f9b4",
+        "createdAt": {
+          "hash": {
+            "type": "Buffer",
+            "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+          },
+          "sequence": 1
+        },
+        "scanningEnabled": true,
+        "proofAuthorizingKey": "1335a3f93f267594215ec5f32cd68beef19dd8a13396052be2d07c4d730d6e0b"
+      },
+      "head": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:R5HXrp+X3xAO8VWOhHctagm0N2I4goP3XG8goyqIqoY="
+        },
+        "sequence": 1
+      }
+    }
+  ]
+}

--- a/ironfish/src/rpc/routes/eth/accounts.test.ts
+++ b/ironfish/src/rpc/routes/eth/accounts.test.ts
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Address } from '@ethereumjs/util'
+import { useAccountFixture } from '../../../testUtilities'
+import { createRouteTest } from '../../../testUtilities/routeTest'
+
+describe('Route eth/accounts', () => {
+  const routeTest = createRouteTest(false)
+
+  it('should fetch account addresses on the node', async () => {
+    const { node } = routeTest
+    node.chain.consensus.parameters.enableEvmDescriptions = 2
+
+    const account = await useAccountFixture(node.wallet, 'test')
+    const address = Address.fromPrivateKey(Buffer.from(account.spendingKey, 'hex'))
+
+    const response = await routeTest.client.eth.accounts(undefined)
+
+    expect(response.status).toEqual(200)
+    expect(response.content).toEqual([address.toString()])
+  })
+})

--- a/ironfish/src/rpc/routes/eth/accounts.ts
+++ b/ironfish/src/rpc/routes/eth/accounts.ts
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import * as yup from 'yup'
+import { Assert } from '../../../assert'
+import { FullNode } from '../../../node'
+import { registerEthRoute } from '../eth/ethRouter'
+import { ApiNamespace } from '../namespaces'
+
+export type AccountsRequest = undefined
+
+export const AccountsRequestSchema: yup.MixedSchema<AccountsRequest> = yup
+  .mixed()
+  .oneOf([undefined] as const)
+
+export type AccountsResponse = string[]
+
+export const AccountsResponseSchema: yup.MixedSchema<AccountsResponse> = yup
+  .mixed<AccountsResponse>()
+  .defined()
+
+registerEthRoute<typeof AccountsRequestSchema, AccountsResponse>(
+  `eth_accounts`,
+  `${ApiNamespace.eth}/accounts`,
+  AccountsRequestSchema,
+  (request, node): void => {
+    Assert.isInstanceOf(node, FullNode)
+
+    const addresses: string[] = []
+    const accounts = node.wallet.listAccounts()
+    for (const account of accounts) {
+      if (account.ethAddress) {
+        addresses.push(account.ethAddress)
+      }
+    }
+    request.end(addresses)
+  },
+)

--- a/ironfish/src/rpc/routes/eth/blockNumber.ts
+++ b/ironfish/src/rpc/routes/eth/blockNumber.ts
@@ -8,8 +8,7 @@ import { FullNode } from '../../../node'
 import { registerEthRoute } from '../eth/ethRouter'
 import { ApiNamespace } from '../namespaces'
 
-// eslint-disable-next-line @typescript-eslint/ban-types
-export type BlockNumberRequest = Record<string, never> | undefined
+export type BlockNumberRequest = undefined
 
 export const BlockNumberRequestSchema: yup.MixedSchema<BlockNumberRequest> = yup
   .mixed()

--- a/ironfish/src/rpc/routes/eth/estimateGas.ts
+++ b/ironfish/src/rpc/routes/eth/estimateGas.ts
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import * as yup from 'yup'
+import { Assert } from '../../../assert'
+import { FullNode } from '../../../node'
+import { registerEthRoute } from '../eth/ethRouter'
+import { ApiNamespace } from '../namespaces'
+
+export type EstimateGasRequest = [
+  {
+    from?: string
+    to: string
+    gas?: string
+    gasPrice?: string
+    value?: string
+    data?: string
+  },
+]
+
+export const EstimateGasRequestSchema: yup.MixedSchema<EstimateGasRequest> = yup
+  .mixed<EstimateGasRequest>()
+  .defined()
+
+export type EstimateGasResponse = string
+
+export const EstimateGasResponseSchema: yup.StringSchema<EstimateGasResponse> = yup
+  .string()
+  .defined()
+
+registerEthRoute<typeof EstimateGasRequestSchema, EstimateGasResponse>(
+  `eth_estimateGas`,
+  `${ApiNamespace.eth}/estimateGas`,
+  EstimateGasRequestSchema,
+  (request, node): void => {
+    Assert.isInstanceOf(node, FullNode)
+    // TODO provide real gas estimation
+    request.end('0x0')
+  },
+)

--- a/ironfish/src/rpc/routes/eth/index.ts
+++ b/ironfish/src/rpc/routes/eth/index.ts
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+export * from './accounts'
 export * from './call'
 export * from './blockNumber'
 export * from './getAccount'


### PR DESCRIPTION
## Summary
https://www.quicknode.com/docs/ethereum/eth_getTransactionReceipt
## Testing Plan
tests pass
## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
