### PR TITLE
clients submit identity when starting or joining session

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/dkg/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/create.ts
@@ -102,6 +102,12 @@ export class DkgCreateCommand extends IronfishCommand {
       accountCreatedAt = statusResponse.content.blockchain.head.sequence
     }
 
+    const { name: participantName, identity } = await this.getOrCreateIdentity(
+      client,
+      ledger,
+      accountName,
+    )
+
     let sessionManager: DkgSessionManager
     if (flags.server || flags.connection || flags.sessionId || flags.passphrase) {
       sessionManager = new MultisigClientDkgSessionManager({
@@ -122,14 +128,9 @@ export class DkgCreateCommand extends IronfishCommand {
         totalParticipants: flags.totalParticipants,
         minSigners: flags.minSigners,
         ledger: flags.ledger,
+        identity,
       })
     }, this.logger)
-
-    const { name: participantName, identity } = await this.getOrCreateIdentity(
-      client,
-      ledger,
-      accountName,
-    )
 
     const { round1 } = await ui.retryStep(
       async () => {

--- a/ironfish-cli/src/commands/wallet/multisig/sign.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/sign.ts
@@ -143,6 +143,7 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
     const { numSigners, unsignedTransaction } = await ui.retryStep(async () => {
       return sessionManager.startSession({
         unsignedTransaction: flags.unsignedTransaction,
+        identity: participant.identity,
       })
     }, this.logger)
 

--- a/ironfish-cli/src/multisigBroker/messages.ts
+++ b/ironfish-cli/src/multisigBroker/messages.ts
@@ -27,22 +27,22 @@ export type DkgStartSessionMessage = {
   minSigners: number
   maxSigners: number
   challenge: string
+  identity: string
 }
 
 export type SigningStartSessionMessage = {
   numSigners: number
   unsignedTransaction: string
   challenge: string
+  identity: string
 }
 
-export type JoinSessionMessage = object | undefined
+export type JoinSessionMessage = {
+  identity: string
+}
 
 export type JoinedSessionMessage = {
   challenge: string
-}
-
-export type IdentityMessage = {
-  identity: string
 }
 
 export type Round1PublicPackageMessage = {
@@ -117,6 +117,7 @@ export const DkgStartSessionSchema: yup.ObjectSchema<DkgStartSessionMessage> = y
     minSigners: yup.number().defined(),
     maxSigners: yup.number().defined(),
     challenge: yup.string().defined(),
+    identity: yup.string().defined(),
   })
   .defined()
 
@@ -125,25 +126,21 @@ export const SigningStartSessionSchema: yup.ObjectSchema<SigningStartSessionMess
     numSigners: yup.number().defined(),
     unsignedTransaction: yup.string().defined(),
     challenge: yup.string().defined(),
+    identity: yup.string().defined(),
   })
   .defined()
 
 export const JoinSessionSchema: yup.ObjectSchema<JoinSessionMessage> = yup
-  .object({})
-  .notRequired()
-  .default(undefined)
+  .object({
+    identity: yup.string().defined(),
+  })
+  .defined()
 
 export const JoinedSessionSchema: yup.ObjectSchema<JoinedSessionMessage> = yup
   .object({
     challenge: yup.string().required(),
   })
   .required()
-
-export const IdentitySchema: yup.ObjectSchema<IdentityMessage> = yup
-  .object({
-    identity: yup.string().defined(),
-  })
-  .defined()
 
 export const Round1PublicPackageSchema: yup.ObjectSchema<Round1PublicPackageMessage> = yup
   .object({ package: yup.string().defined() })

--- a/ironfish-cli/src/multisigBroker/sessionManagers/sessionManager.ts
+++ b/ironfish-cli/src/multisigBroker/sessionManagers/sessionManager.ts
@@ -84,10 +84,10 @@ export abstract class MultisigClientSessionManager extends MultisigSessionManage
     ux.action.stop()
   }
 
-  async joinSession(sessionId: string, passphrase: string): Promise<void> {
+  async joinSession(sessionId: string, passphrase: string, identity: string): Promise<void> {
     await this.connect()
 
-    this.client.joinSession(sessionId, passphrase)
+    this.client.joinSession(sessionId, passphrase, identity)
 
     await this.waitForJoinedSession()
     this.sessionId = sessionId

--- a/ironfish-cli/src/multisigBroker/sessionManagers/signingSessionManager.ts
+++ b/ironfish-cli/src/multisigBroker/sessionManagers/signingSessionManager.ts
@@ -11,6 +11,7 @@ export interface SigningSessionManager extends MultisigSessionManager {
   startSession(options: {
     numSigners?: number
     unsignedTransaction?: string
+    identity: string
   }): Promise<{ numSigners: number; unsignedTransaction: UnsignedTransaction }>
   getIdentities(options: {
     identity: string
@@ -31,6 +32,7 @@ export class MultisigClientSigningSessionManager
   async startSession(options: {
     numSigners?: number
     unsignedTransaction?: string
+    identity: string
   }): Promise<{ numSigners: number; unsignedTransaction: UnsignedTransaction }> {
     if (!this.sessionId) {
       this.sessionId = await ui.inputPrompt(
@@ -47,7 +49,7 @@ export class MultisigClientSigningSessionManager
     }
 
     if (this.sessionId) {
-      await this.joinSession(this.sessionId, this.passphrase)
+      await this.joinSession(this.sessionId, this.passphrase, options.identity)
       return this.getSessionConfig()
     }
 
@@ -58,7 +60,12 @@ export class MultisigClientSigningSessionManager
 
     await this.connect()
 
-    this.client.startSigningSession(this.passphrase, numSigners, unsignedTransaction)
+    this.client.startSigningSession(
+      this.passphrase,
+      numSigners,
+      unsignedTransaction,
+      options.identity,
+    )
     this.sessionId = this.client.sessionId
 
     this.logger.info(`\nStarting new signing session: ${this.sessionId}\n`)
@@ -104,8 +111,6 @@ export class MultisigClientSigningSessionManager
 
   async getIdentities(options: { identity: string; numSigners: number }): Promise<string[]> {
     const { identity, numSigners } = options
-
-    this.client.submitSigningIdentity(identity)
 
     let identities = [identity]
 


### PR DESCRIPTION
## Summary

modifies multisigBroker messages so that each client submits its identity when it starts or joins a session

simplifies the session flow by removing separate messages for submitting identities

Closes IFL-3076

## Testing Plan
- created multisig account with 'wallet:multiisg:dkg:create'
- signed transaction with 'wallet:multisig:sign'

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
