### PR TITLE
renderSpan: add more time intervals

### DIFF
--- a/ironfish-cli/src/commands/wallet/unlock.ts
+++ b/ironfish-cli/src/commands/wallet/unlock.ts
@@ -60,11 +60,7 @@ export class UnlockCommand extends IronfishCommand {
         'Unlocked the wallet. Call wallet:lock or stop the node to lock the wallet again.',
       )
     } else {
-      const timeoutDuration = TimeUtils.renderSpan(timeout, {
-        hideMilliseconds: true,
-        forceSecond: true,
-        forceMinute: true,
-      })
+      const timeoutDuration = TimeUtils.renderSpan(timeout)
       this.log(`Unlocked the wallet for ${timeoutDuration}.`)
     }
 

--- a/ironfish-cli/src/commands/wallet/unlock.ts
+++ b/ironfish-cli/src/commands/wallet/unlock.ts
@@ -60,7 +60,11 @@ export class UnlockCommand extends IronfishCommand {
         'Unlocked the wallet. Call wallet:lock or stop the node to lock the wallet again.',
       )
     } else {
-      const timeoutDuration = TimeUtils.renderSpan(timeout)
+      const timeoutDuration = TimeUtils.renderSpan(timeout, {
+        hideMilliseconds: true,
+        forceSecond: true,
+        forceMinute: true
+      })
       this.log(`Unlocked the wallet for ${timeoutDuration}.`)
     }
 

--- a/ironfish-cli/src/commands/wallet/unlock.ts
+++ b/ironfish-cli/src/commands/wallet/unlock.ts
@@ -63,7 +63,7 @@ export class UnlockCommand extends IronfishCommand {
       const timeoutDuration = TimeUtils.renderSpan(timeout, {
         hideMilliseconds: true,
         forceSecond: true,
-        forceMinute: true
+        forceMinute: true,
       })
       this.log(`Unlocked the wallet for ${timeoutDuration}.`)
     }

--- a/ironfish/src/utils/time.test.ts
+++ b/ironfish/src/utils/time.test.ts
@@ -10,7 +10,10 @@ describe('TimeUtils', () => {
       expect(TimeUtils.renderEstimate(50, 100, 60)).toEqual('soon')
       expect(TimeUtils.renderEstimate(50, 100, 20)).toEqual('2s')
       expect(TimeUtils.renderEstimate(50, 200, 1)).toEqual('2m 30s')
-      expect(TimeUtils.renderEstimate(10, 10000, 1)).toEqual('2h 46m 30s')
+      expect(TimeUtils.renderEstimate(10, 10000, 1)).toEqual('2h 46m')
+      expect(TimeUtils.renderEstimate(10, 198010, 1)).toEqual('2d 7h')
+      expect(TimeUtils.renderEstimate(10, 7689610, 1)).toEqual('2M 29d')
+      expect(TimeUtils.renderEstimate(10, 73699210, 1)).toEqual('2y 4M 3d')
     })
 
     it('should render time spans', () => {
@@ -21,6 +24,10 @@ describe('TimeUtils', () => {
       expect(TimeUtils.renderSpan(1150)).toEqual('1s 150ms')
       expect(TimeUtils.renderSpan(330000)).toEqual('5m 30s')
       expect(TimeUtils.renderSpan(7530000)).toEqual('2h 5m')
+      expect(TimeUtils.renderSpan(90000000)).toEqual('1d 1h')
+      expect(TimeUtils.renderSpan(7775940000)).toEqual('2M 29d')
+      expect(TimeUtils.renderSpan(31622400000)).toEqual('1y')
+      expect(TimeUtils.renderSpan(71193600000)).toEqual('2y 3M')
     })
 
     it('should render negative times', () => {
@@ -31,6 +38,10 @@ describe('TimeUtils', () => {
       expect(TimeUtils.renderSpan(-1150)).toEqual('-1s 150ms')
       expect(TimeUtils.renderSpan(-330000)).toEqual('-5m 30s')
       expect(TimeUtils.renderSpan(-7530000)).toEqual('-2h 5m')
+      expect(TimeUtils.renderSpan(-90000000)).toEqual('-1d 1h')
+      expect(TimeUtils.renderSpan(-7775940000)).toEqual('-2M 29d')
+      expect(TimeUtils.renderSpan(-31622400000)).toEqual('-1y')
+      expect(TimeUtils.renderSpan(-71193600000)).toEqual('-2y 3M')
     })
   })
 })

