### PR TITLE
allows multisig users to enter connection string for session ID

### DIFF
--- a/ironfish-cli/src/utils/multisig/sessionManagers/dkgSessionManager.ts
+++ b/ironfish-cli/src/utils/multisig/sessionManagers/dkgSessionManager.ts
@@ -66,10 +66,7 @@ export class MultisigClientDkgSessionManager
     identity: string
   }): Promise<{ totalParticipants: number; minSigners: number }> {
     if (!this.sessionId) {
-      this.sessionId = await ui.inputPrompt(
-        'Enter the ID of a multisig session to join, or press enter to start a new session',
-        false,
-      )
+      await this.promptSessionConnection()
     }
 
     if (!this.passphrase) {

--- a/ironfish-cli/src/utils/multisig/sessionManagers/signingSessionManager.ts
+++ b/ironfish-cli/src/utils/multisig/sessionManagers/signingSessionManager.ts
@@ -60,10 +60,7 @@ export class MultisigClientSigningSessionManager
     allowedIdentities?: string[]
   }): Promise<{ numSigners: number; unsignedTransaction: UnsignedTransaction }> {
     if (!this.sessionId) {
-      this.sessionId = await ui.inputPrompt(
-        'Enter the ID of a multisig session to join, or press enter to start a new session',
-        false,
-      )
+      await this.promptSessionConnection()
     }
 
     if (!this.passphrase) {


### PR DESCRIPTION
## Summary

when prompting for session ID, tries to parse the user input as a connection string. this allows the user to enter a connection string (e.g., 'tcp://session-id:passphrase@hostname:port') in this prompt instead of only the session ID

updates MultisigClientSessionManager to delay instantiating the client until connection time to allow the prompt to change the hostname and/or port

Closes IFL-3096

## Testing Plan
1. start dkg session using `wallet:multisig:dkg:create --server`
2. join dkg session in second window using `wallet:multisig:dkg:create --server` and entering the connection string from step 1 in the session ID prompt

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
