### PR TITLE
adds ledger flag to participant creation

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/dkg/round2.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/round2.ts
@@ -70,7 +70,7 @@ export class DkgRound2Command extends IronfishCommand {
     round1PublicPackages = round1PublicPackages.map((i) => i.trim())
 
     if (flags.ledger) {
-      await this.performRound2WithLedger()
+      await this.performRound2WithLedger(round1PublicPackages, round1SecretPackage)
       return
     }
 
@@ -93,10 +93,13 @@ export class DkgRound2Command extends IronfishCommand {
     this.log('Send the round 2 public package to each participant')
   }
 
-  async performRound2WithLedger(): Promise<void> {
+  async performRound2WithLedger(
+    round1PublicPackages: string[],
+    round1SecretPackage: string,
+  ): Promise<void> {
     const ledger = new Ledger(this.logger)
     try {
-      await ledger.connect()
+      await ledger.connect(true)
     } catch (e) {
       if (e instanceof Error) {
         this.error(e.message)
@@ -104,5 +107,24 @@ export class DkgRound2Command extends IronfishCommand {
         throw e
       }
     }
+
+    // TODO(hughy): determine how to handle multiple identities using index
+    const { publicPackage, secretPackage } = await ledger.dkgRound2(
+      0,
+      round1PublicPackages,
+      round1SecretPackage,
+    )
+
+    this.log('\nRound 2 Encrypted Secret Package:\n')
+    this.log(secretPackage.toString('hex'))
+    this.log()
+
+    this.log('\nRound 2 Public Package:\n')
+    this.log(publicPackage.toString('hex'))
+    this.log()
+
+    this.log()
+    this.log('Next step:')
+    this.log('Send the round 2 public package to each participant')
   }
 }

--- a/ironfish-cli/src/commands/wallet/multisig/participant/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/participant/create.ts
@@ -37,7 +37,7 @@ export class MultisigIdentityCreate extends IronfishCommand {
 
     let identity
     if (flags.ledger) {
-      identity = await this.createParticipantWithLedger()
+      identity = await this.getIdentityFromLedger()
     }
 
     let response
@@ -70,7 +70,7 @@ export class MultisigIdentityCreate extends IronfishCommand {
     this.log(response.content.identity)
   }
 
-  async createParticipantWithLedger(): Promise<Buffer> {
+  async getIdentityFromLedger(): Promise<Buffer> {
     const ledger = new Ledger(this.logger)
     try {
       await ledger.connect(true)

--- a/ironfish/src/wallet/index.ts
+++ b/ironfish/src/wallet/index.ts
@@ -3,8 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 export * from './account/account'
 export * from './wallet'
-export * from './exporter/encoder'
-export * from './exporter/account'
+export * from './exporter'
 export { AccountValue } from './walletdb/accountValue'
 export { Base64JsonEncoder } from './exporter/encoders/base64json'
 export { JsonEncoder } from './exporter/encoders/json'


### PR DESCRIPTION
## Summary

adds dkgGetIDentity method to ledger util module

adds '--ledger' flag to 'wallet:multisig:participant:create' command

uses 'wallet/multisig/importParticipant' RPC to add the participant identity to the walletDb

## Testing Plan

- manual testing with `wallet:multisig:participant:create --ledger`

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
