### PR TITLE
Wallet Unlock Log: Added Lock Timeout in Hrs, Min, Sec

### DIFF
--- a/ironfish-cli/src/commands/wallet/unlock.ts
+++ b/ironfish-cli/src/commands/wallet/unlock.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { DEFAULT_UNLOCK_TIMEOUT_MS, RpcRequestError } from '@ironfish/sdk'
+import { TimeUtils } from '@ironfish/sdk'
 import { Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
@@ -59,7 +60,12 @@ export class UnlockCommand extends IronfishCommand {
         'Unlocked the wallet. Call wallet:lock or stop the node to lock the wallet again.',
       )
     } else {
-      this.log(`Unlocked the wallet for ${timeout}ms`)
+      const timeoutDuration = TimeUtils.renderSpan(timeout, {
+        hideMilliseconds: true,
+        forceSecond: true,
+        forceMinute: true
+      })
+      this.log(`Unlocked the wallet for ${timeoutDuration}.`)
     }
 
     this.exit(0)

--- a/ironfish-cli/src/commands/wallet/unlock.ts
+++ b/ironfish-cli/src/commands/wallet/unlock.ts
@@ -60,11 +60,7 @@ export class UnlockCommand extends IronfishCommand {
         'Unlocked the wallet. Call wallet:lock or stop the node to lock the wallet again.',
       )
     } else {
-      const timeoutDuration = TimeUtils.renderSpan(timeout, {
-        hideMilliseconds: true,
-        forceSecond: true,
-        forceMinute: true,
-      })
+      const timeoutDuration = TimeUtils.renderSpan(timeout)
       this.log(`Unlocked the wallet for ${timeoutDuration}.`)
     }
 

--- a/ironfish-cli/src/commands/wallet/unlock.ts
+++ b/ironfish-cli/src/commands/wallet/unlock.ts
@@ -63,7 +63,7 @@ export class UnlockCommand extends IronfishCommand {
       const timeoutDuration = TimeUtils.renderSpan(timeout, {
         hideMilliseconds: true,
         forceSecond: true,
-        forceMinute: true
+        forceMinute: true,
       })
       this.log(`Unlocked the wallet for ${timeoutDuration}.`)
     }


### PR DESCRIPTION
## Summary
Imported TimeUtils to access renderSpan
Updated log to output lock timeout in hrs, mins, secs.

## Testing Plan
Encrypt, lock, and unlock wallet to see log

## Documentation
N/A
```

## Breaking Change
N/A
```
