### PR TITLE
handles reconnect/rejoin status in session managers

### DIFF
--- a/ironfish-cli/src/multisigBroker/clients/client.ts
+++ b/ironfish-cli/src/multisigBroker/clients/client.ts
@@ -59,6 +59,7 @@ export abstract class MultisigClient {
   private tryConnectUntil: number | null = null
 
   readonly onConnected = new Event<[]>()
+  readonly onDisconnected = new Event<[]>()
   readonly onDkgStatus = new Event<[DkgStatusMessage]>()
   readonly onSigningStatus = new Event<[SigningStatusMessage]>()
   readonly onConnectedMessage = new Event<[ConnectedMessage]>()
@@ -288,6 +289,8 @@ export abstract class MultisigClient {
       this.logger.warn('Disconnected from server unexpectedly. Reconnecting.')
       this.connectTimeout = setTimeout(() => void this.startConnecting(), 5000)
     }
+
+    this.onDisconnected.emit()
   }
 
   protected onError = (error: unknown): void => {

--- a/ironfish-cli/src/multisigBroker/sessionManagers/dkgSessionManager.ts
+++ b/ironfish-cli/src/multisigBroker/sessionManagers/dkgSessionManager.ts
@@ -143,9 +143,11 @@ export class MultisigClientDkgSessionManager
       identities = message.identities
     })
 
-    ux.action.start('Waiting for Identities from server')
     while (identities.length < totalParticipants) {
       this.client.getDkgStatus()
+      if (!ux.action.running) {
+        ux.action.start('Waiting for Identities from server')
+      }
       ux.action.status = `${identities.length}/${totalParticipants}`
       await PromiseUtils.sleep(3000)
     }
@@ -169,9 +171,11 @@ export class MultisigClientDkgSessionManager
       round1PublicPackages = message.round1PublicPackages
     })
 
-    ux.action.start('Waiting for Round 1 Public Packages from server')
     while (round1PublicPackages.length < totalParticipants) {
       this.client.getDkgStatus()
+      if (!ux.action.running) {
+        ux.action.start('Waiting for Round 1 Public Packages from server')
+      }
       ux.action.status = `${round1PublicPackages.length}/${totalParticipants}`
       await PromiseUtils.sleep(3000)
     }
@@ -195,9 +199,11 @@ export class MultisigClientDkgSessionManager
       round2PublicPackages = message.round2PublicPackages
     })
 
-    ux.action.start('Waiting for Round 2 Public Packages from server')
     while (round2PublicPackages.length < totalParticipants) {
       this.client.getDkgStatus()
+      if (!ux.action.running) {
+        ux.action.start('Waiting for Round 2 Public Packages from server')
+      }
       ux.action.status = `${round2PublicPackages.length}/${totalParticipants}`
       await PromiseUtils.sleep(3000)
     }

--- a/ironfish-cli/src/multisigBroker/sessionManagers/sessionManager.ts
+++ b/ironfish-cli/src/multisigBroker/sessionManagers/sessionManager.ts
@@ -58,13 +58,22 @@ export abstract class MultisigClientSessionManager extends MultisigSessionManage
       return
     }
 
+    this.client.start()
+
+    await this.waitForConnectedMessage()
+
+    this.client.onDisconnected.on(async () => {
+      await this.waitForConnectedMessage()
+      await this.waitForJoinedSession()
+    })
+  }
+
+  protected async waitForConnectedMessage(): Promise<void> {
     let confirmed = false
 
     ux.action.start(
       `Connecting to multisig broker server: ${this.client.hostname}:${this.client.port}`,
     )
-    this.client.start()
-
     this.client.onConnectedMessage.on(() => {
       confirmed = true
     })

--- a/ironfish-cli/src/multisigBroker/sessionManagers/signingSessionManager.ts
+++ b/ironfish-cli/src/multisigBroker/sessionManagers/signingSessionManager.ts
@@ -144,9 +144,11 @@ export class MultisigClientSigningSessionManager
       identities = message.identities
     })
 
-    ux.action.start('Waiting for Identities from server')
     while (identities.length < numSigners) {
       this.client.getSigningStatus()
+      if (!ux.action.running) {
+        ux.action.start('Waiting for Identities from server')
+      }
       ux.action.status = `${identities.length}/${numSigners}`
       await PromiseUtils.sleep(3000)
     }
@@ -171,9 +173,11 @@ export class MultisigClientSigningSessionManager
       signingCommitments = message.signingCommitments
     })
 
-    ux.action.start('Waiting for Signing Commitments from server')
     while (signingCommitments.length < numSigners) {
       this.client.getSigningStatus()
+      if (!ux.action.running) {
+        ux.action.start('Waiting for Signing Commitments from server')
+      }
       ux.action.status = `${signingCommitments.length}/${numSigners}`
       await PromiseUtils.sleep(3000)
     }
@@ -198,9 +202,11 @@ export class MultisigClientSigningSessionManager
       signatureShares = message.signatureShares
     })
 
-    ux.action.start('Waiting for Signature Shares from server')
     while (signatureShares.length < numSigners) {
       this.client.getSigningStatus()
+      if (!ux.action.running) {
+        ux.action.start('Waiting for Signature Shares from server')
+      }
       ux.action.status = `${signatureShares.length}/${numSigners}`
       await PromiseUtils.sleep(3000)
     }


### PR DESCRIPTION
## Summary

adds 'onDisconnected' event emitter to multisig broker client

uses 'onDisconnected' events in sessionManager to wait from confirmation that client has reconnected to server and rejoined session

by using 'waitForConnectedMessage' and 'waitForJoinedSession' we display ux status output to the user _and_ throw an error if the session can't be rejoined

updates session managers to conditionally start ux actions in polling loops. this makes it so that the session manager won't clear the ux status output from waiting to reconnect or rejoin a session while polling for session status

Closes IFL-3090

## Testing Plan
1. start server using 'wallet:multisig:server'
2. connect to server for dkg session with 'wallet:multisig:dkg:create --hostname localhost', wait until session joined
3. stop and restart server process
4. wait for 'dkg:create' command to reconnect and then throw an error because the session id isn't found on the new server

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
