### PR TITLE
Set approve timeout greater than connect timeout

### DIFF
--- a/ironfish-cli/src/ledger/ledger.ts
+++ b/ironfish-cli/src/ledger/ledger.ts
@@ -22,6 +22,7 @@ export class Ledger {
   PATH = "m/44'/1338'/0"
   isMultisig: boolean
   isConnecting: boolean = false
+  connectTimeout = 2000
 
   constructor(isMultisig: boolean) {
     this.app = undefined
@@ -123,7 +124,7 @@ export class Ledger {
     let transport: Transport | undefined = undefined
 
     try {
-      transport = await TransportNodeHid.create(2000, 2000)
+      transport = await TransportNodeHid.create(this.connectTimeout, this.connectTimeout)
 
       transport.on('disconnect', async () => {
         await transport?.close()

--- a/ironfish-cli/src/ui/ledger.ts
+++ b/ironfish-cli/src/ui/ledger.ts
@@ -56,7 +56,7 @@ export async function ledger<TResult>({
           } else {
             ux.action.status = undefined
           }
-        }, 1500)
+        }, ledger.connectTimeout + 500)
 
         const result = await action()
         ux.action.stop()


### PR DESCRIPTION
## Summary

This fix ensures that the timeout threshold to check the user should approve the action is more than the connect timeout.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
