### PR TITLE
Remove a stray apostrophe from NotEnoughFunds message

### DIFF
--- a/ironfish/src/rpc/routes/wallet/createTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/createTransaction.ts
@@ -236,7 +236,7 @@ routes.register<typeof CreateTransactionRequestSchema, CreateTransactionResponse
           assetData,
         )
         const renderedAmount = CurrencyUtils.render(e.amount, false, e.assetId, assetData)
-        const message = `Insufficient funds: Needed ${renderedAmountNeeded} but have ${renderedAmount} available to spend. Please fund your account and/or wait for any pending transactions to be confirmed.'`
+        const message = `Insufficient funds: Needed ${renderedAmountNeeded} but have ${renderedAmount} available to spend. Please fund your account and/or wait for any pending transactions to be confirmed.`
         throw new RpcValidationError(message, 400, RPC_ERROR_CODES.INSUFFICIENT_BALANCE)
       }
       throw e

--- a/ironfish/src/rpc/routes/wallet/sendTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/sendTransaction.ts
@@ -174,7 +174,7 @@ routes.register<typeof SendTransactionRequestSchema, SendTransactionResponse>(
           assetData,
         )
         const renderedAmount = CurrencyUtils.render(e.amount, false, e.assetId, assetData)
-        const message = `Insufficient funds: Needed ${renderedAmountNeeded} but have ${renderedAmount} available to spend. Please fund your account and/or wait for any pending transactions to be confirmed.'`
+        const message = `Insufficient funds: Needed ${renderedAmountNeeded} but have ${renderedAmount} available to spend. Please fund your account and/or wait for any pending transactions to be confirmed.`
         throw new RpcValidationError(message, 400, RPC_ERROR_CODES.INSUFFICIENT_BALANCE)
       }
       throw e

--- a/ironfish/src/wallet/errors.ts
+++ b/ironfish/src/wallet/errors.ts
@@ -19,7 +19,7 @@ export class NotEnoughFundsError extends Error {
 
     const renderedAmountNeeded = CurrencyUtils.render(amountNeeded, true, this.assetId)
     const renderedAmount = CurrencyUtils.render(amount)
-    this.message = `Insufficient funds: Needed ${renderedAmountNeeded} but have ${renderedAmount} available to spend. Please fund your account and/or wait for any pending transactions to be confirmed.'`
+    this.message = `Insufficient funds: Needed ${renderedAmountNeeded} but have ${renderedAmount} available to spend. Please fund your account and/or wait for any pending transactions to be confirmed.`
   }
 }
 


### PR DESCRIPTION
## Summary

I noticed a stray apostrophe at the end of the NotEnoughFunds error message.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
