### PR TITLE
fix(ironfish): Guard event loop when the wallet is locked

### DIFF
--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -308,18 +308,20 @@ export class Wallet {
     const [promise, resolve] = PromiseUtils.split<void>()
     this.eventLoopPromise = promise
 
-    if (!this.scanner.running) {
-      void this.scan()
-    }
+    if (!this.locked) {
+      if (!this.scanner.running) {
+        void this.scan()
+      }
 
-    void this.syncTransactionGossip()
-    await this.cleanupDeletedAccounts()
+      void this.syncTransactionGossip()
+      await this.cleanupDeletedAccounts()
 
-    const head = await this.getLatestHead()
+      const head = await this.getLatestHead()
 
-    if (head) {
-      await this.expireTransactions(head.sequence)
-      await this.rebroadcastTransactions(head.sequence)
+      if (head) {
+        await this.expireTransactions(head.sequence)
+        await this.rebroadcastTransactions(head.sequence)
+      }
     }
 
     if (this.isStarted) {


### PR DESCRIPTION
## Summary

If the wallet is locked, we can skip all the scanning logic. The wallet scanner already functions without this, but the conditional improves the logging and makes it clear when the scanner is actually scanning.

## Testing Plan

Running CLI commands and toggled locked status

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