--- a/ironfish/src/utils/time.test.ts
+++ b/ironfish/src/utils/time.test.ts
@@ -10,10 +10,10 @@ describe('TimeUtils', () => {
       expect(TimeUtils.renderEstimate(50, 100, 60)).toEqual('soon')
       expect(TimeUtils.renderEstimate(50, 100, 20)).toEqual('2s')
       expect(TimeUtils.renderEstimate(50, 200, 1)).toEqual('2m 30s')
-      expect(TimeUtils.renderEstimate(10, 10000, 1)).toEqual('2h 46m')
+      expect(TimeUtils.renderEstimate(10, 10000, 1)).toEqual('2h 46m 30s')
       expect(TimeUtils.renderEstimate(10, 198010, 1)).toEqual('2d 7h')
       expect(TimeUtils.renderEstimate(10, 7689610, 1)).toEqual('2M 29d')
-      expect(TimeUtils.renderEstimate(10, 73699210, 1)).toEqual('2y 4M 3d')
+      expect(TimeUtils.renderEstimate(10, 73699210, 1)).toEqual('2y 4M 72h')
     })
 
     it('should render time spans', () => {

--- a/ironfish/src/utils/time.ts
+++ b/ironfish/src/utils/time.ts
@@ -2,11 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import { tr } from 'date-fns/locale'
 import { MathUtils } from './math'
 
 const MS_PER_SEC = 1000.0
 const MS_PER_MIN = 60.0 * 1000.0
 const MS_PER_HOUR = 60.0 * 60.0 * 1000.0
+const MS_PER_DAY = 24 * 60.0 * 60.0 * 1000.0
+const MS_PER_MONTH = 30 * 24 * 60.0 * 60.0 * 1000.0
+const MS_PER_YEAR = 12 * 30 * 24 * 60.0 * 60.0 * 1000.0
 
 /**
  *
@@ -31,6 +35,9 @@ const renderEstimate = (done: number, total: number, speed: number): string => {
     forceSecond: true,
     forceMinute: true,
     forceHour: true,
+    forceDay: true,
+    forceMonth: true,
+    forceYear: true,
     hideMilliseconds: true,
   })
 }
@@ -41,6 +48,9 @@ const renderEstimate = (done: number, total: number, speed: number): string => {
 const renderSpan = (
   time: number,
   options?: {
+    forceYear?: boolean
+    forceMonth?: boolean
+    forceDay?: boolean
     forceHour?: boolean
     forceMinute?: boolean
     forceSecond?: boolean
@@ -58,6 +68,29 @@ const renderSpan = (
 
   const parts = []
   let magnitude = 0
+  // Do we want to include years? Is it ok to estimate at 365 days?
+  if (time >= MS_PER_YEAR && (magnitude <= 8 || options?.forceYear)) {
+    const years = Math.floor(time / MS_PER_YEAR)
+    time -= years * MS_PER_YEAR
+    parts.push(`${years.toFixed(0)}y`)
+    magnitude = Math.max(magnitude, 7)
+  }
+
+  // Do we want to include months? Is it ok to estimate at 30 days?
+  // Should we update the abbreviation for months and minutes (both currently m) to mo and min? Do this for all time periods?
+  if (time >= MS_PER_MONTH && (magnitude <= 7 || options?.forceMonth)) {
+    const months = Math.floor(time / MS_PER_MONTH)
+    time -= months * MS_PER_MONTH
+    parts.push(`${months.toFixed(0)}m`)
+    magnitude = Math.max(magnitude, 6)
+  }
+
+  if (time >= MS_PER_DAY && (magnitude <= 6 || options?.forceDay)) {
+    const days = Math.floor(time / MS_PER_DAY)
+    time -= days * MS_PER_DAY
+    parts.push(`${days.toFixed(0)}d`)
+    magnitude = Math.max(magnitude, 5)
+  }
 
   if (time >= MS_PER_HOUR && (magnitude <= 5 || options?.forceHour)) {
     const hours = Math.floor(time / MS_PER_HOUR)

--- a/ironfish/src/utils/time.ts
+++ b/ironfish/src/utils/time.ts
@@ -67,6 +67,7 @@ const renderSpan = (
 
   const parts = []
   let magnitude = 0
+
   if (time >= MS_PER_YEAR && (magnitude <= 8 || options?.forceYear)) {
     const years = Math.floor(time / MS_PER_YEAR)
     time -= years * MS_PER_YEAR

--- a/ironfish/src/utils/time.ts
+++ b/ironfish/src/utils/time.ts
@@ -31,9 +31,9 @@ const renderEstimate = (done: number, total: number, speed: number): string => {
 
   return renderSpan(estimate, {
     forceMillisecond: false,
-    forceSecond: true,
-    forceMinute: true,
-    forceHour: true,
+    forceSecond: false,
+    forceMinute: false,
+    forceHour: false,
     forceDay: true,
     forceMonth: true,
     forceYear: true,

--- a/ironfish/src/utils/time.ts
+++ b/ironfish/src/utils/time.ts
@@ -31,12 +31,12 @@ const renderEstimate = (done: number, total: number, speed: number): string => {
 
   return renderSpan(estimate, {
     forceMillisecond: false,
-    forceSecond: false,
-    forceMinute: false,
-    forceHour: false,
-    forceDay: true,
-    forceMonth: true,
-    forceYear: true,
+    forceSecond: true,
+    forceMinute: true,
+    forceHour: true,
+    forceDay: false,
+    forceMonth: false,
+    forceYear: false,
     hideMilliseconds: true,
   })
 }

--- a/ironfish/src/utils/time.ts
+++ b/ironfish/src/utils/time.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { tr } from 'date-fns/locale'
 import { MathUtils } from './math'
 
 const MS_PER_SEC = 1000.0
@@ -10,7 +9,7 @@ const MS_PER_MIN = 60.0 * 1000.0
 const MS_PER_HOUR = 60.0 * 60.0 * 1000.0
 const MS_PER_DAY = 24 * 60.0 * 60.0 * 1000.0
 const MS_PER_MONTH = 30 * 24 * 60.0 * 60.0 * 1000.0
-const MS_PER_YEAR = 12 * 30 * 24 * 60.0 * 60.0 * 1000.0
+const MS_PER_YEAR = 365 * 24 * 60.0 * 60.0 * 1000.0
 
 /**
  *
@@ -68,7 +67,6 @@ const renderSpan = (
 
   const parts = []
   let magnitude = 0
-  // Do we want to include years? Is it ok to estimate at 365 days?
   if (time >= MS_PER_YEAR && (magnitude <= 8 || options?.forceYear)) {
     const years = Math.floor(time / MS_PER_YEAR)
     time -= years * MS_PER_YEAR
@@ -76,12 +74,10 @@ const renderSpan = (
     magnitude = Math.max(magnitude, 7)
   }
 
-  // Do we want to include months? Is it ok to estimate at 30 days?
-  // Should we update the abbreviation for months and minutes (both currently m) to mo and min? Do this for all time periods?
   if (time >= MS_PER_MONTH && (magnitude <= 7 || options?.forceMonth)) {
     const months = Math.floor(time / MS_PER_MONTH)
     time -= months * MS_PER_MONTH
-    parts.push(`${months.toFixed(0)}m`)
+    parts.push(`${months.toFixed(0)}M`)
     magnitude = Math.max(magnitude, 6)
   }
 


### PR DESCRIPTION
## Summary
Added years, months, and days to renderSpan
Estimated years to 365 days and months to 30 days.

## Testing Plan
Lock and unlock a wallet with flags for various time intervals.
Confirmed it returns the highest 2 time units (year & month, month & day, etc.)

## Documentation
N/A

## Breaking Change
N/A
