### PR TITLE
allows constructing NativeSigningCommitment from raw

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1524,7 +1524,7 @@ dependencies = [
 [[package]]
 name = "ironfish-frost"
 version = "0.1.0"
-source = "git+https://github.com/iron-fish/ironfish-frost.git?branch=main#06f16dd1684b7741f3bd6ba3e490343671626129"
+source = "git+https://github.com/iron-fish/ironfish-frost.git?branch=main#d4681df8a5a613fd9e716212aae3be8602acd227"
 dependencies = [
  "blake3",
  "chacha20 0.9.1",

--- a/ironfish-rust-nodejs/index.d.ts
+++ b/ironfish-rust-nodejs/index.d.ts
@@ -251,7 +251,6 @@ export class UnsignedTransaction {
   publicKeyRandomness(): string
   hash(): Buffer
   signingPackage(nativeIdentiferCommitments: Array<string>): string
-  signingPackageFromRaw(identities: Array<string>, rawCommitments: Array<string>): string
   sign(spenderHexKey: string): Buffer
   addSignature(signature: Buffer): Buffer
 }
@@ -363,6 +362,8 @@ export namespace multisig {
   export type NativeSigningCommitment = SigningCommitment
     export class SigningCommitment {
     constructor(jsBytes: Buffer)
+    static fromRaw(identity: string, rawCommitments: Buffer, transactionHash: Buffer, signers: Array<string>): NativeSigningCommitment
+    serialize(): Buffer
     identity(): Buffer
     rawCommitments(): Buffer
     verifyChecksum(transactionHash: Buffer, signerIdentities: Array<string>): boolean

--- a/ironfish-rust-nodejs/src/structs/transaction.rs
+++ b/ironfish-rust-nodejs/src/structs/transaction.rs
@@ -12,7 +12,6 @@ use ironfish::frost::round1::SigningCommitments;
 use ironfish::frost::round2::SignatureShare as FrostSignatureShare;
 use ironfish::frost::Identifier;
 use ironfish::frost_utils::signing_package::SigningPackage;
-use ironfish::participant::Identity;
 use ironfish::serializing::bytes_to_hex;
 use ironfish::serializing::fr::FrSerializable;
 use ironfish::serializing::hex_to_vec_bytes;
@@ -443,37 +442,6 @@ impl NativeUnsignedTransaction {
             );
 
             commitments.push((signing_commitment.identity().clone(), commitment));
-        }
-
-        let signing_package = self
-            .transaction
-            .signing_package(commitments)
-            .map_err(to_napi_err)?;
-
-        let mut vec: Vec<u8> = vec![];
-        signing_package.write(&mut vec).map_err(to_napi_err)?;
-
-        Ok(bytes_to_hex(&vec))
-    }
-
-    #[napi]
-    pub fn signing_package_from_raw(
-        &self,
-        identities: Vec<String>,
-        raw_commitments: Vec<String>,
-    ) -> Result<String> {
-        let mut commitments = Vec::new();
-
-        for (index, identity) in identities.iter().enumerate() {
-            let identity_bytes = hex_to_vec_bytes(identity).map_err(to_napi_err)?;
-            let identity = Identity::deserialize_from(&identity_bytes[..]).map_err(to_napi_err)?;
-
-            let raw_commitment = &raw_commitments[index];
-            let commitment_bytes = hex_to_vec_bytes(raw_commitment).map_err(to_napi_err)?;
-            let commitment =
-                SigningCommitments::deserialize(&commitment_bytes[..]).map_err(to_napi_err)?;
-
-            commitments.push((identity, commitment));
         }
 
         let signing_package = self

--- a/ironfish/src/multisig.test.slow.ts
+++ b/ironfish/src/multisig.test.slow.ts
@@ -110,18 +110,23 @@ describe('multisig', () => {
 
       // Simulates receiving raw commitments from Ledger
       // Ledger app generates raw commitments, not wrapped SigningCommitment
-      const commitmentIdentities: string[] = []
-      const rawCommitments: string[] = []
+      const signingCommitments: string[] = []
       for (const commitment of commitments) {
-        const signingCommitment = new multisig.SigningCommitment(Buffer.from(commitment, 'hex'))
-        commitmentIdentities.push(signingCommitment.identity().toString('hex'))
-        rawCommitments.push(signingCommitment.rawCommitments().toString('hex'))
+        const deserializedSigningCommitment = new multisig.SigningCommitment(
+          Buffer.from(commitment, 'hex'),
+        )
+
+        const signingCommitment = multisig.SigningCommitment.fromRaw(
+          deserializedSigningCommitment.identity().toString('hex'),
+          deserializedSigningCommitment.rawCommitments(),
+          transactionHash,
+          identities,
+        )
+
+        signingCommitments.push(signingCommitment.serialize().toString('hex'))
       }
 
-      const signingPackage = unsignedTransaction.signingPackageFromRaw(
-        commitmentIdentities,
-        rawCommitments,
-      )
+      const signingPackage = unsignedTransaction.signingPackage(signingCommitments)
 
       // Ensure that we can extract deserialize and extract frost signing package
       // Ledger app needs frost signing package to generate signature shares


### PR DESCRIPTION
## Summary

updates ironfish-frost dependency to latest commit

adds napi binding for SigningCommitment::from_raw to support constructing a signing commitment from its raw parts (the signer identity, the raw commitments, and the transaction hash and list of signers for computing a checksum)

removes signing_package_from_raw in favor of constructing SingingCommitments and using existing signing_package method

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
