### PR TITLE
Upgrade wallet:import to use ui.ledger

### DIFF
--- a/ironfish-cli/src/commands/wallet/import.ts
+++ b/ironfish-cli/src/commands/wallet/import.ts
@@ -7,6 +7,7 @@ import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 import { LedgerError, LedgerSingleSigner } from '../../ledger'
 import { checkWalletUnlocked, inputPrompt } from '../../ui'
+import * as ui from '../../ui'
 import { importFile, importPipe, longPrompt } from '../../ui/longPrompt'
 import { importAccount } from '../../utils'
 
@@ -119,8 +120,14 @@ export class ImportCommand extends IronfishCommand {
   async importLedger(): Promise<string> {
     try {
       const ledger = new LedgerSingleSigner(this.logger)
-      await ledger.connect()
-      const account = await ledger.importAccount()
+
+      const account = await ui.ledger({
+        ledger,
+        message: 'Import Wallet',
+        approval: true,
+        action: () => ledger.importAccount(),
+      })
+
       return encodeAccountImport(account, AccountFormat.Base64Json)
     } catch (e) {
       if (e instanceof LedgerError) {


### PR DESCRIPTION
## Summary

This uses the new ledger UI action so that it will wait for the user to connect and unlock their ledger.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
