### PR TITLE
uses actionable error message for common Ledger errors

### DIFF
--- a/ironfish-cli/src/utils/ledger.ts
+++ b/ironfish-cli/src/utils/ledger.ts
@@ -53,10 +53,8 @@ export class LedgerDkg {
         this.logger.debug(`Ledger ResponseError returnCode: ${error.returnCode.toString(16)}`)
         if (error.returnCode === LedgerDeviceLockedError.returnCode) {
           throw new LedgerDeviceLockedError('Please unlock your Ledger device.')
-        } else if (error.returnCode === LedgerAppNotOpenError.returnCode) {
-          throw new LedgerAppNotOpenError(
-            'Please open the Iron Fish app on your Ledger device.',
-          )
+        } else if (LedgerAppUnavailableError.returnCodes.includes(error.returnCode)) {
+          throw new LedgerAppUnavailableError()
         }
 
         throw new LedgerError(error.errorMessage)
@@ -445,8 +443,18 @@ export class LedgerDeviceLockedError extends LedgerError {
   static returnCode = 0x5515
 }
 
-export class LedgerAppNotOpenError extends LedgerError {
-  static returnCode = 0x6f00
+export class LedgerAppUnavailableError extends LedgerError {
+  static returnCodes = [
+    0x6d00, // Instruction not supported
+    0xffff, // Unknown transport error
+    0x6f00, // Technical error
+  ]
+
+  constructor() {
+    super(
+      `Unable to connect to Ironfish app on Ledger. Please check that the device is unlocked and the app is open.`,
+    )
+  }
 }
 
 export async function sendTransactionWithLedger(


### PR DESCRIPTION
## Summary

we've seen several errors occur commonly when the Ledger app is unavailable either because the device is locked or the app isn't open

catches errors with these codes and displays an error message telling the user that the error may be due to a locked device or closed app

## Testing Plan
before:
<img width="354" alt="image" src="https://github.com/user-attachments/assets/21a9d2d3-c4ba-4dcb-9177-15b3c28c3a9b">
<img width="362" alt="image" src="https://github.com/user-attachments/assets/2cd02c99-2bdf-47b1-bc3c-9d3ca8adcc56">

after:
<img width="890" alt="image" src="https://github.com/user-attachments/assets/c03d1794-7dc1-4042-8226-6db8dfb3a318">
<img width="884" alt="image" src="https://github.com/user-attachments/assets/1a57dacc-e9b0-46a3-9070-1b4974c362bd">

Note that `returnCode` in examples above is from debug outout

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
