### PR TITLE
Use Chainport fallback token list API

### DIFF
--- a/ironfish-cli/src/utils/chainport/requests.ts
+++ b/ironfish-cli/src/utils/chainport/requests.ts
@@ -37,7 +37,7 @@ export const fetchChainportVerifiedTokens = async (
   networkId: number,
 ): Promise<ChainportVerifiedToken[]> => {
   const config = getConfig(networkId)
-  const url = `${config.endpoint}/token/list?network_name=IRONFISH`
+  const url = `${config.endpoint}/token_list?network_name=IRONFISH`
 
   return (await makeChainportRequest<{ verified_tokens: ChainportVerifiedToken[] }>(url))
     .verified_tokens


### PR DESCRIPTION
## Summary

Use the Chainport fallback API temporarily until we're ready to use the new one.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
