### PR TITLE
handles errors from full dkg sessions

### DIFF
--- a/ironfish-cli/package.json
+++ b/ironfish-cli/package.json
@@ -60,7 +60,7 @@
     "oclif:version": "oclif readme && git add README.md"
   },
   "dependencies": {
-    "@ironfish/multisig-broker": "0.1.1",
+    "@ironfish/multisig-broker": "0.3.0",
     "@ironfish/rust-nodejs": "2.7.0",
     "@ironfish/sdk": "2.8.1",
     "@ledgerhq/errors": "6.19.1",

--- a/ironfish-cli/src/commands/wallet/multisig/dkg/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/create.ts
@@ -116,14 +116,18 @@ export class DkgCreateCommand extends IronfishCommand {
       logger: this.logger,
     })
 
-    const { totalParticipants, minSigners } = await ui.retryStep(async () => {
-      return sessionManager.startSession({
-        totalParticipants: flags.totalParticipants,
-        minSigners: flags.minSigners,
-        ledger: flags.ledger,
-        identity,
-      })
-    }, this.logger)
+    const { totalParticipants, minSigners } = await ui.retryStep(
+      async () => {
+        return sessionManager.startSession({
+          totalParticipants: flags.totalParticipants,
+          minSigners: flags.minSigners,
+          ledger: flags.ledger,
+          identity,
+        })
+      },
+      this.logger,
+      true,
+    )
 
     const { round1 } = await ui.retryStep(
       async () => {

--- a/ironfish-cli/src/utils/multisig/sessionManagers/sessionManager.ts
+++ b/ironfish-cli/src/utils/multisig/sessionManagers/sessionManager.ts
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import {
-  IdentityNotAllowedError,
-  InvalidSessionError,
   MultisigBrokerErrorCodes,
   MultisigBrokerUtils,
   MultisigClient,
@@ -113,6 +111,8 @@ export abstract class MultisigClientSessionManager extends MultisigSessionManage
     this.client.onMultisigBrokerError.on((errorMessage) => {
       if (errorMessage.error.code === MultisigBrokerErrorCodes.SESSION_ID_NOT_FOUND) {
         clientError = new InvalidSessionError(errorMessage.error.message)
+      } else if (errorMessage.error.code === MultisigBrokerErrorCodes.DKG_SESSION_FULL) {
+        clientError = new DkgSessionFullError(errorMessage.error.message)
       } else if (errorMessage.error.code === MultisigBrokerErrorCodes.IDENTITY_NOT_ALLOWED) {
         // Throws error immediately instead of deferring to loop, below
         throw new IdentityNotAllowedError(errorMessage.error.message)
@@ -143,3 +143,11 @@ export abstract class MultisigClientSessionManager extends MultisigSessionManage
 
   abstract getSessionConfig(): Promise<object>
 }
+
+export class MultisigSessionError extends Error {
+  name = this.constructor.name
+}
+
+export class DkgSessionFullError extends MultisigSessionError {}
+export class InvalidSessionError extends MultisigSessionError {}
+export class IdentityNotAllowedError extends MultisigSessionError {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1115,10 +1115,10 @@
   dependencies:
     mute-stream "^1.0.0"
 
-"@ironfish/multisig-broker@0.1.1":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@ironfish/multisig-broker/-/multisig-broker-0.1.1.tgz#9c4abfbe09f8199fb13fb672d0e1714203ed9a60"
-  integrity sha512-v7KaSvmsx3ihlVRi6er8YyLf7zRHB46uP6Rc2/zVvZqSoEeASViN1bpdDYM4YzuVeqTNQBF6Em79eT4tI40IpA==
+"@ironfish/multisig-broker@0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@ironfish/multisig-broker/-/multisig-broker-0.3.0.tgz#6779c9fdae428cd59e46d7e300c82a1bb97d1f1a"
+  integrity sha512-D2hW7GV7SutnFAb0B1DVM9VV3+BWB31AdsCtQLuMeD9z4MHJJYTzzGFjsQ77sFI4lauVSCfPoPmpVQYd/KdxLA==
   dependencies:
     "@ironfish/rust-nodejs" "^2.7.0"
     "@ironfish/sdk" "^2.8.1"


### PR DESCRIPTION
## Summary

upgrades '@ironfish/multisig-broker'

catches error messages with the 'DKG_SESSION_FULL' error code and throws an appropriate error in 'waitForJoinedSession'

changes 'dkg:create' to ask the user if they want to retry joining the session. gives the user an opportunity to wait before immediately trying to rejoin a full session

defines error types that were removed from '@ironfish/multisig-broker'

Closes IFL-3098

## Testing Plan
1. start dev server
2. start dkg session using `ironfish wallet:multisig:dkg:create --hostname localhost --ledger`. set total participants to 2. use ledger so that round1 does not start before extra client tries to join.
3. join dkg session with second client
4. try to join dkg session with third client and observe error and prompt to retry
<img width="486" alt="image" src="https://github.com/user-attachments/assets/724bdab0-a388-4f0c-b355-154ecf13577a">


## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
