### PR TITLE
Remove S3 uploading from Homebrew deployment

### DIFF
--- a/.github/workflows/deploy-brew.yml
+++ b/.github/workflows/deploy-brew.yml
@@ -30,14 +30,6 @@ jobs:
       - name: Build Ironfish CLI
         run: ./ironfish-cli/scripts/build.sh
 
-      - name: Deploy Ironfish CLI Brew
-        run: ./ironfish-cli/scripts/deploy-brew.sh
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          BREW_GITHUB_USERNAME: ${{ secrets.BREW_GITHUB_USERNAME }}
-          BREW_GITHUB_TOKEN: ${{ secrets.BREW_GITHUB_TOKEN }}
-
       - name: Deploy Ironfish CLI Brew to R2
         run: ./ironfish-cli/scripts/deploy-brew.sh
         env:

--- a/.github/workflows/deploy-brew.yml
+++ b/.github/workflows/deploy-brew.yml
@@ -38,4 +38,3 @@ jobs:
           BREW_GITHUB_USERNAME: ${{ secrets.BREW_GITHUB_USERNAME }}
           BREW_GITHUB_TOKEN: ${{ secrets.BREW_GITHUB_TOKEN }}
           AWS_DEFAULT_REGION: auto
-          UPLOAD_TO_R2: true

--- a/ironfish-cli/scripts/deploy-brew.sh
+++ b/ironfish-cli/scripts/deploy-brew.sh
@@ -28,13 +28,7 @@ UPLOAD_HASH=$(shasum -a 256 $SOURCE_PATH | awk '{print $1}')
 
 UPLOAD_NAME=ironfish-cli-$GIT_HASH.tar.gz
 UPLOAD_URL=s3://ironfish-cli/$UPLOAD_NAME
-
-if [ -z "${UPLOAD_TO_R2-}" ];
-then
-  PUBLIC_URL=https://ironfish-cli.s3.amazonaws.com/$UPLOAD_NAME
-else
-  PUBLIC_URL=https://releases.ironfish.network/$UPLOAD_NAME
-fi
+PUBLIC_URL=https://releases.ironfish.network/$UPLOAD_NAME
 
 echo ""
 echo "GIT HASH:     $GIT_HASH"
@@ -44,24 +38,13 @@ echo "UPLOAD URL:   $UPLOAD_URL"
 echo "PUBLIC URL:   $PUBLIC_URL"
 echo ""
 
-if [ -z "${UPLOAD_TO_R2-}" ];
-then
-  if aws s3api head-object --bucket ironfish-cli --key $UPLOAD_NAME > /dev/null 2>&1 ; then
-    echo "Release already uploaded: $PUBLIC_URL"
-    exit 1
-  fi
-
-  echo "Uploading $SOURCE_NAME to $UPLOAD_URL"
-  aws s3 cp $SOURCE_PATH $UPLOAD_URL
-else
-  if aws s3api head-object --bucket ironfish-cli --endpoint-url https://a93bebf26da4c2fe205f71c896afcf89.r2.cloudflarestorage.com --key $UPLOAD_NAME > /dev/null 2>&1 ; then
-    echo "Release already uploaded: $PUBLIC_URL"
-    exit 1
-  fi
-
-  echo "Uploading $SOURCE_NAME to $UPLOAD_URL"
-  aws s3 cp $SOURCE_PATH $UPLOAD_URL --endpoint-url https://a93bebf26da4c2fe205f71c896afcf89.r2.cloudflarestorage.com
+if aws s3api head-object --bucket ironfish-cli --endpoint-url https://a93bebf26da4c2fe205f71c896afcf89.r2.cloudflarestorage.com --key $UPLOAD_NAME > /dev/null 2>&1 ; then
+  echo "Release already uploaded: $PUBLIC_URL"
+  exit 1
 fi
+
+echo "Uploading $SOURCE_NAME to $UPLOAD_URL"
+aws s3 cp $SOURCE_PATH $UPLOAD_URL --endpoint-url https://a93bebf26da4c2fe205f71c896afcf89.r2.cloudflarestorage.com
 
 echo ""
 echo "You are almost finished! To finish the process you need to update update url and sha256 in"


### PR DESCRIPTION
## Summary

We've been deploying these to R2 for a while, but the script still uploads releases to both. Since we've had some confusion over which to use, we can remove the S3 upload.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
