### PR TITLE
adds sessions to multisig server

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/dkg/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/create.ts
@@ -47,6 +47,10 @@ export class DkgCreateCommand extends IronfishCommand {
     server: Flags.string({
       description: "multisig server to connect to. formatted as '<host>:<port>'",
     }),
+    sessionId: Flags.string({
+      description: 'Unique ID for a multisig server session to join',
+      dependsOn: ['server'],
+    }),
   }
 
   async start(): Promise<void> {
@@ -90,6 +94,10 @@ export class DkgCreateCommand extends IronfishCommand {
 
       multisigClient = new MultisigTcpClient({ host, port, logger: this.logger })
       multisigClient.start()
+
+      if (flags.sessionId) {
+        multisigClient.joinSession(flags.sessionId)
+      }
     }
 
     const { name: participantName, identity } = ledger
@@ -105,9 +113,25 @@ export class DkgCreateCommand extends IronfishCommand {
 
     this.log(`Identity for ${participantName}: \n${identity} \n`)
 
-    const { round1, totalParticipants } = await ui.retryStep(
+    const { totalParticipants, minSigners } = await ui.retryStep(
       async () => {
-        return this.performRound1(client, multisigClient, participantName, identity, ledger)
+        return this.getDkgConfig(multisigClient, !!ledger)
+      },
+      this.logger,
+      true,
+    )
+
+    const { round1 } = await ui.retryStep(
+      async () => {
+        return this.performRound1(
+          client,
+          multisigClient,
+          participantName,
+          identity,
+          totalParticipants,
+          minSigners,
+          ledger,
+        )
       },
       this.logger,
       true,
@@ -274,6 +298,65 @@ export class DkgCreateCommand extends IronfishCommand {
     }
   }
 
+  async getDkgConfig(
+    multisigClient: MultisigTcpClient | null,
+    ledger: boolean,
+  ): Promise<{ totalParticipants: number; minSigners: number }> {
+    if (multisigClient?.sessionId) {
+      let totalParticipants = 0
+      let minSigners = 0
+      let waiting = true
+      multisigClient.onDkgStatus.on((message) => {
+        totalParticipants = message.maxSigners
+        minSigners = message.minSigners
+        waiting = false
+      })
+      multisigClient.getDkgStatus()
+
+      ux.action.start('Waiting for signer config from server')
+      while (waiting) {
+        await PromiseUtils.sleep(3000)
+      }
+      multisigClient.onDkgStatus.clear()
+      ux.action.stop()
+
+      return { totalParticipants, minSigners }
+    }
+
+    const totalParticipants = await ui.inputNumberPrompt(
+      this.logger,
+      'Enter the total number of participants',
+      { required: true, integer: true },
+    )
+
+    if (totalParticipants < 2) {
+      throw new Error('Total number of participants must be at least 2')
+    }
+
+    if (ledger && totalParticipants > 4) {
+      throw new Error('DKG with Ledger supports a maximum of 4 participants')
+    }
+
+    const minSigners = await ui.inputNumberPrompt(
+      this.logger,
+      'Enter the number of minimum signers',
+      { required: true, integer: true },
+    )
+
+    if (minSigners < 2 || minSigners > totalParticipants) {
+      throw new Error(
+        'Minimum number of signers must be between 2 and the total number of participants',
+      )
+    }
+
+    if (multisigClient) {
+      multisigClient.startDkgSession(totalParticipants, minSigners)
+      this.log(`Started new DKG server session with ID ${multisigClient.sessionId}`)
+    }
+
+    return { totalParticipants, minSigners }
+  }
+
   async performRound1WithLedger(
     ledger: LedgerDkg,
     client: RpcClient,
@@ -306,59 +389,13 @@ export class DkgCreateCommand extends IronfishCommand {
     multisigClient: MultisigTcpClient | null,
     participantName: string,
     currentIdentity: string,
+    totalParticipants: number,
+    minSigners: number,
     ledger: LedgerDkg | undefined,
   ): Promise<{
     round1: { secretPackage: string; publicPackage: string }
-    totalParticipants: number
   }> {
     this.log('\nCollecting Participant Info and Performing Round 1...')
-
-    let totalParticipants
-    let minSigners
-    if (!multisigClient) {
-      totalParticipants = await ui.inputNumberPrompt(
-        this.logger,
-        'Enter the total number of participants',
-        { required: true, integer: true },
-      )
-
-      if (totalParticipants < 2) {
-        throw new Error('Total number of participants must be at least 2')
-      }
-
-      if (ledger && totalParticipants > 4) {
-        throw new Error('DKG with Ledger supports a maximum of 4 participants')
-      }
-
-      minSigners = await ui.inputNumberPrompt(
-        this.logger,
-        'Enter the number of minimum signers',
-        { required: true, integer: true },
-      )
-
-      if (minSigners < 2 || minSigners > totalParticipants) {
-        throw new Error(
-          'Minimum number of signers must be between 2 and the total number of participants',
-        )
-      }
-    } else {
-      let waiting = true
-      multisigClient.onDkgStatus.on((message) => {
-        totalParticipants = message.maxSigners
-        minSigners = message.minSigners
-        waiting = false
-      })
-      multisigClient.getDkgStatus()
-
-      ux.action.start('Waiting for signer config from server')
-      while (waiting) {
-        await PromiseUtils.sleep(3000)
-      }
-      multisigClient.onDkgStatus.clear()
-      ux.action.stop()
-    }
-    Assert.isNotUndefined(totalParticipants)
-    Assert.isNotUndefined(minSigners)
 
     let identities: string[] = []
     if (!multisigClient) {
@@ -372,6 +409,8 @@ export class DkgCreateCommand extends IronfishCommand {
         errorOnDuplicate: true,
       })
     } else {
+      multisigClient.submitIdentity(currentIdentity)
+
       multisigClient.onDkgStatus.on((message) => {
         identities = message.identities
       })
@@ -380,31 +419,26 @@ export class DkgCreateCommand extends IronfishCommand {
           identities.push(message.identity)
         }
       })
-      multisigClient.getDkgStatus()
-      multisigClient.submitIdentity(currentIdentity)
 
       ux.action.start('Waiting for other Identities from server')
       while (identities.length < totalParticipants) {
+        multisigClient.getDkgStatus()
         await PromiseUtils.sleep(3000)
       }
+
       multisigClient.onDkgStatus.clear()
       multisigClient.onIdentity.clear()
       ux.action.stop()
     }
 
     if (ledger) {
-      const result = await this.performRound1WithLedger(
+      return await this.performRound1WithLedger(
         ledger,
         client,
         participantName,
         identities,
         minSigners,
       )
-
-      return {
-        ...result,
-        totalParticipants,
-      }
     }
 
     this.log('\nPerforming DKG Round 1...')
@@ -419,7 +453,6 @@ export class DkgCreateCommand extends IronfishCommand {
         secretPackage: response.content.round1SecretPackage,
         publicPackage: response.content.round1PublicPackage,
       },
-      totalParticipants,
     }
   }
 
@@ -470,6 +503,7 @@ export class DkgCreateCommand extends IronfishCommand {
         },
       )
     } else {
+      multisigClient.submitRound1PublicPackage(round1Result.publicPackage)
       multisigClient.onDkgStatus.on((message) => {
         round1PublicPackages = message.round1PublicPackages
       })
@@ -478,13 +512,13 @@ export class DkgCreateCommand extends IronfishCommand {
           round1PublicPackages.push(message.package)
         }
       })
