### PR TITLE
Improve RPC client types for broadcastTransaction and isValidPublicAddress

### DIFF
--- a/ironfish-cli/src/commands/chain/broadcast.ts
+++ b/ironfish-cli/src/commands/chain/broadcast.ts
@@ -26,8 +26,22 @@ export class BroadcastCommand extends IronfishCommand {
     ux.action.start(`Broadcasting transaction`)
     const client = await this.connectRpc()
     const response = await client.chain.broadcastTransaction({ transaction })
-    if (response.content) {
-      ux.action.stop(`Transaction broadcasted: ${response.content.hash}`)
+
+    if (response.content.accepted && response.content.broadcasted) {
+      ux.action.stop(
+        `Transaction broadcast successfully. Transaction hash: ${response.content.hash}`,
+      )
+    } else {
+      ux.action.stop()
+      this.error(
+        `Transaction broadcast may have failed.${
+          !response.content.accepted ? ' Transaction was not accepted by the node.' : ''
+        }${
+          !response.content.broadcasted
+            ? ' Transaction was not broadcasted to the network.'
+            : ''
+        }`,
+      )
     }
   }
 }

--- a/ironfish-cli/src/commands/chain/broadcast.ts
+++ b/ironfish-cli/src/commands/chain/broadcast.ts
@@ -28,9 +28,7 @@ export class BroadcastCommand extends IronfishCommand {
     const response = await client.chain.broadcastTransaction({ transaction })
 
     if (response.content.accepted && response.content.broadcasted) {
-      ux.action.stop(
-        `Transaction broadcast successfully. Transaction hash: ${response.content.hash}`,
-      )
+      ux.action.stop(`Transaction broadcasted: ${response.content.hash}`)
     } else {
       ux.action.stop()
       this.error(

--- a/ironfish/src/rpc/clients/client.ts
+++ b/ironfish/src/rpc/clients/client.ts
@@ -1013,7 +1013,7 @@ export abstract class RpcClient {
 
     isValidPublicAddress: (
       params: IsValidPublicAddressRequest,
-    ): Promise<RpcResponse<IsValidPublicAddressResponse>> => {
+    ): Promise<RpcResponseEnded<IsValidPublicAddressResponse>> => {
       return this.request<IsValidPublicAddressResponse>(
         `${ApiNamespace.chain}/isValidPublicAddress`,
         params,
@@ -1022,7 +1022,7 @@ export abstract class RpcClient {
 
     broadcastTransaction: (
       params: BroadcastTransactionRequest,
-    ): Promise<RpcResponse<BroadcastTransactionResponse>> => {
+    ): Promise<RpcResponseEnded<BroadcastTransactionResponse>> => {
       return this.request<BroadcastTransactionResponse>(
         `${ApiNamespace.chain}/broadcastTransaction`,
         params,


### PR DESCRIPTION
## Summary

We call `.waitForEnd()` on `broadcastTransaction` and `isValidPublicAddress`, but we don't use the proper RpcResponseEnded type, so users of the client function have to check for null anyway. Also improved the handling of error responses from the `broadcastTransaction` RPC.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
