### PR TITLE
renders fee and expiration in unsigned transaction summary

### DIFF
--- a/ironfish-cli/src/utils/transaction.ts
+++ b/ironfish-cli/src/utils/transaction.ts
@@ -124,6 +124,8 @@ export async function renderTransactionDetails(
 
   await _renderTransactionDetails(
     client,
+    transaction.fee(),
+    transaction.expiration(),
     transaction.mints,
     transaction.burns,
     account,
@@ -148,6 +150,8 @@ export async function renderUnsignedTransactionDetails(
 
   await _renderTransactionDetails(
     client,
+    unsignedTransaction.fee(),
+    unsignedTransaction.expiration(),
     unsignedTransaction.mints,
     unsignedTransaction.burns,
     account,
@@ -158,6 +162,8 @@ export async function renderUnsignedTransactionDetails(
 
 async function _renderTransactionDetails(
   client: RpcClient,
+  fee: bigint,
+  expiration: number,
   mints: MintDescription[],
   burns: BurnDescription[],
   account?: string,
@@ -168,6 +174,14 @@ async function _renderTransactionDetails(
 
   const assetIds = collectAssetIds(mints, burns, notes)
   const assetLookup = await getAssetVerificationByIds(client, assetIds, account, undefined)
+
+  logger.log('')
+  logger.log('===================')
+  logger.log('Transaction Summary')
+  logger.log('===================')
+  logger.log('')
+  logger.log(`Fee             ${CurrencyUtils.render(fee, true)}`)
+  logger.log(`Expiration      ${expiration}`)
 
   if (mints.length > 0) {
     logger.log('')

--- a/ironfish/src/primitives/unsignedTransaction.ts
+++ b/ironfish/src/primitives/unsignedTransaction.ts
@@ -176,4 +176,12 @@ export class UnsignedTransaction {
     this.returnReference()
     return publicKeyRandomness
   }
+
+  fee(): bigint {
+    return this._fee
+  }
+
+  expiration(): number {
+    return this._expiration
+  }
 }


### PR DESCRIPTION
## Summary

when reviewing an unsigned transaction it will be helpful to display the transaction fee and expiration

these fields are shown when reviewing the transaction on a ledger device, so we should also display them on the CLI

## Testing Plan
<img width="612" alt="image" src="https://github.com/user-attachments/assets/06bce00b-d589-43b8-a166-8ef2865986e8">


## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
