### PR TITLE
ensures that min signers entered is <= total participants

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/dkg/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/create.ts
@@ -308,6 +308,10 @@ export class DkgCreateCommand extends IronfishCommand {
     const minSigners = parseInt(input)
     if (isNaN(minSigners) || minSigners < 2) {
       throw new Error('Minimum number of signers must be at least 2')
+    } else if (minSigners > totalParticipants) {
+      throw new Error(
+        'Minimum number of signers cannot be more than total number of participants',
+      )
     }
 
     if (ledger) {


### PR DESCRIPTION
## Summary

the minimum number of signers cannot be greater than the number of total participants

throw an error when the user enters an invalid number instead of failing during round1

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
