### PR TITLE
uses decrypt_legacy to decrypt legacy account exports

### DIFF
--- a/ironfish-rust-nodejs/index.d.ts
+++ b/ironfish-rust-nodejs/index.d.ts
@@ -339,6 +339,7 @@ export namespace multisig {
     static random(): ParticipantSecret
     toIdentity(): ParticipantIdentity
     decryptData(jsBytes: Buffer): Buffer
+    decryptLegacyData(jsBytes: Buffer): Buffer
   }
   export class ParticipantIdentity {
     constructor(jsBytes: Buffer)

--- a/ironfish-rust-nodejs/src/multisig.rs
+++ b/ironfish-rust-nodejs/src/multisig.rs
@@ -178,6 +178,16 @@ impl ParticipantSecret {
             .map(Buffer::from)
             .map_err(to_napi_err)
     }
+
+    #[napi]
+    pub fn decrypt_legacy_data(&self, js_bytes: JsBuffer) -> Result<Buffer> {
+        let bytes = js_bytes.into_value()?;
+        let encrypted_blob =
+            multienc::MultiRecipientBlob::deserialize_from(bytes.as_ref()).map_err(to_napi_err)?;
+        multienc::decrypt_legacy(&self.secret, &encrypted_blob)
+            .map(Buffer::from)
+            .map_err(to_napi_err)
+    }
 }
 
 #[napi(namespace = "multisig")]

--- a/ironfish/src/wallet/exporter/encryption.ts
+++ b/ironfish/src/wallet/exporter/encryption.ts
@@ -59,7 +59,11 @@ export function decryptEncodedAccountWithMultisigSecret(
   try {
     return secret.decryptData(encoded).toString('utf8')
   } catch (e: unknown) {
-    return null
+    try {
+      return secret.decryptLegacyData(encoded).toString('utf8')
+    } catch (e: unknown) {
+      return null
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

we've updated encryption/decryption in the ironfish-frost crate and changed the structure of encrypted data

older account exports cannot be decrypted with the current 'decrypt' method and must use 'decrypt_legacy' instead

defines 'decrypt_legacy_data' on ParticipantSecret and updates account decryption to try decrypting with that method if the first decryption attempt fails

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
