### PR TITLE
Fix rejection type on C vs Rust SDK

### DIFF
--- a/ironfish-cli/src/ledger/ledger.ts
+++ b/ironfish-cli/src/ledger/ledger.ts
@@ -95,6 +95,13 @@ export class Ledger {
           throw new LedgerGPAuthFailed()
         } else if (
           [
+            IronfishLedgerStatusCodes.COMMAND_NOT_ALLOWED,
+            IronfishLedgerStatusCodes.CONDITIONS_OF_USE_NOT_SATISFIED,
+          ].includes(error.returnCode)
+        ) {
+          throw new LedgerActionRejected()
+        } else if (
+          [
             IronfishLedgerStatusCodes.INS_NOT_SUPPORTED,
             IronfishLedgerStatusCodes.TECHNICAL_PROBLEM,
             0xffff, // Unknown transport error


### PR DESCRIPTION
## Summary

This handles the error as either a ResponseError or a TransportStatusError. The C SDK throws ResponseError and the Rust SDK throws TransportStatusError.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
