### PR TITLE
Upgrade wallet:multisig:sign to use ui.ledger

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/sign.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/sign.ts
@@ -515,6 +515,7 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
         ledger,
         message: 'Review Transaction',
         action: () => ledger.reviewTransaction(unsignedTransactionHex),
+        approval: true,
       })
 
       commitment = await this.createSigningCommitmentWithLedger(


### PR DESCRIPTION
## Summary

This uses the new ledger UI action so that it will wait for the user to connect and unlock their ledger.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
