### PR TITLE
optionally sets createdAt when importing multisig accounts

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/dkg/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/create.ts
@@ -37,7 +37,8 @@ export class DkgCreateCommand extends IronfishCommand {
       description: 'Perform operation with a ledger device',
     }),
     createdAt: Flags.integer({
-      description: 'Block sequence to begin scanning from for the created account',
+      description:
+        "Block sequence to begin scanning from for the created account. Uses node's chain head by default",
     }),
   }
 
@@ -62,6 +63,12 @@ export class DkgCreateCommand extends IronfishCommand {
     }
 
     const accountName = await this.getAccountName(client, flags.newAccount)
+
+    let accountCreatedAt = flags.createdAt
+    if (!accountCreatedAt) {
+      const statusResponse = await client.node.getStatus()
+      accountCreatedAt = statusResponse.content.blockchain.head.sequence
+    }
 
     const { name: participantName, identity } = ledger
       ? await ui.retryStep(
@@ -121,7 +128,7 @@ export class DkgCreateCommand extends IronfishCommand {
           round1PublicPackages,
           totalParticipants,
           ledger,
-          flags.createdAt,
+          accountCreatedAt,
         )
       },
       this.logger,

--- a/ironfish-cli/src/commands/wallet/multisig/dkg/round3.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/round3.ts
@@ -54,7 +54,8 @@ export class DkgRound3Command extends IronfishCommand {
       hidden: true,
     }),
     createdAt: Flags.integer({
-      description: 'Block sequence to begin scanning from for the created account',
+      description:
+        "Block sequence to begin scanning from for the created account. Uses node's chain head by default.",
     }),
   }
 
@@ -120,6 +121,12 @@ export class DkgRound3Command extends IronfishCommand {
     }
     round2PublicPackages = round2PublicPackages.map((i) => i.trim())
 
+    let accountCreatedAt = flags.createdAt
+    if (!accountCreatedAt) {
+      const statusResponse = await client.node.getStatus()
+      accountCreatedAt = statusResponse.content.blockchain.head.sequence
+    }
+
     if (flags.ledger) {
       await this.performRound3WithLedger(
         client,
@@ -127,7 +134,7 @@ export class DkgRound3Command extends IronfishCommand {
         round1PublicPackages,
         round2PublicPackages,
         round2SecretPackage,
-        flags.createdAt,
+        accountCreatedAt,
       )
       return
     }
@@ -138,7 +145,7 @@ export class DkgRound3Command extends IronfishCommand {
       round2SecretPackage,
       round1PublicPackages,
       round2PublicPackages,
-      accountCreatedAt: flags.createdAt,
+      accountCreatedAt,
     })
 
     this.log()

--- a/ironfish-cli/src/commands/wallet/multisig/dkg/round3.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/round3.ts
@@ -53,6 +53,9 @@ export class DkgRound3Command extends IronfishCommand {
       description: 'Perform operation with a ledger device',
       hidden: true,
     }),
+    createdAt: Flags.integer({
+      description: 'Block sequence to begin scanning from for the created account',
+    }),
   }
 
   async start(): Promise<void> {
@@ -124,6 +127,7 @@ export class DkgRound3Command extends IronfishCommand {
         round1PublicPackages,
         round2PublicPackages,
         round2SecretPackage,
+        flags.createdAt,
       )
       return
     }
@@ -134,6 +138,7 @@ export class DkgRound3Command extends IronfishCommand {
       round2SecretPackage,
       round1PublicPackages,
       round2PublicPackages,
+      accountCreatedAt: flags.createdAt,
     })
 
     this.log()
