### PR TITLE
multisig broker server broadcasts on step completions

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/dkg/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/create.ts
@@ -405,15 +405,10 @@ export class DkgCreateCommand extends IronfishCommand {
         errorOnDuplicate: true,
       })
     } else {
-      multisigClient.submitIdentity(currentIdentity)
+      multisigClient.submitDkgIdentity(currentIdentity)
 
       multisigClient.onDkgStatus.on((message) => {
         identities = message.identities
-      })
-      multisigClient.onIdentity.on((message) => {
-        if (!identities.includes(message.identity)) {
-          identities.push(message.identity)
-        }
       })
 
       ux.action.start('Waiting for other Identities from server')
@@ -423,7 +418,6 @@ export class DkgCreateCommand extends IronfishCommand {
       }
 
       multisigClient.onDkgStatus.clear()
-      multisigClient.onIdentity.clear()
       ux.action.stop()
     }
 
@@ -511,11 +505,6 @@ export class DkgCreateCommand extends IronfishCommand {
       multisigClient.onDkgStatus.on((message) => {
         round1PublicPackages = message.round1PublicPackages
       })
-      multisigClient.onRound1PublicPackage.on((message) => {
-        if (!round1PublicPackages.includes(message.package)) {
-          round1PublicPackages.push(message.package)
-        }
-      })
 
       ux.action.start('Waiting for other Round 1 Public Packages from server')
       while (round1PublicPackages.length < totalParticipants) {
@@ -524,7 +513,6 @@ export class DkgCreateCommand extends IronfishCommand {
       }
 
       multisigClient.onDkgStatus.clear()
-      multisigClient.onRound1PublicPackage.clear()
       ux.action.stop()
     }
 
@@ -703,11 +691,6 @@ export class DkgCreateCommand extends IronfishCommand {
       multisigClient.onDkgStatus.on((message) => {
         round2PublicPackages = message.round2PublicPackages
       })
-      multisigClient.onRound2PublicPackage.on((message) => {
-        if (!round2PublicPackages.includes(message.package)) {
-          round2PublicPackages.push(message.package)
-        }
-      })
 
       ux.action.start('Waiting for other Round 2 Public Packages from server')
       while (round2PublicPackages.length < totalParticipants) {
@@ -716,7 +699,6 @@ export class DkgCreateCommand extends IronfishCommand {
       }
 
       multisigClient.onDkgStatus.clear()
-      multisigClient.onRound2PublicPackage.clear()
       ux.action.stop()
     }
 

--- a/ironfish-cli/src/commands/wallet/multisig/sign.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/sign.ts
@@ -239,10 +239,10 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
         unsignedTransactionHex = message.unsignedTransaction
         waiting = false
       })
-      multisigClient.getSigningStatus()
 
       ux.action.start('Waiting for signer config from server')
       while (waiting) {
+        multisigClient.getSigningStatus()
         await PromiseUtils.sleep(3000)
       }
       multisigClient.onSigningStatus.clear()
@@ -314,11 +314,6 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
       multisigClient.onSigningStatus.on((message) => {
         signatureShares = message.signatureShares
       })
-      multisigClient.onSignatureShare.on((message) => {
-        if (!signatureShares.includes(message.signatureShare)) {
-          signatureShares.push(message.signatureShare)
-        }
-      })
 
       ux.action.start('Waiting for other Signature Shares from server')
       while (signatureShares.length < totalParticipants) {
@@ -327,7 +322,6 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
       }
 
       multisigClient.onSigningStatus.clear()
-      multisigClient.onSignatureShare.clear()
       ux.action.stop()
     }
 
@@ -448,11 +442,6 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
       multisigClient.onSigningStatus.on((message) => {
         commitments = message.signingCommitments
       })
-      multisigClient.onSigningCommitment.on((message) => {
-        if (!commitments.includes(message.signingCommitment)) {
-          commitments.push(message.signingCommitment)
-        }
-      })
 
       ux.action.start('Waiting for other Signing Commitments from server')
       while (commitments.length < totalParticipants) {
@@ -461,7 +450,6 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
       }
 
       multisigClient.onSigningStatus.clear()
-      multisigClient.onSigningCommitment.clear()
       ux.action.stop()
     }
 
@@ -497,15 +485,10 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
         errorOnDuplicate: true,
       })
     } else {
-      multisigClient.submitIdentity(participant.identity)
+      multisigClient.submitSigningIdentity(participant.identity)
 
       multisigClient.onSigningStatus.on((message) => {
         identities = message.identities
-      })
-      multisigClient.onIdentity.on((message) => {
-        if (!identities.includes(message.identity)) {
-          identities.push(message.identity)
-        }
       })
 
       ux.action.start('Waiting for other Identities from server')
@@ -515,7 +498,6 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
       }
 
       multisigClient.onSigningStatus.clear()
-      multisigClient.onIdentity.clear()
       ux.action.stop()
     }
 


### PR DESCRIPTION
## Summary

uses maxSigners for dkg and numSigners for signing to broadcast the session status once the required number of  participants have submitted data of a particular type

removes broadcasts of individual identities, packages, etc.

removes client handlers for messages containing individual identities, packages, etc.

simplifies client logic for waiting on data from server: only uses status messages instead of listening for individual identities etc AND polling status

distinguishes message methods for dkg identities and signing identities. the message bodies are the same, but it allows the server to distinguish how to handle the session

Closes IFL-3024

## Testing Plan
manual testing:
- created multisig account with `wallet:multisig:dkg:create` via server
- signed transaction using `wallet:multisig:sign` via server

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
