### PR TITLE
fix resolution of @zondax/ledger-js package

### DIFF
--- a/ironfish-cli/package.json
+++ b/ironfish-cli/package.json
@@ -87,9 +87,6 @@
     "tar": "6.1.11",
     "uuid": "8.3.2"
   },
-  "resolutions": {
-    "@zondax/ledger-ironfish/**/@zondax/ledger-js": "^0.2.1"
-  },
   "oclif": {
     "macos": {
       "identifier": "network.ironfish.cli"

--- a/ironfish-cli/package.json
+++ b/ironfish-cli/package.json
@@ -70,7 +70,7 @@
     "@types/tar": "6.1.1",
     "@zondax/ledger-ironfish": "0.1.2",
     "@zondax/ledger-ironfish-dkg": "npm:@zondax/ledger-ironfish@0.4.0",
-    "@zondax/ledger-js-dkg": "npm:@zondax/ledger-js@1.0.1",
+    "@zondax/ledger-js": "^1.0.1",
     "axios": "1.7.2",
     "bech32": "2.0.0",
     "blessed": "0.1.81",
@@ -86,6 +86,9 @@
     "supports-hyperlinks": "2.2.0",
     "tar": "6.1.11",
     "uuid": "8.3.2"
+  },
+  "resolutions": {
+    "@zondax/ledger-ironfish/**/@zondax/ledger-js": "^0.2.1"
   },
   "oclif": {
     "macos": {

--- a/ironfish-cli/src/utils/ledger.ts
+++ b/ironfish-cli/src/utils/ledger.ts
@@ -31,7 +31,7 @@ import {
   ResponseViewKey as ResponseViewKeyDkg,
 } from '@zondax/ledger-ironfish-dkg'
 import { default as IronfishDkgApp } from '@zondax/ledger-ironfish-dkg'
-import { ResponseError } from '@zondax/ledger-js-dkg'
+import { ResponseError } from '@zondax/ledger-js'
 import * as ui from '../ui'
 import { watchTransaction } from './transaction'
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3925,20 +3925,19 @@
   dependencies:
     "@zondax/ledger-js" "^0.2.1"
 
-"@zondax/ledger-js-dkg@npm:@zondax/ledger-js@1.0.1", "@zondax/ledger-js@^1.0.1":
-  name "@zondax/ledger-js-dkg"
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@zondax/ledger-js/-/ledger-js-1.0.1.tgz#a1c51943c5b7d1370cea588b193197234485d196"
-  integrity sha512-9h+aIXyEK+Rdic5Ppsmq+tptDFwPTacG1H6tpZHFdhtBFHYFOLLkKTTmq5rMTv84aAPS1v0tnsF1e2Il6M05Cg==
-  dependencies:
-    "@ledgerhq/hw-transport" "6.31.2"
-
 "@zondax/ledger-js@^0.2.1":
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/@zondax/ledger-js/-/ledger-js-0.2.2.tgz#b334cecaa372a8bfb91ae4fc5dd0d1c52411da4e"
   integrity sha512-7wOUlRF2+kRaRU2KSzKb7XjPfScwEg3Cjg6NH/p+ikQLJ9eMkGC45NhSxYn8lixIIk+TgZ4yzTNOzFvF836gQw==
   dependencies:
     "@ledgerhq/hw-transport" "6.28.1"
+
+"@zondax/ledger-js@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@zondax/ledger-js/-/ledger-js-1.0.1.tgz#a1c51943c5b7d1370cea588b193197234485d196"
+  integrity sha512-9h+aIXyEK+Rdic5Ppsmq+tptDFwPTacG1H6tpZHFdhtBFHYFOLLkKTTmq5rMTv84aAPS1v0tnsF1e2Il6M05Cg==
+  dependencies:
+    "@ledgerhq/hw-transport" "6.31.2"
 
 JSONStream@^1.0.4:
   version "1.3.5"


### PR DESCRIPTION
## Summary

we have two versions of @zondax/ledger-ironfish in our dependencies that require different versions of @zondax/ledger-js

we need to make sure that each version's dependencies resolve correctly in order for both the DKG and single signer apps to work

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
