### PR TITLE
defines MultisigHardwareSigner for Ledger multisig keys

### DIFF
--- a/ironfish/src/wallet/interfaces/multisigKeys.ts
+++ b/ironfish/src/wallet/interfaces/multisigKeys.ts
@@ -8,8 +8,13 @@ export interface MultisigSigner {
   publicKeyPackage: string
 }
 
+export interface MultisigHardwareSigner {
+  identity: string
+  publicKeyPackage: string
+}
+
 export interface MultisigCoordinator {
   publicKeyPackage: string
 }
 
-export type MultisigKeys = MultisigSigner | MultisigCoordinator
+export type MultisigKeys = MultisigSigner | MultisigHardwareSigner | MultisigCoordinator

--- a/ironfish/src/wallet/walletdb/multiSigKeys.test.ts
+++ b/ironfish/src/wallet/walletdb/multiSigKeys.test.ts
@@ -1,7 +1,11 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { MultisigCoordinator, MultisigSigner } from '../interfaces/multisigKeys'
+import {
+  MultisigCoordinator,
+  MultisigHardwareSigner,
+  MultisigSigner,
+} from '../interfaces/multisigKeys'
 import { MultisigKeysEncoding } from './multisigKeys'
 
 describe('multisigKeys encoder', () => {
@@ -26,6 +30,20 @@ describe('multisigKeys encoder', () => {
 
       const value: MultisigCoordinator = {
         publicKeyPackage: 'aaaa',
+      }
+      const buffer = encoder.serialize(value)
+      const deserializedValue = encoder.deserialize(buffer)
+      expect(deserializedValue).toEqual(value)
+    })
+  })
+
+  describe('with a hardware multisig', () => {
+    it('serializes the value into a buffer and deserialized to the original value', () => {
+      const encoder = new MultisigKeysEncoding()
+
+      const value: MultisigHardwareSigner = {
+        publicKeyPackage: 'aaaa',
+        identity: 'c0ffee',
       }
       const buffer = encoder.serialize(value)
       const deserializedValue = encoder.deserialize(buffer)


### PR DESCRIPTION
## Summary

a multisig account generated using a Ledger device will have a access to the participant identity, but not the secret or keyPackage

uses a separate interface for MultisigHardwareSigner to cover this case and expands the MultisigKeys type to cover this interface

the distinct interface allows us to store multisig keys for the Ledger case without a database migration for existing multisig keys

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
