### PR TITLE
Revert "exports makeFakeWitness test util from ironfish sdk (#5415)"

### DIFF
--- a/ironfish/src/index.ts
+++ b/ironfish/src/index.ts
@@ -28,6 +28,3 @@ export * from './package'
 export * from './platform'
 export * from './primitives'
 export { getFeeRate } from './memPool'
-
-import { makeFakeWitness } from './testUtilities'
-export const testUtilities = { makeFakeWitness }


### PR DESCRIPTION
## Summary

This reverts commit dcaabd851816e9f994a6f81739d6d090f6e6fad9.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
