### PR TITLE
always reviews tx in same connection as commit or sign

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/commitment/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/commitment/create.ts
@@ -138,16 +138,12 @@ export class CreateSigningCommitmentCommand extends IronfishCommand {
     const identityResponse = await client.wallet.multisig.getIdentity({ name: participantName })
     const identity = identityResponse.content.identity
 
-    const transactionHash = await ledger.reviewTransaction(
-      unsignedTransaction.serialize().toString('hex'),
-    )
-
-    const rawCommitments = await ledger.dkgGetCommitments(transactionHash.toString('hex'))
+    const rawCommitments = await ledger.dkgGetCommitments(unsignedTransaction)
 
     const signingCommitment = multisig.SigningCommitment.fromRaw(
       identity,
       rawCommitments,
-      transactionHash,
+      unsignedTransaction.hash(),
       signers,
     )
 

--- a/ironfish-cli/src/commands/wallet/multisig/sign.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/sign.ts
@@ -383,9 +383,8 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
         message: 'Sign Transaction',
         action: () =>
           ledger.dkgSign(
-            unsignedTransaction.publicKeyRandomness(),
+            unsignedTransaction,
             signingPackage.frostSigningPackage().toString('hex'),
-            unsignedTransaction.hash().toString('hex'),
           ),
       })
 
@@ -511,17 +510,10 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
 
     let commitment
     if (ledger) {
-      await ui.ledger({
-        ledger,
-        message: 'Review Transaction',
-        action: () => ledger.reviewTransaction(unsignedTransactionHex),
-        approval: true,
-      })
-
       commitment = await this.createSigningCommitmentWithLedger(
         ledger,
         participant,
-        unsignedTransaction.hash(),
+        unsignedTransaction,
         identities,
       )
     } else {
@@ -543,19 +535,19 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
   async createSigningCommitmentWithLedger(
     ledger: LedgerMultiSigner,
     participant: MultisigParticipant,
-    transactionHash: Buffer,
+    unsignedTransaction: UnsignedTransaction,
     signers: string[],
   ): Promise<string> {
     const rawCommitments = await ui.ledger({
       ledger,
       message: 'Get Commitments',
-      action: () => ledger.dkgGetCommitments(transactionHash.toString('hex')),
+      action: () => ledger.dkgGetCommitments(unsignedTransaction),
     })
 
     const sigingCommitment = multisig.SigningCommitment.fromRaw(
       participant.identity,
       rawCommitments,
-      transactionHash,
+      unsignedTransaction.hash(),
       signers,
     )
 

--- a/ironfish-cli/src/commands/wallet/multisig/signature/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/signature/create.ts
@@ -134,15 +134,7 @@ export class CreateSignatureShareCommand extends IronfishCommand {
     const identityResponse = await client.wallet.multisig.getIdentity({ name: participantName })
     const identity = identityResponse.content.identity
 
-    const transactionHash = await ledger.reviewTransaction(
-      unsignedTransaction.serialize().toString('hex'),
-    )
-
-    const frostSignatureShare = await ledger.dkgSign(
-      unsignedTransaction.publicKeyRandomness(),
-      frostSigningPackage,
-      transactionHash.toString('hex'),
-    )
+    const frostSignatureShare = await ledger.dkgSign(unsignedTransaction, frostSigningPackage)
 
     const signatureShare = multisig.SignatureShare.fromFrost(
       frostSignatureShare,


### PR DESCRIPTION
## Summary

clear signing in the Ironfish DKG Ledger App requires that the client review the transaction with 'reviewTransaction' before generating signing commitments with 'dkgGetCommitments' or creating a signature share with 'dkgSign'

an approved 'reviewTransaction' instruction stores the transaction hash of the approved transaction in the device memory. however, storage of that hash does not persist between transport connections. so, if a connection is lost due to an error, or if a new connection is created for each instruction, then the hash cannot be accessed to allow generation of commitments or signature shares

modifies 'dkgGetCommitments' and 'dkgSign' in 'LedgerMultiSigner' to take an unsigned transaction and always call the 'reviewTransaction' instruction in the same connection as 'dkgGetCommitments' and 'dkgSign'

## Testing Plan
manual testing

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
