### PR TITLE
feat(ironfish): Write encrypted accounts when toggling scanning

### DIFF
--- a/ironfish/src/rpc/routes/wallet/setScanning.ts
+++ b/ironfish/src/rpc/routes/wallet/setScanning.ts
@@ -28,7 +28,7 @@ routes.register<typeof SetScanningRequestSchema, SetScanningResponse>(
     AssertHasRpcContext(request, context, 'wallet')
 
     const account = getAccount(context.wallet, request.data.account)
-    await account.updateScanningEnabled(request.data.enabled)
+    await context.wallet.setScanningEnabled(account, request.data.enabled)
     request.end()
   },
 )

--- a/ironfish/src/wallet/account/account.ts
+++ b/ironfish/src/wallet/account/account.ts
@@ -1299,10 +1299,20 @@ export class Account {
 
   async updateScanningEnabled(
     scanningEnabled: boolean,
+    options?: { masterKey: MasterKey | null },
     tx?: IDatabaseTransaction,
   ): Promise<void> {
+    const walletEncrypted = await this.walletDb.accountsEncrypted(tx)
+
     this.scanningEnabled = scanningEnabled
-    await this.walletDb.setAccount(this, tx)
+
+    if (walletEncrypted) {
+      Assert.isNotUndefined(options)
+      Assert.isNotNull(options?.masterKey)
+      await this.walletDb.setEncryptedAccount(this, options.masterKey, tx)
+    } else {
+      await this.walletDb.setAccount(this, tx)
+    }
   }
 
   async getTransactionNotes(

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -1569,6 +1569,14 @@ export class Wallet {
     await account.setName(name, { masterKey: this.masterKey }, tx)
   }
 
+  async setScanningEnabled(
+    account: Account,
+    enabled: boolean,
+    tx?: IDatabaseTransaction,
+  ): Promise<void> {
+    await account.updateScanningEnabled(enabled, { masterKey: this.masterKey }, tx)
+  }
+
   get accounts(): Account[] {
     return Array.from(this.accountById.values())
   }


### PR DESCRIPTION
## Summary

Check if the wallet is encrypted before toggling scanning

## Testing Plan

Run CLI commands for scanning

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
