### PR TITLE
dont cache yarn

### DIFF
--- a/.github/workflows/perf_test.yml
+++ b/.github/workflows/perf_test.yml
@@ -25,7 +25,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: 'yarn'
 
       - name: Install packages
         run: yarn --non-interactive --frozen-lockfile


### PR DESCRIPTION
## Summary

The performance test CI job was regularly taking ~45 minutes, with it sometimes taking up to an hour and a half. The reason it takes more than 10 minutes at all is because it is downloading a 7.5gb yarn cache via the `actions/setup-node` job. This is unnecessary since it seems to have all of these files cached locally as it is.

After removing the yarn cache, it has to recompile the rust code on each run. However, since the runner is a fairly powerful machine, it only takes about a minute, which seems better than trying to download the cache from a data center somewhere over a somewhat slow wifi network.

See: https://github.com/iron-fish/ironfish/actions/runs/11523779611/job/32082513578

## Testing Plan

Ran the perf job directly on the branch by adding it to the job's push branches and allowing the runner to run on this branch. https://github.com/iron-fish/ironfish/actions/runs/11523779611/job/32082513578

## Documentation

N/A

## Breaking Change

N/A