### PR TITLE
allows tryInstruction to skip error checks

### DIFF
--- a/ironfish-cli/src/ledger/ledger.ts
+++ b/ironfish-cli/src/ledger/ledger.ts
@@ -29,10 +29,7 @@ export class Ledger {
     this.isMultisig = isMultisig
   }
 
-  async tryInstruction<T>(
-    instruction: (app: IronfishApp) => Promise<T>,
-    unsafe = false,
-  ): Promise<T> {
+  tryInstruction = async <T>(instruction: (app: IronfishApp) => Promise<T>, unsafe = false) => {
     try {
       await this.connect()
 

--- a/ironfish-cli/src/ledger/ledger.ts
+++ b/ironfish-cli/src/ledger/ledger.ts
@@ -97,6 +97,8 @@ export class Ledger {
       if (error instanceof ResponseError) {
         if (error.returnCode === IronfishLedgerStatusCodes.LOCKED_DEVICE) {
           throw new LedgerDeviceLockedError()
+        } else if (error.returnCode === IronfishLedgerStatusCodes.INS_NOT_SUPPORTED) {
+          throw new LedgerAppLocked()
         } else if (error.returnCode === IronfishLedgerStatusCodes.CLA_NOT_SUPPORTED) {
           throw new LedgerClaNotSupportedError()
         } else if (error.returnCode === IronfishLedgerStatusCodes.GP_AUTH_FAILED) {
@@ -110,7 +112,6 @@ export class Ledger {
           throw new LedgerActionRejected()
         } else if (
           [
-            IronfishLedgerStatusCodes.INS_NOT_SUPPORTED,
             IronfishLedgerStatusCodes.TECHNICAL_PROBLEM,
             0xffff, // Unknown transport error
             0x6e01, // App not open

--- a/ironfish-cli/src/ledger/ledger.ts
+++ b/ironfish-cli/src/ledger/ledger.ts
@@ -29,7 +29,10 @@ export class Ledger {
     this.isMultisig = isMultisig
   }
 
-  tryInstruction = async <T>(instruction: (app: IronfishApp) => Promise<T>) => {
+  async tryInstruction<T>(
+    instruction: (app: IronfishApp) => Promise<T>,
+    unsafe = false,
+  ): Promise<T> {
     try {
       await this.connect()
 
@@ -40,7 +43,9 @@ export class Ledger {
       // App info is a request to the dashboard CLA. The purpose of this it to
       // produce a Locked Device error and works if an app is open or closed.
       try {
-        await app.appInfo()
+        if (!unsafe) {
+          await app.appInfo()
+        }
       } catch (error) {
         if (
           error instanceof ResponseError &&
@@ -56,7 +61,9 @@ export class Ledger {
       // INS_NOT_SUPPORTED in the case that the app is locked which is useful to
       // know versus the device is locked.
       try {
-        await app.getVersion()
+        if (!unsafe) {
+          await app.getVersion()
+        }
       } catch (error) {
         if (
           error instanceof ResponseError &&

--- a/ironfish-cli/src/ledger/ledgerMultiSigner.ts
+++ b/ironfish-cli/src/ledger/ledgerMultiSigner.ts
@@ -111,8 +111,9 @@ export class LedgerMultiSigner extends Ledger {
   }
 
   dkgGetCommitments = async (transactionHash: string): Promise<Buffer> => {
-    const { commitments } = await this.tryInstruction((app) =>
-      app.dkgGetCommitments(transactionHash),
+    const { commitments } = await this.tryInstruction(
+      (app) => app.dkgGetCommitments(transactionHash),
+      true,
     )
 
     return commitments
@@ -123,8 +124,9 @@ export class LedgerMultiSigner extends Ledger {
     frostSigningPackage: string,
     transactionHash: string,
   ): Promise<Buffer> => {
-    const { signature } = await this.tryInstruction((app) =>
-      app.dkgSign(randomness, frostSigningPackage, transactionHash),
+    const { signature } = await this.tryInstruction(
+      (app) => app.dkgSign(randomness, frostSigningPackage, transactionHash),
+      true,
     )
 
     return signature


### PR DESCRIPTION
## Summary

calling another instruction like 'getVersion' between 'reviewTransaction' and 'dkgGetCommitments' will cause the transaction hash stored in device memory to be cleared and cause 'dkgGetCommitments' to fail

adds an 'unsafe' option to bypass these calls in 'tryInstruction' and changes 'dkgGetCommitments' and 'dkgSign' to use the unsafe option

these methods will now work (provided they are called after 'reviewTransaction'), but they will not have the benefits of the error handling from 'appInfo' and 'getVersion'

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
