### PR TITLE
Fix wallet:chainport:send fee selection when -a is used

### DIFF
--- a/ironfish-cli/src/commands/wallet/chainport/send.ts
+++ b/ironfish-cli/src/commands/wallet/chainport/send.ts
@@ -311,6 +311,7 @@ export class BridgeCommand extends IronfishCommand {
     if (params.fee === null && params.feeRate === null) {
       rawTransaction = await selectFee({
         client,
+        account: from,
         transaction: params,
         logger: this.logger,
       })

--- a/ironfish-cli/src/utils/fees.ts
+++ b/ironfish-cli/src/utils/fees.ts
@@ -20,7 +20,7 @@ import { promptCurrency } from './currency'
 export async function selectFee(options: {
   client: Pick<RpcClient, 'wallet'>
   transaction: CreateTransactionRequest
-  account?: string
+  account: string | undefined
   confirmations?: number
   logger: Logger
 }): Promise<RawTransaction> {


### PR DESCRIPTION
## Summary

`wallet:chainport:send`'s fee selector wasn't respecting the `-a` flag.

Fixes IFL-3003

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
