### PR TITLE
Handle app command rejections from device

### DIFF
--- a/ironfish-cli/src/ledger/ledger.ts
+++ b/ironfish-cli/src/ledger/ledger.ts
@@ -78,7 +78,11 @@ export class Ledger {
       }
 
       if (error instanceof TransportStatusError) {
-        throw new LedgerConnectError()
+        if (error.statusCode === IronfishLedgerStatusCodes.COMMAND_NOT_ALLOWED) {
+          throw new LedgerActionRejected()
+        } else {
+          throw new LedgerConnectError()
+        }
       }
 
       if (error instanceof ResponseError) {
@@ -184,3 +188,4 @@ export class LedgerAppLocked extends LedgerError {}
 export class LedgerGPAuthFailed extends LedgerError {}
 export class LedgerClaNotSupportedError extends LedgerError {}
 export class LedgerAppNotOpen extends LedgerError {}
+export class LedgerActionRejected extends LedgerError {}

--- a/ironfish-cli/src/ui/ledger.ts
+++ b/ironfish-cli/src/ui/ledger.ts
@@ -15,6 +15,7 @@ import { Errors, ux } from '@oclif/core'
 import inquirer from 'inquirer'
 import {
   Ledger,
+  LedgerActionRejected,
   LedgerAppLocked,
   LedgerAppNotOpen,
   LedgerClaNotSupportedError,
@@ -60,6 +61,7 @@ export async function ledger<TResult>({
         return result
       } catch (e) {
         clearTimeout(clearStatusTimer)
+
         if (e instanceof LedgerAppLocked) {
           // If an app is running and it's locked, trying to poll the device
           // will cause the Ledger device to hide the pin screen as the user
@@ -85,6 +87,9 @@ export async function ledger<TResult>({
           if (!wasRunning) {
             ux.action.start(message)
           }
+        } else if (e instanceof LedgerActionRejected) {
+          ux.action.status = 'User Rejected Ledger Request!'
+          ledger.logger.warn('User Rejected Ledger Request!')
         } else if (e instanceof LedgerConnectError) {
           ux.action.status = 'Connect and unlock your Ledger'
         } else if (e instanceof LedgerAppNotOpen) {


### PR DESCRIPTION
## Summary

If you don't approve the command you will now get a nice error.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
