### PR TITLE
multisig broker server disconnects on invalid message

### DIFF
--- a/ironfish-cli/src/multisigBroker/server.ts
+++ b/ironfish-cli/src/multisigBroker/server.ts
@@ -186,7 +186,8 @@ export class MultisigServer {
       )
 
       if (parseError) {
-        this.sendErrorMessage(client, 0, `Error parsing message`)
+        client.close(parseError)
+        this.clients.delete(client.id)
         return
       }
 

--- a/ironfish-cli/src/multisigBroker/server.ts
+++ b/ironfish-cli/src/multisigBroker/server.ts
@@ -186,6 +186,12 @@ export class MultisigServer {
       )
 
       if (parseError) {
+        this.logger.debug(
+          `Error parsing message from client ${client.id}: ${ErrorUtils.renderError(
+            parseError,
+            true,
+          )}`,
+        )
         client.close(parseError)
         this.clients.delete(client.id)
         return


### PR DESCRIPTION
## Summary

if the broker server receives a message that it cannot parse then it should disconnect from the client that sent the message

the server cannot send an 'ack' message to the client if it cannot parse the message and cannot send an error message with the message id of the errant message, so the client may continue retrying the malformed message if the server does not disconnect

for now the server does not implement client banning

Closes IFL-3062

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
