### PR TITLE
fixes wallet/multisig/getIdentity for undefined secrets

### DIFF
--- a/ironfish/src/rpc/routes/wallet/multisig/getIdentity.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/getIdentity.ts
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { multisig } from '@ironfish/rust-nodejs'
 import * as yup from 'yup'
 import { RpcValidationError } from '../../../adapters/errors'
 import { ApiNamespace } from '../../namespaces'
@@ -36,13 +35,11 @@ routes.register<typeof GetIdentityRequestSchema, GetIdentityResponse>(
 
     const { name } = request.data
 
-    const secret = await context.wallet.walletDb.getMultisigSecretByName(name)
-    if (secret === undefined) {
+    const identity = await context.wallet.walletDb.getMultisigIdentityByName(name)
+    if (identity === undefined) {
       throw new RpcValidationError(`No identity found with name ${name}`, 404)
     }
 
-    const identity = new multisig.ParticipantSecret(secret).toIdentity()
-
-    request.end({ identity: identity.serialize().toString('hex') })
+    request.end({ identity: identity.toString('hex') })
   },
 )


### PR DESCRIPTION
## Summary

uses walletDb.getMultisigIdentityByName instead of looking up secret by name

since some identities may not have secrets (i.e., identities created using Ledger) these identities won't be found when looking identities up using walletDb.getMultisigSecretByName

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
