### PR TITLE
updates 'wallet:import' to support ledger multisig

### DIFF
--- a/ironfish-cli/src/ledger/ledgerMultiSigner.ts
+++ b/ironfish-cli/src/ledger/ledgerMultiSigner.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { UnsignedTransaction } from '@ironfish/sdk'
+import { ACCOUNT_SCHEMA_VERSION, UnsignedTransaction } from '@ironfish/sdk'
 import {
   IronfishKeys,
   KeyResponse,
@@ -164,5 +164,25 @@ export class LedgerMultiSigner extends Ledger {
 
   dkgRestoreKeys = async (encryptedKeys: string): Promise<void> => {
     await this.tryInstruction((app) => app.dkgRestoreKeys(encryptedKeys))
+  }
+
+  importAccount = async () => {
+    const identity = await this.dkgGetIdentity(0)
+    const dkgKeys = await this.dkgRetrieveKeys()
+    const publicKeyPackage = await this.dkgGetPublicPackage()
+
+    const accountImport = {
+      ...dkgKeys,
+      name: 'ledger-multisig',
+      multisigKeys: {
+        publicKeyPackage: publicKeyPackage.toString('hex'),
+        identity: identity.toString('hex'),
+      },
+      version: ACCOUNT_SCHEMA_VERSION,
+      spendingKey: null,
+      createdAt: null,
+    }
+
+    return accountImport
   }
 }


### PR DESCRIPTION
## Summary

adds a '--multisig' flag to use with the '--ledger' flag to import a multisig account from the Ironfish DKG Ledger app

adds an 'importAccount' method to 'LedgerMultiSigner' to match the function signature in the 'LedgerSingleSigner' class

updates 'wallet:multisig:ledger:import' to use the same lgoic

hides 'wallet:multisig:ledger:import' and adds a deprecation message

## Testing Plan
<img width="582" alt="image" src="https://github.com/user-attachments/assets/e164ae60-0315-4c0c-b73d-e3729b1fcbc6">


## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
