### PR TITLE
improves error message from importParticipant RPC

### DIFF
--- a/ironfish/src/rpc/routes/wallet/multisig/importParticipant.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/importParticipant.ts
@@ -45,13 +45,12 @@ routes.register<typeof ImportParticipantRequestSchema, ImportParticipantResponse
       )
     }
 
-    if (
-      await context.wallet.walletDb.getMultisigIdentity(
-        Buffer.from(request.data.identity, 'hex'),
-      )
-    ) {
+    const existingIdentity = await context.wallet.walletDb.getMultisigIdentity(
+      Buffer.from(request.data.identity, 'hex'),
+    )
+    if (existingIdentity) {
       throw new RpcValidationError(
-        `Multisig identity ${request.data.identity} already exists`,
+        `Multisig identity ${request.data.identity} already exists with the name ${existingIdentity.name}`,
         400,
       )
     }


### PR DESCRIPTION
## Summary

includes name of conflicting identity in error message if the request tries to import an identity that already exists in the database

## Testing Plan
manual testing: tried to import the same identity from Ledger twice

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
