### PR TITLE
use github action for uploading codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,12 @@ jobs:
 
       - name: Upload coverage
         if: github.repository == 'iron-fish/ironfish'
-        run: CODECOV_TOKEN=${{ secrets.CODECOV_TOKEN }} ROOT_PATH=$GITHUB_WORKSPACE/ yarn coverage:upload
+        uses: codecov/codecov-action@v4
+        with:
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: ironfish
+
 
   testslow:
     name: Slow Tests
@@ -111,4 +116,8 @@ jobs:
 
       - name: Upload coverage
         if: github.repository == 'iron-fish/ironfish'
-        run: CODECOV_TOKEN=${{ secrets.CODECOV_TOKEN }} ROOT_PATH=$GITHUB_WORKSPACE/ yarn coverage:upload
+        uses: codecov/codecov-action@v4
+        with:
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: ironfish

--- a/.github/workflows/rust_ci.yml
+++ b/.github/workflows/rust_ci.yml
@@ -105,7 +105,7 @@ jobs:
 
       # Upload code coverage to Codecov
       - name: Upload to codecov.io
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           token: ${{secrets.CODECOV_TOKEN}}
           flags: ironfish-rust
@@ -131,7 +131,7 @@ jobs:
 
       # Upload code coverage to Codecov
       - name: Upload to codecov.io
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           token: ${{secrets.CODECOV_TOKEN}}
           flags: ironfish-zkp

--- a/package.json
+++ b/package.json
@@ -32,8 +32,7 @@
     "test:slow:coverage": "lerna run test:slow --stream -- --testPathIgnorePatterns --collect-coverage",
     "test:perf:report": "lerna run test:perf:report",
     "typecheck": "lerna exec -- tsc --noEmit",
-    "typecheck:changed": "lerna exec --since origin/master --include-dependents -- tsc --noEmit",
-    "coverage:upload": "lerna exec '\"yarn codecov -t $CODECOV_TOKEN -f ./coverage/clover.xml -F $LERNA_PACKAGE_NAME -p $ROOT_PATH/ --disable=gcov\"'"
+    "typecheck:changed": "lerna exec --since origin/master --include-dependents -- tsc --noEmit"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "6.19.0",


### PR DESCRIPTION
## Summary

We were getting intermittent issues using the original codecov upload process,
which has been deprecated for a few years now. The coverage also has been
broken for some unknown amount of time. Using the github action is the
officially recommended way to upload to codecov now.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
