### PR TITLE
prompts user to re-enter sessionId if session not found

### DIFF
--- a/ironfish-cli/src/multisigBroker/errors.ts
+++ b/ironfish-cli/src/multisigBroker/errors.ts
@@ -57,3 +57,9 @@ export class SessionDecryptionError extends MultisigClientError {
     super(message)
   }
 }
+
+export class InvalidSessionError extends MultisigClientError {
+  constructor(message: string) {
+    super(message)
+  }
+}


### PR DESCRIPTION
## Summary

listens for server error messages with the error code for sessionId not found while waiting for a session. throws an error if the sessionId is not found

Closes IFL-3052

## Testing Plan
<img width="870" alt="image" src="https://github.com/user-attachments/assets/f80faaeb-99ea-4093-893a-55f419292f8e">


## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
