### PR TITLE
Upgrade ledger:restore cmd to use ledger ui

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/ledger/restore.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/ledger/restore.ts
@@ -27,17 +27,13 @@ export class MultisigLedgerRestore extends IronfishCommand {
     }
 
     const ledger = new LedgerMultiSigner()
-    try {
-      await ledger.connect()
-    } catch (e) {
-      if (e instanceof Error) {
-        this.error(e.message)
-      } else {
-        throw e
-      }
-    }
 
-    await ledger.dkgRestoreKeys(encryptedKeys)
+    await ui.ledger({
+      ledger,
+      message: 'Restoring Keys to Ledger',
+      approval: true,
+      action: () => ledger.dkgRestoreKeys(encryptedKeys),
+    })
 
     this.log()
     this.log('Encrypted multisig key backup restored to Ledger.')


### PR DESCRIPTION
## Summary

This uses the new reliable ledger connection

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
