### PR TITLE
adds cli command to restore ledger multisig backup

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/ledger/restore.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/ledger/restore.ts
@@ -1,0 +1,45 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Flags } from '@oclif/core'
+import { IronfishCommand } from '../../../../command'
+import * as ui from '../../../../ui'
+import { Ledger } from '../../../../utils/ledger'
+
+export class MultisigLedgerRestore extends IronfishCommand {
+  static description = `Restore encrypted multisig keys to a Ledger device`
+
+  static flags = {
+    backup: Flags.string({
+      description: 'Encrypted multisig key backup from your Ledger device',
+      char: 'b',
+    }),
+  }
+
+  async start(): Promise<void> {
+    const { flags } = await this.parse(MultisigLedgerRestore)
+
+    let encryptedKeys = flags.backup
+    if (!encryptedKeys) {
+      encryptedKeys = await ui.longPrompt(
+        'Enter the encrypted multisig key backup to restore to your Ledger device',
+      )
+    }
+
+    const ledger = new Ledger(this.logger)
+    try {
+      await ledger.connect(true)
+    } catch (e) {
+      if (e instanceof Error) {
+        this.error(e.message)
+      } else {
+        throw e
+      }
+    }
+
+    await ledger.dkgRestoreKeys(encryptedKeys)
+
+    this.log()
+    this.log('Encrypted multisig key backup restored to Ledger.')
+  }
+}

--- a/ironfish-cli/src/commands/wallet/multisig/ledger/restore.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/ledger/restore.ts
@@ -7,7 +7,7 @@ import * as ui from '../../../../ui'
 import { Ledger } from '../../../../utils/ledger'
 
 export class MultisigLedgerRestore extends IronfishCommand {
-  static description = `Restore encrypted multisig keys to a Ledger device`
+  static description = `restore encrypted multisig keys to a Ledger device`
 
   static flags = {
     backup: Flags.string({

--- a/ironfish-cli/src/utils/ledger.ts
+++ b/ironfish-cli/src/utils/ledger.ts
@@ -317,6 +317,16 @@ export class Ledger {
 
     return encryptedKeys
   }
+
+  dkgRestoreKeys = async (encryptedKeys: string): Promise<void> => {
+    if (!this.app) {
+      throw new Error('Connect to Ledger first')
+    }
+
+    this.logger.log('Please approve the request on your ledger device.')
+
+    await this.tryInstruction(this.app.dkgRestoreKeys(encryptedKeys))
+  }
 }
 
 function isResponseAddress(response: KeyResponse): response is ResponseAddress {


### PR DESCRIPTION
## Summary

if the ironfish dkg ledger app is uninstalled, or if it is used to create a second set of keys, then the multisig keys on the device may be lost

the 'wallet:multisig:ledger:backup' command creates an encrypted key backup that can be restored to the device

the 'wallet:multisig:ledger:restore' command restores the backed up keys to the ledger

## Testing Plan
manual testing:
- created backup using 'wallet:multisig:ledger:backup' (#5400 )
- uninstalled and reinstalled ironfish dkg app
- ran 'wallet:multisig:ledger:restore' to restore keys and printed our keys to verify that they are the same as before

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
