### PR TITLE
Error for too many participants

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/dkg/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/create.ts
@@ -269,6 +269,10 @@ export class DkgCreateCommand extends IronfishCommand {
       throw new Error('Total number of participants must be at least 2')
     }
 
+    if (ledger && totalParticipants > 4) {
+      throw new Error('DKG with Ledger supports a maximum of 4 participants')
+    }
+
     this.log(
       `\nEnter ${
         totalParticipants - 1


### PR DESCRIPTION
## Summary

At the moment, ledger dkg only supports up to 4 participants. This commit adds an error message when the user tries to create a dkg with more than 4 participants.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
