### PR TITLE
encodes passphrase as URI component in connection string

### DIFF
--- a/ironfish-cli/src/multisigBroker/clients/client.ts
+++ b/ironfish-cli/src/multisigBroker/clients/client.ts
@@ -87,7 +87,8 @@ export abstract class MultisigClient {
   }
 
   get connectionString(): string {
-    return `tcp://${this.sessionId}:${this.passphrase}@${this.hostname}:${this.port}`
+    const passphrase = this.passphrase ? encodeURIComponent(this.passphrase) : ''
+    return `tcp://${this.sessionId}:${passphrase}@${this.hostname}:${this.port}`
   }
 
   get key(): xchacha20poly1305.XChaCha20Poly1305Key {

--- a/ironfish-cli/src/multisigBroker/utils.ts
+++ b/ironfish-cli/src/multisigBroker/utils.ts
@@ -34,7 +34,7 @@ function parseConnectionOptions(options: {
         sessionId = url.username
       }
       if (url.password) {
-        passphrase = url.password
+        passphrase = decodeURI(url.password)
       }
     } catch (e) {
       if (e instanceof TypeError && e.message.includes('Invalid URL')) {


### PR DESCRIPTION
## Summary

supports passphrases that contain spaces and other unicode characters that would result in invalid connection strings

decodes passphrase when parsing connection string

Closes IFL-3073

## Testing Plan
manual testing
<img width="642" alt="image" src="https://github.com/user-attachments/assets/8de93c2e-f340-437a-b4a2-9a43323d674e">

<img width="607" alt="image" src="https://github.com/user-attachments/assets/4739c360-9013-4b6c-9b4b-68c634f2dcf5">


## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