-      multisigClient.getDkgStatus()
-      multisigClient.submitRound1PublicPackage(round1Result.publicPackage)
 
       ux.action.start('Waiting for other Round 1 Public Packages from server')
       while (round1PublicPackages.length < totalParticipants) {
+        multisigClient.getDkgStatus()
         await PromiseUtils.sleep(3000)
       }
+
       multisigClient.onDkgStatus.clear()
       multisigClient.onRound1PublicPackage.clear()
       ux.action.stop()
@@ -642,6 +676,7 @@ export class DkgCreateCommand extends IronfishCommand {
         },
       )
     } else {
+      multisigClient.submitRound2PublicPackage(round2Result.publicPackage)
       multisigClient.onDkgStatus.on((message) => {
         round2PublicPackages = message.round2PublicPackages
       })
@@ -650,13 +685,13 @@ export class DkgCreateCommand extends IronfishCommand {
           round2PublicPackages.push(message.package)
         }
       })
-      multisigClient.getDkgStatus()
-      multisigClient.submitRound2PublicPackage(round2Result.publicPackage)
 
       ux.action.start('Waiting for other Round 2 Public Packages from server')
       while (round2PublicPackages.length < totalParticipants) {
+        multisigClient.getDkgStatus()
         await PromiseUtils.sleep(3000)
       }
