### PR TITLE
always display asset id with notes in transaction details

### DIFF
--- a/ironfish-cli/src/utils/transaction.ts
+++ b/ironfish-cli/src/utils/transaction.ts
@@ -243,13 +243,20 @@ async function _renderTransactionDetails(
       }
       logger.log('')
 
+      const verifiedAssetMetadata = assetLookup[note.assetId].verification
+
       const renderedAmount = CurrencyUtils.render(
         note.value,
         true,
         note.assetId,
-        assetLookup[note.assetId].verification,
+        verifiedAssetMetadata,
       )
       logger.log(`Amount:        ${renderedAmount}`)
+
+      if (verifiedAssetMetadata.symbol) {
+        logger.log(`Asset ID:      ${note.assetId}`)
+      }
+
       logger.log(`Memo:          ${note.memo}`)
       logger.log(`Recipient:     ${note.owner}`)
       logger.log(`Sender:        ${note.sender}`)
@@ -267,13 +274,20 @@ async function _renderTransactionDetails(
       }
       logger.log('')
 
+      const verifiedAssetMetadata = assetLookup[note.assetId].verification
+
       const renderedAmount = CurrencyUtils.render(
         note.value,
         true,
         note.assetId,
-        assetLookup[note.assetId].verification,
+        verifiedAssetMetadata,
       )
       logger.log(`Amount:        ${renderedAmount}`)
+
+      if (verifiedAssetMetadata.symbol) {
+        logger.log(`Asset ID:      ${note.assetId}`)
+      }
+
       logger.log(`Memo:          ${note.memo}`)
       logger.log(`Recipient:     ${note.owner}`)
       logger.log(`Sender:        ${note.sender}`)


### PR DESCRIPTION
## Summary

when approving a transaction using a ledger device users are shown the asset id of each output note on the ledger device

the transaction details they see in the cli will not include the asset id if the asset is verified (the symbol will be displayed instead). this makes it more difficult to verify that the transaction you're seeing on the ledger is correct based on what the cli is showing you

if the asset has a verified symbol, also displays the asset id for the note on the line below the amount

## Testing Plan
manual testing:

before:
<img width="557" alt="image" src="https://github.com/user-attachments/assets/cc19ea44-0116-4f31-82f0-a2f03b6c33fd">

after:
<img width="567" alt="image" src="https://github.com/user-attachments/assets/9c22b7ec-ceb8-4ac3-b542-aecf80ef236a">


## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
