### PR TITLE
multisig server signing

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/sign.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/sign.ts
@@ -228,7 +228,7 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
       this.logger,
     )
 
-    this.log('Mutlisignature sign process completed!')
+    this.log('Multisignature sign process completed!')
     multisigClient?.stop()
   }
 

--- a/ironfish-cli/src/commands/wallet/multisig/sign.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/sign.ts
@@ -251,7 +251,7 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
       while (waiting) {
         await PromiseUtils.sleep(3000)
       }
-      multisigClient.onDkgStatus.clear()
+      multisigClient.onSigningStatus.clear()
       ux.action.stop()
 
       const unsignedTransaction = new UnsignedTransaction(
@@ -324,8 +324,8 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
         await PromiseUtils.sleep(3000)
       }
 
-      multisigClient.onDkgStatus.clear()
-      multisigClient.onIdentity.clear()
+      multisigClient.onSigningStatus.clear()
+      multisigClient.onSignatureShare.clear()
       ux.action.stop()
     }
 
@@ -446,8 +446,8 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
         await PromiseUtils.sleep(3000)
       }
 
-      multisigClient.onDkgStatus.clear()
-      multisigClient.onIdentity.clear()
+      multisigClient.onSigningStatus.clear()
+      multisigClient.onSigningCommitment.clear()
       ux.action.stop()
     }
 

--- a/ironfish-cli/src/utils/multisig/network/messages.ts
+++ b/ironfish-cli/src/utils/multisig/network/messages.ts
@@ -23,6 +23,11 @@ export type DkgStartSessionMessage = {
   maxSigners: number
 }
 
+export type SigningStartSessionMessage = {
+  numSigners: number
+  unsignedTransaction: string
+}
+
 export type JoinSessionMessage = object | undefined
 
 export type IdentityMessage = {
@@ -37,6 +42,14 @@ export type Round2PublicPackageMessage = {
   package: string
 }
 
+export type SigningCommitmentMessage = {
+  signingCommitment: string
+}
+
+export type SignatureShareMessage = {
+  signatureShare: string
+}
+
 export type DkgGetStatusMessage = object | undefined
 
 export type DkgStatusMessage = {
@@ -45,6 +58,16 @@ export type DkgStatusMessage = {
   identities: string[]
   round1PublicPackages: string[]
   round2PublicPackages: string[]
+}
+
+export type SigningGetStatusMessage = object | undefined
+
+export type SigningStatusMessage = {
+  numSigners: number
+  unsignedTransaction: string
+  identities: string[]
+  signingCommitments: string[]
+  signatureShares: string[]
 }
 
 export const StratumMessageSchema: yup.ObjectSchema<StratumMessage> = yup
@@ -75,6 +98,13 @@ export const DkgStartSessionSchema: yup.ObjectSchema<DkgStartSessionMessage> = y
   })
   .defined()
 
+export const SigningStartSessionSchema: yup.ObjectSchema<SigningStartSessionMessage> = yup
+  .object({
+    numSigners: yup.number().defined(),
+    unsignedTransaction: yup.string().defined(),
+  })
+  .defined()
+
 export const JoinSessionSchema: yup.ObjectSchema<JoinSessionMessage> = yup
   .object({})
   .notRequired()
@@ -94,6 +124,14 @@ export const Round2PublicPackageSchema: yup.ObjectSchema<Round2PublicPackageMess
   .object({ package: yup.string().defined() })
   .defined()
 
+export const SigningCommitmentSchema: yup.ObjectSchema<SigningCommitmentMessage> = yup
+  .object({ signingCommitment: yup.string().defined() })
+  .defined()
+
+export const SignatureShareSchema: yup.ObjectSchema<SignatureShareMessage> = yup
+  .object({ signatureShare: yup.string().defined() })
+  .defined()
+
 export const DkgGetStatusSchema: yup.ObjectSchema<DkgGetStatusMessage> = yup
   .object({})
   .notRequired()
@@ -106,5 +144,20 @@ export const DkgStatusSchema: yup.ObjectSchema<DkgStatusMessage> = yup
     identities: yup.array(yup.string().defined()).defined(),
     round1PublicPackages: yup.array(yup.string().defined()).defined(),
     round2PublicPackages: yup.array(yup.string().defined()).defined(),
+  })
+  .defined()
+
+export const SigningGetStatusSchema: yup.ObjectSchema<SigningGetStatusMessage> = yup
+  .object({})
+  .notRequired()
+  .default(undefined)
+
+export const SigningStatusSchema: yup.ObjectSchema<SigningStatusMessage> = yup
+  .object({
+    numSigners: yup.number().defined(),
+    unsignedTransaction: yup.string().defined(),
+    identities: yup.array(yup.string().defined()).defined(),
+    signingCommitments: yup.array(yup.string().defined()).defined(),
+    signatureShares: yup.array(yup.string().defined()).defined(),
   })
   .defined()


### PR DESCRIPTION
## Summary

defines common interface for storing dkg sessions and signing sessions in server memory

adds network messages for signing flow: starting a signing session, signing commitments, signature shares, and retrieving the status of a signing session

updates server and client implementations for new message types

updates 'sign' command:
- adds '--server' flag
- adds '--sessionId' flag
- prompts user to enter a session id or start a new session if server is set, but not session id
- connects to server, starts or joins a session, and uses messages to/from server to complete signing

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
