### PR TITLE
implements ledger dkg round3

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/dkg/round3.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/round3.ts
@@ -157,10 +157,9 @@ export class DkgRound3Command extends IronfishCommand {
     const identityResponse = await client.wallet.multisig.getIdentity({ name: participantName })
     const identity = identityResponse.content.identity
 
-    // Filter out participant's own package and sort by identity
+    // Sort packages by identity
     const round1PublicPackages = round1PublicPackagesStr
       .map(deserializePublicPackage)
-      .filter((pkg) => pkg.identity !== identity)
       .sort((a, b) => a.identity.localeCompare(b.identity))
 
     // Filter out packages not intended for participant and sort by sender identity
@@ -178,8 +177,12 @@ export class DkgRound3Command extends IronfishCommand {
     const round1FrostPackages = []
     const gskBytes = []
     for (const pkg of round1PublicPackages) {
-      participants.push(pkg.identity)
-      round1FrostPackages.push(pkg.frostPackage)
+      // Exclude participant's own identity and round1 public package
+      if (pkg.identity !== identity) {
+        participants.push(pkg.identity)
+        round1FrostPackages.push(pkg.frostPackage)
+      }
+
       gskBytes.push(pkg.groupSecretKeyShardEncrypted)
     }
 

--- a/ironfish-cli/src/commands/wallet/multisig/dkg/round3.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/round3.ts
@@ -1,6 +1,11 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import {
+  deserializePublicPackage,
+  deserializeRound2CombinedPublicPackage,
+} from '@ironfish/rust-nodejs'
+import { AccountFormat, encodeAccountImport, RpcClient } from '@ironfish/sdk'
 import { Flags } from '@oclif/core'
 import { IronfishCommand } from '../../../../command'
 import { RemoteFlags } from '../../../../flags'
@@ -107,7 +112,13 @@ export class DkgRound3Command extends IronfishCommand {
     round2PublicPackages = round2PublicPackages.map((i) => i.trim())
 
     if (flags.ledger) {
-      await this.performRound3WithLedger()
+      await this.performRound3WithLedger(
+        client,
+        participantName,
+        round1PublicPackages,
+        round2PublicPackages,
+        round2SecretPackage,
+      )
       return
     }
 
@@ -125,10 +136,16 @@ export class DkgRound3Command extends IronfishCommand {
     )
   }
 
-  async performRound3WithLedger(): Promise<void> {
+  async performRound3WithLedger(
+    client: RpcClient,
+    participantName: string,
+    round1PublicPackagesStr: string[],
+    round2PublicPackagesStr: string[],
+    round2SecretPackage: string,
+  ): Promise<void> {
     const ledger = new Ledger(this.logger)
     try {
-      await ledger.connect()
+      await ledger.connect(true)
     } catch (e) {
       if (e instanceof Error) {
         this.error(e.message)
@@ -136,5 +153,73 @@ export class DkgRound3Command extends IronfishCommand {
         throw e
       }
     }
+
+    const identityResponse = await client.wallet.multisig.getIdentity({ name: participantName })
+    const identity = identityResponse.content.identity
+
+    // Filter out participant's own package and sort by identity
+    const round1PublicPackages = round1PublicPackagesStr
+      .map(deserializePublicPackage)
+      .filter((pkg) => pkg.identity !== identity)
+      .sort((a, b) => a.identity.localeCompare(b.identity))
+
+    // Filter out packages not intended for participant and sort by sender identity
+    const round2CombinedPublicPackages = round2PublicPackagesStr.map(
+      deserializeRound2CombinedPublicPackage,
+    )
+    const round2PublicPackages = round2CombinedPublicPackages
+      .flatMap((combined) =>
+        combined.packages.filter((pkg) => pkg.recipientIdentity === identity),
+      )
+      .sort((a, b) => a.senderIdentity.localeCompare(b.senderIdentity))
+
+    // Extract raw parts from round1 and round2 public packages
+    const participants = []
+    const round1FrostPackages = []
+    const gskBytes = []
+    for (const pkg of round1PublicPackages) {
+      participants.push(pkg.identity)
+      round1FrostPackages.push(pkg.frostPackage)
+      gskBytes.push(pkg.groupSecretKeyShardEncrypted)
+    }
+
+    const round2FrostPackages = round2PublicPackages.map((pkg) => pkg.frostPackage)
+
+    // Perform round3 with Ledger
+    await ledger.dkgRound3(
+      0,
+      participants,
+      round1FrostPackages,
+      round2FrostPackages,
+      round2SecretPackage,
+      gskBytes,
+    )
+
+    // Retrieve all multisig account keys and publicKeyPackage
+    const dkgKeys = await ledger.dkgRetrieveKeys()
+
+    const publicKeyPackage = await ledger.dkgGetPublicPackage()
+
+    const accountImport = {
+      ...dkgKeys,
+      multisigKeys: {
+        publicKeyPackage: publicKeyPackage.toString('hex'),
+        identity,
+      },
+      version: 4,
+      name: participantName,
+      spendingKey: null,
+      createdAt: null,
+    }
+
+    // Import multisig account
+    const response = await client.wallet.importAccount({
+      account: encodeAccountImport(accountImport, AccountFormat.Base64Json),
+    })
+
+    this.log()
+    this.log(
+      `Account ${response.content.name} imported with public address: ${dkgKeys.publicAddress}`,
+    )
   }
 }

--- a/ironfish-cli/src/utils/ledger.ts
+++ b/ironfish-cli/src/utils/ledger.ts
@@ -1,8 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { createRootLogger, Logger } from '@ironfish/sdk'
-import { AccountImport } from '@ironfish/sdk/src/wallet/exporter'
+import { AccountImport, createRootLogger, Logger } from '@ironfish/sdk'
 import TransportNodeHid from '@ledgerhq/hw-transport-node-hid'
 import IronfishApp, {
   IronfishKeys,
@@ -94,7 +93,7 @@ export class Ledger {
     }
   }
 
-  importAccount = async () => {
+  importAccount = async (): Promise<AccountImport> => {
     if (!this.app) {
       throw new Error('Connect to Ledger first')
     }
@@ -106,8 +105,6 @@ export class Ledger {
     if (!isResponseAddress(responseAddress)) {
       throw new Error(`No public address returned.`)
     }
-
-    this.logger.log('Please confirm the request on your ledger device.')
 
     const responseViewKey = await this.tryInstruction(
       this.app.retrieveKeys(this.PATH, IronfishKeys.ViewKey, true),
@@ -199,6 +196,88 @@ export class Ledger {
     return this.tryInstruction(
       this.app.dkgRound2(index, round1PublicPackages, round1SecretPackage),
     )
+  }
+
+  dkgRound3 = async (
+    index: number,
+    participants: string[],
+    round1PublicPackages: string[],
+    round2PublicPackages: string[],
+    round2SecretPackage: string,
+    gskBytes: string[],
+  ): Promise<void> => {
+    if (!this.app) {
+      throw new Error('Connect to Ledger first')
+    }
+
+    return this.tryInstruction(
+      this.app.dkgRound3Min(
+        index,
+        participants,
+        round1PublicPackages,
+        round2PublicPackages,
+        round2SecretPackage,
+        gskBytes,
+      ),
+    )
+  }
+
+  dkgRetrieveKeys = async (): Promise<{
+    publicAddress: string
+    viewKey: string
+    incomingViewKey: string
+    outgoingViewKey: string
+    proofAuthorizingKey: string
+  }> => {
+    if (!this.app) {
+      throw new Error('Connect to Ledger first')
+    }
+
+    const responseAddress: KeyResponse = await this.tryInstruction(
+      this.app.dkgRetrieveKeys(IronfishKeys.PublicAddress),
+    )
+
+    if (!isResponseAddress(responseAddress)) {
+      throw new Error(`No public address returned.`)
+    }
+
+    this.logger.log('Please confirm the request on your ledger device.')
+
+    const responseViewKey = await this.tryInstruction(
+      this.app.dkgRetrieveKeys(IronfishKeys.ViewKey),
+    )
+
+    if (!isResponseViewKey(responseViewKey)) {
+      throw new Error(`No view key returned.`)
+    }
+
+    const responsePGK: KeyResponse = await this.tryInstruction(
+      this.app.dkgRetrieveKeys(IronfishKeys.ProofGenerationKey),
+    )
+
+    if (!isResponseProofGenKey(responsePGK)) {
+      throw new Error(`No proof authorizing key returned.`)
+    }
+
+    return {
+      publicAddress: responseAddress.publicAddress.toString('hex'),
+      viewKey: responseViewKey.viewKey.toString('hex'),
+      incomingViewKey: responseViewKey.ivk.toString('hex'),
+      outgoingViewKey: responseViewKey.ovk.toString('hex'),
+      proofAuthorizingKey: responsePGK.nsk.toString('hex'),
+    }
+  }
+
+  dkgGetPublicPackage = async (): Promise<Buffer> => {
+    if (!this.app) {
+      throw new Error('Connect to Ledger first')
+    }
+
+    this.logger.log('Please approve the request on your ledger device.')
+
+    const response = await this.tryInstruction(this.app.dkgGetPublicPackage())
+
+    return response.publicPackage
   }
 }
 

--- a/ironfish/src/wallet/index.ts
+++ b/ironfish/src/wallet/index.ts
@@ -3,8 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 export * from './account/account'
 export * from './wallet'
-export * from './exporter/encoder'
-export * from './exporter/account'
+export * from './exporter'
 export { AccountValue } from './walletdb/accountValue'
 export { Base64JsonEncoder } from './exporter/encoders/base64json'
 export { JsonEncoder } from './exporter/encoders/json'


### PR DESCRIPTION
## Summary

implements dkgRound3 method on Ledger util class

implements dkgRetrieveKeys on Ledger util class to retrieve all shared multisig keys

implements dkgGetPublicPackage on Ledger util class to retrieve public key package

updates round3 command to run dkg round3, retrieve keys, get public key package, and import account with ledger flag

## Testing Plan

- manual testing with `wallet:multisig:dkg:round3 --ledger`

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
