### PR TITLE
updates collectStrings to prompt for new item on duplicate

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/dkg/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/create.ts
@@ -420,7 +420,7 @@ export class DkgCreateCommand extends IronfishCommand {
       )
       identities = await ui.collectStrings('Participant Identity', totalParticipants - 1, {
         additionalStrings: [currentIdentity],
-        errorOnDuplicate: true,
+        logger: this.logger,
       })
     } else {
       identities = await sessionManager.getIdentities(currentIdentity, totalParticipants)
@@ -504,7 +504,7 @@ export class DkgCreateCommand extends IronfishCommand {
         totalParticipants - 1,
         {
           additionalStrings: [round1Result.publicPackage],
-          errorOnDuplicate: true,
+          logger: this.logger,
         },
       )
     } else {
@@ -669,7 +669,7 @@ export class DkgCreateCommand extends IronfishCommand {
         totalParticipants - 1,
         {
           additionalStrings: [round2Result.publicPackage],
-          errorOnDuplicate: true,
+          logger: this.logger,
         },
       )
     } else {

--- a/ironfish-cli/src/commands/wallet/multisig/sign.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/sign.ts
@@ -272,7 +272,7 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
 
       signatureShares = await ui.collectStrings('Signature Share', totalParticipants - 1, {
         additionalStrings: [signatureShare],
-        errorOnDuplicate: true,
+        logger: this.logger,
       })
     } else {
       signatureShares = await sessionManager.getSignatureShares(
@@ -395,7 +395,7 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
 
       commitments = await ui.collectStrings('Commitment', identities.length - 1, {
         additionalStrings: [commitment],
-        errorOnDuplicate: true,
+        logger: this.logger,
       })
     } else {
       commitments = await sessionManager.getSigningCommitments(commitment, totalParticipants)
@@ -430,7 +430,7 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
 
       identities = await ui.collectStrings('Participant Identity', totalParticipants - 1, {
         additionalStrings: [participant.identity],
-        errorOnDuplicate: true,
+        logger: this.logger,
       })
     } else {
       identities = await sessionManager.getIdentities(participant.identity, totalParticipants)


### PR DESCRIPTION
## Summary

if a user inputs a duplicate string into a prompt from collectStrings, they will be informed of the duplicate and the prompt will be repeated

adds option to allow duplicates

updates usage of collectStrings in 'wallet:multisig:dkg:create' and 'wallet:multisig:sign' not to error on duplicates

## Testing Plan
<img width="1127" alt="image" src="https://github.com/user-attachments/assets/4e35ef85-3eee-496a-9442-5a7b306f7f67">


## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
