### PR TITLE
Add the ability to use a ledger device with the mint command

### DIFF
--- a/ironfish-cli/src/commands/wallet/mint.ts
+++ b/ironfish-cli/src/commands/wallet/mint.ts
@@ -23,6 +23,7 @@ import { promptCurrency } from '../../utils/currency'
 import { promptExpiration } from '../../utils/expiration'
 import { getExplorer } from '../../utils/explorer'
 import { selectFee } from '../../utils/fees'
+import { sendTransactionWithLedger } from '../../utils/ledger'
 import { watchTransaction } from '../../utils/transaction'
 
 export class Mint extends IronfishCommand {
@@ -101,6 +102,10 @@ This will create tokens and increase supply for a given asset.`
       description:
         'Return a serialized UnsignedTransaction. Use it to create a transaction and build proofs but not post to the network',
       exclusive: ['rawTransaction'],
+    }),
+    ledger: Flags.boolean({
+      default: false,
+      description: 'Mint a transaction using a Ledger device',
     }),
   }
 
@@ -285,6 +290,18 @@ This will create tokens and increase supply for a given asset.`
       flags.confirm,
       assetData,
     )
+
+    if (flags.ledger) {
+      await sendTransactionWithLedger(
+        client,
+        raw,
+        account,
+        flags.watch,
+        flags.confirm,
+        this.logger,
+      )
+      this.exit(0)
+    }
 
     ux.action.start('Sending the transaction')
 

--- a/ironfish-cli/src/utils/ledger.ts
+++ b/ironfish-cli/src/utils/ledger.ts
@@ -1,9 +1,18 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { createRootLogger, Logger } from '@ironfish/sdk'
+import {
+  createRootLogger,
+  CurrencyUtils,
+  Logger,
+  RawTransaction,
+  RawTransactionSerde,
+  RpcClient,
+  Transaction,
+} from '@ironfish/sdk'
 import { AccountImport } from '@ironfish/sdk/src/wallet/exporter'
 import TransportNodeHid from '@ledgerhq/hw-transport-node-hid'
+import { Errors, ux } from '@oclif/core'
 import IronfishApp, {
   IronfishKeys,
   ResponseAddress,
@@ -11,6 +20,8 @@ import IronfishApp, {
   ResponseSign,
   ResponseViewKey,
 } from '@zondax/ledger-ironfish'
+import * as ui from '../ui'
+import { watchTransaction } from './transaction'
 
 export class Ledger {
   app: IronfishApp | undefined
@@ -158,5 +169,85 @@ export class Ledger {
     }
 
     return response.signature
+  }
+}
+
+export async function sendTransactionWithLedger(
+  client: RpcClient,
+  raw: RawTransaction,
+  from: string | undefined,
+  watch: boolean,
+  confirm: boolean,
+  logger?: Logger,
+): Promise<void> {
+  const ledger = new Ledger(logger)
+  try {
+    await ledger.connect()
+  } catch (e) {
+    if (e instanceof Error) {
+      Errors.error(e.message)
+    } else {
+      throw e
+    }
+  }
+
+  const publicKey = (await client.wallet.getAccountPublicKey({ account: from })).content
+    .publicKey
+
+  const ledgerPublicKey = await ledger.getPublicAddress()
+
+  if (publicKey !== ledgerPublicKey) {
+    Errors.error(
+      `The public key on the ledger device does not match the public key of the account '${from}'`,
+    )
+  }
+
+  const buildTransactionResponse = await client.wallet.buildTransaction({
+    account: from,
+    rawTransaction: RawTransactionSerde.serialize(raw).toString('hex'),
+  })
+
+  const unsignedTransaction = buildTransactionResponse.content.unsignedTransaction
+
+  const signature = (await ledger.sign(unsignedTransaction)).toString('hex')
+
+  ux.stdout(`\nSignature: ${signature}`)
+
+  const addSignatureResponse = await client.wallet.addSignature({
+    unsignedTransaction,
+    signature,
+  })
+
+  const signedTransaction = addSignatureResponse.content.transaction
+  const bytes = Buffer.from(signedTransaction, 'hex')
+
+  const transaction = new Transaction(bytes)
+
+  ux.stdout(`\nSigned Transaction: ${signedTransaction}`)
+  ux.stdout(`\nHash: ${transaction.hash().toString('hex')}`)
+  ux.stdout(`Fee: ${CurrencyUtils.render(transaction.fee(), true)}`)
+
+  await ui.confirmOrQuit('', confirm)
+
+  const addTransactionResponse = await client.wallet.addTransaction({
+    transaction: signedTransaction,
+    broadcast: true,
+  })
+
+  if (addTransactionResponse.content.accepted === false) {
+    Errors.error(
+      `Transaction '${transaction.hash().toString('hex')}' was not accepted into the mempool`,
+    )
+  }
+
+  if (watch) {
+    ux.stdout('')
+
+    await watchTransaction({
+      client,
+      logger,
+      account: from,
+      hash: transaction.hash().toString('hex'),
+    })
   }
 }


### PR DESCRIPTION
## Summary

Adds the `--ledger` flag, so ledger accounts can be used to mint assets.

Closes IFL-2970

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
