### PR TITLE
shard rust unit tests on ci

### DIFF
--- a/.github/workflows/rust_ci.yml
+++ b/.github/workflows/rust_ci.yml
@@ -100,10 +100,6 @@ jobs:
       - name: Install nextest
         uses: taiki-e/install-action@nextest
 
-      - name: Clean coverage artifacts
-        run: |
-          cargo llvm-cov clean --workspace
-
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:
@@ -138,10 +134,6 @@ jobs:
 
       - name: Install nextest
         uses: taiki-e/install-action@nextest
-
-      - name: Clean coverage artifacts
-        run: |
-          cargo llvm-cov clean --workspace
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/rust_ci.yml
+++ b/.github/workflows/rust_ci.yml
@@ -87,8 +87,22 @@ jobs:
   ironfish_rust:
     name: Test ironfish-rust
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        shard: [1/2, 2/2]
+
     steps:
       - uses: actions/checkout@v4
+
+      - name: install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
+
+      - name: Clean coverage artifacts
+        run: |
+          cargo llvm-cov clean --workspace
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
@@ -96,12 +110,15 @@ jobs:
           shared-key: base
 
       # Run tests to collect code coverage
-      - name: Run cargo-tarpaulin on ironfish-rust
+      - name: Run tests
         run: |
-          wget -O tarpaulin.tar.gz https://github.com/xd009642/tarpaulin/releases/download/0.22.0/cargo-tarpaulin-0.22.0-travis.tar.gz
-          tar -xzf tarpaulin.tar.gz
-          mv cargo-tarpaulin ~/.cargo/bin/
-          cargo tarpaulin -p ironfish --release --out Xml --avoid-cfg-tarpaulin --skip-clean --timeout 300 -- --test-threads 1
+          cargo llvm-cov nextest \
+            --no-clean \
+            --codecov \
+            --output-path codecov.json \
+            --package ironfish \
+            --release \
+            --partition count:${{ matrix.shard }}
 
       # Upload code coverage to Codecov
       - name: Upload to codecov.io
@@ -116,18 +133,30 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
+
+      - name: Clean coverage artifacts
+        run: |
+          cargo llvm-cov clean --workspace
+
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: zkp
 
       # Run tests to collect code coverage
-      - name: Run cargo-tarpaulin on ironfish-zkp
+      - name: Run tests
         run: |
-          wget -O tarpaulin.tar.gz https://github.com/xd009642/tarpaulin/releases/download/0.22.0/cargo-tarpaulin-0.22.0-travis.tar.gz
-          tar -xzf tarpaulin.tar.gz
-          mv cargo-tarpaulin ~/.cargo/bin/
-          cargo tarpaulin -p ironfish_zkp --release --out Xml --avoid-cfg-tarpaulin --skip-clean --timeout 300 -- --test-threads 1
+          cargo llvm-cov nextest \
+            --no-clean \
+            --codecov \
+            --output-path codecov.json \
+            --package ironfish_zkp \
+            --release
 
       # Upload code coverage to Codecov
       - name: Upload to codecov.io


### PR DESCRIPTION
## Summary

uses nextest as a test runner and llvm-cov as the coverage reporter. neither the default test runner nor cargo tarpaulin support sharding, so opting to use nextest for this purpose.

see: https://github.com/iron-fish/ironfish/actions/runs/11507837608

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
