### PR TITLE
Handle appInfo() crash on rust app

### DIFF
--- a/ironfish-cli/src/ledger/ledger.ts
+++ b/ironfish-cli/src/ledger/ledger.ts
@@ -33,7 +33,18 @@ export class Ledger {
 
       // App info is a request to the dashboard CLA. The purpose of this it to
       // produce a Locked Device error and works if an app is open or closed.
-      await this.app.appInfo()
+      try {
+        await this.app.appInfo()
+      } catch (error) {
+        if (
+          error instanceof ResponseError &&
+          error.message.includes('Attempt to read beyond buffer length') &&
+          error.returnCode === LedgerStatusCodes.TECHNICAL_PROBLEM
+        ) {
+          // Catch this error and swollow it until the SDK fix merges to fix
+          // this
+        }
+      }
 
       // This is an app specific request. This is useful because this throws
       // INS_NOT_SUPPORTED in the case that the app is locked which is useful to


### PR DESCRIPTION
## Summary

This is currently broken while waiting for a fix from the zondax devs. This will at least make it work for now. We just cannot use the app info on any rust based app like DKG.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
