### PR TITLE
implements ledger multisig backup command

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/ledger/backup.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/ledger/backup.ts
@@ -26,6 +26,8 @@ export class MultisigLedgerBackup extends IronfishCommand {
     this.log(encryptedKeys.toString('hex'))
     this.log()
     this.log('Please save the encrypted keys show above.')
-    this.log('Use `ironfish wallet:multisig:ledger:restore` if you need to restore the keys to your Ledger.')
+    this.log(
+      'Use `ironfish wallet:multisig:ledger:restore` if you need to restore the keys to your Ledger.',
+    )
   }
 }

--- a/ironfish-cli/src/commands/wallet/multisig/ledger/backup.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/ledger/backup.ts
@@ -5,7 +5,7 @@ import { IronfishCommand } from '../../../../command'
 import { Ledger } from '../../../../utils/ledger'
 
 export class MultisigLedgerBackup extends IronfishCommand {
-  static description = `Backup encrypted multisig keys from a Ledger device`
+  static description = `show encrypted multisig keys from a Ledger device`
 
   async start(): Promise<void> {
     const ledger = new Ledger(this.logger)
@@ -24,5 +24,8 @@ export class MultisigLedgerBackup extends IronfishCommand {
     this.log()
     this.log('Encrypted Ledger Multisig Backup:')
     this.log(encryptedKeys.toString('hex'))
+    this.log()
+    this.log('Please save the encrypted keys show above.')
+    this.log('Use `ironfish wallet:multisig:ledger:restore` if you need to restore the keys to your Ledger.')
   }
 }

--- a/ironfish-cli/src/commands/wallet/multisig/ledger/backup.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/ledger/backup.ts
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { IronfishCommand } from '../../../../command'
+import { Ledger } from '../../../../utils/ledger'
+
+export class MultisigLedgerBackup extends IronfishCommand {
+  static description = `Backup encrypted multisig keys from a Ledger device`
+
+  async start(): Promise<void> {
+    const ledger = new Ledger(this.logger)
+    try {
+      await ledger.connect(true)
+    } catch (e) {
+      if (e instanceof Error) {
+        this.error(e.message)
+      } else {
+        throw e
+      }
+    }
+
+    const encryptedKeys = await ledger.dkgBackupKeys()
+
+    this.log()
+    this.log('Encrypted Ledger Multisig Backup:')
+    this.log(encryptedKeys.toString('hex'))
+  }
+}

--- a/ironfish-cli/src/commands/wallet/multisig/ledger/restore.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/ledger/restore.ts
@@ -1,0 +1,45 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Flags } from '@oclif/core'
+import { IronfishCommand } from '../../../../command'
+import * as ui from '../../../../ui'
+import { Ledger } from '../../../../utils/ledger'
+
+export class MultisigLedgerRestore extends IronfishCommand {
+  static description = `restore encrypted multisig keys to a Ledger device`
+
+  static flags = {
+    backup: Flags.string({
+      description: 'Encrypted multisig key backup from your Ledger device',
+      char: 'b',
+    }),
+  }
+
+  async start(): Promise<void> {
+    const { flags } = await this.parse(MultisigLedgerRestore)
+
+    let encryptedKeys = flags.backup
+    if (!encryptedKeys) {
+      encryptedKeys = await ui.longPrompt(
+        'Enter the encrypted multisig key backup to restore to your Ledger device',
+      )
+    }
+
+    const ledger = new Ledger(this.logger)
+    try {
+      await ledger.connect(true)
+    } catch (e) {
+      if (e instanceof Error) {
+        this.error(e.message)
+      } else {
+        throw e
+      }
+    }
+
+    await ledger.dkgRestoreKeys(encryptedKeys)
+
+    this.log()
+    this.log('Encrypted multisig key backup restored to Ledger.')
+  }
+}

--- a/ironfish-cli/src/utils/ledger.ts
+++ b/ironfish-cli/src/utils/ledger.ts
@@ -317,6 +317,16 @@ export class Ledger {
 
     return encryptedKeys
   }
+
+  dkgRestoreKeys = async (encryptedKeys: string): Promise<void> => {
+    if (!this.app) {
+      throw new Error('Connect to Ledger first')
+    }
+
+    this.logger.log('Please approve the request on your ledger device.')
+
+    await this.tryInstruction(this.app.dkgRestoreKeys(encryptedKeys))
+  }
 }
 
 function isResponseAddress(response: KeyResponse): response is ResponseAddress {

--- a/ironfish-cli/src/utils/ledger.ts
+++ b/ironfish-cli/src/utils/ledger.ts
@@ -305,6 +305,18 @@ export class Ledger {
 
     return signature
   }
+
+  dkgBackupKeys = async (): Promise<Buffer> => {
+    if (!this.app) {
+      throw new Error('Connect to Ledger first')
+    }
+
+    this.logger.log('Please approve the request on your ledger device.')
+
+    const { encryptedKeys } = await this.tryInstruction(this.app.dkgBackupKeys())
+
+    return encryptedKeys
+  }
 }
 
 function isResponseAddress(response: KeyResponse): response is ResponseAddress {


### PR DESCRIPTION
## Summary

adds a CLI command, 'wallet:multisig:ledger:backup', to create an encrypted backup of multisig keys from the ironfish dkg ledger app

users can restore the keys to their ledger app if they reinstall the app on their device or overwrite the multisig keys in the app

## Testing Plan
manual testing: used the command to create key backup

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
