### PR TITLE
dont parse this diagram as a doctest

### DIFF
--- a/ironfish-rust/src/frost_utils/account_keys.rs
+++ b/ironfish-rust/src/frost_utils/account_keys.rs
@@ -23,7 +23,7 @@ pub struct MultisigAccountKeys {
 
 /// Derives the account keys for a multisig account, realizing the following key hierarchy:
 ///
-/// ```
+/// ```ignore
 ///                 ak ─┐
 ///                     ├─ ivk ── pk
 ///   gsk ── nsk ── nk ─┘


### PR DESCRIPTION
## Summary

This diagram is written in a codeblock so it's displayed in monospace, which was erroneously also parsing it as a doctest when running `cargo test`. Add the `ignore` keyword to avoid it being parsed as a doctest.

## Testing Plan

`cargo test`

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
