### PR TITLE
Fixes fetching assets for display in wallet:transactions:info

### DIFF
--- a/ironfish-cli/src/commands/wallet/transactions/info.ts
+++ b/ironfish-cli/src/commands/wallet/transactions/info.ts
@@ -122,6 +122,7 @@ export class TransactionInfoCommand extends IronfishCommand {
 
       for (const note of transaction.notes) {
         const asset = await client.wallet.getAsset({
+          account: account,
           id: note.assetId,
         })
 


### PR DESCRIPTION
## Summary

We weren't passing the `account` flag to client.wallet.getAsset, so if your default account didn't happen to have a custom asset, the command would error.

## Testing Plan

Manually tested before/after on an account with a custom asset.

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
