### PR TITLE
automatically rejoins session when reconnecting to server

### DIFF
--- a/ironfish-cli/src/multisigBroker/clients/client.ts
+++ b/ironfish-cli/src/multisigBroker/clients/client.ts
@@ -68,6 +68,7 @@ export abstract class MultisigClient {
 
   sessionId: string | null = null
   passphrase: string | null = null
+  identity: string | null = null
 
   retries: Map<number, NodeJS.Timer> = new Map()
 
@@ -148,6 +149,11 @@ export abstract class MultisigClient {
     this.connectWarned = false
     this.onConnect()
     this.onConnected.emit()
+
+    if (this.sessionId && this.passphrase && this.identity) {
+      this.logger.debug(`Rejoining session ${this.sessionId}`)
+      this.joinSession(this.sessionId, this.passphrase, this.identity)
+    }
   }
 
   stop(): void {
@@ -170,6 +176,7 @@ export abstract class MultisigClient {
   joinSession(sessionId: string, passphrase: string, identity: string): void {
     this.sessionId = sessionId
     this.passphrase = passphrase
+    this.identity = identity
     this.send('join_session', { identity })
   }
 
@@ -181,6 +188,7 @@ export abstract class MultisigClient {
   ): void {
     this.sessionId = uuid()
     this.passphrase = passphrase
+    this.identity = identity
     const challenge = this.key.encrypt(Buffer.from('DKG')).toString('hex')
     this.send('dkg.start_session', { maxSigners, minSigners, challenge, identity })
   }
@@ -194,6 +202,7 @@ export abstract class MultisigClient {
   ): void {
     this.sessionId = uuid()
     this.passphrase = passphrase
+    this.identity = identity
     const challenge = this.key.encrypt(Buffer.from('SIGNING')).toString('hex')
     this.send('sign.start_session', {
       numSigners,


### PR DESCRIPTION
## Summary

if a client disconnects from the multisig broker server unexpectedly then the server will remove the client and its identity from the session

client automatically rejoins the session after automatically reconnecting so that the server adds it and its identity back into the session

nests sessionId and passphrase properties into a single 'session' property along with the identity. sessionId, passphrase, and identity must all be non-null or all null, and grouping them into an object reflects this

## Testing Plan
apply the diff below (`git diff apply`) to make the server drop a client's connection on ~50% of 'dkg.get_status' messages:
```
diff --git a/ironfish-cli/src/multisigBroker/server.ts b/ironfish-cli/src/multisigBroker/server.ts
index adf297087..88d841165 100644
--- a/ironfish-cli/src/multisigBroker/server.ts
+++ b/ironfish-cli/src/multisigBroker/server.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { ErrorUtils, Logger, YupUtils } from '@ironfish/sdk'
+import { randomInt } from 'crypto'
 import net from 'net'
 import { IMultisigBrokerAdapter } from './adapters'
 import { ClientMessageMalformedError, MultisigBrokerErrorCodes } from './errors'
@@ -201,6 +202,13 @@ export class MultisigServer {
       this.logger.debug(`Client ${client.id} sent ${message.method} message`)
       this.send(client.socket, 'ack', message.sessionId, { messageId: message.id })
 
+      if (message.method === 'dkg.get_status' && randomInt(10) < 5) {
+        this.removeClientFromSession(client)
+        client.close()
+        this.clients.delete(client.id)
+        return
+      }
+
       if (message.method === 'dkg.start_session') {
         await this.handleDkgStartSessionMessage(client, message)
         return

```
run `wallet:multisig:dkg:create` with two participants, and the process should still complete (eventually) with clients reconnecting

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
