### PR TITLE
fix(ironfish): Fix unlock hanging in memory client CLI

### DIFF
--- a/ironfish/src/rpc/clients/memoryClient.ts
+++ b/ironfish/src/rpc/clients/memoryClient.ts
@@ -30,5 +30,7 @@ export class RpcMemoryClient extends RpcClient {
     return RpcMemoryAdapter.requestStream<TEnd, TStream>(this.router, route, data)
   }
 
-  close(): void {}
+  async close(): Promise<void> {
+    await this.node.stopNode()
+  }
 }

--- a/ironfish/src/rpc/routes/node/stopNode.ts
+++ b/ironfish/src/rpc/routes/node/stopNode.ts
@@ -24,7 +24,7 @@ routes.register<typeof StopNodeRequestSchema, StopNodeResponse>(
   async (request, context): Promise<void> => {
     AssertHasRpcContext(request, context, 'shutdown', 'logger')
 
-    context.logger.withTag('stopnode').info('Shutting down')
+    context.logger.withTag('stopnode').debug('Shutting down')
     request.end()
     await context.shutdown()
   },

--- a/ironfish/src/wallet/masterKey.ts
+++ b/ironfish/src/wallet/masterKey.ts
@@ -93,7 +93,5 @@ export class MasterKey {
 
   async destroy(): Promise<void> {
     await this.lock()
-    this.nonce.fill(0)
-    this.salt.fill(0)
   }
 }

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -280,6 +280,12 @@ export class Wallet {
   }
 
   async stop(): Promise<void> {
+    if (this.masterKey) {
+      await this.masterKey.destroy()
+    }
+
+    this.stopUnlockTimeout()
+
     if (!this.isStarted) {
       return
     }
@@ -288,12 +294,6 @@ export class Wallet {
     if (this.eventLoopTimeout) {
       clearTimeout(this.eventLoopTimeout)
     }
-
-    if (this.masterKey) {
-      await this.masterKey.destroy()
-    }
-
-    this.stopUnlockTimeout()
 
     await this.scanner.abort()
     this.eventLoopAbortController.abort()


### PR DESCRIPTION
## Summary

When unlocking a wallet without a running node (i.e. using the rpc memory client), the process will hang until the timeout to re-lock the wallet is called (by default, this is 24h). There are several ways to address this issue:
* Don't enqueue a timeout if unlocking via the UI utility in the CLI. This is not ideal, because if you have a running node, you may just leave it unlocked indefinitely. We can add further logic to prevent this probably.
* Remove the utility to unlock the wallet, but that ruins UX a bit.

This PR does several things:
* Implement the `close` method for the memory client. This did nothing before, but now shuts down the node connection
* Destroy the master key and clear any timeouts before checking if the wallet is started. 

## Testing Plan

Run CLI commands

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
