### PR TITLE
Don't crash when invalid dkg config input is given

### DIFF
--- a/ironfish-cli/src/multisigBroker/sessionManagers/dkgSessionManager.ts
+++ b/ironfish-cli/src/multisigBroker/sessionManagers/dkgSessionManager.ts
@@ -284,32 +284,49 @@ async function inputDkgConfig(options: {
   totalParticipants: number
   minSigners: number
 }> {
-  const totalParticipants =
-    options.totalParticipants ??
-    (await ui.inputNumberPrompt(options.logger, 'Enter the total number of participants', {
-      required: true,
-      integer: true,
-    }))
+  let totalParticipants
 
-  if (totalParticipants < 2) {
-    throw new Error('Total number of participants must be at least 2')
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    totalParticipants =
+      options.totalParticipants ??
+      (await ui.inputNumberPrompt(options.logger, 'Enter the total number of participants', {
+        required: true,
+        integer: true,
+      }))
+
+    if (totalParticipants < 2) {
+      options.logger.error('Total number of participants must be at least 2')
+      continue
+    }
+
+    if (options.ledger && totalParticipants > 4) {
+      options.logger.error('DKG with Ledger supports a maximum of 4 participants')
+      continue
+    }
+
+    break
   }
 
-  if (options.ledger && totalParticipants > 4) {
-    throw new Error('DKG with Ledger supports a maximum of 4 participants')
-  }
+  let minSigners
 
-  const minSigners =
-    options.minSigners ??
-    (await ui.inputNumberPrompt(options.logger, 'Enter the number of minimum signers', {
-      required: true,
-      integer: true,
-    }))
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    minSigners =
+      options.minSigners ??
+      (await ui.inputNumberPrompt(options.logger, 'Enter the number of minimum signers', {
+        required: true,
+        integer: true,
+      }))
 
-  if (minSigners < 2 || minSigners > totalParticipants) {
-    throw new Error(
-      'Minimum number of signers must be between 2 and the total number of participants',
-    )
+    if (minSigners < 2 || minSigners > totalParticipants) {
+      options.logger.error(
+        'Minimum number of signers must be between 2 and the total number of participants',
+      )
+      continue
+    }
+
+    break
   }
 
   return { totalParticipants, minSigners }


### PR DESCRIPTION
## Summary

Right now, if you input an invalid number for total participants or min signers, it will end the process by throwing an error. A better experience is to display the error and allow the user to try again with proper input.

## Testing Plan

Run `wallet:multisig:dkg:create --server --ledger` and:
- for total participants:
  - press enter without a number
  - enter 0
  - enter 99
  - enter 4
- for min signers:
  - press enter without a number
  - enter 0
  - enter 99
  - enter 3

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
