### PR TITLE
feat(cli): Update transaction summary for chainport transactions

### DIFF
--- a/ironfish-cli/src/commands/wallet/transactions/info.ts
+++ b/ironfish-cli/src/commands/wallet/transactions/info.ts
@@ -14,6 +14,7 @@ import { IronfishCommand } from '../../../command'
 import { RemoteFlags } from '../../../flags'
 import * as ui from '../../../ui'
 import {
+  ChainportNetwork,
   displayChainportTransactionSummary,
   extractChainportDataFromTransaction,
   fetchChainportNetworks,
@@ -99,12 +100,18 @@ export class TransactionInfoCommand extends IronfishCommand {
     if (chainportTxnDetails) {
       this.log(`\n---Chainport Bridge Transaction Summary---\n`)
 
-      ux.action.start('Fetching network details')
-      const chainportNetworks = await fetchChainportNetworks(networkId)
-      const network = chainportNetworks.find(
-        (n) => n.chainport_network_id === chainportTxnDetails.chainportNetworkId,
-      )
-      ux.action.stop()
+      let network: ChainportNetwork | undefined
+      try {
+        ux.action.start('Fetching network details')
+        const chainportNetworks = await fetchChainportNetworks(networkId)
+        network = chainportNetworks.find(
+          (n) => n.chainport_network_id === chainportTxnDetails.chainportNetworkId,
+        )
+        ux.action.stop()
+      } catch (e: unknown) {
+        ux.action.stop('error')
+        this.logger.debug((e as Error).message)
+      }
 
       await displayChainportTransactionSummary(
         networkId,

--- a/ironfish-cli/src/commands/wallet/transactions/info.ts
+++ b/ironfish-cli/src/commands/wallet/transactions/info.ts
@@ -110,7 +110,10 @@ export class TransactionInfoCommand extends IronfishCommand {
         ux.action.stop()
       } catch (e: unknown) {
         ux.action.stop('error')
-        this.logger.debug((e as Error).message)
+
+        if (e instanceof Error) {
+          this.logger.debug(e.message)
+        }
       }
 
       await displayChainportTransactionSummary(

--- a/ironfish-cli/src/utils/chainport/utils.ts
+++ b/ironfish-cli/src/utils/chainport/utils.ts
@@ -128,6 +128,7 @@ Target Network:               ${network?.label ?? 'Error fetching network detail
   // We'll wait to show the transaction status if the transaction is still pending on Iron Fish
   if (transaction.status !== TransactionStatus.CONFIRMED) {
     logger.log(basicInfo)
+    logger.log(`       Transaction Status:    ${transaction.status} (Iron Fish)`)
     return
   }
 
@@ -149,29 +150,31 @@ Target Network:               ${network?.label ?? 'Error fetching network detail
     return
   }
 
-  if (Object.keys(transactionStatus).length === 0) {
+  // States taken from https://docs.chainport.io/for-developers/api-reference/port
+  if (Object.keys(transactionStatus).length === 0 || !transactionStatus.base_tx_status) {
+    logger.log(`       Transaction Status:    Pending confirmation (Iron Fish)`)
     logger.log(`
-Transaction status not found on target network.
 Note: Bridge transactions may take up to 30 minutes to surface on the target network.
 If this issue persists, please contact chainport support: https://helpdesk.chainport.io/`)
     return
   }
 
   if (
-    !transactionStatus.base_tx_hash ||
-    !transactionStatus.base_tx_status ||
+    transactionStatus.base_tx_hash &&
+    transactionStatus.base_tx_status === 1 &&
     !transactionStatus.target_tx_hash
   ) {
-    logger.log(`       Transaction Status:    pending`)
+    logger.log(`       Transaction Status:    Pending creation (target network)`)
     return
   }
 
-  if (transactionStatus.target_tx_status === 1) {
-    logger.log(`       Transaction Status:    completed`)
-  } else {
-    logger.log(`       Transaction Status:    in progress`)
-  }
-
+  logger.log(
+    `       Transaction Status:    ${
+      transactionStatus.target_tx_status === 1
+        ? 'Completed'
+        : 'Pending confirmation (target network)'
+    }`,
+  )
   logger.log(`       Transaction Hash:      ${transactionStatus.target_tx_hash}
        Explorer Transaction:  ${
          network

--- a/ironfish-cli/src/utils/chainport/utils.ts
+++ b/ironfish-cli/src/utils/chainport/utils.ts
@@ -139,23 +139,22 @@ Target Network:               ${network?.label ?? 'Error fetching network detail
     ux.action.stop()
   } catch (e: unknown) {
     ux.action.stop('error')
-    logger.debug((e as Error).message)
+
+    if (e instanceof Error) {
+      logger.debug(e.message)
+    }
   }
 
   logger.log(basicInfo)
 
   if (!transactionStatus) {
     logger.log(`       Transaction Status:    Error fetching transaction details`)
-    logger.log(`       Transaction Hash:      Error fetching transaction details`)
     return
   }
 
   // States taken from https://docs.chainport.io/for-developers/api-reference/port
   if (Object.keys(transactionStatus).length === 0 || !transactionStatus.base_tx_status) {
     logger.log(`       Transaction Status:    Pending confirmation (Iron Fish)`)
-    logger.log(`
-Note: Bridge transactions may take up to 30 minutes to surface on the target network.
-If this issue persists, please contact chainport support: https://helpdesk.chainport.io/`)
     return
   }
 


### PR DESCRIPTION
## Summary

* Show tx details even if there's an error fetching network details
* Remove extra source information from logs
* Use states in line with bridge prototype and update checks using Chainport API docs

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
