### PR TITLE
adds allowed identities set to multisig server sessions

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/sign.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/sign.ts
@@ -144,6 +144,7 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
       return sessionManager.startSession({
         unsignedTransaction: flags.unsignedTransaction,
         identity: participant.identity,
+        allowedIdentities: accountIdentities,
       })
     }, this.logger)
 

--- a/ironfish-cli/src/multisigBroker/clients/client.ts
+++ b/ironfish-cli/src/multisigBroker/clients/client.ts
@@ -178,11 +178,18 @@ export abstract class MultisigClient {
     maxSigners: number,
     minSigners: number,
     identity: string,
+    allowedIdentities?: string[],
   ): void {
     this.sessionId = uuid()
     this.passphrase = passphrase
     const challenge = this.key.encrypt(Buffer.from('DKG')).toString('hex')
-    this.send('dkg.start_session', { maxSigners, minSigners, challenge, identity })
+    this.send('dkg.start_session', {
+      maxSigners,
+      minSigners,
+      challenge,
+      identity,
+      allowedIdentities,
+    })
   }
 
   startSigningSession(
@@ -190,11 +197,18 @@ export abstract class MultisigClient {
     numSigners: number,
     unsignedTransaction: string,
     identity: string,
+    allowedIdentities?: string[],
   ): void {
     this.sessionId = uuid()
     this.passphrase = passphrase
     const challenge = this.key.encrypt(Buffer.from('SIGNING')).toString('hex')
-    this.send('sign.start_session', { numSigners, unsignedTransaction, challenge, identity })
+    this.send('sign.start_session', {
+      numSigners,
+      unsignedTransaction,
+      challenge,
+      identity,
+      allowedIdentities,
+    })
   }
 
   submitRound1PublicPackage(round1PublicPackage: string): void {

--- a/ironfish-cli/src/multisigBroker/clients/client.ts
+++ b/ironfish-cli/src/multisigBroker/clients/client.ts
@@ -182,12 +182,7 @@ export abstract class MultisigClient {
     this.sessionId = uuid()
     this.passphrase = passphrase
     const challenge = this.key.encrypt(Buffer.from('DKG')).toString('hex')
-    this.send('dkg.start_session', {
-      maxSigners,
-      minSigners,
-      challenge,
-      identity,
-    })
+    this.send('dkg.start_session', { maxSigners, minSigners, challenge, identity })
   }
 
   startSigningSession(

--- a/ironfish-cli/src/multisigBroker/clients/client.ts
+++ b/ironfish-cli/src/multisigBroker/clients/client.ts
@@ -178,7 +178,6 @@ export abstract class MultisigClient {
     maxSigners: number,
     minSigners: number,
     identity: string,
-    allowedIdentities?: string[],
   ): void {
     this.sessionId = uuid()
     this.passphrase = passphrase
@@ -188,7 +187,6 @@ export abstract class MultisigClient {
       minSigners,
       challenge,
       identity,
-      allowedIdentities,
     })
   }
 

--- a/ironfish-cli/src/multisigBroker/errors.ts
+++ b/ironfish-cli/src/multisigBroker/errors.ts
@@ -9,6 +9,7 @@ export const MultisigBrokerErrorCodes = {
   SESSION_ID_NOT_FOUND: 2,
   INVALID_DKG_SESSION_ID: 3,
   INVALID_SIGNING_SESSION_ID: 4,
+  IDENTITY_NOT_ALLOWED: 5,
 }
 
 export class MessageMalformedError extends Error {
@@ -59,6 +60,12 @@ export class SessionDecryptionError extends MultisigClientError {
 }
 
 export class InvalidSessionError extends MultisigClientError {
+  constructor(message: string) {
+    super(message)
+  }
+}
+
+export class IdentityNotAllowedError extends MultisigClientError {
   constructor(message: string) {
     super(message)
   }

--- a/ironfish-cli/src/multisigBroker/messages.ts
+++ b/ironfish-cli/src/multisigBroker/messages.ts
@@ -28,7 +28,6 @@ export type DkgStartSessionMessage = {
   maxSigners: number
   challenge: string
   identity: string
-  allowedIdentities?: string[]
 }
 
 export type SigningStartSessionMessage = {
@@ -120,7 +119,6 @@ export const DkgStartSessionSchema: yup.ObjectSchema<DkgStartSessionMessage> = y
     maxSigners: yup.number().defined(),
     challenge: yup.string().defined(),
     identity: yup.string().defined(),
-    allowedIdentities: yup.array(yup.string().defined()).optional(),
   })
   .defined()
 

--- a/ironfish-cli/src/multisigBroker/messages.ts
+++ b/ironfish-cli/src/multisigBroker/messages.ts
@@ -28,6 +28,7 @@ export type DkgStartSessionMessage = {
   maxSigners: number
   challenge: string
   identity: string
+  allowedIdentities?: string[]
 }
 
 export type SigningStartSessionMessage = {
@@ -35,6 +36,7 @@ export type SigningStartSessionMessage = {
   unsignedTransaction: string
   challenge: string
   identity: string
+  allowedIdentities?: string[]
 }
 
 export type JoinSessionMessage = {
@@ -118,6 +120,7 @@ export const DkgStartSessionSchema: yup.ObjectSchema<DkgStartSessionMessage> = y
     maxSigners: yup.number().defined(),
     challenge: yup.string().defined(),
     identity: yup.string().defined(),
+    allowedIdentities: yup.array(yup.string().defined()).optional(),
   })
   .defined()
 
@@ -127,6 +130,7 @@ export const SigningStartSessionSchema: yup.ObjectSchema<SigningStartSessionMess
     unsignedTransaction: yup.string().defined(),
     challenge: yup.string().defined(),
     identity: yup.string().defined(),
+    allowedIdentities: yup.array(yup.string().defined()).optional(),
   })
   .defined()
 

--- a/ironfish-cli/src/multisigBroker/sessionManagers/sessionManager.ts
+++ b/ironfish-cli/src/multisigBroker/sessionManagers/sessionManager.ts
@@ -5,6 +5,7 @@ import { Assert, Logger, PromiseUtils } from '@ironfish/sdk'
 import { ux } from '@oclif/core'
 import { MultisigClient } from '../clients'
 import {
+  IdentityNotAllowedError,
   InvalidSessionError,
   MultisigBrokerErrorCodes,
   SessionDecryptionError,
@@ -110,6 +111,9 @@ export abstract class MultisigClientSessionManager extends MultisigSessionManage
     this.client.onMultisigBrokerError.on((errorMessage) => {
       if (errorMessage.error.code === MultisigBrokerErrorCodes.SESSION_ID_NOT_FOUND) {
         clientError = new InvalidSessionError(errorMessage.error.message)
+      } else if (errorMessage.error.code === MultisigBrokerErrorCodes.IDENTITY_NOT_ALLOWED) {
+        // Throws error immediately instead of deferring to loop, below
+        throw new IdentityNotAllowedError(errorMessage.error.message)
       }
     })
 

--- a/ironfish-cli/src/multisigBroker/sessionManagers/signingSessionManager.ts
+++ b/ironfish-cli/src/multisigBroker/sessionManagers/signingSessionManager.ts
@@ -12,6 +12,7 @@ export interface SigningSessionManager extends MultisigSessionManager {
     numSigners?: number
     unsignedTransaction?: string
     identity: string
+    allowedIdentities?: string[]
   }): Promise<{ numSigners: number; unsignedTransaction: UnsignedTransaction }>
   getIdentities(options: {
     identity: string
@@ -33,6 +34,7 @@ export class MultisigClientSigningSessionManager
     numSigners?: number
     unsignedTransaction?: string
     identity: string
+    allowedIdentities?: string[]
   }): Promise<{ numSigners: number; unsignedTransaction: UnsignedTransaction }> {
     if (!this.sessionId) {
       this.sessionId = await ui.inputPrompt(
@@ -65,6 +67,7 @@ export class MultisigClientSigningSessionManager
       numSigners,
       unsignedTransaction,
       options.identity,
+      options.allowedIdentities,
     )
     this.sessionId = this.client.sessionId
 


### PR DESCRIPTION
## Summary

server blocks any client from joining the session if its identity is not in the set of allowed identities

sends the (encrypted) list of account identities to the server when starting a signing session. guards against user accidentally joining signing session with the wrong account

throws an error when joining the session with an identity that is not in the allowed set (does not retry)

allowedIdentities is optional for dkg sessions, but there's not a clear way yet of specifying this set

Closes IFL-3074

## Testing Plan
- tried to join session with the wrong account/identity
- joined session and signed transaction with correct identity

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
