### PR TITLE
Use Iron Fish API for bridge info

### DIFF
--- a/ironfish-cli/src/commands/wallet/chainport/send.ts
+++ b/ironfish-cli/src/commands/wallet/chainport/send.ts
@@ -283,7 +283,7 @@ export class BridgeCommand extends IronfishCommand {
   ) {
     const { flags } = await this.parse(BridgeCommand)
 
-    ux.action.start('Fetching bridge transaction fees')
+    ux.action.start('Fetching bridge transaction details')
     const txn = await fetchChainportBridgeTransaction(
       networkId,
       amount,

--- a/ironfish-cli/src/commands/wallet/transactions/info.ts
+++ b/ironfish-cli/src/commands/wallet/transactions/info.ts
@@ -16,7 +16,7 @@ import * as ui from '../../../ui'
 import {
   displayChainportTransactionSummary,
   extractChainportDataFromTransaction,
-  fetchChainportNetworkMap,
+  fetchChainportNetworks,
   getAssetsByIDs,
   useAccount,
 } from '../../../utils'
@@ -100,14 +100,17 @@ export class TransactionInfoCommand extends IronfishCommand {
       this.log(`\n---Chainport Bridge Transaction Summary---\n`)
 
       ux.action.start('Fetching network details')
-      const chainportNetworks = await fetchChainportNetworkMap(networkId)
+      const chainportNetworks = await fetchChainportNetworks(networkId)
+      const network = chainportNetworks.find(
+        (n) => n.chainport_network_id === chainportTxnDetails.chainportNetworkId,
+      )
       ux.action.stop()
 
       await displayChainportTransactionSummary(
         networkId,
         transaction,
         chainportTxnDetails,
-        chainportNetworks[chainportTxnDetails.chainportNetworkId],
+        network,
         this.logger,
       )
     }

--- a/ironfish-cli/src/commands/wallet/transactions/info.ts
+++ b/ironfish-cli/src/commands/wallet/transactions/info.ts
@@ -122,6 +122,7 @@ export class TransactionInfoCommand extends IronfishCommand {
 
       for (const note of transaction.notes) {
         const asset = await client.wallet.getAsset({
+          account: account,
           id: note.assetId,
         })
 

--- a/ironfish-cli/src/utils/chainport/config.ts
+++ b/ironfish-cli/src/utils/chainport/config.ts
@@ -6,8 +6,7 @@ import { MAINNET, TESTNET } from '@ironfish/sdk'
 
 const config = {
   [TESTNET.id]: {
-    chainportId: 22,
-    endpoint: 'https://preprod-api.chainport.io',
+    endpoint: 'https://testnet.api.ironfish.network/',
     outgoingAddresses: new Set([
       '06102d319ab7e77b914a1bd135577f3e266fd82a3e537a02db281421ed8b3d13',
       'db2cf6ec67addde84cc1092378ea22e7bb2eecdeecac5e43febc1cb8fb64b5e5',
@@ -18,8 +17,7 @@ const config = {
     ]),
   },
   [MAINNET.id]: {
-    chainportId: 22,
-    endpoint: 'https://api.chainport.io',
+    endpoint: 'https://api.ironfish.network/',
     outgoingAddresses: new Set([
       '576ffdcc27e11d81f5180d3dc5690294941170d492b2d9503c39130b1f180405',
       '7ac2d6a59e19e66e590d014af013cd5611dc146e631fa2aedf0ee3ed1237eebe',

--- a/ironfish-cli/src/utils/chainport/types.ts
+++ b/ironfish-cli/src/utils/chainport/types.ts
@@ -32,7 +32,7 @@ export type ChainportNetwork = {
   label: string
   // blockchain_type: string
   // native_token_symbol: string
-  // network_icon: string
+  network_icon: string
 }
 
 export type ChainportToken = {

--- a/ironfish-cli/src/utils/chainport/types.ts
+++ b/ironfish-cli/src/utils/chainport/types.ts
@@ -25,13 +25,8 @@ export type ChainportBridgeTransaction = {
 
 export type ChainportNetwork = {
   chainport_network_id: number
-  // shortname: string
-  // name: string
-  // chain_id: number
   explorer_url: string
   label: string
-  // blockchain_type: string
-  // native_token_symbol: string
   network_icon: string
 }
 

--- a/ironfish-cli/src/utils/chainport/types.ts
+++ b/ironfish-cli/src/utils/chainport/types.ts
@@ -25,25 +25,24 @@ export type ChainportBridgeTransaction = {
 
 export type ChainportNetwork = {
   chainport_network_id: number
-  shortname: string
-  name: string
-  chain_id: number
+  // shortname: string
+  // name: string
+  // chain_id: number
   explorer_url: string
   label: string
-  blockchain_type: string
-  native_token_symbol: string
-  network_icon: string
+  // blockchain_type: string
+  // native_token_symbol: string
+  // network_icon: string
 }
 
-export type ChainportVerifiedToken = {
-  decimals: number
+export type ChainportToken = {
   id: number
+  decimals: number
   name: string
   pinned: boolean
   web3_address: string
   symbol: string
   token_image: string
-  target_networks: number[]
   chain_id: number | null
   network_name: string
   network_id: number

--- a/ironfish-cli/src/utils/chainport/utils.ts
+++ b/ironfish-cli/src/utils/chainport/utils.ts
@@ -119,7 +119,7 @@ export const displayChainportTransactionSummary = async (
   if (data.type === TransactionType.RECEIVE) {
     logger.log(`
 Direction:                    Incoming
-Source Network:               ${network.name}
+Source Network:               ${network.label}
        Address:               ${data.address}
        Explorer Account:      ${network.explorer_url + 'address/' + data.address}
 Target (Ironfish) Network:    ${defaultNetworkName(networkId)}`)
@@ -134,7 +134,7 @@ Source Network:               ${defaultNetworkName(networkId)}
        Transaction Status:    ${transaction.status}
        Transaction Hash:      ${transaction.hash}
 ==============================================
-Target Network:               ${network.name}
+Target Network:               ${network.label}
        Address:               ${data.address}
        Explorer Account:      ${network.explorer_url + 'address/' + data.address}`
 
@@ -146,7 +146,6 @@ Target Network:               ${network.name}
 
   ux.action.start('Fetching transaction information on target network')
   const transactionStatus = await fetchChainportTransactionStatus(networkId, transaction.hash)
-  logger.log(`Transaction status fetched`)
   ux.action.stop()
 
   logger.log(basicInfo)
@@ -159,12 +158,11 @@ If this issue persists, please contact chainport support: https://helpdesk.chain
     return
   }
 
-  if (!transactionStatus.base_tx_hash || !transactionStatus.base_tx_status) {
-    logger.log(`       Transaction Status:    pending`)
-    return
-  }
-
-  if (transactionStatus.target_tx_hash === null) {
+  if (
+    !transactionStatus.base_tx_hash ||
+    !transactionStatus.base_tx_status ||
+    !transactionStatus.target_tx_hash
+  ) {
     logger.log(`       Transaction Status:    pending`)
     return
   }


### PR DESCRIPTION
## Summary

Switches from using the Chainport API directly to using a proxy through [our API](https://github.com/iron-fish/ironfish-api/pull/1767) to avoid breaking old CLI versions when Chainport deploys their new API.

Fixes IFL-2977

## Testing Plan

* [x] Loaded incoming and outgoing transactions on preprod
* [x] Went through the send flow up until confirmation (but didn't send) on prod
* [x] Went through the send flow up until confirmation on preprod (The preprod Iron Fish metadata API is currently down)

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
