### PR TITLE
Temporarily assign different URL for mainnet

### DIFF
--- a/ironfish-cli/src/utils/chainport/requests.ts
+++ b/ironfish-cli/src/utils/chainport/requests.ts
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { MAINNET } from '@ironfish/sdk'
 import axios from 'axios'
 import { getConfig } from './config'
 import {
@@ -37,7 +38,12 @@ export const fetchChainportVerifiedTokens = async (
   networkId: number,
 ): Promise<ChainportVerifiedToken[]> => {
   const config = getConfig(networkId)
-  const url = `${config.endpoint}/token_list?network_name=IRONFISH`
+  let url
+  if (networkId === MAINNET.id) {
+    url = `${config.endpoint}/token/list?network_name=IRONFISH`
+  } else {
+    url = `${config.endpoint}/token_list?network_name=IRONFISH`
+  }
 
   return (await makeChainportRequest<{ verified_tokens: ChainportVerifiedToken[] }>(url))
     .verified_tokens


### PR DESCRIPTION
## Summary

This will be fixed with a more robust solution soon

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
