### PR TITLE
adds default multisig broker server

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/dkg/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/create.ts
@@ -61,11 +61,9 @@ export class DkgCreateCommand extends IronfishCommand {
     }),
     sessionId: Flags.string({
       description: 'Unique ID for a multisig server session to join',
-      dependsOn: ['server'],
     }),
     passphrase: Flags.string({
       description: 'Passphrase to join the multisig server session',
-      dependsOn: ['server'],
     }),
     tls: Flags.boolean({
       description: 'connect to the multisig server over TLS',
@@ -102,7 +100,7 @@ export class DkgCreateCommand extends IronfishCommand {
     }
 
     let multisigClient: MultisigClient | null = null
-    if (flags.server || flags.connection) {
+    if (flags.server || flags.connection || flags.sessionId || flags.passphrase) {
       const { hostname, port, sessionId, passphrase } =
         await MultisigBrokerUtils.parseConnectionOptions({
           connection: flags.connection,

--- a/ironfish-cli/src/commands/wallet/multisig/dkg/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/create.ts
@@ -44,8 +44,20 @@ export class DkgCreateCommand extends IronfishCommand {
       description:
         "Block sequence to begin scanning from for the created account. Uses node's chain head by default",
     }),
-    server: Flags.string({
-      description: "multisig server to connect to. formatted as '<host>:<port>'",
+    server: Flags.boolean({
+      description: 'connect to a multisig broker server',
+    }),
+    connection: Flags.string({
+      char: 'c',
+      description: 'connection string for a multisig server session',
+    }),
+    hostname: Flags.string({
+      description: 'hostname of the multisig broker server to connect to',
+      default: 'multisig.ironfish.network',
+    }),
+    port: Flags.integer({
+      description: 'port to connect to on the multisig broker server',
+      default: 9035,
     }),
     sessionId: Flags.string({
       description: 'Unique ID for a multisig server session to join',
@@ -90,21 +102,18 @@ export class DkgCreateCommand extends IronfishCommand {
     }
 
     let multisigClient: MultisigClient | null = null
-    if (flags.server) {
-      let sessionId = flags.sessionId
-      if (!sessionId && !flags.totalParticipants && !flags.minSigners) {
-        sessionId = await ui.inputPrompt(
-          'Enter the ID of a multisig session to join, or press enter to start a new session',
-          false,
-        )
-      }
+    if (flags.server || flags.connection) {
+      const { hostname, port, sessionId, passphrase } =
+        await MultisigBrokerUtils.parseConnectionOptions({
+          connection: flags.connection,
+          hostname: flags.hostname,
+          port: flags.port,
+          sessionId: flags.sessionId,
+          passphrase: flags.passphrase,
+          logger: this.logger,
+        })
 
-      let passphrase = flags.passphrase
-      if (!passphrase) {
-        passphrase = await ui.inputPrompt('Enter the passphrase for the multisig session', true)
-      }
-
-      multisigClient = await MultisigBrokerUtils.createClient(flags.server, {
+      multisigClient = MultisigBrokerUtils.createClient(hostname, port, {
         passphrase,
         tls: flags.tls ?? true,
         logger: this.logger,
@@ -380,6 +389,8 @@ export class DkgCreateCommand extends IronfishCommand {
       multisigClient.startDkgSession(totalParticipants, minSigners)
       this.log('\nStarted new DKG session:')
       this.log(`${multisigClient.sessionId}`)
+      this.log('\nDKG session connection string:')
+      this.log(`${multisigClient.connectionString}`)
     }
 
     return { totalParticipants, minSigners }

--- a/ironfish-cli/src/commands/wallet/multisig/sign.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/sign.ts
@@ -46,8 +46,20 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
       default: false,
       description: 'Perform operation with a ledger device',
     }),
-    server: Flags.string({
-      description: "multisig server to connect to. formatted as '<host>:<port>'",
+    server: Flags.boolean({
+      description: 'connect to a multisig broker server',
+    }),
+    connection: Flags.string({
+      char: 'c',
+      description: 'connection string for a multisig server session',
+    }),
+    hostname: Flags.string({
+      description: 'hostname of the multisig broker server to connect to',
+      default: 'multisig.ironfish.network',
+    }),
+    port: Flags.integer({
+      description: 'port to connect to on the multisig broker server',
+      default: 9035,
     }),
     sessionId: Flags.string({
       description: 'Unique ID for a multisig server session to join',
@@ -114,21 +126,18 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
     }
 
     let multisigClient: MultisigClient | null = null
-    if (flags.server) {
-      let sessionId = flags.sessionId
-      if (!sessionId) {
-        sessionId = await ui.inputPrompt(
-          'Enter the ID of a multisig session to join, or press enter to start a new session',
-          false,
-        )
-      }
+    if (flags.server || flags.connection) {
+      const { hostname, port, sessionId, passphrase } =
+        await MultisigBrokerUtils.parseConnectionOptions({
+          connection: flags.connection,
+          hostname: flags.hostname,
+          port: flags.port,
+          sessionId: flags.sessionId,
+          passphrase: flags.passphrase,
+          logger: this.logger,
+        })
 
-      let passphrase = flags.passphrase
-      if (!passphrase) {
-        passphrase = await ui.inputPrompt('Enter the passphrase for the multisig session', true)
-      }
-
-      multisigClient = await MultisigBrokerUtils.createClient(flags.server, {
+      multisigClient = MultisigBrokerUtils.createClient(hostname, port, {
         passphrase,
         tls: flags.tls ?? true,
         logger: this.logger,
@@ -267,6 +276,8 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
       multisigClient.startSigningSession(totalParticipants, unsignedTransactionInput)
       this.log('\nStarted new signing session:')
       this.log(`${multisigClient.sessionId}`)
+      this.log('\nSigning session connection string:')
+      this.log(`${multisigClient.connectionString}`)
     }
 
     return { unsignedTransaction, totalParticipants }

--- a/ironfish-cli/src/commands/wallet/multisig/sign.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/sign.ts
@@ -63,11 +63,9 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
     }),
     sessionId: Flags.string({
       description: 'Unique ID for a multisig server session to join',
-      dependsOn: ['server'],
     }),
     passphrase: Flags.string({
       description: 'Passphrase to join the multisig server session',
-      dependsOn: ['server'],
     }),
     tls: Flags.boolean({
       description: 'connect to the multisig server over TLS',
@@ -126,7 +124,7 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
     }
 
     let multisigClient: MultisigClient | null = null
-    if (flags.server || flags.connection) {
+    if (flags.server || flags.connection || flags.sessionId || flags.passphrase) {
       const { hostname, port, sessionId, passphrase } =
         await MultisigBrokerUtils.parseConnectionOptions({
           connection: flags.connection,

--- a/ironfish-cli/src/multisigBroker/clients/client.ts
+++ b/ironfish-cli/src/multisigBroker/clients/client.ts
@@ -42,6 +42,8 @@ const RETRY_INTERVAL = 5000
 export abstract class MultisigClient {
   readonly logger: Logger
   readonly version: number
+  readonly hostname: string
+  readonly port: number
 
   private started: boolean
   private isClosing = false
@@ -65,9 +67,11 @@ export abstract class MultisigClient {
 
   retries: Map<number, NodeJS.Timer> = new Map()
 
-  constructor(options: { passphrase: string; logger: Logger }) {
+  constructor(options: { hostname: string; port: number; passphrase: string; logger: Logger }) {
     this.logger = options.logger
     this.version = 3
+    this.hostname = options.hostname
+    this.port = options.port
 
     this.started = false
     this.nextMessageId = 0
@@ -76,6 +80,10 @@ export abstract class MultisigClient {
     this.connectTimeout = null
 
     this.passphrase = options.passphrase
+  }
+
+  get connectionString(): string {
+    return `tcp://${this.sessionId}:${this.passphrase}@${this.hostname}:${this.port}`
   }
 
   get key(): xchacha20poly1305.XChaCha20Poly1305Key {

--- a/ironfish-cli/src/multisigBroker/clients/tcpClient.ts
+++ b/ironfish-cli/src/multisigBroker/clients/tcpClient.ts
@@ -6,15 +6,15 @@ import net from 'net'
 import { MultisigClient } from './client'
 
 export class MultisigTcpClient extends MultisigClient {
-  readonly host: string
-  readonly port: number
-
   client: net.Socket | null = null
 
-  constructor(options: { host: string; port: number; passphrase: string; logger: Logger }) {
-    super({ passphrase: options.passphrase, logger: options.logger })
-    this.host = options.host
-    this.port = options.port
+  constructor(options: { hostname: string; port: number; passphrase: string; logger: Logger }) {
+    super({
+      hostname: options.hostname,
+      port: options.port,
+      passphrase: options.passphrase,
+      logger: options.logger,
+    })
   }
 
   protected onSocketDisconnect = (): void => {
@@ -50,7 +50,7 @@ export class MultisigTcpClient extends MultisigClient {
       client.on('error', onError)
       client.on('connect', onConnect)
       client.on('data', this.onSocketData)
-      client.connect({ host: this.host, port: this.port })
+      client.connect({ host: this.hostname, port: this.port })
       this.client = client
     })
   }

--- a/ironfish-cli/src/multisigBroker/clients/tlsClient.ts
+++ b/ironfish-cli/src/multisigBroker/clients/tlsClient.ts
@@ -24,7 +24,7 @@ export class MultisigTlsClient extends MultisigTcpClient {
       }
 
       const client = tls.connect({
-        host: this.host,
+        host: this.hostname,
         port: this.port,
         rejectUnauthorized: false,
       })


### PR DESCRIPTION
## Summary

changes '--server' to boolean flag in 'wallet:multisig:sign' and 'wallet:multisig:dkg:create'

adds '--hostname' and '--port' flags in place of previous '--server' flag to supply server hostname and port

defaults 'hostname' to 'multisig.ironfish.network' and 'port' to 9035

adds support for connection strings with '--connection' flag

adds util function to parse all connection options from flags

prints connection string to console after starting session

Closes IFL-3043

## Testing Plan
```
? Enter a name for the multisig account: test0
? Enter the ID of a multisig session to join, or press enter to start a new session: 
? Enter the passphrase for the multisig session: test
? Enter the total number of participants: 2
? Enter the number of minimum signers: 2

Started new DKG session:
91b68c04-87ea-42c6-9f7a-4f9723f1e045

DKG session connection string:
tcp://91b68c04-87ea-42c6-9f7a-4f9723f1e045:test@multisig.ironfish.network:9035
```

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
