### PR TITLE
get identity after dkg parameters in dkg:create

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/dkg/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/create.ts
@@ -121,18 +121,18 @@ export class DkgCreateCommand extends IronfishCommand {
       }
     }
 
-    const { name: participantName, identity } = await this.getOrCreateIdentity(
-      client,
-      ledger,
-      accountName,
-    )
-
     const { totalParticipants, minSigners } = await ui.retryStep(
       async () => {
         return this.getDkgConfig(multisigClient, !!ledger)
       },
       this.logger,
       true,
+    )
+
+    const { name: participantName, identity } = await this.getOrCreateIdentity(
+      client,
+      ledger,
+      accountName,
     )
 
     const { round1 } = await ui.retryStep(


### PR DESCRIPTION
## Summary

when starting a new dkg session with a ledger the user currently sees output about getting the identity from the ledger in between choosing to start a new session and entering the max/min signers for that session

## Testing Plan
before:
<img width="620" alt="image" src="https://github.com/user-attachments/assets/5011b0b9-e8d7-493f-8b19-43b080cc3188">

after:
<img width="619" alt="image" src="https://github.com/user-attachments/assets/5f6d60f1-cc62-47bd-8832-39226711e0ad">


## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
