### PR TITLE
feat(IFL-2710): Show default account in account list

### DIFF
--- a/ironfish-cli/src/commands/wallet/index.ts
+++ b/ironfish-cli/src/commands/wallet/index.ts
@@ -44,6 +44,10 @@ export class AccountsCommand extends IronfishCommand {
           header: 'Account',
           minWidth: 11,
         },
+        default: {
+          get: (row) => (row.default ? chalk.green('✓') : ''),
+          header: 'Default',
+        },
         viewOnly: {
           get: (row) => (row.viewOnly ? chalk.green('✓') : ''),
           header: 'View Only',
@@ -73,7 +77,6 @@ export class AccountsCommand extends IronfishCommand {
       {
         ...flags,
         printLine: this.log.bind(this),
-        'no-header': flags['no-header'] ?? !flags.extended,
       },
     )
 

--- a/ironfish/src/rpc/routes/wallet/serializers.ts
+++ b/ironfish/src/rpc/routes/wallet/serializers.ts
@@ -170,5 +170,6 @@ export async function serializeRpcAccountStatus(
       : null,
     scanningEnabled: account.scanningEnabled,
     viewOnly: !account.isSpendingAccount(),
+    default: wallet.getDefaultAccount()?.id === account.id,
   }
 }

--- a/ironfish/src/rpc/routes/wallet/types.ts
+++ b/ironfish/src/rpc/routes/wallet/types.ts
@@ -172,6 +172,7 @@ export type RpcAccountStatus = {
   } | null
   scanningEnabled: boolean
   viewOnly: boolean
+  default: boolean
 }
 
 export const RpcAccountStatusSchema: yup.ObjectSchema<RpcAccountStatus> = yup
@@ -188,5 +189,6 @@ export const RpcAccountStatusSchema: yup.ObjectSchema<RpcAccountStatus> = yup
       .defined(),
     scanningEnabled: yup.boolean().defined(),
     viewOnly: yup.boolean().defined(),
+    default: yup.boolean().defined(),
   })
   .defined()


### PR DESCRIPTION
## Summary
defaults to showing table header so that we can display default account column as well.
## Testing Plan
```
...
  {
    "name": "testnet genesis",
    "id": "b0557e1c-16e1-4f2b-b491-38e87422df58",
    "head": {
      "hash": "0000025a50df477c9699d4149558857b6955f84b0e7032b3880fd6612baa7076",
      "sequence": 738626,
      "inChain": true
    },
    "scanningEnabled": true,
    "viewOnly": false,
    "default": true
  },
```

```
 Account         Default
 ─────────────── ───────
 foo                    
 nodeapptest            
 testnetnodeapp         
 testnet                
 testnet genesis ✓      
 rahuldaniel            
 nodeappdkg             
 50a26d7134        
```

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
