### PR TITLE
Add ability for sessions to track specific clients

### DIFF
--- a/ironfish-cli/src/multisigBroker/server.ts
+++ b/ironfish-cli/src/multisigBroker/server.ts
@@ -317,8 +317,9 @@ export class MultisigServer {
       const client = this.clients.get(clientId)
       if (!client) {
         this.logger.debug(
-          `Client ${clientId} does not exist, but session ${sessionId} thinks it does`,
+          `Client ${clientId} does not exist, but session ${sessionId} thinks it does, removing.`,
         )
+        session.clientIds.delete(clientId)
         continue
       }
 


### PR DESCRIPTION
## Summary

Sessions now track client IDs
Server has encapsulated logic to add/remove clients to/from sessions

Removes the need to iterate over all clients to determine if a session is active or not, and for broadcasting

Closes IFL-3029

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
