### PR TITLE
Target network fees is in IRON

### DIFF
--- a/ironfish-cli/src/commands/wallet/chainport/send.ts
+++ b/ironfish-cli/src/commands/wallet/chainport/send.ts
@@ -342,12 +342,7 @@ export class BridgeCommand extends IronfishCommand {
     )
     const ironfishNetworkFee = CurrencyUtils.render(raw.fee, true)
 
-    const targetNetworkFee = CurrencyUtils.render(
-      BigInt(txn.gas_fee_output.amount),
-      true,
-      asset.web3_address,
-      assetData.verification,
-    )
+    const targetNetworkFee = CurrencyUtils.render(BigInt(txn.gas_fee_output.amount), true)
 
     let chainportFee: string
 


### PR DESCRIPTION
## Summary

Previously, we showed this fee as the token being sent to the target network. This was an incorrect assumption on our part.

The fee is actually taken in IRON. The chainport fee is the one that is always either in the target token or portx token.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
