### PR TITLE
Detects whether ironfish dkg app is open

### DIFF
--- a/ironfish-cli/src/utils/ledger.ts
+++ b/ironfish-cli/src/utils/ledger.ts
@@ -75,6 +75,7 @@ export class LedgerDkg {
 
     const app = new IronfishDkgApp(transport, true)
 
+    // If the app isn't open or the device is locked, this will throw an error.
     await app.getVersion()
 
     this.app = app

--- a/ironfish-cli/src/utils/ledger.ts
+++ b/ironfish-cli/src/utils/ledger.ts
@@ -22,6 +22,7 @@ import IronfishApp, {
   ResponseViewKey,
 } from '@zondax/ledger-ironfish'
 import {
+  default as IronfishDkgApp,
   KeyResponse,
   ResponseAddress as ResponseAddressDkg,
   ResponseDkgRound1,
@@ -30,7 +31,6 @@ import {
   ResponseProofGenKey as ResponseProofGenKeyDkg,
   ResponseViewKey as ResponseViewKeyDkg,
 } from '@zondax/ledger-ironfish-dkg'
-import { default as IronfishDkgApp } from '@zondax/ledger-ironfish-dkg'
 import { ResponseError } from '@zondax/ledger-js'
 import * as ui from '../ui'
 import { watchTransaction } from './transaction'
@@ -74,6 +74,8 @@ export class LedgerDkg {
     }
 
     const app = new IronfishDkgApp(transport, true)
+
+    await app.getVersion()
 
     this.app = app
 


### PR DESCRIPTION
## Summary

Calling app.getVersion errors when the app is locked and when the app is not open. This is sufficient enough for us to detect whether the app is open or not.

If it isn't open, we just end the process for the dkg commands.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
