### PR TITLE
Convert ui.retry to new confirmListPrompt

### DIFF
--- a/ironfish-cli/src/ui/ledger.ts
+++ b/ironfish-cli/src/ui/ledger.ts
@@ -12,7 +12,6 @@ import {
   Transaction,
 } from '@ironfish/sdk'
 import { Errors, ux } from '@oclif/core'
-import inquirer from 'inquirer'
 import {
   Ledger,
   LedgerActionRejected,
@@ -69,20 +68,15 @@ export async function ledger<TResult>({
           // cannot send any commands to the Ledger in the app's CLA.
           ux.action.stop('Ledger App Locked')
 
-          await inquirer.prompt<{ retry: boolean }>([
-            {
-              name: 'retry',
-              message: `Ledger App Locked. Unlock and press enter to retry:`,
-              type: 'list',
-              choices: [
-                {
-                  name: `Retry`,
-                  value: true,
-                  default: true,
-                },
-              ],
-            },
-          ])
+          const confirmed = await ui.confirmList(
+            'Ledger App Locked. Unlock and press enter to retry:',
+            'Retry',
+          )
+
+          if (!confirmed) {
+            ux.stdout('Operation aborted.')
+            ux.exit(0)
+          }
 
           if (!wasRunning) {
             ux.action.start(message)

--- a/ironfish-cli/src/ui/prompt.ts
+++ b/ironfish-cli/src/ui/prompt.ts
@@ -138,6 +138,29 @@ export async function confirmPrompt(message: string): Promise<boolean> {
   return result.prompt
 }
 
+export async function confirmList(message: string, action = 'Confirm'): Promise<boolean> {
+  const result = await inquirer.prompt<{ confirm: boolean }>([
+    {
+      name: 'confirm',
+      message,
+      type: 'list',
+      choices: [
+        {
+          name: action,
+          value: true,
+          default: true,
+        },
+        {
+          name: 'Cancel',
+          value: false,
+        },
+      ],
+    },
+  ])
+
+  return result.confirm
+}
+
 export async function confirmOrQuit(message?: string, confirm?: boolean): Promise<void> {
   if (confirm) {
     return

--- a/ironfish-cli/src/ui/retry.ts
+++ b/ironfish-cli/src/ui/retry.ts
@@ -2,7 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { ErrorUtils, Logger } from '@ironfish/sdk'
-import { confirmPrompt } from './prompt'
+import { ux } from '@oclif/core'
+import { confirmList } from './prompt'
 
 export async function retryStep<T>(
   stepFunction: () => Promise<T>,
@@ -20,9 +21,10 @@ export async function retryStep<T>(
       logger.log(`An Error Occurred: ${ErrorUtils.renderError(error)}`)
 
       if (askToRetry) {
-        const continueResponse = await confirmPrompt('Do you want to retry this step?')
+        const continueResponse = await confirmList('Do you want to retry this step?', 'Retry')
         if (!continueResponse) {
-          throw new Error('User chose to not continue')
+          ux.stdout('User chose to not continue.')
+          ux.exit(0)
         }
       }
     }


### PR DESCRIPTION
## Summary

And convert ui.ledger to use it.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
