### PR TITLE
ensure artifacts folder exists when deploying rust bindings

### DIFF
--- a/.github/workflows/deploy-npm-ironfish-rust-nodejs.yml
+++ b/.github/workflows/deploy-npm-ironfish-rust-nodejs.yml
@@ -42,6 +42,13 @@ jobs:
         run: ls -R .
         shell: bash
 
+      - name: Verify artifacts exist
+        run: |
+          if [ -z "$(ls -A './artifacts')" ]; then
+            echo "artifacts folder was empty. ironfish-rust-nodejs artifacts were not uploaded correctly."
+            exit 1
+          fi
+
       - name: Move and publish artifacts
         run: yarn artifacts
 


### PR DESCRIPTION
## Summary

When deploying the rust binding packages, if the download-artifacts step fails to download any artifacts, it will not raise an error. Neither will the npm publish step. This will lead to problems where the packages depending on the bindings will be broken since the bindings will not get released.

This PR adds a basic sanity check to make sure that some artifacts are downloaded, otherwise it will fail. 

Closes IFL-2719

## Testing Plan

Temporarily added this step into a different CI job to ensure it works as expected.
- Folder doesn't exist (fail): https://github.com/iron-fish/ironfish/actions/runs/11526254922/job/32090058598
- Folder is empty (fail): https://github.com/iron-fish/ironfish/actions/runs/11526268604/job/32090093439
- Folder exists and has at least one file in it (pass): https://github.com/iron-fish/ironfish/actions/runs/11526278391/job/32090121177 

## Documentation

N/A

## Breaking Change

N/A