### PR TITLE
Avoid connect handshake and handle all error cases

### DIFF
--- a/ironfish-cli/src/ledger/README.md
+++ b/ironfish-cli/src/ledger/README.md
@@ -1,0 +1,33 @@
+# Ledger
+
+#### IronfishApp.appInfo() (OS CLA)
+    C APP
+        If Dashboard Open:
+            If Locked: throw 0x5515 DeviceLocked
+            If Unlocked: throw 0x6e01 (APP NOT OPEN)
+        If App Open:
+            If Locked: throw 0x5515 Device Locked
+            If Unlocked: returns successfully
+    RUST APP (OS RPC)
+        If Dashboard Open:
+            If Locked: throw 0x5515 DeviceLocked
+            If Unlocked: throw 0x6e01 (APP NOT OPEN)
+        If App Open:
+            If Locked: throw INS_NOT_SUPPORTED
+            If Unlocked: returns successfully
+
+##### IronfishApp.getVersion (APP CLA)
+    C APP
+        If Dashboard Open:
+            If Locked: throw 0x5515 DeviceLocked
+            If Unlocked: throw 0x6e01 (APP NOT OPEN)
+        If App Open:
+            If Locked: throw 0x5515 Device Locked
+            If Unlocked: returns successfully
+    RUST APP
+        If Dashboard Open:
+            If Locked: throw 0x5515 DeviceLocked
+            If Unlocked: throw 0x6e01 (APP NOT OPEN)
+        If App Open:
+            If Locked: throw INS_NOT_SUPPORTED
+            If Unlocked: returns successfully()

--- a/ironfish-cli/src/ledger/ledger.ts
+++ b/ironfish-cli/src/ledger/ledger.ts
@@ -15,6 +15,8 @@ import { ResponseError, Transport } from '@zondax/ledger-js'
 export const IronfishLedgerStatusCodes = {
   ...StatusCodes,
   COMMAND_NOT_ALLOWED: 0x6986,
+  APP_NOT_OPEN: 0x6e01,
+  UNKNOWN_TRANSPORT_ERROR: 0xffff,
 }
 
 export class Ledger {
@@ -35,61 +37,25 @@ export class Ledger {
 
       Assert.isNotUndefined(this.app, 'Unable to establish connection with Ledger device')
 
-      const app = this.app
+      return await instruction(this.app)
+    } catch (e: unknown) {
+      let error = e
 
-      // App info is a request to the dashboard CLA. The purpose of this it to
-      // produce a Locked Device error and works if an app is open or closed.
-      try {
-        await app.appInfo()
-      } catch (error) {
-        if (
-          error instanceof ResponseError &&
-          error.message.includes('Attempt to read beyond buffer length') &&
-          error.returnCode === IronfishLedgerStatusCodes.TECHNICAL_PROBLEM
-        ) {
-          // Catch this error and swollow it until the SDK fix merges to fix
-          // this
-        }
-      }
-
-      // This is an app specific request. This is useful because this throws
-      // INS_NOT_SUPPORTED in the case that the app is locked which is useful to
-      // know versus the device is locked.
-      try {
-        await app.getVersion()
-      } catch (error) {
-        if (
-          error instanceof ResponseError &&
-          error.returnCode === IronfishLedgerStatusCodes.INS_NOT_SUPPORTED
-        ) {
-          throw new LedgerAppLocked()
-        }
-
-        throw error
-      }
-
-      return await instruction(app)
-    } catch (error: unknown) {
-      if (LedgerPortIsBusyError.IsError(error)) {
+      if (LedgerPortIsBusyError.IsError(e)) {
         throw new LedgerPortIsBusyError()
-      } else if (LedgerConnectError.IsError(error)) {
+      } else if (LedgerConnectError.IsError(e)) {
         throw new LedgerConnectError()
       }
 
       if (error instanceof TransportStatusError) {
-        if (
-          error.statusCode === IronfishLedgerStatusCodes.COMMAND_NOT_ALLOWED ||
-          error.statusCode === IronfishLedgerStatusCodes.CONDITIONS_OF_USE_NOT_SATISFIED
-        ) {
-          throw new LedgerActionRejected()
-        } else {
-          throw new LedgerConnectError()
-        }
+        error = new ResponseError(error.statusCode, error.statusText)
       }
 
       if (error instanceof ResponseError) {
         if (error.returnCode === IronfishLedgerStatusCodes.LOCKED_DEVICE) {
           throw new LedgerDeviceLockedError()
+        } else if (error.returnCode === IronfishLedgerStatusCodes.INS_NOT_SUPPORTED) {
+          throw new LedgerAppLocked()
         } else if (error.returnCode === IronfishLedgerStatusCodes.CLA_NOT_SUPPORTED) {
           throw new LedgerClaNotSupportedError()
         } else if (error.returnCode === IronfishLedgerStatusCodes.GP_AUTH_FAILED) {
@@ -103,15 +69,16 @@ export class Ledger {
           throw new LedgerActionRejected()
         } else if (
           [
-            IronfishLedgerStatusCodes.INS_NOT_SUPPORTED,
             IronfishLedgerStatusCodes.TECHNICAL_PROBLEM,
-            0xffff, // Unknown transport error
-            0x6e01, // App not open
+            IronfishLedgerStatusCodes.UNKNOWN_TRANSPORT_ERROR,
+            IronfishLedgerStatusCodes.APP_NOT_OPEN,
           ].includes(error.returnCode)
         ) {
           throw new LedgerAppNotOpen(
             `Unable to connect to Ironfish app on Ledger. Please check that the device is unlocked and the app is open.`,
           )
+        } else if (e instanceof TransportStatusError) {
+          throw new LedgerConnectError()
         }
 
         throw new LedgerError(error.message)


### PR DESCRIPTION
## Summary

This adds new documentation about what and which errors are thrown. It
also removes appInfo() and getVersion() during tryInstruction because it
duplicates the error cdoes you get from just running any app commands.
This also transforms ledger app errors from TransportStatusError into
ResponseError so we can handle all the error codes in a single way.

The original investigation of this fix was done by @hughy and we furthered the research on figuring out that the entire connect handshake is not needed.

Original PR: https://github.com/iron-fish/ironfish/pull/5511

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
