### PR TITLE
Enable transfering in a mint in the CLI

### DIFF
--- a/ironfish-cli/src/commands/wallet/mint.ts
+++ b/ironfish-cli/src/commands/wallet/mint.ts
@@ -98,7 +98,7 @@ This will create tokens and increase supply for a given asset.`
       description: 'The public address of the account to transfer ownership of this asset to.',
     }),
     transferTo: Flags.string({
-      description: 'transfer all newly minted coins to this public address.',
+      description: 'transfer all newly minted coins to this public address',
     }),
     transferToMemo: Flags.string({
       description: 'The memo of transfer when using transferTo',

--- a/ironfish-cli/src/commands/wallet/mint.ts
+++ b/ironfish-cli/src/commands/wallet/mint.ts
@@ -97,6 +97,12 @@ This will create tokens and increase supply for a given asset.`
     transferOwnershipTo: Flags.string({
       description: 'The public address of the account to transfer ownership of this asset to.',
     }),
+    transferTo: Flags.string({
+      description: 'transfer all newly minted coins to this public address.',
+    }),
+    transferToMemo: Flags.string({
+      description: 'The memo of transfer when using transferTo',
+    }),
     unsignedTransaction: Flags.boolean({
       default: false,
       description:
@@ -218,6 +224,12 @@ This will create tokens and increase supply for a given asset.`
       }
     }
 
+    if (flags.transferTo) {
+      if (!isValidPublicAddress(flags.transferTo)) {
+        this.error('transferTo must be a valid public address')
+      }
+    }
+
     let expiration = flags.expiration
     if ((flags.rawTransaction || flags.unsignedTransaction) && expiration === undefined) {
       expiration = await promptExpiration({ logger: this.logger, client: client })
@@ -228,23 +240,32 @@ This will create tokens and increase supply for a given asset.`
       this.exit(1)
     }
 
+    const mint = {
+      // Only provide the asset id if we are not minting an asset for the first time
+      ...(assetData != null ? { assetId } : {}),
+      name: name,
+      metadata: metadata,
+      value: CurrencyUtils.encode(amount),
+      transferOwnershipTo: flags.transferOwnershipTo,
+    }
+
     const params: CreateTransactionRequest = {
       account,
       outputs: [],
-      mints: [
-        {
-          // Only provide the asset id if we are not minting an asset for the first time
-          ...(assetData != null ? { assetId } : {}),
-          name,
-          metadata,
-          value: CurrencyUtils.encode(amount),
-          transferOwnershipTo: flags.transferOwnershipTo,
-        },
-      ],
+      mints: [mint],
       fee: flags.fee ? CurrencyUtils.encode(flags.fee) : null,
       feeRate: flags.feeRate ? CurrencyUtils.encode(flags.feeRate) : null,
       expiration: expiration,
       confirmations: flags.confirmations,
+    }
+
+    if (flags.transferTo) {
+      params.outputs.push({
+        publicAddress: flags.transferTo,
+        amount: mint.value,
+        assetId: assetId,
+        memo: flags.transferToMemo,
+      })
     }
 
     let raw: RawTransaction
@@ -287,6 +308,7 @@ This will create tokens and increase supply for a given asset.`
       name,
       metadata,
       flags.transferOwnershipTo,
+      flags.transferTo,
       flags.confirm,
       assetData,
     )
@@ -341,6 +363,7 @@ This will create tokens and increase supply for a given asset.`
         Value: renderedValue,
         Fee: renderedFee,
         Hash: transaction.hash().toString('hex'),
+        'Transfered To': flags.transferTo ? flags.transferTo : undefined,
       }),
     )
 
@@ -373,6 +396,7 @@ This will create tokens and increase supply for a given asset.`
     name?: string,
     metadata?: string,
     transferOwnershipTo?: string,
+    transferTo?: string,
     confirm?: boolean,
     assetData?: RpcAsset,
   ): Promise<void> {
@@ -392,6 +416,17 @@ This will create tokens and increase supply for a given asset.`
       `Amount: ${renderedAmount}`,
       `Fee: ${renderedFee}`,
     ]
+
+    if (transferTo) {
+      confirmMessage.push(
+        `\nAll ${CurrencyUtils.render(
+          amount,
+          false,
+          assetId,
+          assetData?.verification,
+        )} of this asset will be transferred to ${transferTo}.`,
+      )
+    }
 
     if (transferOwnershipTo) {
       confirmMessage.push(


### PR DESCRIPTION
## Summary

This allows you to both mint new coins, and transfer them in the same transaction using the CLI. This is something that was already possible using the SDK or the RPC.

This is done by adding outputs with the same amount as the mint amount.

Example to mint 1 new asset called `foo-coin` and transfer the 1 new coin to `eccfd79c841e02cda4e2c53f3a149070f1bc8c7f76a41886d268b6ec8ed2ae3b`

```
fishy wallet:mint \
--transferTo eccfd79c841e02cda4e2c53f3a149070f1bc8c7f76a41886d268b6ec8ed2ae3b \
--transferMemo "this is a memo" \
--name foo-coin  \
--metadata meta  \
--amount 1  \
--fee 0.00000001
```

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
