### PR TITLE
adds ledger flag for creating signature shares

### DIFF
--- a/ironfish-cli/src/utils/ledger.ts
+++ b/ironfish-cli/src/utils/ledger.ts
@@ -291,6 +291,22 @@ export class Ledger {
 
     return commitments
   }
+
+  dkgSign = async (
+    randomness: string,
+    frostSigningPackage: string,
+    transactionHash: string,
+  ): Promise<Buffer> => {
+    if (!this.app) {
+      throw new Error('Connect to Ledger first')
+    }
+
+    const { signature } = await this.tryInstruction(
+      this.app.dkgSign(randomness, frostSigningPackage, transactionHash),
+    )
+
+    return signature
+  }
 }
 
 function isResponseAddress(response: KeyResponse): response is ResponseAddress {

--- a/ironfish-rust-nodejs/index.d.ts
+++ b/ironfish-rust-nodejs/index.d.ts
@@ -337,6 +337,7 @@ export namespace multisig {
     static fromFrost(frostSignatureShare: Buffer, identity: Buffer): NativeSignatureShare
     identity(): Buffer
     frostSignatureShare(): Buffer
+    serialize(): Buffer
   }
   export class ParticipantSecret {
     constructor(jsBytes: Buffer)

--- a/ironfish-rust-nodejs/src/multisig.rs
+++ b/ironfish-rust-nodejs/src/multisig.rs
@@ -190,6 +190,11 @@ impl NativeSignatureShare {
                 .as_slice(),
         )
     }
+
+    #[napi]
+    pub fn serialize(&self) -> Buffer {
+        Buffer::from(self.signature_share.serialize().as_slice())
+    }
 }
 
 #[napi(namespace = "multisig")]

--- a/ironfish/src/primitives/unsignedTransaction.ts
+++ b/ironfish/src/primitives/unsignedTransaction.ts
@@ -170,4 +170,10 @@ export class UnsignedTransaction {
     this.returnReference()
     return hash
   }
+
+  publicKeyRandomness(): string {
+    const publicKeyRandomness = this.takeReference().publicKeyRandomness()
+    this.returnReference()
+    return publicKeyRandomness
+  }
 }


### PR DESCRIPTION
## Summary

implements dkgSign on Ledger util class to obtain a signature share from the device

adds '--ledger' flag to 'wallet:multisig:signature:create' command

adds selector to command to choose multisig account if one is not provided

adds 'publicKeyRandomness' method to UnsignedTransaction primitive to extract the randomness from the transaction (needed for signing)

adds 'serialize' napi method to NativeSignatureShare to support constructing the signature share from its raw parts and then printing it

## Testing Plan
manual testing:
- continued signing process from #5398 
- created signature share using `wallet:multisig:signature:create --ledger`
- aggregated signature shares using `wallet:multisig:signature:aggregate`
- mined transaction on devnet

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
