### PR TITLE
make sapling params public

### DIFF
--- a/ironfish-rust/src/lib.rs
+++ b/ironfish-rust/src/lib.rs
@@ -49,12 +49,12 @@ pub use ironfish_zkp::primitives::ValueCommitment;
 //
 // The values are all loaded from a file in serialized form.
 pub struct Sapling {
-    spend_params: groth16::Parameters<Bls12>,
-    output_params: groth16::Parameters<Bls12>,
-    mint_params: groth16::Parameters<Bls12>,
-    spend_verifying_key: groth16::PreparedVerifyingKey<Bls12>,
-    output_verifying_key: groth16::PreparedVerifyingKey<Bls12>,
-    mint_verifying_key: groth16::PreparedVerifyingKey<Bls12>,
+    pub spend_params: groth16::Parameters<Bls12>,
+    pub output_params: groth16::Parameters<Bls12>,
+    pub mint_params: groth16::Parameters<Bls12>,
+    pub spend_verifying_key: groth16::PreparedVerifyingKey<Bls12>,
+    pub output_verifying_key: groth16::PreparedVerifyingKey<Bls12>,
+    pub mint_verifying_key: groth16::PreparedVerifyingKey<Bls12>,
 }
 
 impl Sapling {


### PR DESCRIPTION
## Summary
These are used in downstream consumers of `ironfish` package, making them public.
## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
