### PR TITLE
Adding zondax/ledger-js dependency

### DIFF
--- a/ironfish-cli/package.json
+++ b/ironfish-cli/package.json
@@ -70,6 +70,7 @@
     "@types/keccak": "3.0.4",
     "@types/tar": "6.1.1",
     "@zondax/ledger-ironfish": "0.5.1",
+    "@zondax/ledger-js": "1.0.1",
     "axios": "1.7.2",
     "bech32": "2.0.0",
     "blessed": "0.1.81",

--- a/ironfish-cli/src/utils/ledger.ts
+++ b/ironfish-cli/src/utils/ledger.ts
@@ -26,7 +26,7 @@ import IronfishApp, {
   ResponseSign,
   ResponseViewKey,
 } from '@zondax/ledger-ironfish'
-import { ResponseError } from '@zondax/ledger-js'
+import { ResponseError } from '@zondax/ledger-js' // todo: ResponseError will be exported from @zondax/ledger-ironfish in the future. Remove this line when it happens.
 import * as ui from '../ui'
 import { watchTransaction } from './transaction'
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3909,7 +3909,7 @@
   dependencies:
     "@zondax/ledger-js" "^1.0.1"
 
-"@zondax/ledger-js@^1.0.1":
+"@zondax/ledger-js@1.0.1", "@zondax/ledger-js@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@zondax/ledger-js/-/ledger-js-1.0.1.tgz#a1c51943c5b7d1370cea588b193197234485d196"
   integrity sha512-9h+aIXyEK+Rdic5Ppsmq+tptDFwPTacG1H6tpZHFdhtBFHYFOLLkKTTmq5rMTv84aAPS1v0tnsF1e2Il6M05Cg==


### PR DESCRIPTION
## Summary

zondax/ledger-js is a subdependency of @zondax/ledger-ironfish. We rely on the ResponseError type from ledger-js which should ideally be exported from zondax/ledger-ironfish. This way we don't have to explicitly include this subdependency in our package.json.

A todo has been added to remove this dependency when the ResponseError type is exported from ledger-ironfish.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
