### PR TITLE
defines from_frost factory method on NativePublicKeyPackage

### DIFF
--- a/ironfish-rust-nodejs/index.d.ts
+++ b/ironfish-rust-nodejs/index.d.ts
@@ -354,7 +354,10 @@ export namespace multisig {
   export type NativePublicKeyPackage = PublicKeyPackage
     export class PublicKeyPackage {
     constructor(value: string)
+    static fromFrost(frostPublicKeyPackage: Buffer, identities: Array<string>, minSigners: number): NativePublicKeyPackage
+    serialize(): Buffer
     identities(): Array<Buffer>
+    frostPublicKeyPackage(): Buffer
     minSigners(): number
   }
   export type NativeSigningCommitment = SigningCommitment

--- a/ironfish/src/multisig.test.slow.ts
+++ b/ironfish/src/multisig.test.slow.ts
@@ -54,6 +54,24 @@ describe('multisig', () => {
 
       const publicAddress = round3Packages[0].publicAddress
 
+      // Ensure that we can construct PublicKeyPackage from the raw frost public
+      // key package
+      for (const round3Package of round3Packages) {
+        const deserializedPublicKeyPackage = new multisig.PublicKeyPackage(
+          round3Package.publicKeyPackage,
+        )
+
+        const publicKeyPackage = multisig.PublicKeyPackage.fromFrost(
+          deserializedPublicKeyPackage.frostPublicKeyPackage(),
+          deserializedPublicKeyPackage.identities().map((i) => i.toString('hex')),
+          deserializedPublicKeyPackage.minSigners(),
+        )
+
+        expect(publicKeyPackage.serialize().toString('hex')).toEqual(
+          round3Package.publicKeyPackage,
+        )
+      }
+
       const raw = new RawTransaction(TransactionVersion.V1)
 
       const inNote = new NativeNote(


### PR DESCRIPTION
## Summary

allows us to construct a PublicKeyPackage from the raw parts: the frost public key package, the list of signer identities, and the minimum number of signers

following the round3_min changes to ironfish-frost the Ledger app will produce a raw frost public key package at the end of DKG round3, so we will need to construct the ironfish-frost PublicKeyPackage from its parts

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
