### PR TITLE
wait for server to confirm session started

### DIFF
--- a/ironfish-cli/src/multisigBroker/server.ts
+++ b/ironfish-cli/src/multisigBroker/server.ts
@@ -452,6 +452,10 @@ export class MultisigServer {
     this.logger.debug(`Client ${client.id} started dkg session ${message.sessionId}`)
 
     this.addClientToSession(client, sessionId)
+
+    this.send(client.socket, 'joined_session', message.sessionId, {
+      challenge: session.challenge,
+    })
   }
 
   async handleSigningStartSessionMessage(
@@ -491,6 +495,10 @@ export class MultisigServer {
     this.logger.debug(`Client ${client.id} started signing session ${message.sessionId}`)
 
     this.addClientToSession(client, sessionId)
+
+    this.send(client.socket, 'joined_session', message.sessionId, {
+      challenge: session.challenge,
+    })
   }
 
   handleJoinSessionMessage(client: MultisigServerClient, message: MultisigBrokerMessage) {

--- a/ironfish-cli/src/multisigBroker/sessionManagers/dkgSessionManager.ts
+++ b/ironfish-cli/src/multisigBroker/sessionManagers/dkgSessionManager.ts
@@ -57,8 +57,10 @@ export class MultisigClientDkgSessionManager
     this.client.startDkgSession(totalParticipants, minSigners)
     this.sessionId = this.client.sessionId
 
-    this.logger.info('\nStarted new DKG session:')
-    this.logger.info(`${this.sessionId}`)
+    this.logger.info(`\nStarted new DKG session: ${this.sessionId}\n`)
+
+    await this.waitForJoinedSession()
+
     this.logger.info('\nDKG session connection string:')
     this.logger.info(`${this.client.connectionString}`)
 

--- a/ironfish-cli/src/multisigBroker/sessionManagers/sessionManager.ts
+++ b/ironfish-cli/src/multisigBroker/sessionManagers/sessionManager.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Assert, Logger, PromiseUtils } from '@ironfish/sdk'
+import { ux } from '@oclif/core'
 import { MultisigClient } from '../clients'
 import { MultisigBrokerUtils } from '../utils'
 
@@ -70,6 +71,7 @@ export abstract class MultisigClientSessionManager extends MultisigSessionManage
     Assert.isNotNull(this.client)
     let confirmed = false
 
+    ux.action.start(`Waiting to join session: ${this.client.sessionId}`)
     this.client.onJoinedSession.on(() => {
       confirmed = true
     })
@@ -79,6 +81,7 @@ export abstract class MultisigClientSessionManager extends MultisigSessionManage
     }
 
     this.client.onJoinedSession.clear()
+    ux.action.stop()
   }
 
   endSession(): void {

--- a/ironfish-cli/src/multisigBroker/sessionManagers/signingSessionManager.ts
+++ b/ironfish-cli/src/multisigBroker/sessionManagers/signingSessionManager.ts
@@ -47,8 +47,10 @@ export class MultisigClientSigningSessionManager
     this.client.startSigningSession(numSigners, unsignedTransaction)
     this.sessionId = this.client.sessionId
 
-    this.logger.info('\nStarted new signing session:')
-    this.logger.info(`${this.sessionId}`)
+    this.logger.info(`\nStarting new signing session: ${this.sessionId}\n`)
+
+    await this.waitForJoinedSession()
+
     this.logger.info('\nSigning session connection string:')
     this.logger.info(`${this.client.connectionString}`)
 


### PR DESCRIPTION
## Summary

updates server to send 'joined_session' message to client after starting the session on the server side

updates session manager to wait for 'joined_session' message before returning from startSession

adds ux status output when waiting for confirmation of joined session

Closes IFL-3057

## Testing Plan
<img width="735" alt="image" src="https://github.com/user-attachments/assets/1cb51e2a-d081-4fd1-bf2a-3c810a2182cd">


## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
