### PR TITLE
returns unwrapped data from http adapter for json rpc requests

### DIFF
--- a/ironfish/src/rpc/adapters/httpAdapter.ts
+++ b/ironfish/src/rpc/adapters/httpAdapter.ts
@@ -8,7 +8,7 @@ import { Assert } from '../../assert'
 import { createRootLogger, Logger } from '../../logger'
 import { Gauge, Meter } from '../../metrics'
 import { ErrorUtils } from '../../utils'
-import { RpcRequest } from '../request'
+import { isJsonRcpRequest, RpcRequest } from '../request'
 import { ApiNamespace, Router } from '../routes'
 import { RpcServer } from '../server'
 import { IRpcAdapter } from './adapter'
@@ -226,6 +226,8 @@ export class RpcHttpAdapter implements IRpcAdapter {
       // so keeping that convention here. Could think of a better way to handle?
       const body = combined.length ? combined.toString('utf8') : undefined
 
+      const useJsonRpc = isJsonRcpRequest(body)
+
       const rpcRequest = new RpcRequest(
         body === undefined ? undefined : JSON.parse(body),
         route,
@@ -233,7 +235,7 @@ export class RpcHttpAdapter implements IRpcAdapter {
           response.statusCode = status
           const delimiter = chunkStreamed ? MESSAGE_DELIMITER : ''
 
-          const responseMessage: RpcHttpResponse = { status, data }
+          const responseMessage = useJsonRpc ? data : { status, data }
           const responseData = JSON.stringify(responseMessage)
           const responseSize = Buffer.byteLength(responseData, 'utf-8')
           this.outboundTraffic.add(responseSize)

--- a/ironfish/src/rpc/request.ts
+++ b/ironfish/src/rpc/request.ts
@@ -2,16 +2,20 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Event } from '../event'
+import { JSONUtils } from '../utils'
 
-export function isJsonRcpRequest(body: string | undefined): boolean {
+export function isJsonRcpRequest(body?: string): boolean {
   if (!body) {
     return false
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const data = JSON.parse(body)
+  const [data, error] = JSONUtils.tryParse(body)
 
-  return 'jsonrpc' in data
+  if (error) {
+    return false
+  }
+
+  return data instanceof Object && 'jsonrpc' in data
 }
 
 export class RpcRequest<TRequest = unknown, TResponse = unknown> {

--- a/ironfish/src/rpc/request.ts
+++ b/ironfish/src/rpc/request.ts
@@ -1,8 +1,18 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-
 import { Event } from '../event'
+
+export function isJsonRcpRequest(body: string | undefined): boolean {
+  if (!body) {
+    return false
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const data = JSON.parse(body)
+
+  return 'jsonrpc' in data
+}
 
 export class RpcRequest<TRequest = unknown, TResponse = unknown> {
   data: TRequest


### PR DESCRIPTION
## Summary

json rpc responses include only a single object rather than the nested objects in our typical responses

checks or the 'jsonrpc' tag in http rpc requests and returns the response data as a flat object for json rpc requests

## Testing Plan

manual testing:
```
hughy@Hughs-MacBook-Pro ~ % curl http://localhost:8021/eth/ethRouter \
  -X POST \
  -H "Content-Type: application/json" \
  --data '{"method":"eth_blockNumber","params":[],"id":1,"jsonrpc":"2.0"}'
{"jsonrpc":"2.0","id":1,"result":{"number":"0x52"}}%                                                                                                            hughy@Hughs-MacBook-Pro ~ % curl https://docs-demo.quiknode.pro/ \    
  -X POST \
  -H "Content-Type: application/json" \
  --data '{"method":"eth_blockNumber","params":[],"id":1,"jsonrpc":"2.0"}'
{"jsonrpc":"2.0","id":1,"result":"0x13b72f6"}%   
```

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
