### PR TITLE
allows multisig commands to disable tls without server flag

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/dkg/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/create.ts
@@ -67,7 +67,6 @@ export class DkgCreateCommand extends IronfishCommand {
     }),
     tls: Flags.boolean({
       description: 'connect to the multisig server over TLS',
-      dependsOn: ['server'],
       allowNo: true,
     }),
     minSigners: Flags.integer({

--- a/ironfish-cli/src/commands/wallet/multisig/sign.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/sign.ts
@@ -69,7 +69,6 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
     }),
     tls: Flags.boolean({
       description: 'connect to the multisig server over TLS',
-      dependsOn: ['server'],
       allowNo: true,
     }),
   }


### PR DESCRIPTION
## Summary

removes dependency of tls flag on server flag in 'wallet:multisig:dkg:create' and 'wallet:multisig:sign'

allows user to use flag combinations like '--hostname localhost --no-tls' without needing to also set the '--server' flag

## Testing Plan
1. start dev server in `multisig-broker` repo using `yarn start`. the dev server does not use TLS
2. run `wallet:multisig:dkg:create --hostname localhost --no-tls` to connect to the dev server without TLS

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
