### PR TITLE
adds ledger option for creating signing commitment

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/commitment/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/commitment/create.ts
@@ -1,11 +1,13 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { UnsignedTransaction } from '@ironfish/sdk'
+import { multisig } from '@ironfish/rust-nodejs'
+import { RpcClient, UnsignedTransaction } from '@ironfish/sdk'
 import { Flags } from '@oclif/core'
 import { IronfishCommand } from '../../../../command'
 import { RemoteFlags } from '../../../../flags'
 import * as ui from '../../../../ui'
+import { Ledger } from '../../../../utils/ledger'
 import { MultisigTransactionJson } from '../../../../utils/multisig'
 import { renderUnsignedTransactionDetails } from '../../../../utils/transaction'
 
@@ -36,6 +38,10 @@ export class CreateSigningCommitmentCommand extends IronfishCommand {
     path: Flags.string({
       description: 'Path to a JSON file containing multisig transaction data',
     }),
+    ledger: Flags.boolean({
+      default: false,
+      description: 'Create signing commitment using a Ledger device',
+    }),
   }
 
   async start(): Promise<void> {
@@ -46,6 +52,11 @@ export class CreateSigningCommitmentCommand extends IronfishCommand {
 
     const client = await this.connectRpc()
     await ui.checkWalletUnlocked(client)
+
+    let participantName = flags.account
+    if (!participantName) {
+      participantName = await ui.multisigSecretPrompt(client)
+    }
 
     let identities = options.identity
     if (!identities || identities.length < 2) {
@@ -77,20 +88,67 @@ export class CreateSigningCommitmentCommand extends IronfishCommand {
     await renderUnsignedTransactionDetails(
       client,
       unsignedTransaction,
-      flags.account,
+      participantName,
       this.logger,
     )
 
     await ui.confirmOrQuit('Confirm signing commitment creation', flags.confirm)
 
+    if (flags.ledger) {
+      await this.createSigningCommitmentWithLedger(
+        client,
+        participantName,
+        unsignedTransaction.hash(),
+        identities,
+      )
+      return
+    }
+
     const response = await client.wallet.multisig.createSigningCommitment({
-      account: flags.account,
+      account: participantName,
       unsignedTransaction: unsignedTransactionInput,
       signers: identities.map((identity) => ({ identity })),
     })
 
     this.log('\nCommitment:\n')
     this.log(response.content.commitment)
+
+    this.log()
+    this.log('Next step:')
+    this.log('Send the commitment to the multisig account coordinator.')
+  }
+
+  async createSigningCommitmentWithLedger(
+    client: RpcClient,
+    participantName: string,
+    transactionHash: Buffer,
+    signers: string[],
+  ): Promise<void> {
+    const ledger = new Ledger(this.logger)
+    try {
+      await ledger.connect(true)
+    } catch (e) {
+      if (e instanceof Error) {
+        this.error(e.message)
+      } else {
+        throw e
+      }
+    }
+
+    const identityResponse = await client.wallet.multisig.getIdentity({ name: participantName })
+    const identity = identityResponse.content.identity
+
+    const rawCommitments = await ledger.dkgGetCommitments(transactionHash.toString('hex'))
+
+    const sigingCommitment = multisig.SigningCommitment.fromRaw(
+      identity,
+      rawCommitments,
+      transactionHash,
+      signers,
+    )
+
+    this.log('\nCommitment:\n')
+    this.log(sigingCommitment.serialize().toString('hex'))
 
     this.log()
     this.log('Next step:')

--- a/ironfish-cli/src/utils/ledger.ts
+++ b/ironfish-cli/src/utils/ledger.ts
@@ -291,6 +291,22 @@ export class Ledger {
 
     return commitments
   }
+
+  dkgSign = async (
+    randomness: string,
+    frostSigningPackage: string,
+    transactionHash: string,
+  ): Promise<Buffer> => {
+    if (!this.app) {
+      throw new Error('Connect to Ledger first')
+    }
+
+    const { signature } = await this.tryInstruction(
+      this.app.dkgSign(randomness, frostSigningPackage, transactionHash),
+    )
+
+    return signature
+  }
 }
 
 function isResponseAddress(response: KeyResponse): response is ResponseAddress {

--- a/ironfish-cli/src/utils/ledger.ts
+++ b/ironfish-cli/src/utils/ledger.ts
@@ -279,6 +279,18 @@ export class Ledger {
 
     return response.publicPackage
   }
+
+  dkgGetCommitments = async (transactionHash: string): Promise<Buffer> => {
+    if (!this.app) {
+      throw new Error('Connect to Ledger first')
+    }
+
+    const { commitments } = await this.tryInstruction(
+      this.app.dkgGetCommitments(transactionHash),
+    )
+
+    return commitments
+  }
 }
 
 function isResponseAddress(response: KeyResponse): response is ResponseAddress {

--- a/ironfish-rust-nodejs/index.d.ts
+++ b/ironfish-rust-nodejs/index.d.ts
@@ -337,6 +337,7 @@ export namespace multisig {
     static fromFrost(frostSignatureShare: Buffer, identity: Buffer): NativeSignatureShare
     identity(): Buffer
     frostSignatureShare(): Buffer
+    serialize(): Buffer
   }
   export class ParticipantSecret {
     constructor(jsBytes: Buffer)

--- a/ironfish-rust-nodejs/src/multisig.rs
+++ b/ironfish-rust-nodejs/src/multisig.rs
@@ -190,6 +190,11 @@ impl NativeSignatureShare {
                 .as_slice(),
         )
     }
+
+    #[napi]
+    pub fn serialize(&self) -> Buffer {
+        Buffer::from(self.signature_share.serialize().as_slice())
+    }
 }
 
 #[napi(namespace = "multisig")]

--- a/ironfish/src/primitives/unsignedTransaction.ts
+++ b/ironfish/src/primitives/unsignedTransaction.ts
@@ -170,4 +170,10 @@ export class UnsignedTransaction {
     this.returnReference()
     return hash
   }
+
+  publicKeyRandomness(): string {
+    const publicKeyRandomness = this.takeReference().publicKeyRandomness()
+    this.returnReference()
+    return publicKeyRandomness
+  }
 }

--- a/ironfish/src/primitives/unsignedTransaction.ts
+++ b/ironfish/src/primitives/unsignedTransaction.ts
@@ -164,4 +164,10 @@ export class UnsignedTransaction {
 
     return result
   }
+
+  hash(): Buffer {
+    const hash = this.takeReference().hash()
+    this.returnReference()
+    return hash
+  }
 }


### PR DESCRIPTION
## Summary

implements dkgGetCommitments on Ledger util class

adds '--ledger' flag to 'wallet:multisig:commitment:create'

adds multisig account selector to 'commitment:create', fetches the identity for the selected account

adds 'hash' method to UnsignedTransaction primitive

## Testing Plan

manual testing:
- created ledger multisig account using dkg
- ran miner to fund default account, sent transaction to ledger multisig
- created unsigned transaction from ledger multisig
- created signing commitment using ledger multisig

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
