### PR TITLE
shard unit tests in CI for faster CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,9 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        shard: [1,2]
 
     steps:
       - name: Check out Git repository
@@ -63,7 +66,7 @@ jobs:
         run: yarn --non-interactive --frozen-lockfile
 
       - name: Run tests
-        run: yarn test:coverage --maxWorkers=2 --workerIdleMemoryLimit=2000MB
+        run: yarn test:coverage --maxWorkers=2 --workerIdleMemoryLimit=2000MB --shard=${{ matrix.shard }}/${{ strategy.job-total }}
 
       - name: Check for missing fixtures
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        shard: [1,2]
+        shard: [1, 2, 3]
 
     steps:
       - name: Check out Git repository
@@ -87,6 +87,9 @@ jobs:
   testslow:
     name: Slow Tests
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        shard: [1, 2]
 
     steps:
       - name: Check out Git repository
@@ -108,7 +111,7 @@ jobs:
         run: yarn --non-interactive --frozen-lockfile
 
       - name: Run slow tests & coverage
-        run: yarn test:slow:coverage --maxWorkers=2 --workerIdleMemoryLimit=2000MB
+        run: yarn test:slow:coverage --maxWorkers=2 --workerIdleMemoryLimit=2000MB --shard=${{ matrix.shard }}/${{ strategy.job-total }}
 
       - name: Check for missing fixtures
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        shard: [1, 2, 3]
+        shard: [1/3, 2/3, 3/3]
 
     steps:
       - name: Check out Git repository
@@ -66,7 +66,7 @@ jobs:
         run: yarn --non-interactive --frozen-lockfile
 
       - name: Run tests
-        run: yarn test:coverage --maxWorkers=2 --workerIdleMemoryLimit=2000MB --shard=${{ matrix.shard }}/${{ strategy.job-total }}
+        run: yarn test:coverage --maxWorkers=2 --workerIdleMemoryLimit=2000MB --shard=${{ matrix.shard }}
 
       - name: Check for missing fixtures
         run: |
@@ -89,7 +89,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        shard: [1, 2]
+        shard: [1/2, 2/2]
 
     steps:
       - name: Check out Git repository
@@ -111,7 +111,7 @@ jobs:
         run: yarn --non-interactive --frozen-lockfile
 
       - name: Run slow tests & coverage
-        run: yarn test:slow:coverage --maxWorkers=2 --workerIdleMemoryLimit=2000MB --shard=${{ matrix.shard }}/${{ strategy.job-total }}
+        run: yarn test:slow:coverage --maxWorkers=2 --workerIdleMemoryLimit=2000MB --shard=${{ matrix.shard }}
 
       - name: Check for missing fixtures
         run: |


### PR DESCRIPTION
## Summary

Shards the main test suite across 3 shards, and slow tests across 2 shards, resulting in a CI runtime reduction from around 15 minutes to around 6.5-7 minutes: https://github.com/iron-fish/ironfish/actions/runs/11486776859

## Testing Plan

Re-ran CI workflow multiple times across 2 branches

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
