### PR TITLE
removes logger from Ledger class

### DIFF
--- a/ironfish-cli/src/commands/wallet/import.ts
+++ b/ironfish-cli/src/commands/wallet/import.ts
@@ -119,7 +119,7 @@ export class ImportCommand extends IronfishCommand {
 
   async importLedger(): Promise<string> {
     try {
-      const ledger = new LedgerSingleSigner(this.logger)
+      const ledger = new LedgerSingleSigner()
 
       const account = await ui.ledger({
         ledger,

--- a/ironfish-cli/src/commands/wallet/multisig/commitment/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/commitment/create.ts
@@ -124,7 +124,7 @@ export class CreateSigningCommitmentCommand extends IronfishCommand {
     unsignedTransaction: UnsignedTransaction,
     signers: string[],
   ): Promise<void> {
-    const ledger = new LedgerMultiSigner(this.logger)
+    const ledger = new LedgerMultiSigner()
     try {
       await ledger.connect()
     } catch (e) {

--- a/ironfish-cli/src/commands/wallet/multisig/dkg/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/create.ts
@@ -78,7 +78,7 @@ export class DkgCreateCommand extends IronfishCommand {
     let ledger: LedgerMultiSigner | undefined = undefined
 
     if (flags.ledger) {
-      ledger = new LedgerMultiSigner(this.logger)
+      ledger = new LedgerMultiSigner()
     }
 
     const accountName = await this.getAccountName(client, flags.name ?? flags.participant)

--- a/ironfish-cli/src/commands/wallet/multisig/dkg/round1.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/round1.ts
@@ -100,7 +100,7 @@ export class DkgRound1Command extends IronfishCommand {
     identities: string[],
     minSigners: number,
   ): Promise<void> {
-    const ledger = new LedgerMultiSigner(this.logger)
+    const ledger = new LedgerMultiSigner()
     try {
       await ledger.connect()
     } catch (e) {

--- a/ironfish-cli/src/commands/wallet/multisig/dkg/round2.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/round2.ts
@@ -97,7 +97,7 @@ export class DkgRound2Command extends IronfishCommand {
     round1PublicPackages: string[],
     round1SecretPackage: string,
   ): Promise<void> {
-    const ledger = new LedgerMultiSigner(this.logger)
+    const ledger = new LedgerMultiSigner()
     try {
       await ledger.connect()
     } catch (e) {

--- a/ironfish-cli/src/commands/wallet/multisig/dkg/round3.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/round3.ts
@@ -162,7 +162,7 @@ export class DkgRound3Command extends IronfishCommand {
     round2SecretPackage: string,
     accountCreatedAt?: number,
   ): Promise<void> {
-    const ledger = new LedgerMultiSigner(this.logger)
+    const ledger = new LedgerMultiSigner()
     try {
       await ledger.connect()
     } catch (e) {

--- a/ironfish-cli/src/commands/wallet/multisig/ledger/backup.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/ledger/backup.ts
@@ -8,7 +8,7 @@ export class MultisigLedgerBackup extends IronfishCommand {
   static description = `show encrypted multisig keys from a Ledger device`
 
   async start(): Promise<void> {
-    const ledger = new LedgerMultiSigner(this.logger)
+    const ledger = new LedgerMultiSigner()
     try {
       await ledger.connect()
     } catch (e) {

--- a/ironfish-cli/src/commands/wallet/multisig/ledger/import.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/ledger/import.ts
@@ -31,7 +31,7 @@ export class MultisigLedgerImport extends IronfishCommand {
 
     const name = flags.name ?? (await ui.inputPrompt('Enter a name for the account', true))
 
-    const ledger = new LedgerMultiSigner(this.logger)
+    const ledger = new LedgerMultiSigner()
     try {
       await ledger.connect()
     } catch (e) {

--- a/ironfish-cli/src/commands/wallet/multisig/ledger/restore.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/ledger/restore.ts
@@ -26,7 +26,7 @@ export class MultisigLedgerRestore extends IronfishCommand {
       )
     }
 
-    const ledger = new LedgerMultiSigner(this.logger)
+    const ledger = new LedgerMultiSigner()
     try {
       await ledger.connect()
     } catch (e) {

--- a/ironfish-cli/src/commands/wallet/multisig/participant/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/participant/create.ts
@@ -71,7 +71,7 @@ export class MultisigIdentityCreate extends IronfishCommand {
   }
 
   async getIdentityFromLedger(): Promise<Buffer> {
-    const ledger = new LedgerMultiSigner(this.logger)
+    const ledger = new LedgerMultiSigner()
     try {
       await ledger.connect()
     } catch (e) {

--- a/ironfish-cli/src/commands/wallet/multisig/sign.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/sign.ts
@@ -72,7 +72,7 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
     let ledger: LedgerMultiSigner | undefined = undefined
 
     if (flags.ledger) {
-      ledger = new LedgerMultiSigner(this.logger)
+      ledger = new LedgerMultiSigner()
     }
 
     let multisigAccountName: string

--- a/ironfish-cli/src/commands/wallet/multisig/signature/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/signature/create.ts
@@ -120,7 +120,7 @@ export class CreateSignatureShareCommand extends IronfishCommand {
     unsignedTransaction: UnsignedTransaction,
     frostSigningPackage: string,
   ): Promise<void> {
-    const ledger = new LedgerMultiSigner(this.logger)
+    const ledger = new LedgerMultiSigner()
     try {
       await ledger.connect()
     } catch (e) {

--- a/ironfish-cli/src/commands/wallet/transactions/sign.ts
+++ b/ironfish-cli/src/commands/wallet/transactions/sign.ts
@@ -109,7 +109,7 @@ export class TransactionsSignCommand extends IronfishCommand {
   }
 
   private async signWithLedger(client: RpcClient, unsignedTransaction: string) {
-    const ledger = new LedgerSingleSigner(this.logger)
+    const ledger = new LedgerSingleSigner()
     try {
       await ledger.connect()
     } catch (e) {

--- a/ironfish-cli/src/ledger/ledger.ts
+++ b/ironfish-cli/src/ledger/ledger.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { Assert, createRootLogger, Logger } from '@ironfish/sdk'
+import { Assert } from '@ironfish/sdk'
 import { StatusCodes, TransportStatusError } from '@ledgerhq/errors'
 import TransportNodeHid from '@ledgerhq/hw-transport-node-hid'
 import IronfishApp, {
@@ -19,14 +19,12 @@ export const IronfishLedgerStatusCodes = {
 
 export class Ledger {
   app: IronfishApp | undefined
-  logger: Logger
   PATH = "m/44'/1338'/0"
   isMultisig: boolean
   isConnecting: boolean = false
 
-  constructor(isMultisig: boolean, logger?: Logger) {
+  constructor(isMultisig: boolean) {
     this.app = undefined
-    this.logger = logger ? logger : createRootLogger()
     this.isMultisig = isMultisig
   }
 
@@ -128,10 +126,6 @@ export class Ledger {
         await transport?.close()
         this.app = undefined
       })
-
-      if (transport.deviceModel) {
-        this.logger.debug(`${transport.deviceModel.productName} found.`)
-      }
 
       const app = new IronfishApp(transport, this.isMultisig)
 

--- a/ironfish-cli/src/ledger/ledgerMultiSigner.ts
+++ b/ironfish-cli/src/ledger/ledgerMultiSigner.ts
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { Logger } from '@ironfish/sdk'
 import {
   IronfishKeys,
   KeyResponse,
@@ -11,13 +10,11 @@ import {
 import { isResponseAddress, isResponseProofGenKey, isResponseViewKey, Ledger } from './ledger'
 
 export class LedgerMultiSigner extends Ledger {
-  constructor(logger?: Logger) {
-    super(true, logger)
+  constructor() {
+    super(true)
   }
 
   dkgGetIdentity = async (index: number): Promise<Buffer> => {
-    this.logger.debug('Retrieving identity from ledger device.')
-
     const response = await this.tryInstruction((app) => app.dkgGetIdentity(index, false))
 
     return response.identity
@@ -28,8 +25,6 @@ export class LedgerMultiSigner extends Ledger {
     identities: string[],
     minSigners: number,
   ): Promise<ResponseDkgRound1> => {
-    this.logger.log('Please approve the request on your ledger device.')
-
     return this.tryInstruction((app) => app.dkgRound1(index, identities, minSigners))
   }
 
@@ -38,8 +33,6 @@ export class LedgerMultiSigner extends Ledger {
     round1PublicPackages: string[],
     round1SecretPackage: string,
   ): Promise<ResponseDkgRound2> => {
-    this.logger.log('Please approve the request on your ledger device.')
-
     return this.tryInstruction((app) =>
       app.dkgRound2(index, round1PublicPackages, round1SecretPackage),
     )
@@ -53,8 +46,6 @@ export class LedgerMultiSigner extends Ledger {
     round2SecretPackage: string,
     gskBytes: string[],
   ): Promise<void> => {
-    this.logger.log('Please approve the request on your ledger device.')
-
     return this.tryInstruction((app) =>
       app.dkgRound3Min(
         index,
@@ -114,10 +105,6 @@ export class LedgerMultiSigner extends Ledger {
   }
 
   reviewTransaction = async (transaction: string): Promise<Buffer> => {
-    this.logger.info(
-      'Please review and approve the outputs of this transaction on your ledger device.',
-    )
-
     const { hash } = await this.tryInstruction((app) => app.reviewTransaction(transaction))
 
     return hash
@@ -144,16 +131,12 @@ export class LedgerMultiSigner extends Ledger {
   }
 
   dkgBackupKeys = async (): Promise<Buffer> => {
-    this.logger.log('Please approve the request on your ledger device.')
-
     const { encryptedKeys } = await this.tryInstruction((app) => app.dkgBackupKeys())
 
     return encryptedKeys
   }
 
   dkgRestoreKeys = async (encryptedKeys: string): Promise<void> => {
-    this.logger.log('Please approve the request on your ledger device.')
-
     await this.tryInstruction((app) => app.dkgRestoreKeys(encryptedKeys))
   }
 }

--- a/ironfish-cli/src/ledger/ledgerSingleSigner.ts
+++ b/ironfish-cli/src/ledger/ledgerSingleSigner.ts
@@ -1,13 +1,13 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { ACCOUNT_SCHEMA_VERSION, AccountImport, Logger } from '@ironfish/sdk'
+import { ACCOUNT_SCHEMA_VERSION, AccountImport } from '@ironfish/sdk'
 import { IronfishKeys, KeyResponse, ResponseSign } from '@zondax/ledger-ironfish'
 import { isResponseAddress, isResponseProofGenKey, isResponseViewKey, Ledger } from './ledger'
 
 export class LedgerSingleSigner extends Ledger {
-  constructor(logger?: Logger) {
-    super(false, logger)
+  constructor() {
+    super(false)
   }
 
   getPublicAddress = async () => {
@@ -24,8 +24,6 @@ export class LedgerSingleSigner extends Ledger {
 
   importAccount = async () => {
     const publicAddress = await this.getPublicAddress()
-
-    this.logger.log('Please confirm the request on your ledger device.')
 
     const responseViewKey: KeyResponse = await this.tryInstruction((app) =>
       app.retrieveKeys(this.PATH, IronfishKeys.ViewKey, true),

--- a/ironfish-cli/src/ui/ledger.ts
+++ b/ironfish-cli/src/ui/ledger.ts
@@ -89,7 +89,7 @@ export async function ledger<TResult>({
           }
         } else if (e instanceof LedgerActionRejected) {
           ux.action.status = 'User Rejected Ledger Request!'
-          ledger.logger.warn('User Rejected Ledger Request!')
+          ux.stdout('User Rejected Ledger Request!')
         } else if (e instanceof LedgerConnectError) {
           ux.action.status = 'Connect and unlock your Ledger'
         } else if (e instanceof LedgerAppNotOpen) {
@@ -131,7 +131,7 @@ export async function sendTransactionWithLedger(
   confirm: boolean,
   logger?: Logger,
 ): Promise<void> {
-  const ledgerApp = new LedgerSingleSigner(logger)
+  const ledgerApp = new LedgerSingleSigner()
 
   const publicKey = (await client.wallet.getAccountPublicKey({ account: from })).content
     .publicKey


### PR DESCRIPTION
## Summary

the Ledger class and subclasses do not log messages. clients that want log output must log themselves

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
