### PR TITLE
updates ux status messages waiting for multisig broker

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/dkg/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/create.ts
@@ -385,9 +385,10 @@ export class DkgCreateCommand extends IronfishCommand {
         identities = message.identities
       })
 
-      ux.action.start('Waiting for other Identities from server')
+      ux.action.start('Waiting for Identities from server')
       while (identities.length < totalParticipants) {
         multisigClient.getDkgStatus()
+        ux.action.status = `${identities.length}/${totalParticipants}`
         await PromiseUtils.sleep(3000)
       }
 
@@ -480,9 +481,10 @@ export class DkgCreateCommand extends IronfishCommand {
         round1PublicPackages = message.round1PublicPackages
       })
 
-      ux.action.start('Waiting for other Round 1 Public Packages from server')
+      ux.action.start('Waiting for Round 1 Public Packages from server')
       while (round1PublicPackages.length < totalParticipants) {
         multisigClient.getDkgStatus()
+        ux.action.status = `${round1PublicPackages.length}/${totalParticipants}`
         await PromiseUtils.sleep(3000)
       }
 
@@ -666,9 +668,10 @@ export class DkgCreateCommand extends IronfishCommand {
         round2PublicPackages = message.round2PublicPackages
       })
 
-      ux.action.start('Waiting for other Round 2 Public Packages from server')
+      ux.action.start('Waiting for Round 2 Public Packages from server')
       while (round2PublicPackages.length < totalParticipants) {
         multisigClient.getDkgStatus()
+        ux.action.status = `${round2PublicPackages.length}/${totalParticipants}`
         await PromiseUtils.sleep(3000)
       }
 

--- a/ironfish-cli/src/commands/wallet/multisig/dkg/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/create.ts
@@ -365,7 +365,7 @@ export class DkgCreateCommand extends IronfishCommand {
   }> {
     this.log('\nCollecting Participant Info and Performing Round 1...')
 
-    let identities: string[] = []
+    let identities: string[] = [currentIdentity]
     if (!multisigClient) {
       this.log(`Identity for ${participantName}: \n${currentIdentity} \n`)
 
@@ -454,7 +454,7 @@ export class DkgCreateCommand extends IronfishCommand {
     round2: { secretPackage: string; publicPackage: string }
     round1PublicPackages: string[]
   }> {
-    let round1PublicPackages: string[] = []
+    let round1PublicPackages: string[] = [round1Result.publicPackage]
     if (!multisigClient) {
       this.log('\n============================================')
       this.debug('\nRound 1 Encrypted Secret Package:')
@@ -641,7 +641,7 @@ export class DkgCreateCommand extends IronfishCommand {
     ledger: LedgerMultiSigner | undefined,
     accountCreatedAt?: number,
   ): Promise<void> {
-    let round2PublicPackages: string[] = []
+    let round2PublicPackages: string[] = [round2Result.publicPackage]
     if (!multisigClient) {
       this.log('\n============================================')
       this.debug('\nRound 2 Encrypted Secret Package:')

--- a/ironfish-cli/src/commands/wallet/multisig/sign.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/sign.ts
@@ -289,7 +289,7 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
     signatureShare: string,
     totalParticipants: number,
   ): Promise<void> {
-    let signatureShares: string[] = []
+    let signatureShares: string[] = [signatureShare]
     if (!multisigClient) {
       this.log('\n============================================')
       this.log('\nSignature Share:')
@@ -420,7 +420,7 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
     totalParticipants: number,
     unsignedTransaction: UnsignedTransaction,
   ) {
-    let commitments: string[] = []
+    let commitments: string[] = [commitment]
     if (!multisigClient) {
       this.log('\n============================================')
       this.log('\nCommitment:')
@@ -473,7 +473,7 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
     unsignedTransaction: UnsignedTransaction,
     ledger: LedgerMultiSigner | undefined,
   ) {
-    let identities: string[] = []
+    let identities: string[] = [participant.identity]
     if (!multisigClient) {
       this.log(`Identity for ${participant.name}: \n${participant.identity} \n`)
       this.log('Share your participant identity with other signers.')

--- a/ironfish-cli/src/commands/wallet/multisig/sign.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/sign.ts
@@ -315,9 +315,10 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
         signatureShares = message.signatureShares
       })
 
-      ux.action.start('Waiting for other Signature Shares from server')
+      ux.action.start('Waiting for Signature Shares from server')
       while (signatureShares.length < totalParticipants) {
         multisigClient.getSigningStatus()
+        ux.action.status = `${signatureShares.length}/${totalParticipants}`
         await PromiseUtils.sleep(3000)
       }
 
@@ -443,9 +444,10 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
         commitments = message.signingCommitments
       })
 
-      ux.action.start('Waiting for other Signing Commitments from server')
+      ux.action.start('Waiting for Signing Commitments from server')
       while (commitments.length < totalParticipants) {
         multisigClient.getSigningStatus()
+        ux.action.status = `${commitments.length}/${totalParticipants}`
         await PromiseUtils.sleep(3000)
       }
 
@@ -491,9 +493,10 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
         identities = message.identities
       })
 
-      ux.action.start('Waiting for other Identities from server')
+      ux.action.start('Waiting for Identities from server')
       while (identities.length < totalParticipants) {
         multisigClient.getSigningStatus()
+        ux.action.status = `${identities.length}/${totalParticipants}`
         await PromiseUtils.sleep(3000)
       }
 


### PR DESCRIPTION
## Summary

displays the number of identities, packages, commitments, etc. that the client has received from the server and how many are expected

Closes IFL-3016

## Testing Plan
<img width="386" alt="image" src="https://github.com/user-attachments/assets/7ec1d490-5dee-4025-a669-6e0e143f8d04">


## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
