### PR TITLE
fixes default tls flag in multisig commands

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/dkg/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/create.ts
@@ -59,7 +59,6 @@ export class DkgCreateCommand extends IronfishCommand {
       description: 'connect to the multisig server over TLS',
       dependsOn: ['server'],
       allowNo: true,
-      default: true,
     }),
   }
 
@@ -108,7 +107,7 @@ export class DkgCreateCommand extends IronfishCommand {
 
       multisigClient = await MultisigBrokerUtils.createClient(flags.server, {
         passphrase,
-        tls: flags.tls,
+        tls: flags.tls ?? true,
         logger: this.logger,
       })
       multisigClient.start()

--- a/ironfish-cli/src/commands/wallet/multisig/sign.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/sign.ts
@@ -60,7 +60,6 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
       description: 'connect to the multisig server over TLS',
       dependsOn: ['server'],
       allowNo: true,
-      default: true,
     }),
   }
 
@@ -139,7 +138,7 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
 
       multisigClient = await MultisigBrokerUtils.createClient(flags.server, {
         passphrase,
-        tls: flags.tls,
+        tls: flags.tls ?? true,
         logger: this.logger,
       })
       multisigClient.start()


### PR DESCRIPTION
## Summary

updates 'dkg:create' and 'multisig:sign' not to set the '--tls' flag by default. since this flag depends on the '--server' flag this means that the '--server' flag must also be provided by default

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
