### PR TITLE
Fix ledger restore to require encrypted key

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/ledger/restore.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/ledger/restore.ts
@@ -19,12 +19,12 @@ export class MultisigLedgerRestore extends IronfishCommand {
   async start(): Promise<void> {
     const { args } = await this.parse(MultisigLedgerRestore)
 
-    let encryptedKeys = args.backup
-    if (!encryptedKeys) {
-      encryptedKeys = await ui.longPrompt(
+    const encryptedKeys =
+      args.backup ||
+      (await ui.longPrompt(
         'Enter the encrypted multisig key backup to restore to your Ledger device',
-      )
-    }
+        { required: true },
+      ))
 
     const ledger = new LedgerMultiSigner()
     try {


### PR DESCRIPTION
## Summary

This also makes the type of `encryptedKeys` `string` and not `string | undefined`.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
