### PR TITLE
clears onDisconnected event handler when ending session

### DIFF
--- a/ironfish-cli/src/multisigBroker/sessionManagers/sessionManager.ts
+++ b/ironfish-cli/src/multisigBroker/sessionManagers/sessionManager.ts
@@ -137,6 +137,7 @@ export abstract class MultisigClientSessionManager extends MultisigSessionManage
   }
 
   endSession(): void {
+    this.client.onDisconnected.clear()
     this.client.stop()
   }
 


### PR DESCRIPTION
## Summary

the handler that we add to the MultisigClient.onDisconnected event assumes that the client will try to reconnect and rejoin a session after a disconnect. however, if the session is ended, the client will not try to reconnect. this results in the CLI displaying an endless action stating that it is waiting to connect after the session ends

clears the handler before stopping the client so that the sessionManager won't wait for messages confirming server reconnection and session rejoin

## Testing Plan
manual testing: ran through signing flow with server

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
