### PR TITLE
adds confirmation prompt to 'multisig:sign' if using server

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/sign.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/sign.ts
@@ -155,8 +155,8 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
     )
 
     // Prompt for confirmation before broker automates signing
-    if (sessionManager instanceof MultisigClientSigningSessionManager) {
-      await ui.confirmOrQuit()
+    if (!flags.ledger && sessionManager instanceof MultisigClientSigningSessionManager) {
+      await ui.confirmOrQuit('Sign this transaction?')
     }
 
     const { commitment, identities } = await ui.retryStep(

--- a/ironfish-cli/src/commands/wallet/multisig/sign.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/sign.ts
@@ -147,6 +147,18 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
       })
     }, this.logger)
 
+    await renderUnsignedTransactionDetails(
+      client,
+      unsignedTransaction,
+      multisigAccountName,
+      this.logger,
+    )
+
+    // Prompt for confirmation before broker automates signing
+    if (sessionManager instanceof MultisigClientSigningSessionManager) {
+      await ui.confirmOrQuit()
+    }
+
     const { commitment, identities } = await ui.retryStep(
       async () => {
         return this.performCreateSigningCommitment(
@@ -348,13 +360,6 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
     })
 
     const unsignedTransactionHex = unsignedTransaction.serialize().toString('hex')
-
-    await renderUnsignedTransactionDetails(
-      client,
-      unsignedTransaction,
-      accountName,
-      this.logger,
-    )
 
     let commitment
     if (ledger) {


### PR DESCRIPTION
## Summary

when running the 'wallet:multisig:sign' command using a broker server there are no prompts or manual steps after the initial setup. this doesn't give the user a chance to confirm the details of the unsigned transaction before the signing process moves forward

adds a confirmation prompt if the 'sessionManager' is connected to a server

moves the rendering of transaction details and the confirmation prompt out of a 'retryStep' function so that confirmation isn't retried

## Testing Plan
manual testing

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
