### PR TITLE
adds idle session timeout to multisig broker server

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/server.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/server.ts
@@ -29,12 +29,19 @@ export class MultisigServerCommand extends IronfishCommand {
       allowNo: true,
       default: true,
     }),
+    idleSessionTimeout: Flags.integer({
+      description: 'time (in ms) to wait before cleaning up idle session data',
+      char: 'i',
+    }),
   }
 
   async start(): Promise<void> {
     const { flags } = await this.parse(MultisigServerCommand)
 
-    const server = new MultisigServer({ logger: this.logger })
+    const server = new MultisigServer({
+      logger: this.logger,
+      idleSessionTimeout: flags.idleSessionTimeout,
+    })
 
     let adapter: IMultisigBrokerAdapter
     if (flags.tls) {


### PR DESCRIPTION
## Summary

uses a timeout to clean up data from idle sessions instead of cleaning up immediately after last client disconnects

allows for clients to reconnect to sessions

adds cli flag to server command

Closes IFL-3040

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