+
       multisigClient.onDkgStatus.clear()
       multisigClient.onRound2PublicPackage.clear()
       ux.action.stop()

--- a/ironfish-cli/src/commands/wallet/multisig/server.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/server.ts
@@ -19,28 +19,12 @@ export class MultisigServerCommand extends IronfishCommand {
       description: 'port for the multisig server',
       default: 9035,
     }),
-    maxSigners: Flags.integer({
-      description: 'total number of participants in multisig account',
-      required: true,
-    }),
-    minSigners: Flags.integer({
-      description: 'minimum number of multisig signers',
-      required: true,
-    }),
   }
 
   async start(): Promise<void> {
     const { flags } = await this.parse(MultisigServerCommand)
 
-    const status = {
-      maxSigners: flags.maxSigners,
-      minSigners: flags.minSigners,
-      identities: [],
-      round1PublicPackages: [],
-      round2PublicPackages: [],
-    }
-
-    const server = new MultisigServer(status, { logger: this.logger })
+    const server = new MultisigServer({ logger: this.logger })
 
     const adapter = new MultisigTcpAdapter({
       logger: this.logger,

--- a/ironfish-cli/src/utils/multisig/network/messages.ts
+++ b/ironfish-cli/src/utils/multisig/network/messages.ts
@@ -6,20 +6,24 @@ import * as yup from 'yup'
 export type StratumMessage = {
   id: number
   method: string
+  sessionId: string
   body?: unknown
 }
 
-export interface StratumMessageWithError extends Omit<StratumMessage, 'method' | 'body'> {
+export interface StratumMessageWithError
+  extends Omit<StratumMessage, 'method' | 'body' | 'sessionId'> {
   error: {
     id: number
     message: string
   }
 }
 
-export type DkgConfigMessage = {
+export type DkgStartSessionMessage = {
   minSigners: number
   maxSigners: number
 }
+
+export type JoinSessionMessage = object | undefined
 
 export type IdentityMessage = {
   identity: string
@@ -47,6 +51,7 @@ export const StratumMessageSchema: yup.ObjectSchema<StratumMessage> = yup
   .object({
     id: yup.number().required(),
     method: yup.string().required(),
+    sessionId: yup.string().required(),
     body: yup.mixed().notRequired(),
   })
   .required()
@@ -63,12 +68,17 @@ export const StratumMessageWithErrorSchema: yup.ObjectSchema<StratumMessageWithE
   })
   .required()
 
-export const DkgConfigSchema: yup.ObjectSchema<DkgConfigMessage> = yup
+export const DkgStartSessionSchema: yup.ObjectSchema<DkgStartSessionMessage> = yup
   .object({
     minSigners: yup.number().defined(),
     maxSigners: yup.number().defined(),
   })
   .defined()
+
+export const JoinSessionSchema: yup.ObjectSchema<JoinSessionMessage> = yup
+  .object({})
+  .notRequired()
+  .default(undefined)
 
 export const IdentitySchema: yup.ObjectSchema<IdentityMessage> = yup
   .object({

--- a/ironfish-cli/src/utils/multisig/network/serverClient.ts
+++ b/ironfish-cli/src/utils/multisig/network/serverClient.ts
@@ -10,6 +10,7 @@ export class MultisigServerClient {
   connected: boolean
   remoteAddress: string
   messageBuffer: MessageBuffer
+  sessionId: string | null = null
 
   private constructor(options: { socket: net.Socket; id: number }) {
     this.id = options.id


### PR DESCRIPTION
## Summary

supports using a single server for multiple runs of dkg and/or signing

updates 'wallet:multisig:dkg:create' to join an existing session with the 'sessionId' flag or create a new session if none is specified

uses UUID strings for session IDs

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
