### PR TITLE
update fixture ci job to use the right secret

### DIFF
--- a/.github/workflows/ci-regenerate-fixtures.yml
+++ b/.github/workflows/ci-regenerate-fixtures.yml
@@ -45,4 +45,4 @@ jobs:
           status: ${{ job.status }}
           notify_when: 'failure'
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.GITHUB_ACTIONS_SLACK_WEBHOOK }}
+          SLACK_WEBHOOK_URL: ${{ secrets.GH_ACTIONS_SLACK_WEBHOOK }}


### PR DESCRIPTION
## Summary

See https://github.com/iron-fish/ironfish/actions/runs/10905813952/job/30265585854

It looks like this secret may have been renamed at some point, but the CI job wasn't updated to reflect it

## Testing Plan

## Documentation

N/A

## Breaking Change

N/A
