### PR TITLE
threadsafe sapling params & provide convenience method for sapling load

### DIFF
--- a/ironfish-rust/src/sapling_bls12.rs
+++ b/ironfish-rust/src/sapling_bls12.rs
@@ -4,11 +4,16 @@
 
 use crate::Sapling;
 use lazy_static::lazy_static;
+use std::sync::Arc;
 
 pub use blstrs::Scalar;
 
 // Loads the Sapling object once when dereferenced,
 // then reuses the reference on future calls.
 lazy_static! {
-    pub static ref SAPLING: Sapling = Sapling::load();
+    pub static ref SAPLING: Arc<Sapling> = Arc::new(load());
+}
+
+fn load() -> Sapling {
+    Sapling::load()
 }


### PR DESCRIPTION
## Summary

Convenience method for sapling load, pull from `ironfish-optimize`
Load a sapling object configured to a BLS12 jubjub curve. This is currently
the only pairing for which a jubjub curve has been defined, and is the
default implementation.

Provided as a convenience method so clients don't have to depend
explicitly on zcash_primitives just to define a JubjubBls12 point.
## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
