### PR TITLE
Displays whether a participant has a secret or not

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/participants/index.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/participants/index.ts
@@ -18,10 +18,15 @@ export class MultisigParticipants extends IronfishCommand {
 
     const response = await client.wallet.multisig.getIdentities()
 
-    const participants = []
-    for (const { name, identity } of response.content.identities) {
+    const participants: {
+      name: string
+      value: string
+      hasSecret: boolean
+    }[] = []
+    for (const { name, identity, hasSecret } of response.content.identities) {
       participants.push({
         name,
+        hasSecret: hasSecret,
         value: identity,
       })
     }
@@ -35,6 +40,10 @@ export class MultisigParticipants extends IronfishCommand {
         name: {
           header: 'Participant Name',
           get: (p) => p.name,
+        },
+        hasSecret: {
+          header: 'Has Secret',
+          get: (p) => (p.hasSecret ? 'Yes' : 'No'),
         },
         identity: {
           header: 'Identity',

--- a/ironfish/src/rpc/routes/wallet/multisig/getIdentities.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/getIdentities.ts
@@ -12,6 +12,7 @@ export type GetIdentitiesResponse = {
   identities: Array<{
     name: string
     identity: string
+    hasSecret: boolean
   }>
 }
 
@@ -27,6 +28,7 @@ export const GetIdentitiesResponseSchema: yup.ObjectSchema<GetIdentitiesResponse
           .object({
             name: yup.string().defined(),
             identity: yup.string().defined(),
+            hasSecret: yup.boolean().defined(),
           })
           .defined(),
       )
@@ -44,11 +46,12 @@ routes.register<typeof GetIdentitiesRequestSchema, GetIdentitiesResponse>(
 
     for await (const [
       identity,
-      { name },
+      { name, secret },
     ] of context.wallet.walletDb.multisigIdentities.getAllIter()) {
       identities.push({
         name,
         identity: identity.toString('hex'),
+        hasSecret: secret ? true : false,
       })
     }
 


### PR DESCRIPTION
## Summary

This is going to be a useful feature when we start to integrate ledger because all identities from ledger will not export their secret.

Updates both the CLI and related RPC

<img width="952" alt="image" src="https://github.com/user-attachments/assets/73e4fad2-fc97-4ef3-b792-c7b9953f605d">

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
