### PR TITLE
chore(IFL-2707): conditionally logs scan starts and ends

### DIFF
--- a/ironfish/src/wallet/scanner/walletScanner.ts
+++ b/ironfish/src/wallet/scanner/walletScanner.ts
@@ -105,9 +105,12 @@ export class WalletScanner {
       this.state = scan
       unlock()
 
-      this.logger.debug(
-        `Scan starting from block ${scan.start.sequence} to ${scan.start.sequence}`,
-      )
+      const logScanState = scan.start.sequence !== scan.end.sequence
+      if (logScanState) {
+        this.logger.debug(
+          `Scan starting from block ${scan.start.sequence} to ${scan.end.sequence}`,
+        )
+      }
 
       decryptor.start(scan.abortController)
 
@@ -136,11 +139,13 @@ export class WalletScanner {
         await decryptor.flush()
       })()
         .then(() => {
-          this.logger.debug(
-            `Finished scanning for transactions after ${Math.floor(
-              (Date.now() - scan.startedAt) / 1000,
-            )} seconds`,
-          )
+          if (logScanState) {
+            this.logger.debug(
+              `Finished scanning for transactions after ${Math.floor(
+                (Date.now() - scan.startedAt) / 1000,
+              )} seconds`,
+            )
+          }
         })
         .finally(() => {
           decryptor.stop()


### PR DESCRIPTION
## Summary

only logs scan starts and ends in debug output if the start and end sequences differ

reduces noise from debug output when running a synced node where each block produces a new scan with equal start and end sequences

Closes IFL-2707

## Testing Plan
ran synced node in verbose node before and after applying changes

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
