### PR TITLE
Clear identities when a user disconnects during the identity collection phase

### DIFF
--- a/ironfish-cli/src/multisigBroker/server.ts
+++ b/ironfish-cli/src/multisigBroker/server.ts
@@ -313,20 +313,14 @@ export class MultisigServer {
     // multiple identities, leaving the session in a bad state.
     if (client.identity != null) {
       if (isDkgSession(session)) {
-        if (
-          session.status.round1PublicPackages.length === 0 &&
-          session.status.round2PublicPackages.length === 0
-        ) {
+        if (session.status.round1PublicPackages.length === 0) {
           const identIndex = session.status.identities.indexOf(client.identity)
           if (identIndex > -1) {
             session.status.identities.splice(identIndex, 1)
           }
         }
       } else if (isSigningSession(session)) {
-        if (
-          session.status.signatureShares.length === 0 &&
-          session.status.signingCommitments.length === 0
-        ) {
+        if (session.status.signingCommitments.length === 0) {
           const identIndex = session.status.identities.indexOf(client.identity)
           if (identIndex > -1) {
             session.status.identities.splice(identIndex, 1)

--- a/ironfish-cli/src/multisigBroker/serverClient.ts
+++ b/ironfish-cli/src/multisigBroker/serverClient.ts
@@ -11,6 +11,7 @@ export class MultisigServerClient {
   remoteAddress: string
   messageBuffer: MessageBuffer
   sessionId: string | null = null
+  identity: string | null = null
 
   private constructor(options: { socket: net.Socket; id: number }) {
     this.id = options.id


### PR DESCRIPTION
## Summary

If you disconnect and re-connect  during the identity phase, and add/remove --ledger flag or otherwise do something that would change the identity, the DKG process will keep the old identity around and move forward to the next stage, making it impossible to complete the process.

We can safely delete the identity from the session when a user disconnects so long as it happens during the identity collection phase. If it has moved past that phase, there are more implications, so I did not handle it in this PR.

This PR also opens the door for other improvements by adding the identity to the server client.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
