### PR TITLE
displays own identity at start of signing process

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/sign.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/sign.ts
@@ -320,6 +320,9 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
     unsignedTransactionInput: string,
     ledger: LedgerDkg | undefined,
   ) {
+    this.log(`Identity for ${participant.name}: \n${participant.identity} \n`)
+    this.log('Share your participant identity with other signers.')
+
     const input = await ui.inputPrompt(
       'Enter the number of participants in signing this transaction',
       true,


### PR DESCRIPTION
## Summary

users must enter the identities of all signers (excluding their own) before creating a signing commitment

displays the user's own identity and asks the user to share it with other signers before prompting for the identities of other signers

## Testing Plan
manual testing:
<img width="544" alt="image" src="https://github.com/user-attachments/assets/795a5286-136e-455c-b756-4df7ef5a1ec8">


## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
