### PR TITLE
Adding ledger support for dkg:create

### DIFF
--- a/ironfish-cli/src/utils/ledger.ts
+++ b/ironfish-cli/src/utils/ledger.ts
@@ -48,7 +48,7 @@ export class Ledger {
   }
 
   connect = async (dkg = false) => {
-    const transport = await TransportNodeHid.create(3000, 3000)
+    const transport = await TransportNodeHid.create(3000)
 
     if (transport.deviceModel) {
       this.logger.debug(`${transport.deviceModel.productName} found.`)
@@ -161,7 +161,7 @@ export class Ledger {
       throw new Error('Connect to Ledger first')
     }
 
-    this.logger.log('Please approve the request on your ledger device.')
+    this.logger.log('Approve identity request on ledger device.')
 
     const response: ResponseIdentity = await this.tryInstruction(this.app.dkgGetIdentity(index))
 


### PR DESCRIPTION
## Summary

Also added the ability to reuse an existing identity for the DKG process. The user can specify the account name separately from the participant name.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
