### PR TITLE
Handle all device locks as manual retry

### DIFF
--- a/ironfish-cli/src/ledger/ledger.ts
+++ b/ironfish-cli/src/ledger/ledger.ts
@@ -65,8 +65,6 @@ export class Ledger {
       if (error instanceof ResponseError) {
         if (error.returnCode === IronfishLedgerStatusCodes.LOCKED_DEVICE) {
           throw new LedgerDeviceLockedError()
-        } else if (error.returnCode === IronfishLedgerStatusCodes.INS_NOT_SUPPORTED) {
-          throw new LedgerAppLocked()
         } else if (error.returnCode === IronfishLedgerStatusCodes.CLA_NOT_SUPPORTED) {
           throw new LedgerClaNotSupportedError()
         } else if (error.returnCode === IronfishLedgerStatusCodes.PANIC) {
@@ -171,7 +169,6 @@ export class LedgerPortIsBusyError extends LedgerError {
 }
 
 export class LedgerDeviceLockedError extends LedgerError {}
-export class LedgerAppLocked extends LedgerError {}
 export class LedgerGPAuthFailed extends LedgerError {}
 export class LedgerClaNotSupportedError extends LedgerError {}
 export class LedgerAppNotOpen extends LedgerError {}

--- a/ironfish-cli/src/ui/ledger.ts
+++ b/ironfish-cli/src/ui/ledger.ts
@@ -15,7 +15,6 @@ import { Errors, ux } from '@oclif/core'
 import {
   Ledger,
   LedgerActionRejected,
-  LedgerAppLocked,
   LedgerAppNotOpen,
   LedgerClaNotSupportedError,
   LedgerConnectError,
@@ -65,15 +64,15 @@ export async function ledger<TResult>({
       } catch (e) {
         clearTimeout(clearStatusTimer)
 
-        if (e instanceof LedgerAppLocked) {
+        if (e instanceof LedgerDeviceLockedError) {
           // If an app is running and it's locked, trying to poll the device
           // will cause the Ledger device to hide the pin screen as the user
           // is trying to enter their pin. When we run into this error, we
           // cannot send any commands to the Ledger in the app's CLA.
-          ux.action.stop('Ledger App Locked')
+          ux.action.stop('Ledger Locked')
 
           const confirmed = await ui.confirmList(
-            'Ledger App Locked. Unlock and press enter to retry:',
+            'Ledger Locked. Unlock and press enter to retry:',
             'Retry',
           )
 
@@ -93,8 +92,6 @@ export async function ledger<TResult>({
         } else if (e instanceof LedgerAppNotOpen) {
           const appName = ledger.isMultisig ? 'Ironfish DKG' : 'Ironfish'
           ux.action.status = `Open Ledger App ${appName}`
-        } else if (e instanceof LedgerDeviceLockedError) {
-          ux.action.status = 'Unlock Ledger'
         } else if (e instanceof LedgerPanicError) {
           ux.action.status = 'Ledger App Crashed'
           ux.stdout('Ledger App Crashed! ⚠️')


### PR DESCRIPTION
## Summary

Because zondax removed the ability to discern between a locked app and a locked device.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
