### PR TITLE
prevents incorrect session encryption from halting process

### DIFF
--- a/ironfish-cli/src/multisigBroker/messages.ts
+++ b/ironfish-cli/src/multisigBroker/messages.ts
@@ -25,14 +25,20 @@ export type MultisigBrokerAckMessage = {
 export type DkgStartSessionMessage = {
   minSigners: number
   maxSigners: number
+  challenge: string
 }
 
 export type SigningStartSessionMessage = {
   numSigners: number
   unsignedTransaction: string
+  challenge: string
 }
 
 export type JoinSessionMessage = object | undefined
+
+export type JoinedSessionMessage = {
+  challenge: string
+}
 
 export type IdentityMessage = {
   identity: string
@@ -108,6 +114,7 @@ export const DkgStartSessionSchema: yup.ObjectSchema<DkgStartSessionMessage> = y
   .object({
     minSigners: yup.number().defined(),
     maxSigners: yup.number().defined(),
+    challenge: yup.string().defined(),
   })
   .defined()
 
@@ -115,6 +122,7 @@ export const SigningStartSessionSchema: yup.ObjectSchema<SigningStartSessionMess
   .object({
     numSigners: yup.number().defined(),
     unsignedTransaction: yup.string().defined(),
+    challenge: yup.string().defined(),
   })
   .defined()
 
@@ -122,6 +130,12 @@ export const JoinSessionSchema: yup.ObjectSchema<JoinSessionMessage> = yup
   .object({})
   .notRequired()
   .default(undefined)
+
+export const JoinedSessionSchema: yup.ObjectSchema<JoinedSessionMessage> = yup
+  .object({
+    challenge: yup.string().required(),
+  })
+  .required()
 
 export const IdentitySchema: yup.ObjectSchema<IdentityMessage> = yup
   .object({


### PR DESCRIPTION
## Summary

if a client submits data to the broker server encrypted with the wrong passphrase and key then all other clients will now skip that data

adds a 'challenge' to the session which is a string encrypted with the session passphrase and key

if a client fails to decrypt the challenge then the client throws an error

decrypts message data only when necessary

Closes IFL-3028

## Testing Plan
manual testing:
- ran dkg with two participants while a third client submitted bad data to the server
- tried to connect with incorrect passphrase and failed decryption challenge

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
