### PR TITLE
resets ledger ui status between errors

### DIFF
--- a/ironfish-cli/src/ui/ledger.ts
+++ b/ironfish-cli/src/ui/ledger.ts
@@ -53,6 +53,7 @@ export async function ledger<TResult>({
     // eslint-disable-next-line no-constant-condition
     while (true) {
       try {
+        ux.action.status = undefined
         const result = await action()
         ux.action.stop()
         return result

--- a/ironfish-cli/src/ui/ledger.ts
+++ b/ironfish-cli/src/ui/ledger.ts
@@ -49,15 +49,17 @@ export async function ledger<TResult>({
     ux.action.start(message)
   }
 
+  let clearStatusTimer
+
   try {
     // eslint-disable-next-line no-constant-condition
     while (true) {
       try {
-        ux.action.status = undefined
         const result = await action()
         ux.action.stop()
         return result
       } catch (e) {
+        clearTimeout(clearStatusTimer)
         if (e instanceof LedgerAppLocked) {
           // If an app is running and it's locked, trying to poll the device
           // will cause the Ledger device to hide the pin screen as the user
@@ -102,6 +104,7 @@ export async function ledger<TResult>({
         }
 
         statusAdded = true
+        clearStatusTimer = setTimeout(() => (ux.action.status = undefined), 2000)
         await PromiseUtils.sleep(1000)
         continue
       }
@@ -109,6 +112,7 @@ export async function ledger<TResult>({
   } finally {
     // Don't interrupt an existing status outside of ledgerAction()
     if (!wasRunning && statusAdded) {
+      clearTimeout(clearStatusTimer)
       ux.action.stop()
     }
   }


### PR DESCRIPTION
## Summary

removes the error status (e.g., 'Open Ledger App Ironfish') after the user has resolved the cause of the error

## Testing Plan
manual testing with `wallet:import --ledger`

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
