### PR TITLE
rejects client messages if client not in session

### DIFF
--- a/ironfish-cli/src/multisigBroker/errors.ts
+++ b/ironfish-cli/src/multisigBroker/errors.ts
@@ -10,6 +10,7 @@ export const MultisigBrokerErrorCodes = {
   INVALID_DKG_SESSION_ID: 3,
   INVALID_SIGNING_SESSION_ID: 4,
   IDENTITY_NOT_ALLOWED: 5,
+  NON_SESSION_CLIENT: 6,
 }
 
 export class MessageMalformedError extends Error {


### PR DESCRIPTION
## Summary

updates the multisig broker server to reject data submissions from clients that haven't joined the session

does not return session status if client not in session

sends an error message for 'NON_SESSION_CLIENT'

consolidates session validation logic to reduce repeated code

Closes IFL-3087

## Testing Plan
1. apply the diff below to forgo adding a client to the dkg session that it starts:
```
diff --git a/ironfish-cli/src/multisigBroker/server.ts b/ironfish-cli/src/multisigBroker/server.ts
index d5fdb00dc..4625ad0bd 100644
--- a/ironfish-cli/src/multisigBroker/server.ts
+++ b/ironfish-cli/src/multisigBroker/server.ts
@@ -480,7 +480,7 @@ export class MultisigServer {
     this.logger.debug(`Client ${client.id} started dkg session ${message.sessionId}`)
 
     client.identity = body.result.identity
-    this.addClientToSession(client, sessionId)
+    //this.addClientToSession(client, sessionId)
 
     this.send(client.socket, 'joined_session', message.sessionId, {
       challenge: session.challenge,
```
2. start a multisig server
3. start a dkg session in verbose mode
4. see error messages from client not being in session

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
