### PR TITLE
adds cli command to import multisig account from ledger

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/dkg/round3.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/round3.ts
@@ -5,7 +5,12 @@ import {
   deserializePublicPackage,
   deserializeRound2CombinedPublicPackage,
 } from '@ironfish/rust-nodejs'
-import { AccountFormat, encodeAccountImport, RpcClient } from '@ironfish/sdk'
+import {
+  ACCOUNT_SCHEMA_VERSION,
+  AccountFormat,
+  encodeAccountImport,
+  RpcClient,
+} from '@ironfish/sdk'
 import { Flags } from '@oclif/core'
 import { IronfishCommand } from '../../../../command'
 import { RemoteFlags } from '../../../../flags'
@@ -210,7 +215,7 @@ export class DkgRound3Command extends IronfishCommand {
         publicKeyPackage: publicKeyPackage.toString('hex'),
         identity,
       },
-      version: 4,
+      version: ACCOUNT_SCHEMA_VERSION,
       name: participantName,
       spendingKey: null,
       createdAt: null,

--- a/ironfish-cli/src/commands/wallet/multisig/ledger/import.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/ledger/import.ts
@@ -1,0 +1,67 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { ACCOUNT_SCHEMA_VERSION, AccountFormat, encodeAccountImport } from '@ironfish/sdk'
+import { Flags } from '@oclif/core'
+import { IronfishCommand } from '../../../../command'
+import { RemoteFlags } from '../../../../flags'
+import * as ui from '../../../../ui'
+import { importAccount } from '../../../../utils'
+import { Ledger } from '../../../../utils/ledger'
+
+export class MultisigLedgerImport extends IronfishCommand {
+  static description = `import a multisig account from a Ledger device`
+
+  static flags = {
+    ...RemoteFlags,
+    name: Flags.string({
+      description: 'Name to use for the account',
+      char: 'n',
+    }),
+  }
+
+  async start(): Promise<void> {
+    const { flags } = await this.parse(MultisigLedgerImport)
+
+    const client = await this.connectRpc()
+    await ui.checkWalletUnlocked(client)
+
+    const name = flags.name ?? (await ui.inputPrompt('Enter a name for the account', true))
+
+    const ledger = new Ledger(this.logger)
+    try {
+      await ledger.connect(true)
+    } catch (e) {
+      if (e instanceof Error) {
+        this.error(e.message)
+      } else {
+        throw e
+      }
+    }
+
+    const identity = await ledger.dkgGetIdentity(0)
+    const dkgKeys = await ledger.dkgRetrieveKeys()
+    const publicKeyPackage = await ledger.dkgGetPublicPackage()
+
+    const accountImport = {
+      ...dkgKeys,
+      multisigKeys: {
+        publicKeyPackage: publicKeyPackage.toString('hex'),
+        identity: identity.toString('hex'),
+      },
+      version: ACCOUNT_SCHEMA_VERSION,
+      name,
+      spendingKey: null,
+      createdAt: null,
+    }
+
+    const { name: accountName } = await importAccount(
+      client,
+      encodeAccountImport(accountImport, AccountFormat.Base64Json),
+      this.logger,
+    )
+
+    this.log()
+    this.log(`Account ${accountName} imported with public address: ${dkgKeys.publicAddress}`)
+  }
+}

--- a/ironfish-cli/src/utils/ledger.ts
+++ b/ironfish-cli/src/utils/ledger.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { AccountImport, createRootLogger, Logger } from '@ironfish/sdk'
+import { ACCOUNT_SCHEMA_VERSION, AccountImport, createRootLogger, Logger } from '@ironfish/sdk'
 import TransportNodeHid from '@ledgerhq/hw-transport-node-hid'
 import IronfishApp, {
   IronfishKeys,
@@ -123,7 +123,7 @@ export class Ledger {
     }
 
     const accountImport: AccountImport = {
-      version: 4, // ACCOUNT_SCHEMA_VERSION as of 2024-05
+      version: ACCOUNT_SCHEMA_VERSION,
       name: 'ledger',
       viewKey: responseViewKey.viewKey.toString('hex'),
       incomingViewKey: responseViewKey.ivk.toString('hex'),


### PR DESCRIPTION
## Summary

reads identity, shared multisig keys, and public key package from Ledger device

imports multisig account to wallet and prompts for new name if the provided name is taken

removes hardcoded account version number from other ledger imports (these imports aren't from serialized accounts, so the schema version should always be the current version)

## Testing Plan

manual testing:
- created multisig account using ledger/dkg
- imported account to new data directory using `wallet:multisig:ledger:import`

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
