### PR TITLE
Add flags for minSigners and totalParticipants for dkg:create

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/dkg/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/create.ts
@@ -92,7 +92,7 @@ export class DkgCreateCommand extends IronfishCommand {
     let multisigClient: MultisigClient | null = null
     if (flags.server) {
       let sessionId = flags.sessionId
-      if (!sessionId) {
+      if (!sessionId && !flags.totalParticipants && !flags.minSigners) {
         sessionId = await ui.inputPrompt(
           'Enter the ID of a multisig session to join, or press enter to start a new session',
           false,


### PR DESCRIPTION
## Summary

Makes it a little easier to get through the setup phase for power users

## Testing Plan

- Test with server and with flags: Should not prompt for total participants and min signers
`wallet:multisig:dkg:create --server <...> --totalParticipants 2 --minSigners 2`
- Test with server and without flags: Should prompt for total participants and min signers
`wallet:multisig:dkg:create --server <...>`
- Test without server and with flags: Should not prompt for total participants and min signers
`wallet:multisig:dkg:create --totalParticipants 2 --minSigners 2`
- Test without server and without flags: Should prompt for total participants and min signers
`wallet:multisig:dkg:create`
- Test with sessionId and with flags: Should throw an error due to these flags being exclusive
`wallet:multisig:dkg:create --sessionId foo --totalParticipants 2 --minSigners 2`
- Test with sessionId and without flags: Should not throw an error
`wallet:multisig:dkg:create --sessionId foo`
## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
