### PR TITLE
reduces log output when using multisig broker

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/dkg/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/create.ts
@@ -128,8 +128,6 @@ export class DkgCreateCommand extends IronfishCommand {
         )
       : await this.getParticipant(client, accountName)
 
-    this.log(`Identity for ${participantName}: \n${identity} \n`)
-
     const { totalParticipants, minSigners } = await ui.retryStep(
       async () => {
         return this.getDkgConfig(multisigClient, !!ledger)
@@ -154,14 +152,6 @@ export class DkgCreateCommand extends IronfishCommand {
       true,
     )
 
-    this.log('\n============================================')
-    this.log('\nRound 1 Encrypted Secret Package:')
-    this.log(round1.secretPackage)
-
-    this.log('\nRound 1 Public Package:')
-    this.log(round1.publicPackage)
-    this.log('\n============================================')
-
     const { round2: round2Result, round1PublicPackages } = await ui.retryStep(
       async () => {
         return this.performRound2(
@@ -176,14 +166,6 @@ export class DkgCreateCommand extends IronfishCommand {
       this.logger,
       true,
     )
-
-    this.log('\n============================================')
-    this.log('\nRound 2 Encrypted Secret Package:')
-    this.log(round2Result.secretPackage)
-
-    this.log('\nRound 2 Public Package:')
-    this.log(round2Result.publicPackage)
-    this.log('\n============================================')
 
     await ui.retryStep(
       async () => {
@@ -309,10 +291,10 @@ export class DkgCreateCommand extends IronfishCommand {
         minSigners = message.minSigners
         waiting = false
       })
-      multisigClient.getDkgStatus()
 
       ux.action.start('Waiting for signer config from server')
       while (waiting) {
+        multisigClient.getDkgStatus()
         await PromiseUtils.sleep(3000)
       }
       multisigClient.onDkgStatus.clear()
@@ -349,7 +331,8 @@ export class DkgCreateCommand extends IronfishCommand {
 
     if (multisigClient) {
       multisigClient.startDkgSession(totalParticipants, minSigners)
-      this.log(`Started new DKG server session with ID ${multisigClient.sessionId}`)
+      this.log('\nStarted new DKG session:')
+      this.log(`${multisigClient.sessionId}`)
     }
 
     return { totalParticipants, minSigners }
@@ -397,6 +380,8 @@ export class DkgCreateCommand extends IronfishCommand {
 
     let identities: string[] = []
     if (!multisigClient) {
+      this.log(`Identity for ${participantName}: \n${currentIdentity} \n`)
+
       this.log(
         `\nEnter ${
           totalParticipants - 1
@@ -489,6 +474,14 @@ export class DkgCreateCommand extends IronfishCommand {
   }> {
     let round1PublicPackages: string[] = []
     if (!multisigClient) {
+      this.log('\n============================================')
+      this.debug('\nRound 1 Encrypted Secret Package:')
+      this.debug(round1Result.secretPackage)
+
+      this.log('\nRound 1 Public Package:')
+      this.log(round1Result.publicPackage)
+      this.log('\n============================================')
+
       this.log('\nShare your Round 1 Public Package with other participants.')
       this.log(`\nEnter ${totalParticipants - 1} Round 1 Public Packages (excluding yours) `)
 
@@ -632,7 +625,6 @@ export class DkgCreateCommand extends IronfishCommand {
     this.log(
       `Account ${response.content.name} imported with public address: ${dkgKeys.publicAddress}`,
     )
-
     this.log()
     this.log('Creating an encrypted backup of multisig keys from your Ledger device...')
     this.log()
@@ -674,6 +666,14 @@ export class DkgCreateCommand extends IronfishCommand {
   ): Promise<void> {
     let round2PublicPackages: string[] = []
     if (!multisigClient) {
+      this.log('\n============================================')
+      this.debug('\nRound 2 Encrypted Secret Package:')
+      this.debug(round2Result.secretPackage)
+
+      this.log('\nRound 2 Public Package:')
+      this.log(round2Result.publicPackage)
+      this.log('\n============================================')
+
       this.log('\nShare your Round 2 Public Package with other participants.')
       this.log(`\nEnter ${totalParticipants - 1} Round 2 Public Packages (excluding yours) `)
 
@@ -729,6 +729,7 @@ export class DkgCreateCommand extends IronfishCommand {
       round2PublicPackages,
     })
 
+    this.log()
     this.log(`Account Name: ${response.content.name}`)
     this.log(`Public Address: ${response.content.publicAddress}`)
   }

--- a/ironfish-cli/src/commands/wallet/multisig/sign.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/sign.ts
@@ -153,13 +153,6 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
       flags.unsignedTransaction,
     )
 
-    await renderUnsignedTransactionDetails(
-      client,
-      unsignedTransaction,
-      multisigAccountName,
-      this.logger,
-    )
-
     const { commitment, identities } = await ui.retryStep(
       async () => {
         return this.performCreateSigningCommitment(
@@ -176,13 +169,6 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
       true,
     )
 
-    this.log('\n============================================')
-    this.log('\nCommitment:')
-    this.log(commitment)
-    this.log('\n============================================')
-
-    this.log('\nShare your commitment with other participants.')
-
     const signingPackage = await ui.retryStep(() => {
       return this.performAggregateCommitments(
         client,
@@ -194,11 +180,6 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
         unsignedTransaction,
       )
     }, this.logger)
-
-    this.log('\n============================================')
-    this.log('\nSigning Package:')
-    this.log(signingPackage)
-    this.log('\n============================================')
 
     const signatureShare = await ui.retryStep(
       () =>
@@ -213,13 +194,6 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
       this.logger,
       true,
     )
-
-    this.log('\n============================================')
-    this.log('\nSignature Share:')
-    this.log(signatureShare)
-    this.log('\n============================================')
-
-    this.log('\nShare your signature share with other participants.')
 
     await ui.retryStep(
       () =>
@@ -286,7 +260,8 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
 
     if (multisigClient) {
       multisigClient.startSigningSession(totalParticipants, unsignedTransactionInput)
-      this.log(`Started new signing session with ID ${multisigClient.sessionId}`)
+      this.log('\nStarted new signing session:')
+      this.log(`${multisigClient.sessionId}`)
     }
 
     return { unsignedTransaction, totalParticipants }
@@ -302,6 +277,13 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
   ): Promise<void> {
     let signatureShares: string[] = []
     if (!multisigClient) {
+      this.log('\n============================================')
+      this.log('\nSignature Share:')
+      this.log(signatureShare)
+      this.log('\n============================================')
+
+      this.log('\nShare your signature share with other participants.')
+
       this.log(
         `Enter ${
           totalParticipants - 1
@@ -386,6 +368,11 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
     unsignedTransaction: UnsignedTransaction,
     ledger: LedgerMultiSigner | undefined,
   ): Promise<string> {
+    this.debug('\n============================================')
+    this.debug('\nSigning Package:')
+    this.debug(signingPackageString)
+    this.debug('\n============================================')
+
     let signatureShare: string
 
     const signingPackage = new multisig.SigningPackage(Buffer.from(signingPackageString, 'hex'))
@@ -426,6 +413,13 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
   ) {
     let commitments: string[] = []
     if (!multisigClient) {
+      this.log('\n============================================')
+      this.log('\nCommitment:')
+      this.log(commitment)
+      this.log('\n============================================')
+
+      this.log('\nShare your commitment with other participants.')
+
       this.log(
         `Enter ${identities.length - 1} commitments of the participants (excluding your own)`,
       )
@@ -512,6 +506,13 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
     }
 
     const unsignedTransactionHex = unsignedTransaction.serialize().toString('hex')
+
+    await renderUnsignedTransactionDetails(
+      client,
+      unsignedTransaction,
+      accountName,
+      this.logger,
+    )
 
     let commitment
     if (ledger) {


### PR DESCRIPTION
## Summary

- changes log messages to debug for packages that don't need to be sent to other participants: signing package, encrypted secret packages
- does not log identities, packages, commitments, shares when using multisig broker

- logs session ID on separate line when starting session

Closes IFL-3014
Closes IFL-3015
Closes IFL-3019

## Testing Plan
DKG logs after changes with broker:
<img width="685" alt="image" src="https://github.com/user-attachments/assets/1648267b-3257-40c1-8244-7846f80d8380">


## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
