### PR TITLE
adds clear signing to ledger signing flows

### DIFF
--- a/ironfish-cli/package.json
+++ b/ironfish-cli/package.json
@@ -68,7 +68,7 @@
     "@oclif/plugin-warn-if-update-available": "3.1.8",
     "@types/keccak": "3.0.4",
     "@types/tar": "6.1.1",
-    "@zondax/ledger-ironfish": "https://github.com/iron-fish/ledger-ironfish-js.git#dev",
+    "@zondax/ledger-ironfish": "0.3.0",
     "axios": "1.7.2",
     "bech32": "2.0.0",
     "blessed": "0.1.81",

--- a/ironfish-cli/src/commands/wallet/multisig/signature/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/signature/create.ts
@@ -134,10 +134,14 @@ export class CreateSignatureShareCommand extends IronfishCommand {
     const identityResponse = await client.wallet.multisig.getIdentity({ name: participantName })
     const identity = identityResponse.content.identity
 
+    const transactionHash = await ledger.reviewTransaction(
+      unsignedTransaction.serialize().toString('hex'),
+    )
+
     const frostSignatureShare = await ledger.dkgSign(
       unsignedTransaction.publicKeyRandomness(),
       frostSigningPackage,
-      unsignedTransaction.hash().toString('hex'),
+      transactionHash.toString('hex'),
     )
 
     const signatureShare = multisig.SignatureShare.fromFrost(

--- a/ironfish-cli/src/utils/ledger.ts
+++ b/ironfish-cli/src/utils/ledger.ts
@@ -278,6 +278,20 @@ export class Ledger {
     return response.publicPackage
   }
 
+  reviewTransaction = async (transaction: string): Promise<Buffer> => {
+    if (!this.app) {
+      throw new Error('Connect to Ledger first')
+    }
+
+    this.logger.info(
+      'Please review and approve the outputs of this transaction on your ledger device.',
+    )
+
+    const { hash } = await this.tryInstruction(this.app.reviewTransaction(transaction))
+
+    return hash
+  }
+
   dkgGetCommitments = async (transactionHash: string): Promise<Buffer> => {
     if (!this.app) {
       throw new Error('Connect to Ledger first')

--- a/yarn.lock
+++ b/yarn.lock
@@ -3902,9 +3902,10 @@
   dependencies:
     argparse "^2.0.1"
 
-"@zondax/ledger-ironfish@https://github.com/iron-fish/ledger-ironfish-js.git#dev":
-  version "0.0.0"
-  resolved "https://github.com/iron-fish/ledger-ironfish-js.git#c45e2bc57b4acd5168af9d3c3dbf080e6f7318c5"
+"@zondax/ledger-ironfish@0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@zondax/ledger-ironfish/-/ledger-ironfish-0.3.0.tgz#8855a63ab56a28f99c55be1a73c47e61b6d5d917"
+  integrity sha512-R7T0GWCZDxfOPZPn66i0rGKsNAeJuzrd1hnsbutKdQ4bWJLiAJch0uUAjJYOTqt5mM2uYF9JWYsFEjsDkyMxDQ==
   dependencies:
     "@zondax/ledger-js" "^1.0.1"
 


### PR DESCRIPTION
## Summary

uses 'reviewTransaction' method from '@zondax/ledger-ironfish' to force user to review decrypted transaction outputs on the ledger device

updates our '@zondax/ledger-ironfish' dependency to use the latest release, which now includes dkg methods

note: for interactive signing we may only need to review once before creating the signing commitments

## Testing Plan

manual testing with signing flow

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
