### PR TITLE
implements ledger dkg round2

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/dkg/round2.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/round2.ts
@@ -70,7 +70,7 @@ export class DkgRound2Command extends IronfishCommand {
     round1PublicPackages = round1PublicPackages.map((i) => i.trim())
 
     if (flags.ledger) {
-      await this.performRound2WithLedger()
+      await this.performRound2WithLedger(round1PublicPackages, round1SecretPackage)
       return
     }
 
@@ -93,10 +93,13 @@ export class DkgRound2Command extends IronfishCommand {
     this.log('Send the round 2 public package to each participant')
   }
 
-  async performRound2WithLedger(): Promise<void> {
+  async performRound2WithLedger(
+    round1PublicPackages: string[],
+    round1SecretPackage: string,
+  ): Promise<void> {
     const ledger = new Ledger(this.logger)
     try {
-      await ledger.connect()
+      await ledger.connect(true)
     } catch (e) {
       if (e instanceof Error) {
         this.error(e.message)
@@ -104,5 +107,24 @@ export class DkgRound2Command extends IronfishCommand {
         throw e
       }
     }
+
+    // TODO(hughy): determine how to handle multiple identities using index
+    const { publicPackage, secretPackage } = await ledger.dkgRound2(
+      0,
+      round1PublicPackages,
+      round1SecretPackage,
+    )
+
+    this.log('\nRound 2 Encrypted Secret Package:\n')
+    this.log(secretPackage.toString('hex'))
+    this.log()
+
+    this.log('\nRound 2 Public Package:\n')
+    this.log(publicPackage.toString('hex'))
+    this.log()
+
+    this.log()
+    this.log('Next step:')
+    this.log('Send the round 2 public package to each participant')
   }
 }

--- a/ironfish-cli/src/utils/ledger.ts
+++ b/ironfish-cli/src/utils/ledger.ts
@@ -9,6 +9,7 @@ import IronfishApp, {
   KeyResponse,
   ResponseAddress,
   ResponseDkgRound1,
+  ResponseDkgRound2,
   ResponseIdentity,
   ResponseProofGenKey,
   ResponseSign,
@@ -182,6 +183,22 @@ export class Ledger {
     this.logger.log('Please approve the request on your ledger device.')
 
     return this.tryInstruction(this.app.dkgRound1(index, identities, minSigners))
+  }
+
+  dkgRound2 = async (
+    index: number,
+    round1PublicPackages: string[],
+    round1SecretPackage: string,
+  ): Promise<ResponseDkgRound2> => {
+    if (!this.app) {
+      throw new Error('Connect to Ledger first')
+    }
+
+    this.logger.log('Please approve the request on your ledger device.')
+
+    return this.tryInstruction(
+      this.app.dkgRound2(index, round1PublicPackages, round1SecretPackage),
+    )
   }
 }
 

--- a/ironfish-cli/src/utils/ledger.ts
+++ b/ironfish-cli/src/utils/ledger.ts
@@ -1,8 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { createRootLogger, Logger } from '@ironfish/sdk'
-import { AccountImport } from '@ironfish/sdk/src/wallet/exporter'
+import { AccountImport, createRootLogger, Logger } from '@ironfish/sdk'
 import TransportNodeHid from '@ledgerhq/hw-transport-node-hid'
 import IronfishApp, {
   IronfishKeys,
@@ -94,7 +93,7 @@ export class Ledger {
     }
   }
 
-  importAccount = async () => {
+  importAccount = async (): Promise<AccountImport> => {
     if (!this.app) {
       throw new Error('Connect to Ledger first')
     }
@@ -106,8 +105,6 @@ export class Ledger {
     if (!isResponseAddress(responseAddress)) {
       throw new Error(`No public address returned.`)
     }
-
-    this.logger.log('Please confirm the request on your ledger device.')
 
     const responseViewKey = await this.tryInstruction(
       this.app.retrieveKeys(this.PATH, IronfishKeys.ViewKey, true),
@@ -199,6 +196,88 @@ export class Ledger {
     return this.tryInstruction(
       this.app.dkgRound2(index, round1PublicPackages, round1SecretPackage),
     )
+  }
+
+  dkgRound3 = async (
+    index: number,
+    participants: string[],
+    round1PublicPackages: string[],
+    round2PublicPackages: string[],
+    round2SecretPackage: string,
+    gskBytes: string[],
+  ): Promise<void> => {
+    if (!this.app) {
+      throw new Error('Connect to Ledger first')
+    }
+
+    return this.tryInstruction(
+      this.app.dkgRound3Min(
+        index,
+        participants,
+        round1PublicPackages,
+        round2PublicPackages,
+        round2SecretPackage,
+        gskBytes,
+      ),
+    )
+  }
+
+  dkgRetrieveKeys = async (): Promise<{
+    publicAddress: string
+    viewKey: string
+    incomingViewKey: string
+    outgoingViewKey: string
+    proofAuthorizingKey: string
+  }> => {
+    if (!this.app) {
+      throw new Error('Connect to Ledger first')
+    }
+
+    const responseAddress: KeyResponse = await this.tryInstruction(
+      this.app.dkgRetrieveKeys(IronfishKeys.PublicAddress),
+    )
+
+    if (!isResponseAddress(responseAddress)) {
+      throw new Error(`No public address returned.`)
+    }
+
+    this.logger.log('Please confirm the request on your ledger device.')
+
+    const responseViewKey = await this.tryInstruction(
+      this.app.dkgRetrieveKeys(IronfishKeys.ViewKey),
+    )
+
+    if (!isResponseViewKey(responseViewKey)) {
+      throw new Error(`No view key returned.`)
+    }
+
+    const responsePGK: KeyResponse = await this.tryInstruction(
+      this.app.dkgRetrieveKeys(IronfishKeys.ProofGenerationKey),
+    )
+
+    if (!isResponseProofGenKey(responsePGK)) {
+      throw new Error(`No proof authorizing key returned.`)
+    }
+
+    return {
+      publicAddress: responseAddress.publicAddress.toString('hex'),
+      viewKey: responseViewKey.viewKey.toString('hex'),
+      incomingViewKey: responseViewKey.ivk.toString('hex'),
+      outgoingViewKey: responseViewKey.ovk.toString('hex'),
+      proofAuthorizingKey: responsePGK.nsk.toString('hex'),
+    }
+  }
+
+  dkgGetPublicPackage = async (): Promise<Buffer> => {
+    if (!this.app) {
+      throw new Error('Connect to Ledger first')
+    }
+
+    this.logger.log('Please approve the request on your ledger device.')
+
+    const response = await this.tryInstruction(this.app.dkgGetPublicPackage())
+
+    return response.publicPackage
   }
 }
 

--- a/ironfish/src/wallet/index.ts
+++ b/ironfish/src/wallet/index.ts
@@ -3,8 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 export * from './account/account'
 export * from './wallet'
-export * from './exporter/encoder'
-export * from './exporter/account'
+export * from './exporter'
 export { AccountValue } from './walletdb/accountValue'
 export { Base64JsonEncoder } from './exporter/encoders/base64json'
 export { JsonEncoder } from './exporter/encoders/json'


### PR DESCRIPTION
## Summary

adds dkgRound2 method to Ledger util

implements performRound2WithLedger in round2 CLI command

## Testing Plan

- manual testing with `wallet:multisig:dkg:round2 --ledger`

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
