### PR TITLE
Allows `--metadata ''` when minting an asset

### DIFF
--- a/ironfish-cli/src/commands/wallet/mint.ts
+++ b/ironfish-cli/src/commands/wallet/mint.ts
@@ -151,7 +151,7 @@ This will create tokens and increase supply for a given asset.`
         name = await ui.inputPrompt('Enter the name for the new asset', true)
       }
 
-      if (!metadata) {
+      if (metadata == null) {
         metadata = await ui.inputPrompt('Enter metadata for the new asset')
       }
 


### PR DESCRIPTION
## Summary

Right now, if you run `ironfish wallet:mint --metadata ''`, it will still interactively prompt you for a metadata. With this change, it will accept that you want an empty metadata. The behavior when not including the metadata flag is unchanged.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
