### PR TITLE
fixes Ledger approval output in round3

### DIFF
--- a/ironfish-cli/src/utils/ledger.ts
+++ b/ironfish-cli/src/utils/ledger.ts
@@ -210,6 +210,8 @@ export class Ledger {
       throw new Error('Connect to Ledger first')
     }
 
+    this.logger.log('Please approve the request on your ledger device.')
+
     return this.tryInstruction(
       this.app.dkgRound3Min(
         index,
@@ -241,8 +243,6 @@ export class Ledger {
       throw new Error(`No public address returned.`)
     }
 
-    this.logger.log('Please confirm the request on your ledger device.')
-
     const responseViewKey = await this.tryInstruction(
       this.app.dkgRetrieveKeys(IronfishKeys.ViewKey),
     )
@@ -272,8 +272,6 @@ export class Ledger {
     if (!this.app) {
       throw new Error('Connect to Ledger first')
     }
-
-    this.logger.log('Please approve the request on your ledger device.')
 
     const response = await this.tryInstruction(this.app.dkgGetPublicPackage())
 


### PR DESCRIPTION
## Summary

ask to approve round3 on Ledger, but don't ask for approval/confirmation when retrieving keys or public package

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
