### PR TITLE
reviews tx on InvalidTxHash error

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/commitment/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/commitment/create.ts
@@ -138,16 +138,12 @@ export class CreateSigningCommitmentCommand extends IronfishCommand {
     const identityResponse = await client.wallet.multisig.getIdentity({ name: participantName })
     const identity = identityResponse.content.identity
 
-    const transactionHash = await ledger.reviewTransaction(
-      unsignedTransaction.serialize().toString('hex'),
-    )
-
-    const rawCommitments = await ledger.dkgGetCommitments(transactionHash.toString('hex'))
+    const rawCommitments = await ledger.dkgGetCommitments(unsignedTransaction)
 
     const signingCommitment = multisig.SigningCommitment.fromRaw(
       identity,
       rawCommitments,
-      transactionHash,
+      unsignedTransaction.hash(),
       signers,
     )
 

--- a/ironfish-cli/src/commands/wallet/multisig/sign.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/sign.ts
@@ -381,6 +381,7 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
       const frostSignatureShare = await ui.ledger({
         ledger,
         message: 'Sign Transaction',
+        approval: true,
         action: () =>
           ledger.dkgSign(
             unsignedTransaction,
@@ -541,6 +542,7 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
     const rawCommitments = await ui.ledger({
       ledger,
       message: 'Get Commitments',
+      approval: true,
       action: () => ledger.dkgGetCommitments(unsignedTransaction),
     })
 

--- a/ironfish-cli/src/commands/wallet/multisig/sign.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/sign.ts
@@ -383,9 +383,8 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
         message: 'Sign Transaction',
         action: () =>
           ledger.dkgSign(
-            unsignedTransaction.publicKeyRandomness(),
+            unsignedTransaction,
             signingPackage.frostSigningPackage().toString('hex'),
-            unsignedTransaction.hash().toString('hex'),
           ),
       })
 
@@ -511,17 +510,10 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
 
     let commitment
     if (ledger) {
-      await ui.ledger({
-        ledger,
-        message: 'Review Transaction',
-        action: () => ledger.reviewTransaction(unsignedTransactionHex),
-        approval: true,
-      })
-
       commitment = await this.createSigningCommitmentWithLedger(
         ledger,
         participant,
-        unsignedTransaction.hash(),
+        unsignedTransaction,
         identities,
       )
     } else {
@@ -543,19 +535,19 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
   async createSigningCommitmentWithLedger(
     ledger: LedgerMultiSigner,
     participant: MultisigParticipant,
-    transactionHash: Buffer,
+    unsignedTransaction: UnsignedTransaction,
     signers: string[],
   ): Promise<string> {
     const rawCommitments = await ui.ledger({
       ledger,
       message: 'Get Commitments',
-      action: () => ledger.dkgGetCommitments(transactionHash.toString('hex')),
+      action: () => ledger.dkgGetCommitments(unsignedTransaction),
     })
 
     const sigingCommitment = multisig.SigningCommitment.fromRaw(
       participant.identity,
       rawCommitments,
-      transactionHash,
+      unsignedTransaction.hash(),
       signers,
     )
 

--- a/ironfish-cli/src/commands/wallet/multisig/signature/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/signature/create.ts
@@ -134,15 +134,7 @@ export class CreateSignatureShareCommand extends IronfishCommand {
     const identityResponse = await client.wallet.multisig.getIdentity({ name: participantName })
     const identity = identityResponse.content.identity
 
-    const transactionHash = await ledger.reviewTransaction(
-      unsignedTransaction.serialize().toString('hex'),
-    )
-
-    const frostSignatureShare = await ledger.dkgSign(
-      unsignedTransaction.publicKeyRandomness(),
-      frostSigningPackage,
-      transactionHash.toString('hex'),
-    )
+    const frostSignatureShare = await ledger.dkgSign(unsignedTransaction, frostSigningPackage)
 
     const signatureShare = multisig.SignatureShare.fromFrost(
       frostSignatureShare,

--- a/ironfish-cli/src/ledger/ledger.ts
+++ b/ironfish-cli/src/ledger/ledger.ts
@@ -17,6 +17,7 @@ export const IronfishLedgerStatusCodes = {
   COMMAND_NOT_ALLOWED: 0x6986,
   APP_NOT_OPEN: 0x6e01,
   UNKNOWN_TRANSPORT_ERROR: 0xffff,
+  INVALID_TX_HASH: 0xb025,
 }
 
 export class Ledger {
@@ -77,6 +78,8 @@ export class Ledger {
           throw new LedgerAppNotOpen(
             `Unable to connect to Ironfish app on Ledger. Please check that the device is unlocked and the app is open.`,
           )
+        } else if (error.returnCode === IronfishLedgerStatusCodes.INVALID_TX_HASH) {
+          throw new LedgerInvalidTxHash()
         } else if (e instanceof TransportStatusError) {
           throw new LedgerConnectError()
         }
@@ -161,3 +164,4 @@ export class LedgerGPAuthFailed extends LedgerError {}
 export class LedgerClaNotSupportedError extends LedgerError {}
 export class LedgerAppNotOpen extends LedgerError {}
 export class LedgerActionRejected extends LedgerError {}
+export class LedgerInvalidTxHash extends LedgerError {}


### PR DESCRIPTION
## Summary

updates dkgGetCommitments and dkgSign to catch Ledger error caused by unreviewed
transaction (InvalidTxHash), call reviewTransaction, and finally recursively
call themselves
    
adds error type for LedgerInvalidTxHash

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
