### PR TITLE
sets passphrase on client when joining session

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/dkg/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/create.ts
@@ -19,7 +19,6 @@ import path from 'path'
 import { IronfishCommand } from '../../../../command'
 import { RemoteFlags } from '../../../../flags'
 import { LedgerMultiSigner } from '../../../../ledger'
-import { MultisigBrokerUtils } from '../../../../multisigBroker'
 import {
   DkgSessionManager,
   MultisigClientDkgSessionManager,
@@ -105,21 +104,12 @@ export class DkgCreateCommand extends IronfishCommand {
 
     let sessionManager: DkgSessionManager
     if (flags.server || flags.connection || flags.sessionId || flags.passphrase) {
-      const { hostname, port, sessionId, passphrase } =
-        await MultisigBrokerUtils.parseConnectionOptions({
-          connection: flags.connection,
-          hostname: flags.hostname,
-          port: flags.port,
-          sessionId: flags.sessionId,
-          passphrase: flags.passphrase,
-          logger: this.logger,
-        })
-
       sessionManager = new MultisigClientDkgSessionManager({
-        hostname,
-        port,
-        passphrase,
-        sessionId,
+        connection: flags.connection,
+        hostname: flags.hostname,
+        port: flags.port,
+        passphrase: flags.passphrase,
+        sessionId: flags.sessionId,
         tls: flags.tls ?? true,
         logger: this.logger,
       })

--- a/ironfish-cli/src/commands/wallet/multisig/sign.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/sign.ts
@@ -14,7 +14,6 @@ import { Flags, ux } from '@oclif/core'
 import { IronfishCommand } from '../../../command'
 import { RemoteFlags } from '../../../flags'
 import { LedgerMultiSigner } from '../../../ledger'
-import { MultisigBrokerUtils } from '../../../multisigBroker'
 import {
   MultisigClientSigningSessionManager,
   MultisigSigningSessionManager,
@@ -128,22 +127,13 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
 
     let sessionManager: SigningSessionManager
     if (flags.server || flags.connection || flags.sessionId || flags.passphrase) {
-      const { hostname, port, sessionId, passphrase } =
-        await MultisigBrokerUtils.parseConnectionOptions({
-          connection: flags.connection,
-          hostname: flags.hostname,
-          port: flags.port,
-          sessionId: flags.sessionId,
-          passphrase: flags.passphrase,
-          logger: this.logger,
-        })
-
       sessionManager = new MultisigClientSigningSessionManager({
         logger: this.logger,
-        hostname,
-        port,
-        passphrase,
-        sessionId,
+        connection: flags.connection,
+        hostname: flags.hostname,
+        port: flags.port,
+        passphrase: flags.passphrase,
+        sessionId: flags.sessionId,
         tls: flags.tls,
       })
     } else {

--- a/ironfish-cli/src/multisigBroker/clients/tcpClient.ts
+++ b/ironfish-cli/src/multisigBroker/clients/tcpClient.ts
@@ -8,11 +8,10 @@ import { MultisigClient } from './client'
 export class MultisigTcpClient extends MultisigClient {
   client: net.Socket | null = null
 
-  constructor(options: { hostname: string; port: number; passphrase: string; logger: Logger }) {
+  constructor(options: { hostname: string; port: number; logger: Logger }) {
     super({
       hostname: options.hostname,
       port: options.port,
-      passphrase: options.passphrase,
       logger: options.logger,
     })
   }

--- a/ironfish-cli/src/multisigBroker/sessionManagers/dkgSessionManager.ts
+++ b/ironfish-cli/src/multisigBroker/sessionManagers/dkgSessionManager.ts
@@ -40,8 +40,22 @@ export class MultisigClientDkgSessionManager
     minSigners?: number
     ledger?: boolean
   }): Promise<{ totalParticipants: number; minSigners: number }> {
+    if (!this.sessionId) {
+      this.sessionId = await ui.inputPrompt(
+        'Enter the ID of a multisig session to join, or press enter to start a new session',
+        false,
+      )
+    }
+
+    if (!this.passphrase) {
+      this.passphrase = await ui.inputPrompt(
+        'Enter the passphrase for the multisig session',
+        true,
+      )
+    }
+
     if (this.sessionId) {
-      await this.joinSession(this.sessionId)
+      await this.joinSession(this.sessionId, this.passphrase)
       return this.getSessionConfig()
     }
 
@@ -54,7 +68,7 @@ export class MultisigClientDkgSessionManager
 
     await this.connect()
 
-    this.client.startDkgSession(totalParticipants, minSigners)
+    this.client.startDkgSession(this.passphrase, totalParticipants, minSigners)
     this.sessionId = this.client.sessionId
 
     this.logger.info(`\nStarted new DKG session: ${this.sessionId}\n`)

--- a/ironfish-cli/src/multisigBroker/sessionManagers/signingSessionManager.ts
+++ b/ironfish-cli/src/multisigBroker/sessionManagers/signingSessionManager.ts
@@ -32,8 +32,22 @@ export class MultisigClientSigningSessionManager
     numSigners?: number
     unsignedTransaction?: string
   }): Promise<{ numSigners: number; unsignedTransaction: UnsignedTransaction }> {
+    if (!this.sessionId) {
+      this.sessionId = await ui.inputPrompt(
+        'Enter the ID of a multisig session to join, or press enter to start a new session',
+        false,
+      )
+    }
+
+    if (!this.passphrase) {
+      this.passphrase = await ui.inputPrompt(
+        'Enter the passphrase for the multisig session',
+        true,
+      )
+    }
+
     if (this.sessionId) {
-      await this.joinSession(this.sessionId)
+      await this.joinSession(this.sessionId, this.passphrase)
       return this.getSessionConfig()
     }
 
@@ -44,7 +58,7 @@ export class MultisigClientSigningSessionManager
 
     await this.connect()
 
-    this.client.startSigningSession(numSigners, unsignedTransaction)
+    this.client.startSigningSession(this.passphrase, numSigners, unsignedTransaction)
     this.sessionId = this.client.sessionId
 
     this.logger.info(`\nStarting new signing session: ${this.sessionId}\n`)

--- a/ironfish-cli/src/multisigBroker/utils.ts
+++ b/ironfish-cli/src/multisigBroker/utils.ts
@@ -2,22 +2,21 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { ErrorUtils, Logger } from '@ironfish/sdk'
-import * as ui from '../ui'
 import { MultisigClient, MultisigTcpClient, MultisigTlsClient } from './clients'
 
-async function parseConnectionOptions(options: {
+function parseConnectionOptions(options: {
   connection?: string
   hostname: string
   port: number
   sessionId?: string
   passphrase?: string
   logger: Logger
-}): Promise<{
+}): {
   hostname: string
   port: number
-  sessionId: string
-  passphrase: string
-}> {
+  sessionId: string | undefined
+  passphrase: string | undefined
+} {
   let hostname
   let port
   let sessionId
@@ -48,19 +47,6 @@ async function parseConnectionOptions(options: {
   hostname = hostname ?? options.hostname
   port = port ?? options.port
 
-  sessionId = sessionId ?? options.sessionId
-  if (!sessionId) {
-    sessionId = await ui.inputPrompt(
-      'Enter the ID of a multisig session to join, or press enter to start a new session',
-      false,
-    )
-  }
-
-  passphrase = passphrase ?? options.passphrase
-  if (!passphrase) {
-    passphrase = await ui.inputPrompt('Enter the passphrase for the multisig session', true)
-  }
-
   return {
     hostname,
     port,
@@ -72,20 +58,18 @@ async function parseConnectionOptions(options: {
 function createClient(
   hostname: string,
   port: number,
-  options: { passphrase: string; tls: boolean; logger: Logger },
+  options: { passphrase?: string; tls: boolean; logger: Logger },
 ): MultisigClient {
   if (options.tls) {
     return new MultisigTlsClient({
       hostname,
       port,
-      passphrase: options.passphrase,
       logger: options.logger,
     })
   } else {
     return new MultisigTcpClient({
       hostname,
       port,
-      passphrase: options.passphrase,
       logger: options.logger,
     })
   }


### PR DESCRIPTION
## Summary

instead of requiring a passphrase at the time of client construction, sets the client passphrase only when starting or joining a session

moves usage of 'parseConnectionOptions' into session manager for sessions that use the multisig broker server

prompts the user for sessionId and passphrase in 'startSession'. this will allow for re-prompting if starting or joining the session fails

## Testing Plan
- manual testing

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
