### PR TITLE
Change the `ironfish-frost` dependency to use the crate from crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1524,17 +1524,37 @@ dependencies = [
 [[package]]
 name = "ironfish-frost"
 version = "0.1.0"
-source = "git+https://github.com/iron-fish/ironfish-frost.git?branch=main#d4681df8a5a613fd9e716212aae3be8602acd227"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bee779ebf008aa92e1bb90993a47ab730065a8d39f5fa6630cde1ddfcf56a46"
 dependencies = [
  "blake3",
  "chacha20 0.9.1",
  "chacha20poly1305 0.10.1",
  "ed25519-dalek",
+ "ironfish-reddsa",
  "rand_chacha",
  "rand_core",
- "reddsa 0.5.1",
  "siphasher",
  "x25519-dalek",
+]
+
+[[package]]
+name = "ironfish-reddsa"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb4aecfd3334f0128215ce47f57360d91d68ff9d6fd890e1faca3c79b2bfa28d"
+dependencies = [
+ "blake2b_simd",
+ "byteorder",
+ "frost-rerandomized",
+ "group 0.13.0",
+ "hex",
+ "jubjub 0.10.0",
+ "pasta_curves 0.5.0",
+ "rand_core",
+ "serde",
+ "thiserror",
+ "zeroize",
 ]
 
 [[package]]
@@ -1960,7 +1980,7 @@ dependencies = [
  "nonempty",
  "pasta_curves 0.4.1",
  "rand",
- "reddsa 0.3.0",
+ "reddsa",
  "serde",
  "subtle",
  "tracing",
@@ -2254,24 +2274,6 @@ dependencies = [
  "group 0.12.1",
  "jubjub 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pasta_curves 0.4.1",
- "rand_core",
- "serde",
- "thiserror",
- "zeroize",
-]
-
-[[package]]
-name = "reddsa"
-version = "0.5.1"
-source = "git+https://github.com/ZcashFoundation/reddsa.git?rev=ed49e9ca0699a6450f6d4a9fe62ff168f5ea1ead#ed49e9ca0699a6450f6d4a9fe62ff168f5ea1ead"
-dependencies = [
- "blake2b_simd",
- "byteorder",
- "frost-rerandomized",
- "group 0.13.0",
- "hex",
- "jubjub 0.10.0",
- "pasta_curves 0.5.0",
  "rand_core",
  "serde",
  "thiserror",

--- a/ironfish-rust-nodejs/Cargo.toml
+++ b/ironfish-rust-nodejs/Cargo.toml
@@ -30,7 +30,7 @@ stats = ["ironfish/note-encryption-stats", "jubjub/stats", "dep:signal-hook"]
 base64 = "0.13.0"
 fish_hash = "0.3.0"
 ironfish = { path = "../ironfish-rust" }
-ironfish-frost = { git = "https://github.com/iron-fish/ironfish-frost.git", branch = "main" }
+ironfish-frost = { version = "0.1.0" }
 napi = { version = "2.14.4", features = ["napi6"] }
 napi-derive = "2.14.6"
 jubjub = { git = "https://github.com/iron-fish/jubjub.git", branch = "blstrs", features = ["multiply-many"] }

--- a/ironfish-rust/Cargo.toml
+++ b/ironfish-rust/Cargo.toml
@@ -43,7 +43,7 @@ chacha20poly1305 = "0.10.1"
 crypto_box = { version = "0.9", features = ["std"] }
 ff = "0.12.0"
 group = "0.12.0"
-ironfish-frost = { git = "https://github.com/iron-fish/ironfish-frost.git", branch = "main" }
+ironfish-frost = { version = "0.1.0" }
 fish_hash = "0.3.0"
 ironfish_zkp = { version = "0.2.0", path = "../ironfish-zkp" }
 jubjub = { git = "https://github.com/iron-fish/jubjub.git", branch = "blstrs", features = ["multiply-many"] }

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -63,6 +63,18 @@ who = "Andrea <andrea@iflabs.network>"
 criteria = "safe-to-deploy"
 delta = "1.9.3 -> 2.2.6"
 
+[[audits.ironfish-frost]]
+who = "andrea <andrea@iflabs.network>"
+criteria = "safe-to-deploy"
+version = "0.1.0"
+notes = "Crate owned by the Iron Fish organization"
+
+[[audits.ironfish-reddsa]]
+who = "andrea <andrea@iflabs.network>"
+criteria = "safe-to-deploy"
+version = "0.1.0"
+notes = "Crate owned by the Iron Fish organization"
+
 [[audits.jubjub]]
 who = "Andrea <andrea@iflabs.network>"
 criteria = "safe-to-deploy"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -40,9 +40,6 @@ audit-as-crates-io = true
 [policy."jubjub:0.9.0@git:531157cfa7b81ade207e819ef50c563843b10e30"]
 audit-as-crates-io = true
 
-[policy.reddsa]
-audit-as-crates-io = true
-
 [policy.zcash_address]
 audit-as-crates-io = true
 
@@ -612,10 +609,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.rand]]
 version = "0.8.5"
-criteria = "safe-to-deploy"
-
-[[exemptions.reddsa]]
-version = "0.5.1@git:ed49e9ca0699a6450f6d4a9fe62ff168f5ea1ead"
 criteria = "safe-to-deploy"
 
 [[exemptions.redjubjub]]


### PR DESCRIPTION
## Summary

Now that `ironfish-frost` is published, we can use the published version instead of the "git" version.

## Testing Plan

Unit tests

## Documentation

N/A

## Breaking Change

N/A