### PR TITLE
Add createdAt to createAccount RPC

### DIFF
--- a/ironfish/src/rpc/routes/wallet/create.test.slow.ts
+++ b/ironfish/src/rpc/routes/wallet/create.test.slow.ts
@@ -10,7 +10,7 @@ import { createRouteTest } from '../../../testUtilities/routeTest'
 import { RPC_ERROR_CODES } from '../../adapters'
 import { RpcRequestError } from '../../clients/errors'
 
-describe('Route wallet/create', () => {
+describe('Route wallet/createAccount', () => {
   jest.setTimeout(15000)
   const routeTest = createRouteTest()
 
@@ -20,6 +20,10 @@ describe('Route wallet/create', () => {
 
   it('should create an account', async () => {
     await routeTest.node.wallet.createAccount('existingAccount', { setDefault: true })
+    const createdAtHead = {
+      hash: routeTest.node.chain.head.hash,
+      sequence: routeTest.node.chain.head.sequence,
+    }
 
     const name = uuid()
 
@@ -35,6 +39,7 @@ describe('Route wallet/create', () => {
     expect(account).toMatchObject({
       name: name,
       publicAddress: response.content.publicAddress,
+      createdAt: createdAtHead,
     })
   })
 
@@ -87,5 +92,35 @@ describe('Route wallet/create', () => {
     })
 
     expect(scanSpy).toHaveBeenCalled()
+  })
+
+  it('should set account createdAt if passed', async () => {
+    const name = uuid()
+    const createdAt = {
+      hash: '00000000000163b1c632498ac8f86cfd33f65c5d4e43e5001c75d5acb4ada4de',
+      sequence: 10,
+    }
+
+    const response = await routeTest.client.wallet.createAccount({
+      name,
+      createdAt,
+    })
+
+    expect(response.status).toBe(200)
+    expect(response.content).toMatchObject({
+      name: name,
+      publicAddress: expect.any(String),
+      isDefaultAccount: true,
+    })
+
+    const account = routeTest.node.wallet.getAccountByName(name)
+    expect(account).toMatchObject({
+      name: name,
+      publicAddress: response.content.publicAddress,
+      createdAt: {
+        hash: Buffer.from(createdAt.hash, 'hex'),
+        sequence: createdAt.sequence,
+      },
+    })
   })
 })

--- a/ironfish/src/rpc/routes/wallet/create.test.slow.ts
+++ b/ironfish/src/rpc/routes/wallet/create.test.slow.ts
@@ -96,10 +96,7 @@ describe('Route wallet/createAccount', () => {
 
   it('should set account createdAt if passed', async () => {
     const name = uuid()
-    const createdAt = {
-      hash: '00000000000163b1c632498ac8f86cfd33f65c5d4e43e5001c75d5acb4ada4de',
-      sequence: 10,
-    }
+    const createdAt = 10
 
     const response = await routeTest.client.wallet.createAccount({
       name,
@@ -118,9 +115,32 @@ describe('Route wallet/createAccount', () => {
       name: name,
       publicAddress: response.content.publicAddress,
       createdAt: {
-        hash: Buffer.from(createdAt.hash, 'hex'),
-        sequence: createdAt.sequence,
+        hash: Buffer.alloc(32, 0),
+        sequence: 10,
       },
+    })
+  })
+
+  it('should set account createdAt to null', async () => {
+    const name = uuid()
+
+    const response = await routeTest.client.wallet.createAccount({
+      name,
+      createdAt: null,
+    })
+
+    expect(response.status).toBe(200)
+    expect(response.content).toMatchObject({
+      name: name,
+      publicAddress: expect.any(String),
+      isDefaultAccount: true,
+    })
+
+    const account = routeTest.node.wallet.getAccountByName(name)
+    expect(account).toMatchObject({
+      name: name,
+      publicAddress: response.content.publicAddress,
+      createdAt: null,
     })
   })
 })


### PR DESCRIPTION
## Summary
Allow account creation to take a createdAt object

## Testing Plan
Unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
