### PR TITLE
uses server if user sets 'hostname' or 'port'

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/dkg/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/create.ts
@@ -20,9 +20,8 @@ import { IronfishCommand } from '../../../../command'
 import { RemoteFlags } from '../../../../flags'
 import { LedgerMultiSigner } from '../../../../ledger'
 import {
+  createDkgSessionManager,
   DkgSessionManager,
-  MultisigClientDkgSessionManager,
-  MultisigDkgSessionManager,
 } from '../../../../multisigBroker/sessionManagers'
 import * as ui from '../../../../ui'
 
@@ -56,11 +55,9 @@ export class DkgCreateCommand extends IronfishCommand {
     }),
     hostname: Flags.string({
       description: 'hostname of the multisig broker server to connect to',
-      default: 'multisig.ironfish.network',
     }),
     port: Flags.integer({
       description: 'port to connect to on the multisig broker server',
-      default: 9035,
     }),
     sessionId: Flags.string({
       description: 'Unique ID for a multisig server session to join',
@@ -108,20 +105,16 @@ export class DkgCreateCommand extends IronfishCommand {
       accountName,
     )
 
-    let sessionManager: DkgSessionManager
-    if (flags.server || flags.connection || flags.sessionId || flags.passphrase) {
-      sessionManager = new MultisigClientDkgSessionManager({
-        connection: flags.connection,
-        hostname: flags.hostname,
-        port: flags.port,
-        passphrase: flags.passphrase,
-        sessionId: flags.sessionId,
-        tls: flags.tls ?? true,
-        logger: this.logger,
-      })
-    } else {
-      sessionManager = new MultisigDkgSessionManager({ logger: this.logger })
-    }
+    const sessionManager = createDkgSessionManager({
+      server: flags.server,
+      connection: flags.connection,
+      hostname: flags.hostname,
+      port: flags.port,
+      passphrase: flags.passphrase,
+      sessionId: flags.sessionId,
+      tls: flags.tls,
+      logger: this.logger,
+    })
 
     const { totalParticipants, minSigners } = await ui.retryStep(async () => {
       return sessionManager.startSession({

--- a/ironfish-cli/src/commands/wallet/multisig/sign.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/sign.ts
@@ -15,8 +15,8 @@ import { IronfishCommand } from '../../../command'
 import { RemoteFlags } from '../../../flags'
 import { LedgerMultiSigner } from '../../../ledger'
 import {
+  createSigningSessionManager,
   MultisigClientSigningSessionManager,
-  MultisigSigningSessionManager,
   SigningSessionManager,
 } from '../../../multisigBroker/sessionManagers'
 import * as ui from '../../../ui'
@@ -57,11 +57,9 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
     }),
     hostname: Flags.string({
       description: 'hostname of the multisig broker server to connect to',
-      default: 'multisig.ironfish.network',
     }),
     port: Flags.integer({
       description: 'port to connect to on the multisig broker server',
-      default: 9035,
     }),
     sessionId: Flags.string({
       description: 'Unique ID for a multisig server session to join',
@@ -125,20 +123,16 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
       )
     }
 
-    let sessionManager: SigningSessionManager
-    if (flags.server || flags.connection || flags.sessionId || flags.passphrase) {
-      sessionManager = new MultisigClientSigningSessionManager({
-        logger: this.logger,
-        connection: flags.connection,
-        hostname: flags.hostname,
-        port: flags.port,
-        passphrase: flags.passphrase,
-        sessionId: flags.sessionId,
-        tls: flags.tls,
-      })
-    } else {
-      sessionManager = new MultisigSigningSessionManager({ logger: this.logger })
-    }
+    const sessionManager = createSigningSessionManager({
+      logger: this.logger,
+      server: flags.server,
+      connection: flags.connection,
+      hostname: flags.hostname,
+      port: flags.port,
+      passphrase: flags.passphrase,
+      sessionId: flags.sessionId,
+      tls: flags.tls,
+    })
 
     const { numSigners, unsignedTransaction } = await ui.retryStep(async () => {
       return sessionManager.startSession({

--- a/ironfish-cli/src/multisigBroker/sessionManagers/dkgSessionManager.ts
+++ b/ironfish-cli/src/multisigBroker/sessionManagers/dkgSessionManager.ts
@@ -6,6 +6,29 @@ import { ux } from '@oclif/core'
 import * as ui from '../../ui'
 import { MultisigClientSessionManager, MultisigSessionManager } from './sessionManager'
 
+export function createDkgSessionManager(options: {
+  logger: Logger
+  server?: boolean
+  connection?: string
+  hostname?: string
+  port?: number
+  passphrase?: string
+  sessionId?: string
+  tls?: boolean
+}): DkgSessionManager {
+  if (
+    options.server ||
+    options.connection ||
+    options.hostname ||
+    options.port ||
+    options.sessionId
+  ) {
+    return new MultisigClientDkgSessionManager(options)
+  } else {
+    return new MultisigDkgSessionManager({ logger: options.logger })
+  }
+}
+
 export interface DkgSessionManager extends MultisigSessionManager {
   startSession(options: {
     totalParticipants?: number

--- a/ironfish-cli/src/multisigBroker/sessionManagers/sessionManager.ts
+++ b/ironfish-cli/src/multisigBroker/sessionManagers/sessionManager.ts
@@ -33,8 +33,8 @@ export abstract class MultisigClientSessionManager extends MultisigSessionManage
   constructor(options: {
     logger: Logger
     connection?: string
-    hostname: string
-    port: number
+    hostname?: string
+    port?: number
     passphrase?: string
     sessionId?: string
     tls?: boolean
@@ -42,14 +42,7 @@ export abstract class MultisigClientSessionManager extends MultisigSessionManage
     super({ logger: options.logger })
 
     const { hostname, port, sessionId, passphrase } =
-      MultisigBrokerUtils.parseConnectionOptions({
-        connection: options.connection,
-        hostname: options.hostname,
-        port: options.port,
-        sessionId: options.sessionId,
-        passphrase: options.passphrase,
-        logger: this.logger,
-      })
+      MultisigBrokerUtils.parseConnectionOptions(options)
 
     this.client = MultisigBrokerUtils.createClient(hostname, port, {
       tls: options.tls ?? true,

--- a/ironfish-cli/src/multisigBroker/sessionManagers/signingSessionManager.ts
+++ b/ironfish-cli/src/multisigBroker/sessionManagers/signingSessionManager.ts
@@ -7,6 +7,29 @@ import { ux } from '@oclif/core'
 import * as ui from '../../ui'
 import { MultisigClientSessionManager, MultisigSessionManager } from './sessionManager'
 
+export function createSigningSessionManager(options: {
+  logger: Logger
+  server?: boolean
+  connection?: string
+  hostname?: string
+  port?: number
+  passphrase?: string
+  sessionId?: string
+  tls?: boolean
+}): SigningSessionManager {
+  if (
+    options.server ||
+    options.connection ||
+    options.hostname ||
+    options.port ||
+    options.sessionId
+  ) {
+    return new MultisigClientSigningSessionManager(options)
+  } else {
+    return new MultisigSigningSessionManager({ logger: options.logger })
+  }
+}
+
 export interface SigningSessionManager extends MultisigSessionManager {
   startSession(options: {
     numSigners?: number

--- a/ironfish-cli/src/multisigBroker/utils.ts
+++ b/ironfish-cli/src/multisigBroker/utils.ts
@@ -4,10 +4,13 @@
 import { ErrorUtils, Logger } from '@ironfish/sdk'
 import { MultisigClient, MultisigTcpClient, MultisigTlsClient } from './clients'
 
+const DEFAULT_MULTISIG_BROKER_HOSTNAME = 'multisig.ironfish.network'
+const DEFAULT_MULTISIG_BROKER_PORT = 9035
+
 function parseConnectionOptions(options: {
   connection?: string
-  hostname: string
-  port: number
+  hostname?: string
+  port?: number
   sessionId?: string
   passphrase?: string
   logger: Logger
@@ -44,8 +47,8 @@ function parseConnectionOptions(options: {
     }
   }
 
-  hostname = hostname ?? options.hostname
-  port = port ?? options.port
+  hostname = hostname ?? options.hostname ?? DEFAULT_MULTISIG_BROKER_HOSTNAME
+  port = port ?? options.port ?? DEFAULT_MULTISIG_BROKER_PORT
 
   return {
     hostname,


### PR DESCRIPTION
## Summary

if a user sets the hostname or port for the multisig broker server using flags then they should not need to _also_ set the '--server' flag in order to connect to the server

defines constants for default multisig broker hostname and port

removes default values for hostname and port flags in 'wallet:multisig:dkg:create' and 'wallet:multisig:sign' and applies defaults only when flags are used. allows flags to be unset to determine whether user has set the flags

adds factory functions for session managers

Closes IFL-3084

## Testing Plan
- ran 'wallet:multisig:dkg:create --hostname localhost', connected to localhost
- ran 'wallet:multisig:dkg:create --server', connected to AWS server

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
