### PR TITLE
uses ux action to show client connecting

### DIFF
--- a/ironfish-cli/src/multisigBroker/sessionManagers/sessionManager.ts
+++ b/ironfish-cli/src/multisigBroker/sessionManagers/sessionManager.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Assert, Logger, PromiseUtils } from '@ironfish/sdk'
+import { ux } from '@oclif/core'
 import { MultisigClient } from '../clients'
 import { MultisigBrokerUtils } from '../utils'
 
@@ -44,6 +45,9 @@ export abstract class MultisigClientSessionManager extends MultisigSessionManage
   protected async connect(): Promise<void> {
     let confirmed = false
 
+    ux.action.start(
+      `Connecting to multisig broker server: ${this.client.hostname}:${this.client.port}`,
+    )
     this.client.start()
 
     this.client.onConnectedMessage.on(() => {
@@ -55,6 +59,7 @@ export abstract class MultisigClientSessionManager extends MultisigSessionManage
     }
 
     this.client.onConnectedMessage.clear()
+    ux.action.stop()
   }
 
   async joinSession(sessionId: string): Promise<void> {


### PR DESCRIPTION
## Summary

gives the user feedback that the command is waiting on a connection to the multisig broker server

Closes IFL-3054

## Testing Plan
<img width="654" alt="image" src="https://github.com/user-attachments/assets/abd2b0cb-3e68-48aa-b56a-a5dda16184cb">


## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
