### PR TITLE
retries joining session if passphrase incorrect

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/dkg/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/create.ts
@@ -117,11 +117,13 @@ export class DkgCreateCommand extends IronfishCommand {
       sessionManager = new MultisigDkgSessionManager({ logger: this.logger })
     }
 
-    const { totalParticipants, minSigners } = await sessionManager.startSession({
-      totalParticipants: flags.totalParticipants,
-      minSigners: flags.minSigners,
-      ledger: flags.ledger,
-    })
+    const { totalParticipants, minSigners } = await ui.retryStep(async () => {
+      return sessionManager.startSession({
+        totalParticipants: flags.totalParticipants,
+        minSigners: flags.minSigners,
+        ledger: flags.ledger,
+      })
+    }, this.logger)
 
     const { name: participantName, identity } = await this.getOrCreateIdentity(
       client,

--- a/ironfish-cli/src/commands/wallet/multisig/sign.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/sign.ts
@@ -140,9 +140,11 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
       sessionManager = new MultisigSigningSessionManager({ logger: this.logger })
     }
 
-    const { numSigners, unsignedTransaction } = await sessionManager.startSession({
-      unsignedTransaction: flags.unsignedTransaction,
-    })
+    const { numSigners, unsignedTransaction } = await ui.retryStep(async () => {
+      return sessionManager.startSession({
+        unsignedTransaction: flags.unsignedTransaction,
+      })
+    }, this.logger)
 
     const { commitment, identities } = await ui.retryStep(
       async () => {

--- a/ironfish-cli/src/multisigBroker/errors.ts
+++ b/ironfish-cli/src/multisigBroker/errors.ts
@@ -47,3 +47,13 @@ export class ServerMessageMalformedError extends MessageMalformedError {
     super('Server', error, method)
   }
 }
+
+export class MultisigClientError extends Error {
+  name = this.constructor.name
+}
+
+export class SessionDecryptionError extends MultisigClientError {
+  constructor(message: string) {
+    super(message)
+  }
+}


### PR DESCRIPTION
## Summary

if a user enters the passphrase for a session by the client is unable to decrypt the session challenge string, the client emits a 'SessionDecryptionError'. the 'wallet:multisig:dkg:create' and 'wallet:multisig:sign' commands will now retry the step and prompt the user to re-enter the passphrase

adds an event emitter, 'onClientError', to the multisig client. emitting client errors as events provides a way for the command logic to define error handlers to throw/catch the error in the control flow of the command instead of in response to server data

## Testing Plan
<img width="895" alt="image" src="https://github.com/user-attachments/assets/a3707c43-1947-44c9-86b4-bc6f7b7b99e7">


## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
