### PR TITLE
encrypts multisig server messages

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/dkg/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/create.ts
@@ -51,6 +51,10 @@ export class DkgCreateCommand extends IronfishCommand {
       description: 'Unique ID for a multisig server session to join',
       dependsOn: ['server'],
     }),
+    passphrase: Flags.string({
+      description: 'Passphrase to join the multisig server session',
+      dependsOn: ['server'],
+    }),
     tls: Flags.boolean({
       description: 'connect to the multisig server over TLS',
       dependsOn: ['server'],
@@ -89,14 +93,28 @@ export class DkgCreateCommand extends IronfishCommand {
 
     let multisigClient: MultisigClient | null = null
     if (flags.server) {
+      let sessionId = flags.sessionId
+      if (!sessionId) {
+        sessionId = await ui.inputPrompt(
+          'Enter the ID of a multisig session to join, or press enter to start a new session',
+          false,
+        )
+      }
+
+      let passphrase = flags.passphrase
+      if (!passphrase) {
+        passphrase = await ui.inputPrompt('Enter the passphrase for the multisig session', true)
+      }
+
       multisigClient = await MultisigBrokerUtils.createClient(flags.server, {
+        passphrase,
         tls: flags.tls,
         logger: this.logger,
       })
       multisigClient.start()
 
-      if (flags.sessionId) {
-        multisigClient.joinSession(flags.sessionId)
+      if (sessionId) {
+        multisigClient.joinSession(sessionId)
       }
     }
 

--- a/ironfish-cli/src/commands/wallet/multisig/sign.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/sign.ts
@@ -52,6 +52,10 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
       description: 'Unique ID for a multisig server session to join',
       dependsOn: ['server'],
     }),
+    passphrase: Flags.string({
+      description: 'Passphrase to join the multisig server session',
+      dependsOn: ['server'],
+    }),
     tls: Flags.boolean({
       description: 'connect to the multisig server over TLS',
       dependsOn: ['server'],
@@ -120,12 +124,6 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
 
     let multisigClient: MultisigClient | null = null
     if (flags.server) {
-      multisigClient = await MultisigBrokerUtils.createClient(flags.server, {
-        tls: flags.tls,
-        logger: this.logger,
-      })
-      multisigClient.start()
-
       let sessionId = flags.sessionId
       if (!sessionId) {
         sessionId = await ui.inputPrompt(
@@ -133,6 +131,18 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
           false,
         )
       }
+
+      let passphrase = flags.passphrase
+      if (!passphrase) {
+        passphrase = await ui.inputPrompt('Enter the passphrase for the multisig session', true)
+      }
+
+      multisigClient = await MultisigBrokerUtils.createClient(flags.server, {
+        passphrase,
+        tls: flags.tls,
+        logger: this.logger,
+      })
+      multisigClient.start()
 
       if (sessionId) {
         multisigClient.joinSession(sessionId)

--- a/ironfish-cli/src/multisigBroker/clients/tcpClient.ts
+++ b/ironfish-cli/src/multisigBroker/clients/tcpClient.ts
@@ -11,8 +11,8 @@ export class MultisigTcpClient extends MultisigClient {
 
   client: net.Socket | null = null
 
-  constructor(options: { host: string; port: number; logger: Logger }) {
-    super({ logger: options.logger })
+  constructor(options: { host: string; port: number; passphrase: string; logger: Logger }) {
+    super({ passphrase: options.passphrase, logger: options.logger })
     this.host = options.host
     this.port = options.port
   }

--- a/ironfish-cli/src/multisigBroker/utils.ts
+++ b/ironfish-cli/src/multisigBroker/utils.ts
@@ -7,7 +7,7 @@ import { MultisigClient, MultisigTcpClient, MultisigTlsClient } from './clients'
 
 async function createClient(
   serverAddress: string,
-  options: { tls: boolean; logger: Logger },
+  options: { passphrase: string; tls: boolean; logger: Logger },
 ): Promise<MultisigClient> {
   const parsed = parseUrl(serverAddress)
 
@@ -19,9 +19,19 @@ async function createClient(
   const port = parsed.port
 
   if (options.tls) {
-    return new MultisigTlsClient({ host, port, logger: options.logger })
+    return new MultisigTlsClient({
+      host,
+      port,
+      passphrase: options.passphrase,
+      logger: options.logger,
+    })
   } else {
-    return new MultisigTcpClient({ host, port, logger: options.logger })
+    return new MultisigTcpClient({
+      host,
+      port,
+      passphrase: options.passphrase,
+      logger: options.logger,
+    })
   }
 }
 


### PR DESCRIPTION
## Summary

uses xchacha20poly1305 to encrypt all string fields in messages sent to multisig server

client decrypts string fields in messages received from multisig server

derives the client key from a passphrase and the session ID (uses the bytes of the session ID, which is a UUID, for the salt and nonce). ensures that any client in the session can derive the key if they have the passphrase.

adds passphrase flags and prompts to dkg:create and multisig:sign

NOTE: numeric fields, like minSigners, are not currently encrypted

NOTE also: this encrypts the fields rather than the entire message so that the server can still distinguish between identities, publlc packages, etc. in its session state

Closes IFL-3013

## Testing Plan
manual testing:
- ran 'dkg:create' with two participants using a passphrase

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
