### PR TITLE
Change the Rust depdendencies to use our newly published crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,33 +135,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf9ff0bbfd639f15c74af777d81383cf53efb7c93613f6cab67c6c11e05bbf8b"
 
 [[package]]
-name = "bellperson"
-version = "0.24.1"
-source = "git+https://github.com/iron-fish/bellperson.git?branch=blstrs#37b9976bcd96986cbdc71ae09fc455015e3dfac0"
-dependencies = [
- "bincode",
- "blake2s_simd",
- "blstrs",
- "byteorder",
- "crossbeam-channel",
- "digest 0.10.6",
- "ec-gpu",
- "ec-gpu-gen",
- "ff 0.12.1",
- "group 0.12.1",
- "log",
- "memmap2",
- "pairing",
- "rand",
- "rand_core",
- "rayon",
- "rustversion",
- "serde",
- "sha2 0.10.6",
- "thiserror",
-]
-
-[[package]]
 name = "benchmarks"
 version = "0.1.0"
 dependencies = [
@@ -180,14 +153,14 @@ dependencies = [
 
 [[package]]
 name = "bip0039"
-version = "0.9.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0830ae4cc96b0617cc912970c2b17e89456fecbf55e8eed53a956f37ab50c41"
+checksum = "e68a5a99c65851e7be249f5cf510c0a136f18c9bca32139576d59bd3f577b043"
 dependencies = [
- "hmac 0.11.0",
- "pbkdf2 0.9.0",
+ "hmac",
+ "pbkdf2",
  "rand",
- "sha2 0.9.9",
+ "sha2 0.10.6",
  "unicode-normalization",
  "zeroize",
 ]
@@ -680,16 +653,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-mac"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
-dependencies = [
- "generic-array",
- "subtle",
-]
-
-[[package]]
 name = "crypto_box"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -903,7 +866,8 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.2.0"
-source = "git+https://github.com/iron-fish/librustzcash.git?branch=blstrs#d551820030cb596eafe82226667f32b47164f91b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab579d7cf78477773b03e80bc2f89702ef02d7112c711d54ca93dcdce68533d5"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -976,7 +940,8 @@ checksum = "8ba569491c70ec8471e34aa7e9c0b9e82bb5d2464c0398442d17d3c4af814e5a"
 [[package]]
 name = "f4jumble"
 version = "0.1.0"
-source = "git+https://github.com/iron-fish/librustzcash.git?branch=blstrs#d551820030cb596eafe82226667f32b47164f91b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a83e8d7fd0c526af4aad893b7c9fe41e2699ed8a776a6c74aecdeafe05afc75"
 dependencies = [
  "blake2b_simd",
 ]
@@ -1343,17 +1308,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac 0.12.1",
-]
-
-[[package]]
-name = "hmac"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
-dependencies = [
- "crypto-mac",
- "digest 0.9.0",
+ "hmac",
 ]
 
 [[package]]
@@ -1495,7 +1450,6 @@ name = "ironfish"
 version = "0.3.0"
 dependencies = [
  "argon2",
- "bellperson",
  "blake2b_simd",
  "blake2s_simd",
  "blake3",
@@ -1509,9 +1463,10 @@ dependencies = [
  "hex",
  "hex-literal",
  "hkdf",
+ "ironfish-bellperson",
  "ironfish-frost",
+ "ironfish-jubjub",
  "ironfish_zkp",
- "jubjub 0.9.0 (git+https://github.com/iron-fish/jubjub.git?branch=blstrs)",
  "lazy_static",
  "libc",
  "rand",
@@ -1519,6 +1474,34 @@ dependencies = [
  "sha2 0.10.6",
  "tiny-bip39",
  "xxhash-rust",
+]
+
+[[package]]
+name = "ironfish-bellperson"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f2e19b8d7c61fdbdfde5ba86cec85b9facf60b2b5ef9968618c353f8f7f6815"
+dependencies = [
+ "bincode",
+ "blake2s_simd",
+ "blstrs",
+ "byteorder",
+ "crossbeam-channel",
+ "digest 0.10.6",
+ "ec-gpu",
+ "ec-gpu-gen",
+ "ff 0.12.1",
+ "group 0.12.1",
+ "log",
+ "memmap2",
+ "pairing",
+ "rand",
+ "rand_core",
+ "rayon",
+ "rustversion",
+ "serde",
+ "sha2 0.10.6",
+ "thiserror",
 ]
 
 [[package]]
@@ -1536,6 +1519,77 @@ dependencies = [
  "rand_core",
  "siphasher",
  "x25519-dalek",
+]
+
+[[package]]
+name = "ironfish-jubjub"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81ee437e98296799ebdff1f62c14c63bbfb65df3e4e19c3913e7c46b9827b148"
+dependencies = [
+ "bitvec",
+ "blst",
+ "blstrs",
+ "ff 0.12.1",
+ "group 0.12.1",
+ "lazy_static",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "ironfish-primitives"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7b213445520fb92462bd4a79274ad9b31c1ce49248f6eaa7ca3a50e8fe413d3"
+dependencies = [
+ "aes",
+ "bip0039",
+ "bitvec",
+ "blake2b_simd",
+ "blake2s_simd",
+ "blstrs",
+ "byteorder",
+ "chacha20poly1305 0.9.1",
+ "equihash",
+ "ff 0.12.1",
+ "fpe",
+ "group 0.12.1",
+ "hex",
+ "incrementalmerkletree",
+ "ironfish-jubjub",
+ "lazy_static",
+ "memuse",
+ "nonempty",
+ "orchard",
+ "rand",
+ "rand_core",
+ "sha2 0.9.9",
+ "subtle",
+ "zcash_address",
+ "zcash_encoding",
+ "zcash_note_encryption",
+]
+
+[[package]]
+name = "ironfish-proofs"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ea51eb3565333b8c67483a16499452215326df95f92160bd567f16c35f82e29"
+dependencies = [
+ "blake2b_simd",
+ "blstrs",
+ "byteorder",
+ "directories",
+ "ff 0.12.1",
+ "group 0.12.1",
+ "ironfish-bellperson",
+ "ironfish-jubjub",
+ "ironfish-primitives",
+ "lazy_static",
+ "rand_core",
+ "redjubjub",
+ "tracing",
 ]
 
 [[package]]
@@ -1565,7 +1619,7 @@ dependencies = [
  "fish_hash",
  "ironfish",
  "ironfish-frost",
- "jubjub 0.9.0 (git+https://github.com/iron-fish/jubjub.git?branch=blstrs)",
+ "ironfish-jubjub",
  "napi",
  "napi-build",
  "napi-derive",
@@ -1578,17 +1632,17 @@ dependencies = [
 name = "ironfish_zkp"
 version = "0.2.0"
 dependencies = [
- "bellperson",
  "blake2s_simd",
  "blstrs",
  "byteorder",
  "ff 0.12.1",
  "group 0.12.1",
- "jubjub 0.9.0 (git+https://github.com/iron-fish/jubjub.git?branch=blstrs)",
+ "ironfish-bellperson",
+ "ironfish-jubjub",
+ "ironfish-primitives",
+ "ironfish-proofs",
  "lazy_static",
  "rand",
- "zcash_primitives",
- "zcash_proofs",
 ]
 
 [[package]]
@@ -1634,21 +1688,6 @@ dependencies = [
  "bls12_381 0.7.1",
  "ff 0.12.1",
  "group 0.12.1",
- "rand_core",
- "subtle",
-]
-
-[[package]]
-name = "jubjub"
-version = "0.9.0"
-source = "git+https://github.com/iron-fish/jubjub.git?branch=blstrs#531157cfa7b81ade207e819ef50c563843b10e30"
-dependencies = [
- "bitvec",
- "blst",
- "blstrs",
- "ff 0.12.1",
- "group 0.12.1",
- "lazy_static",
  "rand_core",
  "subtle",
 ]
@@ -1984,7 +2023,7 @@ dependencies = [
  "serde",
  "subtle",
  "tracing",
- "zcash_note_encryption 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_note_encryption",
 ]
 
 [[package]]
@@ -2004,9 +2043,9 @@ dependencies = [
 
 [[package]]
 name = "password-hash"
-version = "0.3.2"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d791538a6dcc1e7cb7fe6f6b58aca40e7f79403c45b2bc274008b5e647af1d8"
+checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
 dependencies = [
  "base64ct",
  "rand_core",
@@ -2054,21 +2093,12 @@ dependencies = [
 
 [[package]]
 name = "pbkdf2"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05894bce6a1ba4be299d0c5f29563e08af2bc18bb7d48313113bed71e904739"
-dependencies = [
- "crypto-mac",
- "password-hash 0.3.2",
-]
-
-[[package]]
-name = "pbkdf2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
  "digest 0.10.6",
+ "password-hash 0.4.2",
 ]
 
 [[package]]
@@ -2272,7 +2302,7 @@ dependencies = [
  "blake2b_simd",
  "byteorder",
  "group 0.12.1",
- "jubjub 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jubjub 0.9.0",
  "pasta_curves 0.4.1",
  "rand_core",
  "serde",
@@ -2289,7 +2319,7 @@ dependencies = [
  "blake2b_simd",
  "byteorder",
  "digest 0.9.0",
- "jubjub 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jubjub 0.9.0",
  "rand_core",
  "serde",
  "thiserror",
@@ -2760,9 +2790,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62cc94d358b5a1e84a5cb9109f559aa3c4d634d2b1b4de3d0fa4adc7c78e2861"
 dependencies = [
  "anyhow",
- "hmac 0.12.1",
+ "hmac",
  "once_cell",
- "pbkdf2 0.11.0",
+ "pbkdf2",
  "rand",
  "rustc-hash",
  "sha2 0.10.6",
@@ -3309,7 +3339,8 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.1.0"
-source = "git+https://github.com/iron-fish/librustzcash.git?branch=blstrs#d551820030cb596eafe82226667f32b47164f91b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1322a31b757f0087f110cc4a85dc5c6ccf83d0533bac04c4d3d1ce9112cc602"
 dependencies = [
  "bech32",
  "bs58",
@@ -3320,7 +3351,8 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.1.0"
-source = "git+https://github.com/iron-fish/librustzcash.git?branch=blstrs#d551820030cb596eafe82226667f32b47164f91b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb61ea88eb539bc0ac2068e5da99411dd4978595b3d7ff6a4b1562ddc8e8710"
 dependencies = [
  "byteorder",
  "nonempty",
@@ -3336,70 +3368,6 @@ dependencies = [
  "chacha20poly1305 0.9.1",
  "rand_core",
  "subtle",
-]
-
-[[package]]
-name = "zcash_note_encryption"
-version = "0.1.0"
-source = "git+https://github.com/iron-fish/librustzcash.git?branch=blstrs#d551820030cb596eafe82226667f32b47164f91b"
-dependencies = [
- "chacha20 0.8.2",
- "chacha20poly1305 0.9.1",
- "rand_core",
- "subtle",
-]
-
-[[package]]
-name = "zcash_primitives"
-version = "0.7.0"
-source = "git+https://github.com/iron-fish/librustzcash.git?branch=blstrs#d551820030cb596eafe82226667f32b47164f91b"
-dependencies = [
- "aes",
- "bip0039",
- "bitvec",
- "blake2b_simd",
- "blake2s_simd",
- "blstrs",
- "byteorder",
- "chacha20poly1305 0.9.1",
- "equihash",
- "ff 0.12.1",
- "fpe",
- "group 0.12.1",
- "hex",
- "incrementalmerkletree",
- "jubjub 0.9.0 (git+https://github.com/iron-fish/jubjub.git?branch=blstrs)",
- "lazy_static",
- "memuse",
- "nonempty",
- "orchard",
- "rand",
- "rand_core",
- "sha2 0.9.9",
- "subtle",
- "zcash_address",
- "zcash_encoding",
- "zcash_note_encryption 0.1.0 (git+https://github.com/iron-fish/librustzcash.git?branch=blstrs)",
-]
-
-[[package]]
-name = "zcash_proofs"
-version = "0.7.1"
-source = "git+https://github.com/iron-fish/librustzcash.git?branch=blstrs#d551820030cb596eafe82226667f32b47164f91b"
-dependencies = [
- "bellperson",
- "blake2b_simd",
- "blstrs",
- "byteorder",
- "directories",
- "ff 0.12.1",
- "group 0.12.1",
- "jubjub 0.9.0 (git+https://github.com/iron-fish/jubjub.git?branch=blstrs)",
- "lazy_static",
- "rand_core",
- "redjubjub",
- "tracing",
- "zcash_primitives",
 ]
 
 [[package]]

--- a/ironfish-rust-nodejs/Cargo.toml
+++ b/ironfish-rust-nodejs/Cargo.toml
@@ -24,7 +24,7 @@ workspace = true
 crate-type = ["cdylib"]
 
 [features]
-stats = ["ironfish/note-encryption-stats", "jubjub/stats", "dep:signal-hook"]
+stats = ["ironfish/note-encryption-stats", "ironfish-jubjub/stats", "dep:signal-hook"]
 
 [dependencies]
 base64 = "0.13.0"
@@ -33,7 +33,7 @@ ironfish = { path = "../ironfish-rust" }
 ironfish-frost = { version = "0.1.0" }
 napi = { version = "2.14.4", features = ["napi6"] }
 napi-derive = "2.14.6"
-jubjub = { git = "https://github.com/iron-fish/jubjub.git", branch = "blstrs", features = ["multiply-many"] }
+ironfish-jubjub = { version = "0.1.0", features = ["multiply-many"] }
 rand = "0.8.5"
 num_cpus = "1.16.0"
 signal-hook = { version = "0.3.17", optional = true, default-features = false, features = ["iterator"] }

--- a/ironfish-rust-nodejs/src/lib.rs
+++ b/ironfish-rust-nodejs/src/lib.rs
@@ -268,7 +268,7 @@ pub fn randomize_pk(
     let view_key = ViewKey::from_hex(&view_key_string).map_err(to_napi_err)?;
 
     let public_key_randomness =
-        jubjub::Fr::from_hex(&public_key_randomness_string).map_err(to_napi_err)?;
+        ironfish_jubjub::Fr::from_hex(&public_key_randomness_string).map_err(to_napi_err)?;
 
     let public_key =
         generate_randomized_public_key(view_key, public_key_randomness).map_err(to_napi_err)?;

--- a/ironfish-rust-nodejs/src/structs/transaction.rs
+++ b/ironfish-rust-nodejs/src/structs/transaction.rs
@@ -336,7 +336,7 @@ impl NativeTransaction {
         let view_key = ViewKey::from_hex(&view_key_str).map_err(to_napi_err)?;
         let outgoing_view_key =
             OutgoingViewKey::from_hex(&outgoing_view_key_str).map_err(to_napi_err)?;
-        let proof_authorizing_key = jubjub::Fr::from_hex(&proof_authorizing_key_str)
+        let proof_authorizing_key = ironfish_jubjub::Fr::from_hex(&proof_authorizing_key_str)
             .map_err(|_| to_napi_err("PublicKeyPackage authorizing key hex to bytes failed"))?;
 
         let change_address = match change_goes_to {

--- a/ironfish-rust/Cargo.toml
+++ b/ironfish-rust/Cargo.toml
@@ -33,7 +33,7 @@ name = "ironfish"
 path = "src/lib.rs"
 
 [dependencies]
-bellperson = { git = "https://github.com/iron-fish/bellperson.git", branch = "blstrs", features = ["groth16"] }
+ironfish-bellperson = { version = "0.1.0", features = ["groth16"] }
 blake2b_simd = "1.0.0"
 blake2s_simd = "1.0.0"
 blake3 = "1.5.0"
@@ -46,7 +46,7 @@ group = "0.12.0"
 ironfish-frost = { version = "0.1.0" }
 fish_hash = "0.3.0"
 ironfish_zkp = { version = "0.2.0", path = "../ironfish-zkp" }
-jubjub = { git = "https://github.com/iron-fish/jubjub.git", branch = "blstrs", features = ["multiply-many"] }
+ironfish-jubjub = { version = "0.1.0", features = ["multiply-many"] }
 lazy_static = "1.4.0"
 libc = "0.2.126" # sub-dependency that needs a pinned version until a new release of cpufeatures: https://github.com/RustCrypto/utils/pull/789
 rand = "0.8.5"

--- a/ironfish-rust/src/assets/asset.rs
+++ b/ironfish-rust/src/assets/asset.rs
@@ -8,8 +8,8 @@ use crate::{
     PublicAddress,
 };
 use byteorder::{ReadBytesExt, WriteBytesExt};
+use ironfish_jubjub::{ExtendedPoint, SubgroupPoint};
 use ironfish_zkp::constants::{ASSET_ID_LENGTH, ASSET_ID_PERSONALIZATION, GH_FIRST_BLOCK};
-use jubjub::{ExtendedPoint, SubgroupPoint};
 use std::io;
 
 use super::asset_identifier::AssetIdentifier;

--- a/ironfish-rust/src/assets/asset_identifier.rs
+++ b/ironfish-rust/src/assets/asset_identifier.rs
@@ -3,8 +3,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 use crate::errors::{IronfishError, IronfishErrorKind};
 use group::cofactor::CofactorGroup;
+use ironfish_jubjub::{ExtendedPoint, SubgroupPoint};
 use ironfish_zkp::{constants::ASSET_ID_LENGTH, util::asset_hash_to_point};
-use jubjub::{ExtendedPoint, SubgroupPoint};
 use std::io;
 
 pub const NATIVE_ASSET: AssetIdentifier = AssetIdentifier([

--- a/ironfish-rust/src/errors.rs
+++ b/ironfish-rust/src/errors.rs
@@ -129,8 +129,8 @@ impl From<string::FromUtf8Error> for IronfishError {
     }
 }
 
-impl From<bellperson::SynthesisError> for IronfishError {
-    fn from(e: bellperson::SynthesisError) -> IronfishError {
+impl From<ironfish_bellperson::SynthesisError> for IronfishError {
+    fn from(e: ironfish_bellperson::SynthesisError) -> IronfishError {
         IronfishError::new_with_source(IronfishErrorKind::BellpersonSynthesis, e)
     }
 }

--- a/ironfish-rust/src/frost_utils/account_keys.rs
+++ b/ironfish-rust/src/frost_utils/account_keys.rs
@@ -8,12 +8,12 @@ use crate::{
 };
 use group::GroupEncoding;
 use ironfish_frost::frost::VerifyingKey;
+use ironfish_jubjub::SubgroupPoint;
 use ironfish_zkp::constants::PROOF_GENERATION_KEY_GENERATOR;
-use jubjub::SubgroupPoint;
 
 pub struct MultisigAccountKeys {
     /// Equivalent to [`crate::keys::SaplingKey::proof_authorizing_key`]
-    pub proof_authorizing_key: jubjub::Fr,
+    pub proof_authorizing_key: ironfish_jubjub::Fr,
     /// Equivalent to [`crate::keys::SaplingKey::outgoing_viewing_key`]
     pub outgoing_viewing_key: OutgoingViewKey,
     /// Equivalent to [`crate::keys::SaplingKey::view_key`]

--- a/ironfish-rust/src/frost_utils/split_spender_key.rs
+++ b/ironfish-rust/src/frost_utils/split_spender_key.rs
@@ -20,7 +20,7 @@ pub struct TrustedDealerKeyPackages {
     pub view_key: ViewKey,
     pub incoming_view_key: IncomingViewKey,
     pub outgoing_view_key: OutgoingViewKey,
-    pub proof_authorizing_key: jubjub::Fr,
+    pub proof_authorizing_key: ironfish_jubjub::Fr,
     pub key_packages: HashMap<Identity, KeyPackage>,
 }
 

--- a/ironfish-rust/src/keys/ephemeral.rs
+++ b/ironfish-rust/src/keys/ephemeral.rs
@@ -11,13 +11,13 @@ use rand::thread_rng;
 /// [`crate::keys::shared_secret`]
 #[derive(Default)]
 pub struct EphemeralKeyPair {
-    secret: jubjub::Fr,
-    public: jubjub::SubgroupPoint,
+    secret: ironfish_jubjub::Fr,
+    public: ironfish_jubjub::SubgroupPoint,
 }
 
 impl EphemeralKeyPair {
     pub fn new() -> Self {
-        let secret = jubjub::Fr::random(thread_rng());
+        let secret = ironfish_jubjub::Fr::random(thread_rng());
 
         Self {
             secret,
@@ -25,11 +25,11 @@ impl EphemeralKeyPair {
         }
     }
 
-    pub fn secret(&self) -> &jubjub::Fr {
+    pub fn secret(&self) -> &ironfish_jubjub::Fr {
         &self.secret
     }
 
-    pub fn public(&self) -> &jubjub::SubgroupPoint {
+    pub fn public(&self) -> &ironfish_jubjub::SubgroupPoint {
         &self.public
     }
 }

--- a/ironfish-rust/src/keys/mod.rs
+++ b/ironfish-rust/src/keys/mod.rs
@@ -10,11 +10,11 @@ use bip39::Mnemonic;
 use blake2b_simd::Params as Blake2b;
 use blake2s_simd::Params as Blake2s;
 use group::GroupEncoding;
+use ironfish_jubjub::SubgroupPoint;
 use ironfish_zkp::constants::{
     CRH_IVK_PERSONALIZATION, PROOF_GENERATION_KEY_GENERATOR, SPENDING_KEY_GENERATOR,
 };
 pub use ironfish_zkp::ProofGenerationKey;
-use jubjub::SubgroupPoint;
 use rand::prelude::*;
 
 use std::io;
@@ -50,12 +50,12 @@ pub struct SaplingKey {
     /// Part of the expanded form of the spending key, generally referred to as
     /// `ask` in the literature. Derived from spending key using a seeded
     /// pseudorandom hash function. Used to construct authorizing_key.
-    pub(crate) spend_authorizing_key: jubjub::Fr,
+    pub(crate) spend_authorizing_key: ironfish_jubjub::Fr,
 
     /// Part of the expanded form of the spending key, generally referred to as
     /// `nsk` in the literature. Derived from spending key using a seeded
     /// pseudorandom hash function. Used to construct nullifier_deriving_key
-    pub(crate) proof_authorizing_key: jubjub::Fr,
+    pub(crate) proof_authorizing_key: ironfish_jubjub::Fr,
 
     /// Part of the expanded form of the spending key, as well as being used
     /// directly in the full viewing key. Generally referred to as
@@ -80,14 +80,14 @@ impl SaplingKey {
     /// Construct a new key from an array of bytes
     pub fn new(spending_key: [u8; SPEND_KEY_SIZE]) -> Result<Self, IronfishError> {
         let spend_authorizing_key =
-            jubjub::Fr::from_bytes_wide(&Self::convert_key(spending_key, 0));
+            ironfish_jubjub::Fr::from_bytes_wide(&Self::convert_key(spending_key, 0));
 
-        if spend_authorizing_key == jubjub::Fr::zero() {
+        if spend_authorizing_key == ironfish_jubjub::Fr::zero() {
             return Err(IronfishError::new(IronfishErrorKind::IllegalValue));
         }
 
         let proof_authorizing_key =
-            jubjub::Fr::from_bytes_wide(&Self::convert_key(spending_key, 1));
+            ironfish_jubjub::Fr::from_bytes_wide(&Self::convert_key(spending_key, 1));
 
         let mut outgoing_viewing_key = [0; SPEND_KEY_SIZE];
         outgoing_viewing_key[0..SPEND_KEY_SIZE]
@@ -243,7 +243,7 @@ impl SaplingKey {
     pub fn hash_viewing_key(
         authorizing_key: &SubgroupPoint,
         nullifier_deriving_key: &SubgroupPoint,
-    ) -> Result<jubjub::Fr, IronfishError> {
+    ) -> Result<ironfish_jubjub::Fr, IronfishError> {
         let mut view_key_contents = [0; 64];
         view_key_contents[0..32].copy_from_slice(&authorizing_key.to_bytes());
         view_key_contents[32..64].copy_from_slice(&nullifier_deriving_key.to_bytes());

--- a/ironfish-rust/src/keys/public_address.rs
+++ b/ironfish-rust/src/keys/public_address.rs
@@ -7,8 +7,8 @@ use crate::{
     serializing::{bytes_to_hex, hex_to_bytes},
 };
 use group::GroupEncoding;
+use ironfish_jubjub::SubgroupPoint;
 use ironfish_zkp::constants::PUBLIC_KEY_GENERATOR;
-use jubjub::SubgroupPoint;
 
 use std::io;
 

--- a/ironfish-rust/src/keys/test.rs
+++ b/ironfish-rust/src/keys/test.rs
@@ -6,7 +6,7 @@ use crate::keys::{ephemeral::EphemeralKeyPair, PUBLIC_ADDRESS_SIZE};
 
 use super::{shared_secret, PublicAddress, SaplingKey};
 use group::Curve;
-use jubjub::ExtendedPoint;
+use ironfish_jubjub::ExtendedPoint;
 
 #[test]
 fn test_key_generation_and_construction() {

--- a/ironfish-rust/src/keys/util.rs
+++ b/ironfish-rust/src/keys/util.rs
@@ -3,8 +3,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use group::GroupEncoding;
+use ironfish_jubjub::Fr;
 use ironfish_zkp::{constants::SPENDING_KEY_GENERATOR, redjubjub};
-use jubjub::Fr;
 
 use crate::{errors::IronfishError, ViewKey};
 

--- a/ironfish-rust/src/keys/view_keys.rs
+++ b/ironfish-rust/src/keys/view_keys.rs
@@ -21,7 +21,7 @@ use crate::{
 use bip39::{Language, Mnemonic};
 use blake2b_simd::Params as Blake2b;
 use group::GroupEncoding;
-use jubjub::SubgroupPoint;
+use ironfish_jubjub::SubgroupPoint;
 
 use std::io;
 
@@ -32,7 +32,7 @@ const DIFFIE_HELLMAN_PERSONALIZATION: &[u8; 16] = b"Iron Fish shared";
 /// Referred to as `ivk` in the literature.
 #[derive(Clone)]
 pub struct IncomingViewKey {
-    pub(crate) view_key: jubjub::Fr,
+    pub(crate) view_key: ironfish_jubjub::Fr,
 }
 
 impl IncomingViewKey {
@@ -110,11 +110,11 @@ pub struct ViewKey {
     /// Part of the full viewing key. Generally referred to as
     /// `ak` in the literature. Derived from spend_authorizing_key using scalar
     /// multiplication in Sapling. Used to construct incoming viewing key.
-    pub authorizing_key: jubjub::SubgroupPoint,
+    pub authorizing_key: ironfish_jubjub::SubgroupPoint,
     /// Part of the full viewing key. Generally referred to as
     /// `nk` in the literature. Derived from proof_authorizing_key using scalar
     /// multiplication. Used to construct incoming viewing key.
-    pub nullifier_deriving_key: jubjub::SubgroupPoint,
+    pub nullifier_deriving_key: ironfish_jubjub::SubgroupPoint,
 }
 
 impl ViewKey {
@@ -241,7 +241,7 @@ impl OutgoingViewKey {
 /// The resulting key can be used in any symmetric cipher
 #[must_use]
 pub(crate) fn shared_secret(
-    secret_key: &jubjub::Fr,
+    secret_key: &ironfish_jubjub::Fr,
     other_public_key: &SubgroupPoint,
     reference_public_key: &SubgroupPoint,
 ) -> [u8; 32] {

--- a/ironfish-rust/src/lib.rs
+++ b/ironfish-rust/src/lib.rs
@@ -1,8 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-use bellperson::groth16;
 use blstrs::Bls12;
+use ironfish_bellperson::groth16;
 
 pub mod assets;
 pub mod errors;

--- a/ironfish-rust/src/merkle_note.rs
+++ b/ironfish-rust/src/merkle_note.rs
@@ -22,8 +22,8 @@ use blake2b_simd::Params as Blake2b;
 use blstrs::Scalar;
 use ff::PrimeField;
 use group::GroupEncoding;
+use ironfish_jubjub::{ExtendedPoint, SubgroupPoint};
 use ironfish_zkp::primitives::ValueCommitment;
-use jubjub::{ExtendedPoint, SubgroupPoint};
 
 use std::{convert::TryInto, io};
 

--- a/ironfish-rust/src/merkle_note_hash.rs
+++ b/ironfish-rust/src/merkle_note_hash.rs
@@ -11,8 +11,8 @@ use super::serializing::read_scalar;
 use blstrs::Scalar;
 use ff::{PrimeField, PrimeFieldBits};
 use group::Curve;
+use ironfish_jubjub::ExtendedPoint;
 use ironfish_zkp::pedersen_hash::{pedersen_hash, Personalization};
-use jubjub::ExtendedPoint;
 
 use std::io;
 

--- a/ironfish-rust/src/note.rs
+++ b/ironfish-rust/src/note.rs
@@ -19,12 +19,12 @@ use blstrs::Scalar;
 use byteorder::{ByteOrder, LittleEndian, ReadBytesExt, WriteBytesExt};
 use ff::{Field, PrimeField};
 use group::{Curve, GroupEncoding};
+use ironfish_jubjub::SubgroupPoint;
 use ironfish_zkp::{
     constants::{ASSET_ID_LENGTH, NULLIFIER_POSITION_GENERATOR, PRF_NF_PERSONALIZATION},
     util::commitment_full_point,
     Nullifier,
 };
-use jubjub::SubgroupPoint;
 use rand::thread_rng;
 use std::{fmt, io, io::Read};
 pub const ENCRYPTED_NOTE_SIZE: usize =
@@ -99,7 +99,7 @@ pub struct Note {
     /// This helps create zero knowledge around the note,
     /// allowing the owner to prove they have the note without revealing
     /// anything else about it.
-    pub(crate) randomness: jubjub::Fr,
+    pub(crate) randomness: ironfish_jubjub::Fr,
 
     /// Arbitrary note the spender can supply when constructing a spend so the
     /// receiver has some record from whence it came.
@@ -120,7 +120,7 @@ impl Note {
         asset_id: AssetIdentifier,
         sender: PublicAddress,
     ) -> Self {
-        let randomness: jubjub::Fr = jubjub::Fr::random(thread_rng());
+        let randomness: ironfish_jubjub::Fr = ironfish_jubjub::Fr::random(thread_rng());
 
         Self {
             owner,
@@ -142,7 +142,7 @@ impl Note {
         let asset_id = AssetIdentifier::read(&mut reader)?;
 
         let value = reader.read_u64::<LittleEndian>()?;
-        let randomness: jubjub::Fr = read_scalar(&mut reader)?;
+        let randomness: ironfish_jubjub::Fr = read_scalar(&mut reader)?;
 
         let mut memo = Memo::default();
         reader.read_exact(&mut memo.0)?;
@@ -244,7 +244,7 @@ impl Note {
         self.owner
     }
 
-    pub fn asset_generator(&self) -> jubjub::ExtendedPoint {
+    pub fn asset_generator(&self) -> ironfish_jubjub::ExtendedPoint {
         self.asset_id.asset_generator()
     }
 
@@ -286,7 +286,7 @@ impl Note {
     }
 
     /// Computes the note commitment, returning the full point.
-    fn commitment_full_point(&self) -> jubjub::SubgroupPoint {
+    fn commitment_full_point(&self) -> ironfish_jubjub::SubgroupPoint {
         commitment_full_point(
             self.asset_generator(),
             self.value,
@@ -304,7 +304,7 @@ impl Note {
     pub fn nullifier(&self, view_key: &ViewKey, position: u64) -> Nullifier {
         // Compute rho = cm + position.G
         let rho = self.commitment_full_point()
-            + (*NULLIFIER_POSITION_GENERATOR * jubjub::Fr::from(position));
+            + (*NULLIFIER_POSITION_GENERATOR * ironfish_jubjub::Fr::from(position));
 
         // Compute nf = BLAKE2s(nk | rho)
         Nullifier::from_slice(
@@ -335,7 +335,7 @@ impl Note {
     pub(crate) fn commitment_point(&self) -> Scalar {
         // The commitment is in the prime order subgroup, so mapping the
         // commitment to the u-coordinate is an injective encoding.
-        jubjub::ExtendedPoint::from(self.commitment_full_point())
+        ironfish_jubjub::ExtendedPoint::from(self.commitment_full_point())
             .to_affine()
             .get_u()
     }
@@ -352,7 +352,16 @@ impl Note {
     fn decrypt_note_parts(
         shared_secret: &[u8; 32],
         encrypted_bytes: &[u8; ENCRYPTED_NOTE_SIZE + aead::MAC_SIZE],
-    ) -> Result<(jubjub::Fr, AssetIdentifier, u64, Memo, PublicAddress), IronfishError> {
+    ) -> Result<
+        (
+            ironfish_jubjub::Fr,
+            AssetIdentifier,
+            u64,
+            Memo,
+            PublicAddress,
+        ),
+        IronfishError,
+    > {
         let plaintext_bytes: [u8; ENCRYPTED_NOTE_SIZE] =
             aead::decrypt(shared_secret, encrypted_bytes)?;
         let mut reader = &plaintext_bytes[..];

--- a/ironfish-rust/src/serializing/fr.rs
+++ b/ironfish-rust/src/serializing/fr.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use crate::errors::{IronfishError, IronfishErrorKind};
-use jubjub::Fr;
+use ironfish_jubjub::Fr;
 
 use super::{bytes_to_hex, hex_to_bytes};
 
@@ -88,7 +88,7 @@ mod test {
     fn test_hex() {
         let mut rng = StdRng::seed_from_u64(0);
 
-        let fr = jubjub::Fr::random(&mut rng);
+        let fr = ironfish_jubjub::Fr::random(&mut rng);
 
         let hex_key = fr.hex_key();
 

--- a/ironfish-rust/src/transaction/mints.rs
+++ b/ironfish-rust/src/transaction/mints.rs
@@ -4,18 +4,18 @@
 
 use std::io;
 
-use bellperson::groth16;
 use blstrs::{Bls12, Scalar};
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use ff::Field;
 use group::{Curve, GroupEncoding};
+use ironfish_bellperson::groth16;
+use ironfish_jubjub::ExtendedPoint;
 use ironfish_zkp::{
     constants::SPENDING_KEY_GENERATOR,
     proofs::MintAsset,
     redjubjub::{self, Signature},
     ProofGenerationKey,
 };
-use jubjub::ExtendedPoint;
 use rand::thread_rng;
 
 use crate::{
@@ -61,7 +61,7 @@ impl MintBuilder {
         &self,
         proof_generation_key: &ProofGenerationKey,
         public_address: &PublicAddress,
-        public_key_randomness: &jubjub::Fr,
+        public_key_randomness: &ironfish_jubjub::Fr,
         randomized_public_key: &redjubjub::PublicKey,
     ) -> Result<UnsignedMintDescription, IronfishError> {
         let circuit = MintAsset {
@@ -105,7 +105,7 @@ impl MintBuilder {
 pub struct UnsignedMintDescription {
     /// Used to add randomness to signature generation. Referred to as `ar` in
     /// the literature.
-    public_key_randomness: jubjub::Fr,
+    public_key_randomness: ironfish_jubjub::Fr,
 
     /// Proof and public parameters for a user action to issue supply for an
     /// asset.
@@ -391,7 +391,7 @@ mod test {
 
         let value = 5;
 
-        let public_key_randomness = jubjub::Fr::random(thread_rng());
+        let public_key_randomness = ironfish_jubjub::Fr::random(thread_rng());
         let randomized_public_key = redjubjub::PublicKey(key.view_key.authorizing_key.into())
             .randomize(public_key_randomness, *SPENDING_KEY_GENERATOR);
 
@@ -428,7 +428,10 @@ mod test {
             .is_err());
 
         let other_randomized_public_key = redjubjub::PublicKey(key.view_key.authorizing_key.into())
-            .randomize(jubjub::Fr::random(thread_rng()), *SPENDING_KEY_GENERATOR);
+            .randomize(
+                ironfish_jubjub::Fr::random(thread_rng()),
+                *SPENDING_KEY_GENERATOR,
+            );
 
         assert!(verify_mint_proof(
             &description.proof,
@@ -451,7 +454,7 @@ mod test {
 
         let asset = Asset::new(creator, name, metadata).unwrap();
 
-        let public_key_randomness = jubjub::Fr::random(thread_rng());
+        let public_key_randomness = ironfish_jubjub::Fr::random(thread_rng());
         let randomized_public_key = redjubjub::PublicKey(key.view_key.authorizing_key.into())
             .randomize(public_key_randomness, *SPENDING_KEY_GENERATOR);
 
@@ -560,7 +563,7 @@ mod test {
         key: &SaplingKey,
         mint: &MintBuilder,
     ) -> MintDescription {
-        let public_key_randomness = jubjub::Fr::random(thread_rng());
+        let public_key_randomness = ironfish_jubjub::Fr::random(thread_rng());
         let randomized_public_key = redjubjub::PublicKey(key.view_key.authorizing_key.into())
             .randomize(public_key_randomness, *SPENDING_KEY_GENERATOR);
 
@@ -656,7 +659,7 @@ mod test {
 
         let value = 5;
 
-        let public_key_randomness = jubjub::Fr::random(thread_rng());
+        let public_key_randomness = ironfish_jubjub::Fr::random(thread_rng());
         let randomized_public_key = redjubjub::PublicKey(key.view_key.authorizing_key.into())
             .randomize(public_key_randomness, *SPENDING_KEY_GENERATOR);
 
@@ -686,13 +689,13 @@ mod test {
         let public_address = key.public_address();
 
         let asset = Asset::new(public_address, "name", "").expect("should be able to create asset");
-        let public_key_randomness = jubjub::Fr::random(thread_rng());
+        let public_key_randomness = ironfish_jubjub::Fr::random(thread_rng());
         let randomized_public_key = redjubjub::PublicKey(key.view_key.authorizing_key.into())
             .randomize(public_key_randomness, *SPENDING_KEY_GENERATOR);
         let value = random();
         let builder = MintBuilder::new(asset, value);
         // create a random private key and sign random message as placeholder
-        let private_key = redjubjub::PrivateKey(jubjub::Fr::random(thread_rng()));
+        let private_key = redjubjub::PrivateKey(ironfish_jubjub::Fr::random(thread_rng()));
         let public_key = redjubjub::PublicKey::from_private(&private_key, *SPENDING_KEY_GENERATOR);
         let msg = [0u8; 32];
         let signature = private_key.sign(&msg, &mut thread_rng(), *SPENDING_KEY_GENERATOR);

--- a/ironfish-rust/src/transaction/mod.rs
+++ b/ironfish-rust/src/transaction/mod.rs
@@ -23,11 +23,11 @@ use crate::{
 
 use rand::{rngs::OsRng, thread_rng};
 
-use bellperson::groth16::{verify_proofs_batch, PreparedVerifyingKey};
 use blake2b_simd::Params as Blake2b;
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use group::GroupEncoding;
-use jubjub::ExtendedPoint;
+use ironfish_bellperson::groth16::{verify_proofs_batch, PreparedVerifyingKey};
+use ironfish_jubjub::ExtendedPoint;
 
 use ironfish_zkp::{
     constants::{
@@ -116,7 +116,7 @@ pub struct ProposedTransaction {
     // allows us to verify the sender address is valid and stored in the notes
     // Used to add randomness to signature generation without leaking the
     // key. Referred to as `ar` in the literature.
-    public_key_randomness: jubjub::Fr,
+    public_key_randomness: ironfish_jubjub::Fr,
     // NOTE: If adding fields here, you may need to add fields to
     // signature hash method, and also to Transaction.
 }
@@ -131,7 +131,7 @@ impl ProposedTransaction {
             burns: vec![],
             value_balances: ValueBalances::new(),
             expiration: 0,
-            public_key_randomness: jubjub::Fr::random(thread_rng()),
+            public_key_randomness: ironfish_jubjub::Fr::random(thread_rng()),
         }
     }
 
@@ -231,7 +231,7 @@ impl ProposedTransaction {
 
     pub fn build(
         &mut self,
-        proof_authorizing_key: jubjub::Fr,
+        proof_authorizing_key: ironfish_jubjub::Fr,
         view_key: ViewKey,
         outgoing_view_key: OutgoingViewKey,
         intended_transaction_fee: i64,
@@ -480,7 +480,7 @@ impl ProposedTransaction {
     ) -> Result<(redjubjub::PrivateKey, redjubjub::PublicKey), IronfishError> {
         // A "private key" manufactured from a bunch of randomness added for each
         // spend and output.
-        let mut binding_signature_key = jubjub::Fr::zero();
+        let mut binding_signature_key = ironfish_jubjub::Fr::zero();
 
         // A "public key" manufactured from a combination of the values of each
         // description and the same randomness as above
@@ -777,7 +777,7 @@ fn fee_to_point(value: i64) -> Result<ExtendedPoint, IronfishError> {
         None => return Err(IronfishError::new(IronfishErrorKind::IllegalValue)),
     };
 
-    let mut value_balance = *NATIVE_VALUE_COMMITMENT_GENERATOR * jubjub::Fr::from(abs);
+    let mut value_balance = *NATIVE_VALUE_COMMITMENT_GENERATOR * ironfish_jubjub::Fr::from(abs);
 
     if is_negative {
         value_balance = -value_balance;
@@ -802,12 +802,12 @@ fn calculate_value_balance(
 
     for mint in mints {
         let mint_generator = mint.asset.value_commitment_generator();
-        value_balance_point += mint_generator * jubjub::Fr::from(mint.value);
+        value_balance_point += mint_generator * ironfish_jubjub::Fr::from(mint.value);
     }
 
     for burn in burns {
         let burn_generator = burn.asset_id.value_commitment_generator();
-        value_balance_point -= burn_generator * jubjub::Fr::from(burn.value);
+        value_balance_point -= burn_generator * ironfish_jubjub::Fr::from(burn.value);
     }
 
     Ok(value_balance_point)

--- a/ironfish-rust/src/transaction/outputs.rs
+++ b/ironfish-rust/src/transaction/outputs.rs
@@ -11,12 +11,12 @@ use crate::{
     OutgoingViewKey,
 };
 
-use bellperson::groth16;
 use blstrs::{Bls12, Scalar};
 use ff::Field;
 use group::Curve;
+use ironfish_bellperson::groth16;
+use ironfish_jubjub::ExtendedPoint;
 use ironfish_zkp::{primitives::ValueCommitment, proofs::Output, redjubjub, ProofGenerationKey};
-use jubjub::ExtendedPoint;
 use rand::thread_rng;
 
 use std::io;
@@ -83,7 +83,7 @@ impl OutputBuilder {
         &self,
         proof_generation_key: &ProofGenerationKey,
         outgoing_view_key: &OutgoingViewKey,
-        public_key_randomness: &jubjub::Fr,
+        public_key_randomness: &ironfish_jubjub::Fr,
         randomized_public_key: &redjubjub::PublicKey,
     ) -> Result<OutputDescription, IronfishError> {
         let diffie_hellman_keys = EphemeralKeyPair::new();
@@ -232,8 +232,8 @@ mod test {
     };
     use ff::{Field, PrimeField};
     use group::Curve;
+    use ironfish_jubjub::ExtendedPoint;
     use ironfish_zkp::{constants::SPENDING_KEY_GENERATOR, redjubjub};
-    use jubjub::ExtendedPoint;
     use rand::thread_rng;
 
     #[test]
@@ -241,7 +241,7 @@ mod test {
     /// set will use the hard-coded note encryption keys
     fn test_output_miners_fee() {
         let spender_key = SaplingKey::generate_key();
-        let public_key_randomness = jubjub::Fr::random(thread_rng());
+        let public_key_randomness = ironfish_jubjub::Fr::random(thread_rng());
         let randomized_public_key =
             redjubjub::PublicKey(spender_key.view_key.authorizing_key.into())
                 .randomize(public_key_randomness, *SPENDING_KEY_GENERATOR);
@@ -276,7 +276,7 @@ mod test {
     fn test_output_not_miners_fee() {
         let spender_key = SaplingKey::generate_key();
         let receiver_key = SaplingKey::generate_key();
-        let public_key_randomness = jubjub::Fr::random(thread_rng());
+        let public_key_randomness = ironfish_jubjub::Fr::random(thread_rng());
         let randomized_public_key =
             redjubjub::PublicKey(spender_key.view_key.authorizing_key.into())
                 .randomize(public_key_randomness, *SPENDING_KEY_GENERATOR);
@@ -310,12 +310,12 @@ mod test {
         let spender_key = SaplingKey::generate_key();
         let receiver_key = SaplingKey::generate_key();
 
-        let public_key_randomness = jubjub::Fr::random(thread_rng());
+        let public_key_randomness = ironfish_jubjub::Fr::random(thread_rng());
         let randomized_public_key =
             redjubjub::PublicKey(spender_key.view_key.authorizing_key.into())
                 .randomize(public_key_randomness, *SPENDING_KEY_GENERATOR);
 
-        let other_public_key_randomness = jubjub::Fr::random(thread_rng());
+        let other_public_key_randomness = ironfish_jubjub::Fr::random(thread_rng());
         let other_randomized_public_key =
             redjubjub::PublicKey(receiver_key.view_key.authorizing_key.into())
                 .randomize(other_public_key_randomness, *SPENDING_KEY_GENERATOR);
@@ -385,7 +385,7 @@ mod test {
     fn test_output_round_trip() {
         let spender_key = SaplingKey::generate_key();
         let receiver_key = SaplingKey::generate_key();
-        let public_key_randomness = jubjub::Fr::random(thread_rng());
+        let public_key_randomness = ironfish_jubjub::Fr::random(thread_rng());
         let randomized_public_key =
             redjubjub::PublicKey(spender_key.view_key.authorizing_key.into())
                 .randomize(public_key_randomness, *SPENDING_KEY_GENERATOR);

--- a/ironfish-rust/src/transaction/spends.rs
+++ b/ironfish-rust/src/transaction/spends.rs
@@ -13,12 +13,13 @@ use crate::{
     ViewKey,
 };
 
-use bellperson::gadgets::multipack;
-use bellperson::groth16;
 use blstrs::{Bls12, Scalar};
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use ff::{Field, PrimeField};
 use group::{Curve, GroupEncoding};
+use ironfish_bellperson::gadgets::multipack;
+use ironfish_bellperson::groth16;
+use ironfish_jubjub::ExtendedPoint;
 use ironfish_zkp::{
     constants::SPENDING_KEY_GENERATOR,
     primitives::ValueCommitment,
@@ -26,7 +27,6 @@ use ironfish_zkp::{
     redjubjub::{self, Signature},
     Nullifier, ProofGenerationKey,
 };
-use jubjub::ExtendedPoint;
 use rand::thread_rng;
 use std::io;
 
@@ -93,7 +93,7 @@ impl SpendBuilder {
         &self,
         proof_generation_key: &ProofGenerationKey,
         view_key: &ViewKey,
-        public_key_randomness: &jubjub::Fr,
+        public_key_randomness: &ironfish_jubjub::Fr,
         randomized_public_key: &redjubjub::PublicKey,
     ) -> Result<UnsignedSpendDescription, IronfishError> {
         let value_commitment_point = self.value_commitment_point();
@@ -149,7 +149,7 @@ impl SpendBuilder {
 pub struct UnsignedSpendDescription {
     /// Used to add randomness to signature generation without leaking the
     /// key. Referred to as `ar` in the literature.
-    public_key_randomness: jubjub::Fr,
+    public_key_randomness: ironfish_jubjub::Fr,
 
     /// Proof and public parameters for a user action to spend tokens.
     pub(crate) description: SpendDescription,
@@ -424,11 +424,11 @@ mod test {
         let public_address = key.public_address();
         let sender_key = SaplingKey::generate_key();
 
-        let public_key_randomness = jubjub::Fr::random(thread_rng());
+        let public_key_randomness = ironfish_jubjub::Fr::random(thread_rng());
         let randomized_public_key = redjubjub::PublicKey(key.view_key.authorizing_key.into())
             .randomize(public_key_randomness, *SPENDING_KEY_GENERATOR);
 
-        let other_public_key_randomness = jubjub::Fr::random(thread_rng());
+        let other_public_key_randomness = ironfish_jubjub::Fr::random(thread_rng());
         let other_randomized_public_key =
             redjubjub::PublicKey(sender_key.view_key.authorizing_key.into())
                 .randomize(other_public_key_randomness, *SPENDING_KEY_GENERATOR);
@@ -525,7 +525,7 @@ mod test {
 
         let spend = SpendBuilder::new(note, &witness);
 
-        let public_key_randomness = jubjub::Fr::random(thread_rng());
+        let public_key_randomness = ironfish_jubjub::Fr::random(thread_rng());
         let randomized_public_key = redjubjub::PublicKey(key.view_key.authorizing_key.into())
             .randomize(public_key_randomness, *SPENDING_KEY_GENERATOR);
 
@@ -601,13 +601,13 @@ mod test {
             sender_key.public_address(),
         );
         let witness = make_fake_witness(&note);
-        let public_key_randomness = jubjub::Fr::random(thread_rng());
+        let public_key_randomness = ironfish_jubjub::Fr::random(thread_rng());
         let randomized_public_key = redjubjub::PublicKey(key.view_key.authorizing_key.into())
             .randomize(public_key_randomness, *SPENDING_KEY_GENERATOR);
 
         let builder = SpendBuilder::new(note, &witness);
         // create a random private key and sign random message as placeholder
-        let private_key = PrivateKey(jubjub::Fr::random(thread_rng()));
+        let private_key = PrivateKey(ironfish_jubjub::Fr::random(thread_rng()));
         let public_key = PublicKey::from_private(&private_key, *SPENDING_KEY_GENERATOR);
         let msg = [0u8; 32];
         let signature = private_key.sign(&msg, &mut thread_rng(), *SPENDING_KEY_GENERATOR);

--- a/ironfish-rust/src/transaction/tests.rs
+++ b/ironfish-rust/src/transaction/tests.rs
@@ -442,7 +442,7 @@ fn test_batch_verify_wrong_spend_params() {
     let rng = &mut thread_rng();
 
     let wrong_spend_params =
-        bellperson::groth16::generate_random_parameters::<blstrs::Bls12, _, _>(
+        ironfish_bellperson::groth16::generate_random_parameters::<blstrs::Bls12, _, _>(
             Spend {
                 value_commitment: None,
                 proof_generation_key: None,
@@ -457,7 +457,8 @@ fn test_batch_verify_wrong_spend_params() {
         )
         .unwrap();
 
-    let wrong_spend_vk = bellperson::groth16::prepare_verifying_key(&wrong_spend_params.vk);
+    let wrong_spend_vk =
+        ironfish_bellperson::groth16::prepare_verifying_key(&wrong_spend_params.vk);
 
     //
     // TRANSACTION GENERATION
@@ -519,7 +520,7 @@ fn test_batch_verify_wrong_output_params() {
     let rng = &mut thread_rng();
 
     let wrong_output_params =
-        bellperson::groth16::generate_random_parameters::<blstrs::Bls12, _, _>(
+        ironfish_bellperson::groth16::generate_random_parameters::<blstrs::Bls12, _, _>(
             Output {
                 value_commitment: None,
                 payment_address: None,
@@ -533,7 +534,8 @@ fn test_batch_verify_wrong_output_params() {
         )
         .unwrap();
 
-    let wrong_output_vk = bellperson::groth16::prepare_verifying_key(&wrong_output_params.vk);
+    let wrong_output_vk =
+        ironfish_bellperson::groth16::prepare_verifying_key(&wrong_output_params.vk);
 
     //
     // TRANSACTION GENERATION
@@ -594,16 +596,17 @@ fn test_batch_verify_wrong_output_params() {
 fn test_batch_verify_wrong_mint_params() {
     let rng = &mut thread_rng();
 
-    let wrong_mint_params = bellperson::groth16::generate_random_parameters::<blstrs::Bls12, _, _>(
-        MintAsset {
-            proof_generation_key: None,
-            public_key_randomness: None,
-        },
-        rng,
-    )
-    .unwrap();
+    let wrong_mint_params =
+        ironfish_bellperson::groth16::generate_random_parameters::<blstrs::Bls12, _, _>(
+            MintAsset {
+                proof_generation_key: None,
+                public_key_randomness: None,
+            },
+            rng,
+        )
+        .unwrap();
 
-    let wrong_mint_vk = bellperson::groth16::prepare_verifying_key(&wrong_mint_params.vk);
+    let wrong_mint_vk = ironfish_bellperson::groth16::prepare_verifying_key(&wrong_mint_params.vk);
 
     //
     // TRANSACTION GENERATION
@@ -686,7 +689,7 @@ fn test_batch_verify() {
     let key = SaplingKey::generate_key();
     let other_key = SaplingKey::generate_key();
 
-    let public_key_randomness = jubjub::Fr::random(thread_rng());
+    let public_key_randomness = ironfish_jubjub::Fr::random(thread_rng());
     let other_randomized_public_key =
         redjubjub::PublicKey(other_key.view_key.authorizing_key.into())
             .randomize(public_key_randomness, *SPENDING_KEY_GENERATOR);

--- a/ironfish-rust/src/transaction/unsigned.rs
+++ b/ironfish-rust/src/transaction/unsigned.rs
@@ -68,7 +68,7 @@ pub struct UnsignedTransaction {
     pub(crate) randomized_public_key: redjubjub::PublicKey,
 
     // TODO: Verify if this is actually okay to store on the unsigned transaction
-    pub(crate) public_key_randomness: jubjub::Fr,
+    pub(crate) public_key_randomness: ironfish_jubjub::Fr,
 
     /// The balance of total spends - outputs, which is the amount that the miner gets to keep
     pub(crate) fee: i64,
@@ -319,7 +319,7 @@ impl UnsignedTransaction {
     }
 
     // Exposes the public key package for use in round two of FROST multisig protocol
-    pub fn public_key_randomness(&self) -> jubjub::Fr {
+    pub fn public_key_randomness(&self) -> ironfish_jubjub::Fr {
         self.public_key_randomness
     }
 

--- a/ironfish-rust/src/transaction/utils.rs
+++ b/ironfish-rust/src/transaction/utils.rs
@@ -1,8 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-use bellperson::groth16;
 use blstrs::Bls12;
+use ironfish_bellperson::groth16;
 
 use crate::{
     errors::{IronfishError, IronfishErrorKind},

--- a/ironfish-zkp/Cargo.toml
+++ b/ironfish-zkp/Cargo.toml
@@ -21,14 +21,14 @@ workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bellperson = { git = "https://github.com/iron-fish/bellperson.git", branch = "blstrs", features = ["groth16"] }
+ironfish-bellperson = { version = "0.1.0", features = ["groth16"] }
 blake2s_simd = "1.0.0"
 blstrs = { version = "0.6.0", features = ["portable"] }
 byteorder = "1.4.3"
 ff = "0.12.0"
 group = "0.12.0"
-jubjub = { git = "https://github.com/iron-fish/jubjub.git", branch = "blstrs" }
+ironfish-jubjub = { version = "0.1.0" }
 lazy_static = "1.4.0"
 rand = "0.8.5"
-zcash_primitives = { git = "https://github.com/iron-fish/librustzcash.git", branch = "blstrs", package = "zcash_primitives" }
-zcash_proofs = { git = "https://github.com/iron-fish/librustzcash.git", branch = "blstrs", package = "zcash_proofs" }
+ironfish-primitives = { version = "0.1.0" }
+ironfish-proofs = { version = "0.1.0" }

--- a/ironfish-zkp/src/bin/generate_params.rs
+++ b/ironfish-zkp/src/bin/generate_params.rs
@@ -1,5 +1,5 @@
-use bellperson::{groth16, Circuit};
 use blstrs::Bls12;
+use ironfish_bellperson::{groth16, Circuit};
 use ironfish_zkp::{
     constants::ASSET_ID_LENGTH,
     proofs::{MintAsset, Output, Spend},

--- a/ironfish-zkp/src/circuits/util.rs
+++ b/ironfish-zkp/src/circuits/util.rs
@@ -1,13 +1,13 @@
-use bellperson::{
+use ff::PrimeField;
+use group::GroupEncoding;
+use ironfish_bellperson::{
     gadgets::{
         blake2s,
         boolean::{self, AllocatedBit, Boolean},
     },
     ConstraintSystem, SynthesisError,
 };
-use ff::PrimeField;
-use group::GroupEncoding;
-use zcash_proofs::{
+use ironfish_proofs::{
     circuit::ecc::{self, EdwardsPoint},
     constants::VALUE_COMMITMENT_RANDOMNESS_GENERATOR,
 };
@@ -110,7 +110,7 @@ where
     Ok(value_bits)
 }
 
-pub fn assert_valid_asset_generator<CS: bellperson::ConstraintSystem<blstrs::Scalar>>(
+pub fn assert_valid_asset_generator<CS: ironfish_bellperson::ConstraintSystem<blstrs::Scalar>>(
     mut cs: CS,
     asset_id: &[u8; ASSET_ID_LENGTH],
     asset_generator_repr: &[Boolean],
@@ -149,20 +149,20 @@ pub(crate) trait FromBytes: Sized {
     fn read<R: std::io::Read>(reader: R) -> Result<Self, std::io::Error>;
 }
 
-impl FromBytes for jubjub::SubgroupPoint {
+impl FromBytes for ironfish_jubjub::SubgroupPoint {
     fn read<R: std::io::Read>(mut reader: R) -> Result<Self, std::io::Error> {
         let mut bytes = [0u8; 32];
         reader.read_exact(&mut bytes)?;
-        Option::from(jubjub::SubgroupPoint::from_bytes(&bytes))
+        Option::from(ironfish_jubjub::SubgroupPoint::from_bytes(&bytes))
             .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::InvalidData, "Invalid point"))
     }
 }
 
-impl FromBytes for jubjub::Fr {
+impl FromBytes for ironfish_jubjub::Fr {
     fn read<R: std::io::Read>(mut reader: R) -> Result<Self, std::io::Error> {
         let mut bytes = [0u8; 32];
         reader.read_exact(&mut bytes)?;
-        Option::from(jubjub::Fr::from_bytes(&bytes)).ok_or_else(|| {
+        Option::from(ironfish_jubjub::Fr::from_bytes(&bytes)).ok_or_else(|| {
             std::io::Error::new(std::io::ErrorKind::InvalidData, "Invalid field element")
         })
     }

--- a/ironfish-zkp/src/constants.rs
+++ b/ironfish-zkp/src/constants.rs
@@ -1,12 +1,12 @@
-use jubjub::SubgroupPoint;
-use lazy_static::lazy_static;
-pub use zcash_primitives::constants::{
+use ironfish_jubjub::SubgroupPoint;
+pub use ironfish_primitives::constants::{
     CRH_IVK_PERSONALIZATION, GH_FIRST_BLOCK, NOTE_COMMITMENT_RANDOMNESS_GENERATOR,
     NULLIFIER_POSITION_GENERATOR, PROOF_GENERATION_KEY_GENERATOR, SPENDING_KEY_GENERATOR,
     VALUE_COMMITMENT_RANDOMNESS_GENERATOR, VALUE_COMMITMENT_VALUE_GENERATOR,
 };
+use lazy_static::lazy_static;
 
-pub use zcash_proofs::circuit::sapling::TREE_DEPTH;
+pub use ironfish_proofs::circuit::sapling::TREE_DEPTH;
 
 /// Length in bytes of the asset identifier
 pub const ASSET_ID_LENGTH: usize = 32;
@@ -57,8 +57,8 @@ lazy_static! {
 }
 
 pub mod proof {
+    use ironfish_proofs::constants::{generate_circuit_generator, FixedGeneratorOwned};
     use lazy_static::lazy_static;
-    use zcash_proofs::constants::{generate_circuit_generator, FixedGeneratorOwned};
 
     lazy_static! {
         pub static ref PUBLIC_KEY_GENERATOR: FixedGeneratorOwned =

--- a/ironfish-zkp/src/lib.rs
+++ b/ironfish-zkp/src/lib.rs
@@ -4,7 +4,7 @@ pub mod hex;
 pub mod primitives;
 pub mod util;
 
-pub use zcash_primitives::sapling::{
+pub use ironfish_primitives::sapling::{
     group_hash::group_hash, pedersen_hash, redjubjub, Diversifier, Note as SaplingNote, Nullifier,
     PaymentAddress, Rseed, ViewingKey,
 };

--- a/ironfish-zkp/src/primitives/proof_generation_key.rs
+++ b/ironfish-zkp/src/primitives/proof_generation_key.rs
@@ -1,9 +1,9 @@
 use group::GroupEncoding;
-use jubjub::{Fr, SubgroupPoint};
+use ironfish_jubjub::{Fr, SubgroupPoint};
+use ironfish_primitives::sapling::ProofGenerationKey as ZcashProofGenerationKey;
 use std::error::Error;
 use std::fmt;
 use std::ops::Deref;
-use zcash_primitives::sapling::ProofGenerationKey as ZcashProofGenerationKey;
 
 use crate::hex::{bytes_to_hex, hex_to_bytes};
 
@@ -105,7 +105,7 @@ mod test {
     use ff::Field;
     use group::{Group, GroupEncoding};
 
-    use jubjub;
+    use ironfish_jubjub;
     use rand::{rngs::StdRng, SeedableRng};
 
     use crate::primitives::proof_generation_key::{ProofGenerationKey, ProofGenerationKeyError};
@@ -115,8 +115,8 @@ mod test {
         let mut rng = StdRng::seed_from_u64(0);
 
         let proof_generation_key = ProofGenerationKey::new(
-            jubjub::SubgroupPoint::random(&mut rng),
-            jubjub::Fr::random(&mut rng),
+            ironfish_jubjub::SubgroupPoint::random(&mut rng),
+            ironfish_jubjub::Fr::random(&mut rng),
         );
 
         let serialized_bytes = proof_generation_key.to_bytes();
@@ -145,7 +145,7 @@ mod test {
     fn test_deserialize_nsk_error() {
         let mut proof_generation_key_bytes: [u8; 64] = [0; 64];
         // Populate with valid bytes for ak and invalid bytes for nsk
-        let valid_ak = jubjub::SubgroupPoint::random(&mut StdRng::seed_from_u64(0));
+        let valid_ak = ironfish_jubjub::SubgroupPoint::random(&mut StdRng::seed_from_u64(0));
         proof_generation_key_bytes[0..32].copy_from_slice(&valid_ak.to_bytes()); // Assuming these are valid bytes for ak
         proof_generation_key_bytes[32..64].fill(0xFF); // Invalid bytes for nsk
 
@@ -166,8 +166,8 @@ mod test {
         let mut rng = StdRng::seed_from_u64(0);
 
         let proof_generation_key = ProofGenerationKey::new(
-            jubjub::SubgroupPoint::random(&mut rng),
-            jubjub::Fr::random(&mut rng),
+            ironfish_jubjub::SubgroupPoint::random(&mut rng),
+            ironfish_jubjub::Fr::random(&mut rng),
         );
 
         let serialized_bytes = proof_generation_key.to_bytes();
@@ -190,8 +190,8 @@ mod test {
         let mut rng = StdRng::seed_from_u64(0);
 
         let proof_generation_key = ProofGenerationKey::new(
-            jubjub::SubgroupPoint::random(&mut rng),
-            jubjub::Fr::random(&mut rng),
+            ironfish_jubjub::SubgroupPoint::random(&mut rng),
+            ironfish_jubjub::Fr::random(&mut rng),
         );
 
         let hex_key = proof_generation_key.hex_key();

--- a/ironfish-zkp/src/primitives/value_commitment.rs
+++ b/ironfish-zkp/src/primitives/value_commitment.rs
@@ -2,7 +2,7 @@ use byteorder::{LittleEndian, ReadBytesExt};
 use ff::Field;
 use group::{cofactor::CofactorGroup, GroupEncoding};
 
-use jubjub::ExtendedPoint;
+use ironfish_jubjub::ExtendedPoint;
 use rand::thread_rng;
 
 use crate::constants::VALUE_COMMITMENT_RANDOMNESS_GENERATOR;
@@ -12,21 +12,21 @@ use crate::constants::VALUE_COMMITMENT_RANDOMNESS_GENERATOR;
 #[derive(Clone)]
 pub struct ValueCommitment {
     pub value: u64,
-    pub randomness: jubjub::Fr,
-    pub asset_generator: jubjub::ExtendedPoint,
+    pub randomness: ironfish_jubjub::Fr,
+    pub asset_generator: ironfish_jubjub::ExtendedPoint,
 }
 
 impl ValueCommitment {
-    pub fn new(value: u64, asset_generator: jubjub::ExtendedPoint) -> Self {
+    pub fn new(value: u64, asset_generator: ironfish_jubjub::ExtendedPoint) -> Self {
         Self {
             value,
-            randomness: jubjub::Fr::random(thread_rng()),
+            randomness: ironfish_jubjub::Fr::random(thread_rng()),
             asset_generator,
         }
     }
 
-    pub fn commitment(&self) -> jubjub::SubgroupPoint {
-        (self.asset_generator.clear_cofactor() * jubjub::Fr::from(self.value))
+    pub fn commitment(&self) -> ironfish_jubjub::SubgroupPoint {
+        (self.asset_generator.clear_cofactor() * ironfish_jubjub::Fr::from(self.value))
             + (*VALUE_COMMITMENT_RANDOMNESS_GENERATOR * self.randomness)
     }
 
@@ -47,7 +47,7 @@ impl ValueCommitment {
         let value = reader.read_u64::<LittleEndian>()?;
         let mut randomness_bytes = [0u8; 32];
         reader.read_exact(&mut randomness_bytes)?;
-        let randomness = jubjub::Fr::from_bytes(&randomness_bytes).unwrap();
+        let randomness = ironfish_jubjub::Fr::from_bytes(&randomness_bytes).unwrap();
         let mut asset_generator = [0u8; 32];
         reader.read_exact(&mut asset_generator)?;
         let asset_generator = ExtendedPoint::from_bytes(&asset_generator).unwrap();
@@ -74,8 +74,8 @@ mod test {
 
         let value_commitment = ValueCommitment {
             value: 5,
-            randomness: jubjub::Fr::random(&mut rng),
-            asset_generator: jubjub::ExtendedPoint::random(&mut rng),
+            randomness: ironfish_jubjub::Fr::random(&mut rng),
+            asset_generator: ironfish_jubjub::ExtendedPoint::random(&mut rng),
         };
 
         let commitment = value_commitment.commitment();
@@ -91,7 +91,7 @@ mod test {
 
     #[test]
     fn test_value_commitment_new() {
-        let generator = jubjub::ExtendedPoint::random(thread_rng());
+        let generator = ironfish_jubjub::ExtendedPoint::random(thread_rng());
         let value = 5;
 
         let value_commitment = ValueCommitment::new(value, generator);
@@ -105,9 +105,9 @@ mod test {
         // Seed a fixed rng for determinism in the test
         let mut rng = StdRng::seed_from_u64(0);
 
-        let randomness = jubjub::Fr::random(&mut rng);
+        let randomness = ironfish_jubjub::Fr::random(&mut rng);
 
-        let asset_generator_one = jubjub::ExtendedPoint::random(&mut rng);
+        let asset_generator_one = ironfish_jubjub::ExtendedPoint::random(&mut rng);
 
         let value_commitment_one = ValueCommitment {
             value: 5,
@@ -117,7 +117,7 @@ mod test {
 
         let commitment_one = value_commitment_one.commitment();
 
-        let asset_generator_two = jubjub::ExtendedPoint::random(&mut rng);
+        let asset_generator_two = ironfish_jubjub::ExtendedPoint::random(&mut rng);
 
         let value_commitment_two = ValueCommitment {
             value: 5,
@@ -145,9 +145,9 @@ mod test {
         // Seed a fixed rng for determinism in the test
         let mut rng = StdRng::seed_from_u64(0);
 
-        let randomness_one = jubjub::Fr::random(&mut rng);
+        let randomness_one = ironfish_jubjub::Fr::random(&mut rng);
 
-        let asset_generator = jubjub::ExtendedPoint::random(&mut rng);
+        let asset_generator = ironfish_jubjub::ExtendedPoint::random(&mut rng);
 
         let value_commitment_one = ValueCommitment {
             value: 5,
@@ -157,7 +157,7 @@ mod test {
 
         let commitment_one = value_commitment_one.commitment();
 
-        let randomness_two = jubjub::Fr::random(&mut rng);
+        let randomness_two = ironfish_jubjub::Fr::random(&mut rng);
 
         let value_commitment_two = ValueCommitment {
             value: 5,
@@ -184,8 +184,8 @@ mod test {
 
         let value_one = 5;
 
-        let randomness = jubjub::Fr::random(&mut rng);
-        let asset_generator = jubjub::ExtendedPoint::random(&mut rng);
+        let randomness = ironfish_jubjub::Fr::random(&mut rng);
+        let asset_generator = ironfish_jubjub::ExtendedPoint::random(&mut rng);
 
         let value_commitment_one = ValueCommitment {
             value: value_one,
@@ -226,8 +226,8 @@ mod test {
 
         let value_commitment = ValueCommitment {
             value: 5,
-            randomness: jubjub::Fr::random(&mut rng),
-            asset_generator: jubjub::ExtendedPoint::random(&mut rng),
+            randomness: ironfish_jubjub::Fr::random(&mut rng),
+            asset_generator: ironfish_jubjub::ExtendedPoint::random(&mut rng),
         };
 
         // Serialize to bytes

--- a/ironfish-zkp/src/util.rs
+++ b/ironfish-zkp/src/util.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 use byteorder::{LittleEndian, WriteBytesExt};
 use ff::PrimeField;
 use group::{cofactor::CofactorGroup, Group, GroupEncoding};
-use zcash_primitives::{
+use ironfish_primitives::{
     constants::NOTE_COMMITMENT_RANDOMNESS_GENERATOR,
     sapling::pedersen_hash::{pedersen_hash, Personalization},
 };
@@ -12,12 +12,12 @@ use crate::constants::VALUE_COMMITMENT_GENERATOR_PERSONALIZATION;
 
 /// Computes the note commitment with sender address, returning the full point.
 pub fn commitment_full_point(
-    asset_generator: jubjub::ExtendedPoint,
+    asset_generator: ironfish_jubjub::ExtendedPoint,
     value: u64,
-    pk_d: jubjub::SubgroupPoint,
-    rcm: jubjub::Fr,
-    sender_address: jubjub::SubgroupPoint,
-) -> jubjub::SubgroupPoint {
+    pk_d: ironfish_jubjub::SubgroupPoint,
+    rcm: ironfish_jubjub::Fr,
+    sender_address: ironfish_jubjub::SubgroupPoint,
+) -> ironfish_jubjub::SubgroupPoint {
     // Calculate the note contents, as bytes
     let mut note_contents = vec![];
 
@@ -56,7 +56,7 @@ pub fn commitment_full_point(
 
 /// This is a lightly modified group_hash function, for use with the asset identifier/generator flow
 #[allow(clippy::assertions_on_constants)]
-pub fn asset_hash_to_point(tag: &[u8]) -> Option<jubjub::ExtendedPoint> {
+pub fn asset_hash_to_point(tag: &[u8]) -> Option<ironfish_jubjub::ExtendedPoint> {
     assert_eq!(VALUE_COMMITMENT_GENERATOR_PERSONALIZATION.len(), 8);
 
     // Check to see that scalar field is 255 bits
@@ -69,7 +69,7 @@ pub fn asset_hash_to_point(tag: &[u8]) -> Option<jubjub::ExtendedPoint> {
         .update(tag)
         .finalize();
 
-    let p = jubjub::ExtendedPoint::from_bytes(h.as_array());
+    let p = ironfish_jubjub::ExtendedPoint::from_bytes(h.as_array());
     if p.is_some().into() {
         let p = p.unwrap();
 

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -1,42 +1,21 @@
 
 # cargo-vet audits file
 
-[audits]
-reddsa = []
-
 [[audits.arrayvec]]
 who = "Andrea <andrea@iflabs.network>"
 criteria = "safe-to-deploy"
 delta = "0.7.2 -> 0.7.4"
 
-[[audits.bellman]]
-who = "Andrea <andrea@iflabs.network>"
+[[audits.bip0039]]
+who = "andrea <andrea@iflabs.network>"
 criteria = "safe-to-deploy"
-delta = "0.13.1 -> 0.13.1@git:1cc52ca33e6db14233f1cbc0c9c5b7c822b229ec"
-notes = "Fork of the official bellperson owned by Iron Fish"
-
-[[audits.bellperson]]
-who = "Andrea <andrea@iflabs.network>"
-criteria = "safe-to-deploy"
-delta = "0.24.1 -> 0.24.1@git:37b9976bcd96986cbdc71ae09fc455015e3dfac0"
-notes = "Fork of the official bellperson owned by Iron Fish"
+delta = "0.10.1 -> 0.11.0"
+notes = "Main change is how langauges are handled (previous version: through an enum, new version: through a marker type)"
 
 [[audits.crypto_box]]
 who = "Andrea <andrea@iflabs.network>"
 criteria = "safe-to-deploy"
 version = "0.9.1"
-
-[[audits.equihash]]
-who = "Andrea <andrea@iflabs.network>"
-criteria = "safe-to-deploy"
-delta = "0.2.0 -> 0.2.0@git:d551820030cb596eafe82226667f32b47164f91b"
-notes = "Fork of the official equihash owned by Iron Fish"
-
-[[audits.f4jumble]]
-who = "Andrea <andrea@iflabs.network>"
-criteria = "safe-to-deploy"
-delta = "0.1.0 -> 0.1.0@git:d551820030cb596eafe82226667f32b47164f91b"
-notes = "Fork of the official f4jumble owned by Iron Fish"
 
 [[audits.frost-core]]
 who = "Andrea <andrea@iflabs.network>"
@@ -63,24 +42,41 @@ who = "Andrea <andrea@iflabs.network>"
 criteria = "safe-to-deploy"
 delta = "1.9.3 -> 2.2.6"
 
+[[audits.ironfish-bellperson]]
+who = "andrea <andrea@iflabs.network>"
+criteria = "safe-to-deploy"
+version = "0.1.0"
+notes = "Fork of the official bellperson owned by Iron Fish"
+
 [[audits.ironfish-frost]]
 who = "andrea <andrea@iflabs.network>"
 criteria = "safe-to-deploy"
 version = "0.1.0"
 notes = "Crate owned by the Iron Fish organization"
 
+[[audits.ironfish-jubjub]]
+who = "andrea <andrea@iflabs.network>"
+criteria = "safe-to-deploy"
+version = "0.1.0"
+notes = "Fork of the official jubjub owned by Iron Fish"
+
+[[audits.ironfish-primitives]]
+who = "andrea <andrea@iflabs.network>"
+criteria = "safe-to-deploy"
+version = "0.1.0"
+notes = "Fork of the official zcash_primitives owned by Iron Fish"
+
+[[audits.ironfish-proofs]]
+who = "andrea <andrea@iflabs.network>"
+criteria = "safe-to-deploy"
+version = "0.1.0"
+notes = "Fork of the official zcash_proofs owned by Iron Fish"
+
 [[audits.ironfish-reddsa]]
 who = "andrea <andrea@iflabs.network>"
 criteria = "safe-to-deploy"
 version = "0.1.0"
 notes = "Crate owned by the Iron Fish organization"
-
-[[audits.jubjub]]
-who = "Andrea <andrea@iflabs.network>"
-criteria = "safe-to-deploy"
-delta = "0.9.0 -> 0.9.0@git:531157cfa7b81ade207e819ef50c563843b10e30"
-importable = false
-notes = "Fork of the official jubjub owned by Iron Fish"
 
 [[audits.mio]]
 who = "Andrea <andrea@iflabs.network>"
@@ -111,36 +107,6 @@ delta = "1.4.1 -> 1.4.2"
 who = "Andrea <andrea@iflabs.network>"
 criteria = "safe-to-deploy"
 version = "1.0.0"
-
-[[audits.zcash_address]]
-who = "Andrea <andrea@iflabs.network>"
-criteria = "safe-to-deploy"
-delta = "0.1.0 -> 0.1.0@git:d551820030cb596eafe82226667f32b47164f91b"
-notes = "Fork of the official zcash_address owned by Iron Fish"
-
-[[audits.zcash_encoding]]
-who = "Andrea <andrea@iflabs.network>"
-criteria = "safe-to-deploy"
-delta = "0.1.0 -> 0.1.0@git:d551820030cb596eafe82226667f32b47164f91b"
-notes = "Fork of the official zcash_encoding owned by Iron Fish"
-
-[[audits.zcash_note_encryption]]
-who = "Andrea <andrea@iflabs.network>"
-criteria = "safe-to-deploy"
-delta = "0.1.0 -> 0.1.0@git:d551820030cb596eafe82226667f32b47164f91b"
-notes = "Fork of the official zcash_note_encryption owned by Iron Fish"
-
-[[audits.zcash_primitives]]
-who = "Andrea <andrea@iflabs.network>"
-criteria = "safe-to-deploy"
-delta = "0.7.0 -> 0.7.0@git:d551820030cb596eafe82226667f32b47164f91b"
-notes = "Fork of the official zcash_primitives owned by Iron Fish"
-
-[[audits.zcash_proofs]]
-who = "Andrea <andrea@iflabs.network>"
-criteria = "safe-to-deploy"
-delta = "0.7.1 -> 0.7.1@git:d551820030cb596eafe82226667f32b47164f91b"
-notes = "Fork of the official zcash_proofs owned by Iron Fish"
 
 [[trusted.reddsa]]
 criteria = "safe-to-deploy"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -2,7 +2,7 @@
 # cargo-vet config file
 
 [cargo-vet]
-version = "0.9"
+version = "0.10"
 
 [imports.bytecode-alliance]
 url = "https://raw.githubusercontent.com/bytecodealliance/wasmtime/main/supply-chain/audits.toml"
@@ -22,37 +22,10 @@ url = "https://raw.githubusercontent.com/mozilla/supply-chain/main/audits.toml"
 [imports.zcash]
 url = "https://raw.githubusercontent.com/zcash/rust-ecosystem/main/supply-chain/audits.toml"
 
-[policy.bellperson]
-audit-as-crates-io = true
-
-[policy.equihash]
-audit-as-crates-io = true
-
-[policy.f4jumble]
-audit-as-crates-io = true
-
 [policy.ironfish]
 audit-as-crates-io = true
 
 [policy.ironfish_zkp]
-audit-as-crates-io = true
-
-[policy."jubjub:0.9.0@git:531157cfa7b81ade207e819ef50c563843b10e30"]
-audit-as-crates-io = true
-
-[policy.zcash_address]
-audit-as-crates-io = true
-
-[policy.zcash_encoding]
-audit-as-crates-io = true
-
-[policy."zcash_note_encryption:0.1.0@git:d551820030cb596eafe82226667f32b47164f91b"]
-audit-as-crates-io = true
-
-[policy.zcash_primitives]
-audit-as-crates-io = true
-
-[policy.zcash_proofs]
 audit-as-crates-io = true
 
 [[exemptions.aead]]
@@ -85,10 +58,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.bech32]]
 version = "0.8.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.bellperson]]
-version = "0.24.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.bincode]]
@@ -225,10 +194,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.crossbeam-utils]]
 version = "0.8.14"
-criteria = "safe-to-deploy"
-
-[[exemptions.crypto-mac]]
-version = "0.11.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.crypto_secretbox]]
@@ -385,10 +350,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.hkdf]]
 version = "0.12.4"
-criteria = "safe-to-deploy"
-
-[[exemptions.hmac]]
-version = "0.11.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.http]]
@@ -941,14 +902,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.zcash_note_encryption]]
 version = "0.1.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.zcash_primitives]]
-version = "0.7.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.zcash_proofs]]
-version = "0.7.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.zeroize]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -497,6 +497,12 @@ criteria = "safe-to-deploy"
 delta = "0.1.0 -> 0.1.1"
 aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
 
+[[audits.google.audits.password-hash]]
+who = "Joshua Liebow-Feeser <joshlf@google.com>"
+criteria = "safe-to-deploy"
+delta = "0.3.2 -> 0.4.2"
+aggregated-from = "https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/third_party/rust_crates/supply-chain/audits.toml?format=TEXT"
+
 [[audits.google.audits.pbkdf2]]
 who = "Joshua Liebow-Feeser <joshlf@google.com>"
 criteria = "safe-to-deploy"
@@ -756,7 +762,7 @@ who = "Henri Sivonen <hsivonen@hsivonen.fi>"
 criteria = "safe-to-deploy"
 user-id = 4484 # Henri Sivonen (hsivonen)
 start = "2019-02-26"
-end = "2024-08-28"
+end = "2025-10-23"
 notes = "I, Henri Sivonen, wrote encoding_rs for Gecko and have reviewed contributions by others. There are two caveats to the certification: 1) The crate does things that are documented to be UB but that do not appear to actually be UB due to integer types differing from the general rule; https://github.com/hsivonen/encoding_rs/issues/79 . 2) It would be prudent to re-review the code that reinterprets buffers of integers as SIMD vectors; see https://github.com/hsivonen/encoding_rs/issues/87 ."
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
@@ -1121,6 +1127,12 @@ aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/suppl
 who = "Jack Grigg <jack@electriccoin.co>"
 criteria = "safe-to-deploy"
 delta = "0.5.1 -> 0.5.2"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.bip0039]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "0.9.0 -> 0.10.1"
 aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
 
 [[audits.zcash.audits.bls12_381]]


### PR DESCRIPTION
## Summary

This commit replaces all the dependencies on our forked crates on `github.com` to the corresponding crates on `crates.io`. Specifically:

* `bellperson` -> `ironfish-bellperson`
* `jubjub` -> `ironfish-jubjub`
* `zcash_primitives` -> `ironfish-primitives`
* `zcash_proofs` -> `ironfish-proofs`

The following crates were also being consumed from `github.com` and have been restored to the original version on `crates.io` (no need to publish a fork):

* `equihash`
* `f4jumble`
* `zcash_address`
* `zcash_encoding`
* `zcash_encoding`
* `zcash_note_encryption`

With this commit, `ironfish-zkp` and `ironfish-rust` have 100% of their dependencies on crates on `crates.io`.

## Testing Plan

* Unit tests
* `cargo publish --dry-run -p ironfish_zkp` (can't do the same with `ironfish` before `ironfish_zkp` is published)
* Inspect `Cargo.lock` and verify that there are no URIs starting with `git+https://`; alternatively: run `cargo tree` and check that there are no URIs starting with `https://`

## Documentation

N/A

## Breaking Change

N/A