### PR TITLE
updates ledger.ts for upgrade to @zondax/ledger-js

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/dkg/round2.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/round2.ts
@@ -70,7 +70,7 @@ export class DkgRound2Command extends IronfishCommand {
     round1PublicPackages = round1PublicPackages.map((i) => i.trim())
 
     if (flags.ledger) {
-      await this.performRound2WithLedger()
+      await this.performRound2WithLedger(round1PublicPackages, round1SecretPackage)
       return
     }
 
@@ -93,10 +93,13 @@ export class DkgRound2Command extends IronfishCommand {
     this.log('Send the round 2 public package to each participant')
   }
 
-  async performRound2WithLedger(): Promise<void> {
+  async performRound2WithLedger(
+    round1PublicPackages: string[],
+    round1SecretPackage: string,
+  ): Promise<void> {
     const ledger = new Ledger(this.logger)
     try {
-      await ledger.connect()
+      await ledger.connect(true)
     } catch (e) {
       if (e instanceof Error) {
         this.error(e.message)
@@ -104,5 +107,24 @@ export class DkgRound2Command extends IronfishCommand {
         throw e
       }
     }
+
+    // TODO(hughy): determine how to handle multiple identities using index
+    const { publicPackage, secretPackage } = await ledger.dkgRound2(
+      0,
+      round1PublicPackages,
+      round1SecretPackage,
+    )
+
+    this.log('\nRound 2 Encrypted Secret Package:\n')
+    this.log(secretPackage.toString('hex'))
+    this.log()
+
+    this.log('\nRound 2 Public Package:\n')
+    this.log(publicPackage.toString('hex'))
+    this.log()
+
+    this.log()
+    this.log('Next step:')
+    this.log('Send the round 2 public package to each participant')
   }
 }

--- a/ironfish-cli/src/commands/wallet/multisig/participant/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/participant/create.ts
@@ -6,6 +6,7 @@ import { Flags } from '@oclif/core'
 import { IronfishCommand } from '../../../../command'
 import { RemoteFlags } from '../../../../flags'
 import * as ui from '../../../../ui'
+import { Ledger } from '../../../../utils/ledger'
 
 export class MultisigIdentityCreate extends IronfishCommand {
   static description = `Create a multisig participant identity`
@@ -15,6 +16,11 @@ export class MultisigIdentityCreate extends IronfishCommand {
     name: Flags.string({
       char: 'n',
       description: 'Name to associate with the identity',
+    }),
+    ledger: Flags.boolean({
+      default: false,
+      description: 'Perform operation with a ledger device',
+      hidden: true,
     }),
   }
 
@@ -29,14 +35,27 @@ export class MultisigIdentityCreate extends IronfishCommand {
       name = await ui.inputPrompt('Enter a name for the identity', true)
     }
 
+    let identity
+    if (flags.ledger) {
+      identity = await this.getIdentityFromLedger()
+    }
+
     let response
     while (!response) {
       try {
-        response = await client.wallet.multisig.createParticipant({ name })
+        if (identity) {
+          response = await client.wallet.multisig.importParticipant({
+            name,
+            identity: identity.toString('hex'),
+          })
+        } else {
+          response = await client.wallet.multisig.createParticipant({ name })
+        }
       } catch (e) {
         if (
           e instanceof RpcRequestError &&
-          e.code === RPC_ERROR_CODES.DUPLICATE_ACCOUNT_NAME.toString()
+          (e.code === RPC_ERROR_CODES.DUPLICATE_ACCOUNT_NAME.toString() ||
+            e.code === RPC_ERROR_CODES.DUPLICATE_IDENTITY_NAME.toString())
         ) {
           this.log()
           this.log(e.codeMessage)
@@ -49,5 +68,21 @@ export class MultisigIdentityCreate extends IronfishCommand {
 
     this.log('Identity:')
     this.log(response.content.identity)
+  }
+
+  async getIdentityFromLedger(): Promise<Buffer> {
+    const ledger = new Ledger(this.logger)
+    try {
+      await ledger.connect(true)
+    } catch (e) {
+      if (e instanceof Error) {
+        this.error(e.message)
+      } else {
+        throw e
+      }
+    }
+
+    // TODO(hughy): support multiple identities using index
+    return ledger.dkgGetIdentity(0)
   }
 }

--- a/ironfish/src/wallet/index.ts
+++ b/ironfish/src/wallet/index.ts
@@ -3,8 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 export * from './account/account'
 export * from './wallet'
-export * from './exporter/encoder'
-export * from './exporter/account'
+export * from './exporter'
 export { AccountValue } from './walletdb/accountValue'
 export { Base64JsonEncoder } from './exporter/encoders/base64json'
 export { JsonEncoder } from './exporter/encoders/json'


### PR DESCRIPTION
## Summary

removes response handling for error codes, which are no longer included in responses

implements tryInstruction to handle errors from any app instructions

adds methods to help discriminate between KeyResponse types and checks type of KeyResponse for each type of key

adds method to recognize Ledger response errors

defines classes for common recoverable Ledger errors: locked device and app not open. the error code for the app not being open is identified in the docs as a 'technical error', but this is the error code we get when the app isn't open

## Testing Plan

- manual testing with `wallet:import --ledger`

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
