### PR TITLE
Handle all connecting errors as LedgerConnectError

### DIFF
--- a/ironfish-cli/src/ledger/ledger.ts
+++ b/ironfish-cli/src/ledger/ledger.ts
@@ -155,11 +155,19 @@ export class LedgerError extends Error {
 
 export class LedgerConnectError extends LedgerError {
   static IsError(error: unknown): error is Error {
+    const ids = [
+      'ListenTimeout',
+      'InvalidChannel',
+      'InvalidTag',
+      'InvalidSequence',
+      'NoDeviceFound',
+    ]
+
     return (
       error instanceof Error &&
       'id' in error &&
       typeof error['id'] === 'string' &&
-      error.id === 'ListenTimeout'
+      ids.includes(error.id)
     )
   }
 }


### PR DESCRIPTION
## Summary

Found these in the hw-transport library from ledgerhq.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