@@ -148,6 +153,7 @@ export class DkgRound3Command extends IronfishCommand {
     round1PublicPackagesStr: string[],
     round2PublicPackagesStr: string[],
     round2SecretPackage: string,
+    accountCreatedAt?: number,
   ): Promise<void> {
     const ledger = new LedgerDkg(this.logger)
     try {
@@ -226,6 +232,8 @@ export class DkgRound3Command extends IronfishCommand {
       client,
       encodeAccountImport(accountImport, AccountFormat.Base64Json),
       this.logger,
+      participantName,
+      accountCreatedAt,
     )
 
     this.log()

--- a/ironfish-cli/src/commands/wallet/multisig/ledger/import.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/ledger/import.ts
@@ -18,6 +18,9 @@ export class MultisigLedgerImport extends IronfishCommand {
       description: 'Name to use for the account',
       char: 'n',
     }),
+    createdAt: Flags.integer({
+      description: 'Block sequence to begin scanning from for the imported account',
+    }),
   }
 
   async start(): Promise<void> {
@@ -59,6 +62,8 @@ export class MultisigLedgerImport extends IronfishCommand {
       client,
       encodeAccountImport(accountImport, AccountFormat.Base64Json),
       this.logger,
+      name,
+      flags.createdAt,
     )
 
     this.log()

--- a/ironfish/src/rpc/routes/wallet/multisig/dkg/round3.test.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/dkg/round3.test.ts
@@ -52,6 +52,8 @@ describe('Route multisig/dkg/round3', () => {
       ),
     )
 
+    const accountCreatedAt = 2
+
     // Perform DKG round 3
     const round3Responses = await Promise.all(
       participantNames.map((participantName, index) =>
@@ -61,6 +63,7 @@ describe('Route multisig/dkg/round3', () => {
           round2SecretPackage: round2Packages[index].content.round2SecretPackage,
           round1PublicPackages: round1Packages.map((pkg) => pkg.content.round1PublicPackage),
           round2PublicPackages: round2Packages.map((pkg) => pkg.content.round2PublicPackage),
+          accountCreatedAt,
         }),
       ),
     )
@@ -97,6 +100,13 @@ describe('Route multisig/dkg/round3', () => {
         .map((identity) => identity.toString('hex'))
         .sort()
       expect(knownIdentities).toStrictEqual(expectedIdentities)
+    }
+
+    // Check that all imported accounts have createdAt sequence set
+    for (const accountName of accountNames) {
+      const account = routeTest.wallet.getAccountByName(accountName)
+      Assert.isNotNull(account)
+      expect(account.createdAt?.sequence).toEqual(accountCreatedAt)
     }
   })
 

--- a/ironfish/src/rpc/routes/wallet/multisig/dkg/round3.ts
+++ b/ironfish/src/rpc/routes/wallet/multisig/dkg/round3.ts
@@ -16,6 +16,7 @@ export type DkgRound3Request = {
   round1PublicPackages: Array<string>
   round2PublicPackages: Array<string>
   accountName?: string
+  accountCreatedAt?: number
 }
 
 export type DkgRound3Response = {
@@ -30,6 +31,7 @@ export const DkgRound3RequestSchema: yup.ObjectSchema<DkgRound3Request> = yup
     round1PublicPackages: yup.array().of(yup.string().defined()).defined(),
     round2PublicPackages: yup.array().of(yup.string().defined()).defined(),
     accountName: yup.string().optional(),
+    accountCreatedAt: yup.number().optional(),
   })
   .defined()
 
@@ -92,7 +94,9 @@ routes.register<typeof DkgRound3RequestSchema, DkgRound3Response>(
       },
     }
 
-    const account = await node.wallet.importAccount(accountImport)
+    const account = await node.wallet.importAccount(accountImport, {
+      createdAt: request.data.accountCreatedAt,
+    })
     await node.wallet.skipRescan(account)
 
     request.end({


### PR DESCRIPTION
## Summary

adds '--createdAt' flag to 'wallet:multisig:dkg:create', 'wallet:multisig:dkg:round3', and 'wallet:multisig:ledger:import'

updates round3 RPC to accept optional 'accountCreatedAt' parameter

allows user to set the 'createdAt' sequence when creating a multisig account or importing one from a ledger device. this allows users to start using their accounts more quickly without waiting for the account to scan the entire chain

## Testing Plan
manual testing with `wallet:multisig:ledger:import` and `wallet:multisig:dkg:create`

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
