### PR TITLE
Cleanup sessions on Multisig Broker Server

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/dkg/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/create.ts
@@ -112,13 +112,22 @@ export class DkgCreateCommand extends IronfishCommand {
       })
       multisigClient.start()
 
+      let connectionConfirmed = false
+
       multisigClient.onConnectedMessage.on(() => {
-        if (sessionId) {
-          Assert.isNotNull(multisigClient)
-          multisigClient.joinSession(sessionId)
-          multisigClient.onConnectedMessage.clear()
-        }
+        connectionConfirmed = true
+        Assert.isNotNull(multisigClient)
+        multisigClient.onConnectedMessage.clear()
       })
+
+      if (sessionId) {
+        while (!connectionConfirmed) {
+          await PromiseUtils.sleep(500)
+          continue
+        }
+
+        multisigClient.joinSession(sessionId)
+      }
     }
 
     const { name: participantName, identity } = ledger

--- a/ironfish-cli/src/commands/wallet/multisig/dkg/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/create.ts
@@ -112,9 +112,13 @@ export class DkgCreateCommand extends IronfishCommand {
       })
       multisigClient.start()
 
-      if (sessionId) {
-        multisigClient.joinSession(sessionId)
-      }
+      multisigClient.onConnectedMessage.on(() => {
+        if (sessionId) {
+          Assert.isNotNull(multisigClient)
+          multisigClient.joinSession(sessionId)
+          multisigClient.onConnectedMessage.clear()
+        }
+      })
     }
 
     const { name: participantName, identity } = ledger

--- a/ironfish-cli/src/commands/wallet/multisig/sign.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/sign.ts
@@ -4,6 +4,7 @@
 
 import { multisig } from '@ironfish/rust-nodejs'
 import {
+  Assert,
   CurrencyUtils,
   Identity,
   PromiseUtils,
@@ -143,9 +144,13 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
       })
       multisigClient.start()
 
-      if (sessionId) {
-        multisigClient.joinSession(sessionId)
-      }
+      multisigClient.onConnectedMessage.on(() => {
+        if (sessionId) {
+          Assert.isNotNull(multisigClient)
+          multisigClient.joinSession(sessionId)
+          multisigClient.onConnectedMessage.clear()
+        }
+      })
     }
 
     const { unsignedTransaction, totalParticipants } = await this.getSigningConfig(

--- a/ironfish-cli/src/commands/wallet/multisig/sign.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/sign.ts
@@ -144,13 +144,22 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
       })
       multisigClient.start()
 
+      let connectionConfirmed = false
+
       multisigClient.onConnectedMessage.on(() => {
-        if (sessionId) {
-          Assert.isNotNull(multisigClient)
-          multisigClient.joinSession(sessionId)
-          multisigClient.onConnectedMessage.clear()
-        }
+        connectionConfirmed = true
+        Assert.isNotNull(multisigClient)
+        multisigClient.onConnectedMessage.clear()
       })
+
+      if (sessionId) {
+        while (!connectionConfirmed) {
+          await PromiseUtils.sleep(500)
+          continue
+        }
+
+        multisigClient.joinSession(sessionId)
+      }
     }
 
     const { unsignedTransaction, totalParticipants } = await this.getSigningConfig(

--- a/ironfish-cli/src/multisigBroker/clients/client.ts
+++ b/ironfish-cli/src/multisigBroker/clients/client.ts
@@ -13,6 +13,8 @@ import {
 import { v4 as uuid } from 'uuid'
 import { ServerMessageMalformedError } from '../errors'
 import {
+  ConnectedMessage,
+  ConnectedMessageSchema,
   DkgGetStatusMessage,
   DkgStartSessionMessage,
   DkgStatusMessage,
@@ -60,6 +62,7 @@ export abstract class MultisigClient {
   readonly onSigningCommitment = new Event<[SigningCommitmentMessage]>()
   readonly onSignatureShare = new Event<[SignatureShareMessage]>()
   readonly onSigningStatus = new Event<[SigningStatusMessage]>()
+  readonly onConnectedMessage = new Event<[ConnectedMessage]>()
   readonly onMultisigBrokerError = new Event<[MultisigBrokerMessageWithError]>()
 
   sessionId: string | null = null
@@ -340,6 +343,16 @@ export abstract class MultisigClient {
           }
 
           this.onSigningStatus.emit(body.result)
+          break
+        }
+        case 'connected': {
+          const body = await YupUtils.tryValidate(ConnectedMessageSchema, header.result.body)
+
+          if (body.error) {
+            throw new ServerMessageMalformedError(body.error, header.result.method)
+          }
+
+          this.onConnectedMessage.emit(body.result)
           break
         }
 

--- a/ironfish-cli/src/multisigBroker/messages.ts
+++ b/ironfish-cli/src/multisigBroker/messages.ts
@@ -70,6 +70,8 @@ export type SigningStatusMessage = {
   signatureShares: string[]
 }
 
+export type ConnectedMessage = object | undefined
+
 export const MultisigBrokerMessageSchema: yup.ObjectSchema<MultisigBrokerMessage> = yup
   .object({
     id: yup.number().required(),
@@ -162,3 +164,8 @@ export const SigningStatusSchema: yup.ObjectSchema<SigningStatusMessage> = yup
     signatureShares: yup.array(yup.string().defined()).defined(),
   })
   .defined()
+
+export const ConnectedMessageSchema: yup.ObjectSchema<ConnectedMessage> = yup
+  .object({})
+  .notRequired()
+  .default(undefined)


### PR DESCRIPTION
## Summary

- Added logic on the server to check if a session has 0 connected clients when a client disconnects. If it does, it will delete the session
- Added a connected response from the server to the client when a client connects. Previously, it was sending the join session message immediately after connecting, which would lead to the message getting lost in the void

Closes IFL-3022

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
