### PR TITLE
prompts for new name and retries import in round3

### DIFF
--- a/ironfish-cli/src/commands/wallet/import.ts
+++ b/ironfish-cli/src/commands/wallet/import.ts
@@ -1,17 +1,13 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import {
-  AccountFormat,
-  encodeAccountImport,
-  RPC_ERROR_CODES,
-  RpcRequestError,
-} from '@ironfish/sdk'
+import { AccountFormat, encodeAccountImport } from '@ironfish/sdk'
 import { Args, Flags, ux } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 import { checkWalletUnlocked, inputPrompt } from '../../ui'
 import { importFile, importPipe, longPrompt } from '../../ui/longPrompt'
+import { importAccount } from '../../utils'
 import { Ledger } from '../../utils/ledger'
 
 export class ImportCommand extends IronfishCommand {
@@ -102,49 +98,15 @@ export class ImportCommand extends IronfishCommand {
       flags.name = name
     }
 
-    let result
+    const { name, isDefaultAccount } = await importAccount(
+      client,
+      account,
+      this.logger,
+      flags.name,
+      flags.createdAt,
+      flags.rescan,
+    )
 
-    while (!result) {
-      try {
-        result = await client.wallet.importAccount({
-          account,
-          rescan: flags.rescan,
-          name: flags.name,
-          createdAt: flags.createdAt,
-        })
-      } catch (e) {
-        if (
-          e instanceof RpcRequestError &&
-          (e.code === RPC_ERROR_CODES.DUPLICATE_ACCOUNT_NAME.toString() ||
-            e.code === RPC_ERROR_CODES.IMPORT_ACCOUNT_NAME_REQUIRED.toString() ||
-            e.code === RPC_ERROR_CODES.DUPLICATE_IDENTITY_NAME.toString())
-        ) {
-          const message = 'Enter a name for the account'
-
-          if (e.code === RPC_ERROR_CODES.DUPLICATE_ACCOUNT_NAME.toString()) {
-            this.log()
-            this.log(e.codeMessage)
-          }
-
-          if (e.code === RPC_ERROR_CODES.DUPLICATE_IDENTITY_NAME.toString()) {
-            this.log()
-            this.log(e.codeMessage)
-          }
-
-          const name = await inputPrompt(message, true)
-          if (name === flags.name) {
-            this.error(`Entered the same name: '${name}'`)
-          }
-
-          flags.name = name
-          continue
-        }
-
-        throw e
-      }
-    }
-
-    const { name, isDefaultAccount } = result.content
     this.log(`Account ${name} imported.`)
 
     if (isDefaultAccount) {

--- a/ironfish-cli/src/commands/wallet/multisig/dkg/round3.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/round3.ts
@@ -10,6 +10,7 @@ import { Flags } from '@oclif/core'
 import { IronfishCommand } from '../../../../command'
 import { RemoteFlags } from '../../../../flags'
 import * as ui from '../../../../ui'
+import { importAccount } from '../../../../utils'
 import { Ledger } from '../../../../utils/ledger'
 
 export class DkgRound3Command extends IronfishCommand {
@@ -216,14 +217,14 @@ export class DkgRound3Command extends IronfishCommand {
     }
 
     // Import multisig account
-    const response = await client.wallet.importAccount({
-      account: encodeAccountImport(accountImport, AccountFormat.Base64Json),
-    })
+    const { name } = await importAccount(
+      client,
+      encodeAccountImport(accountImport, AccountFormat.Base64Json),
+      this.logger,
+    )
 
     this.log()
-    this.log(
-      `Account ${response.content.name} imported with public address: ${dkgKeys.publicAddress}`,
-    )
+    this.log(`Account ${name} imported with public address: ${dkgKeys.publicAddress}`)
 
     this.log()
     this.log('Creating an encrypted backup of multisig keys from your Ledger device...')

--- a/ironfish-cli/src/utils/account.ts
+++ b/ironfish-cli/src/utils/account.ts
@@ -2,8 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { RpcClient } from '@ironfish/sdk'
+import {
+  ImportResponse,
+  Logger,
+  RPC_ERROR_CODES,
+  RpcClient,
+  RpcRequestError,
+} from '@ironfish/sdk'
 import * as ui from '../ui'
+import { inputPrompt } from '../ui'
 
 export async function useAccount(
   client: RpcClient,
@@ -26,4 +33,58 @@ export async function useAccount(
   }
 
   return ui.accountPrompt(client, message)
+}
+
+export async function importAccount(
+  client: RpcClient,
+  account: string,
+  logger: Logger,
+  accountName?: string,
+  createdAt?: number,
+  rescan?: boolean,
+): Promise<ImportResponse> {
+  let name = accountName
+
+  let result
+  while (!result) {
+    try {
+      result = await client.wallet.importAccount({
+        account,
+        name,
+        rescan,
+        createdAt,
+      })
+    } catch (e) {
+      if (
+        e instanceof RpcRequestError &&
+        (e.code === RPC_ERROR_CODES.DUPLICATE_ACCOUNT_NAME.toString() ||
+          e.code === RPC_ERROR_CODES.IMPORT_ACCOUNT_NAME_REQUIRED.toString() ||
+          e.code === RPC_ERROR_CODES.DUPLICATE_IDENTITY_NAME.toString())
+      ) {
+        const message = 'Enter a name for the account'
+
+        if (e.code === RPC_ERROR_CODES.DUPLICATE_ACCOUNT_NAME.toString()) {
+          logger.info('')
+          logger.info(e.codeMessage)
+        }
+
+        if (e.code === RPC_ERROR_CODES.DUPLICATE_IDENTITY_NAME.toString()) {
+          logger.info('')
+          logger.info(e.codeMessage)
+        }
+
+        const inputName = await inputPrompt(message, true)
+        if (inputName === name) {
+          throw new Error(`Entered the same name: '${name}'`)
+        }
+
+        name = inputName
+        continue
+      }
+
+      throw e
+    }
+  }
+
+  return result.content
 }


### PR DESCRIPTION
## Summary

extracts the import/name prompt loop logic from the 'wallet:import' command into an 'importAccount' util

uses the 'importAccount' util to import the account at the end of round3 so that import is retried in the case of name collisions

## Testing Plan
manual testing with `wallet:import`:
- create account 'test1'
- export account 'test1'
- delete account 'test1'
- create new account 'test1'
- try to import exported 'test1' acccount

manual testing with `wallet:multisig:dkg:* --ledger`:
- create ledger identity 'test'
- run through all steps of dkg to create account
- run through all steps of dkg with the same identity (but different partner) again to try to import another 'test' acount

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
