### PR TITLE
adds owner to RpcMint

### DIFF
--- a/ironfish/src/rpc/routes/chain/followChainStream.ts
+++ b/ironfish/src/rpc/routes/chain/followChainStream.ts
@@ -103,6 +103,7 @@ routes.register<typeof FollowChainStreamRequestSchema, FollowChainStreamResponse
           metadata: BufferUtils.toHuman(mint.asset.metadata()),
           name: BufferUtils.toHuman(mint.asset.name()),
           creator: mint.asset.creator().toString('hex'),
+          owner: mint.asset.creator().toString('hex'),
           value: mint.value.toString(),
           transferOwnershipTo: mint.transferOwnershipTo?.toString('hex'),
           assetId: mint.asset.id().toString('hex'),

--- a/ironfish/src/rpc/routes/chain/getTransactionStream.ts
+++ b/ironfish/src/rpc/routes/chain/getTransactionStream.ts
@@ -186,6 +186,7 @@ routes.register<typeof GetTransactionStreamRequestSchema, GetTransactionStreamRe
             id: mint.asset.id().toString('hex'),
             name: mint.asset.name().toString('hex'),
             creator: mint.asset.creator().toString('hex'),
+            owner: mint.asset.creator().toString('hex'),
             metadata: mint.asset.metadata().toString('hex'),
             transferOwnershipTo: mint.transferOwnershipTo?.toString('hex'),
           })

--- a/ironfish/src/rpc/routes/chain/serializers.ts
+++ b/ironfish/src/rpc/routes/chain/serializers.ts
@@ -91,6 +91,7 @@ export const serializeRpcTransaction = (
       metadata: BufferUtils.toHuman(mint.asset.metadata()),
       name: BufferUtils.toHuman(mint.asset.name()),
       creator: mint.asset.creator().toString('hex'),
+      owner: mint.asset.creator().toString('hex'),
       value: mint.value.toString(),
       transferOwnershipTo: mint.transferOwnershipTo?.toString('hex'),
       assetId: mint.asset.id().toString('hex'),

--- a/ironfish/src/rpc/routes/chain/types.ts
+++ b/ironfish/src/rpc/routes/chain/types.ts
@@ -82,6 +82,10 @@ export type RpcMint = {
    * @deprecated Please use getAsset endpoint to get this information
    */
   creator: string
+  /**
+   * @deprecated Please use getAsset endpoint to get this information
+   */
+  owner: string
 }
 
 export const RpcMintSchema: yup.ObjectSchema<RpcMint> = yup
@@ -93,6 +97,7 @@ export const RpcMintSchema: yup.ObjectSchema<RpcMint> = yup
     metadata: yup.string().defined(),
     name: yup.string().defined(),
     creator: yup.string().defined(),
+    owner: yup.string().defined(),
     assetName: yup.string().defined(),
   })
   .defined()

--- a/ironfish/src/rpc/routes/wallet/mintAsset.test.ts
+++ b/ironfish/src/rpc/routes/wallet/mintAsset.test.ts
@@ -142,6 +142,7 @@ describe('Route wallet/mintAsset', () => {
         ),
         id: asset.id().toString('hex'),
         creator: asset.creator().toString('hex'),
+        owner: asset.creator().toString('hex'),
         assetId: asset.id().toString('hex'),
         metadata: asset.metadata().toString('hex'),
         hash: mintTransaction.hash().toString('hex'),

--- a/ironfish/src/rpc/routes/wallet/mintAsset.ts
+++ b/ironfish/src/rpc/routes/wallet/mintAsset.ts
@@ -164,6 +164,7 @@ routes.register<typeof MintAssetRequestSchema, MintAssetResponse>(
       assetName: mint.asset.name().toString('hex'),
       metadata: mint.asset.metadata().toString('hex'),
       creator: mint.asset.creator().toString('hex'),
+      owner: mint.asset.creator().toString('hex'),
       transferOwnershipTo: mint.transferOwnershipTo?.toString('hex'),
     })
   },

--- a/ironfish/src/rpc/routes/wallet/serializers.ts
+++ b/ironfish/src/rpc/routes/wallet/serializers.ts
@@ -79,6 +79,7 @@ export async function serializeRpcWalletTransaction(
       metadata: BufferUtils.toHuman(mint.asset.metadata()),
       name: BufferUtils.toHuman(mint.asset.name()),
       creator: mint.asset.creator().toString('hex'),
+      owner: mint.asset.creator().toString('hex'),
       value: mint.value.toString(),
       transferOwnershipTo: mint.transferOwnershipTo?.toString('hex'),
       assetId: mint.asset.id().toString('hex'),


### PR DESCRIPTION
## Summary

assets stored in the blockchain database include both 'creator' and 'owner', but the RpcMint type only includes 'creator'

our api expects to receive mint data that includes 'owner'

updates RpcMint to include owner

NOTE: this field is immediately deprecated alongside 'creator' and other fields that can be read from asset RPCs. fully deprecating these fields for endpoints like 'followChainStream' and 'getTransactionStream' that expect streams of chain data could make the process of fetching asset data with separate requests between streaming responses difficult

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
