### PR TITLE
inputNumberPrompt and usage

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/dkg/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/create.ts
@@ -10,8 +10,8 @@ import {
   ACCOUNT_SCHEMA_VERSION,
   AccountFormat,
   Assert,
-  encodeAccountImport,
   RpcClient,
+  encodeAccountImport,
 } from '@ironfish/sdk'
 import { Flags } from '@oclif/core'
 import { IronfishCommand } from '../../../../command'
@@ -72,13 +72,13 @@ export class DkgCreateCommand extends IronfishCommand {
 
     const { name: participantName, identity } = ledger
       ? await ui.retryStep(
-          () => {
-            Assert.isNotUndefined(ledger)
-            return this.getIdentityFromLedger(ledger, client, flags.participant)
-          },
-          this.logger,
-          true,
-        )
+        () => {
+          Assert.isNotUndefined(ledger)
+          return this.getIdentityFromLedger(ledger, client, flags.participant)
+        },
+        this.logger,
+        true,
+      )
       : await this.getParticipant(client, flags.participant)
 
     this.log(`Identity for ${participantName}: \n${identity} \n`)
@@ -284,9 +284,13 @@ export class DkgCreateCommand extends IronfishCommand {
   }> {
     this.log('\nCollecting Participant Info and Performing Round 1...')
 
-    let input = await ui.inputPrompt('Enter the total number of participants', true)
-    const totalParticipants = parseInt(input)
-    if (isNaN(totalParticipants) || totalParticipants < 2) {
+    const totalParticipants = await ui.inputNumberPrompt(
+      this.logger,
+      'Enter the total number of participants',
+      { required: true, integer: true },
+    )
+
+    if (totalParticipants < 2) {
       throw new Error('Total number of participants must be at least 2')
     }
 
@@ -295,8 +299,7 @@ export class DkgCreateCommand extends IronfishCommand {
     }
 
     this.log(
-      `\nEnter ${
-        totalParticipants - 1
+      `\nEnter ${totalParticipants - 1
       } identities of all other participants (excluding yours) `,
     )
     const identities = await ui.collectStrings('Participant Identity', totalParticipants - 1, {
@@ -304,15 +307,11 @@ export class DkgCreateCommand extends IronfishCommand {
       errorOnDuplicate: true,
     })
 
-    input = await ui.inputPrompt('Enter the number of minimum signers', true)
-    const minSigners = parseInt(input)
-    if (isNaN(minSigners) || minSigners < 2) {
-      throw new Error('Minimum number of signers must be at least 2')
-    } else if (minSigners > totalParticipants) {
-      throw new Error(
-        'Minimum number of signers cannot be more than total number of participants',
-      )
-    }
+    const minSigners = await ui.inputNumberPrompt(
+      this.logger,
+      'Enter the number of minimum signers',
+      { required: true, integer: true },
+    )
 
     if (ledger) {
       const result = await this.performRound1WithLedger(
@@ -322,6 +321,7 @@ export class DkgCreateCommand extends IronfishCommand {
         identities,
         minSigners,
       )
+
       return {
         ...result,
         totalParticipants,

--- a/ironfish-cli/src/commands/wallet/multisig/dkg/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/create.ts
@@ -10,8 +10,8 @@ import {
   ACCOUNT_SCHEMA_VERSION,
   AccountFormat,
   Assert,
-  RpcClient,
   encodeAccountImport,
+  RpcClient,
 } from '@ironfish/sdk'
 import { Flags } from '@oclif/core'
 import { IronfishCommand } from '../../../../command'
@@ -72,13 +72,13 @@ export class DkgCreateCommand extends IronfishCommand {
 
     const { name: participantName, identity } = ledger
       ? await ui.retryStep(
-        () => {
-          Assert.isNotUndefined(ledger)
-          return this.getIdentityFromLedger(ledger, client, flags.participant)
-        },
-        this.logger,
-        true,
-      )
+          () => {
+            Assert.isNotUndefined(ledger)
+            return this.getIdentityFromLedger(ledger, client, flags.participant)
+          },
+          this.logger,
+          true,
+        )
       : await this.getParticipant(client, flags.participant)
 
     this.log(`Identity for ${participantName}: \n${identity} \n`)
@@ -299,7 +299,8 @@ export class DkgCreateCommand extends IronfishCommand {
     }
 
     this.log(
-      `\nEnter ${totalParticipants - 1
+      `\nEnter ${
+        totalParticipants - 1
       } identities of all other participants (excluding yours) `,
     )
     const identities = await ui.collectStrings('Participant Identity', totalParticipants - 1, {
@@ -312,6 +313,12 @@ export class DkgCreateCommand extends IronfishCommand {
       'Enter the number of minimum signers',
       { required: true, integer: true },
     )
+
+    if (minSigners < 2 || minSigners > totalParticipants) {
+      throw new Error(
+        'Minimum number of signers must be between 2 and the total number of participants',
+      )
+    }
 
     if (ledger) {
       const result = await this.performRound1WithLedger(

--- a/ironfish-cli/src/ui/prompt.ts
+++ b/ironfish-cli/src/ui/prompt.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import { Logger } from '@ironfish/sdk'
 import { ux } from '@oclif/core'
 import inquirer from 'inquirer'
 import { longPrompt } from './longPrompt'
@@ -43,6 +44,47 @@ async function _inputPrompt(message: string, options?: { password: boolean }): P
     message: `${message}:`,
   })
   return result.prompt.trim()
+}
+
+export async function inputNumberPrompt(
+  logger: Logger,
+  message: string,
+  options: {
+    required?: boolean
+    integer?: boolean
+  },
+): Promise<number> {
+  const validateNumber = (input: string): number => {
+    const num = Number(input)
+
+    if (isNaN(num)) {
+      throw new Error('Input must be a number')
+    }
+
+    if (options.integer && num % 1 !== 0) {
+      throw new Error('Input must be an integer')
+    }
+
+    return num
+  }
+
+  if (options.required) {
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      try {
+        const userInput = await _inputPrompt(message)
+        return validateNumber(userInput)
+      } catch (e) {
+        if (e instanceof Error) {
+          logger.error(e.message)
+        } else {
+          logger.error('An error occurred. Please try again.')
+        }
+      }
+    }
+  }
+
+  return validateNumber(await _inputPrompt(message))
 }
 
 export async function inputPrompt(


### PR DESCRIPTION
## Summary

Adds prompt util specific to numbers 

The problem with parse int is that even if you pass it something like "1234123asdf" it will return a success and return 1234123.
This is not what we want. We want to make sure that the user has entered a valid number.

We also want to retry the prompt if the user enters an invalid number or a decimal when an integer is expected.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
