### PR TITLE
Expect to participant in signing

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/sign.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/sign.ts
@@ -196,6 +196,12 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
     signatureShare: string,
     totalParticipants: number,
   ): Promise<void> {
+    this.log(
+      `Enter ${
+        totalParticipants - 1
+      } signature shares of the participants (excluding your own)`,
+    )
+
     const signatureShares = await ui.collectStrings('Signature Share', totalParticipants - 1, {
       additionalStrings: [signatureShare],
       errorOnDuplicate: true,
@@ -288,6 +294,10 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
     identities: string[],
     unsignedTransaction: UnsignedTransaction,
   ) {
+    this.log(
+      `Enter ${identities.length - 1} commitments of the participants (excluding your own)`,
+    )
+
     const commitments = await ui.collectStrings('Commitment', identities.length - 1, {
       additionalStrings: [commitment],
       errorOnDuplicate: true,
@@ -320,8 +330,12 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
       this.error('Minimum number of participants must be at least 2')
     }
 
-    const identities = await ui.collectStrings('Identity', totalParticipants, {
-      additionalStrings: [],
+    this.log(
+      `Enter ${totalParticipants - 1} identities of the participants (excluding your own)`,
+    )
+
+    const identities = await ui.collectStrings('Identity', totalParticipants - 1, {
+      additionalStrings: [participant.identity],
       errorOnDuplicate: true,
     })
 


### PR DESCRIPTION
## Summary

Previously, this command was written in a way where the user performing this command didn't have to be a participant. This changes that to make sure that the user performing this command is a participant in the multisig wallet.

This is because this command is catering to the most common use case.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
