### PR TITLE
displays resolved file path on export path conflicts

### DIFF
--- a/ironfish-cli/src/commands/wallet/export.ts
+++ b/ironfish-cli/src/commands/wallet/export.ts
@@ -82,7 +82,7 @@ export class ExportCommand extends IronfishCommand {
 
         if (fs.existsSync(resolved)) {
           await confirmOrQuit(
-            `There is already an account backup at ${exportPath}` +
+            `There is already an account backup at ${resolved}` +
               `\n\nOverwrite the account backup with new file?`,
           )
         }


### PR DESCRIPTION
## Summary

instead of displaying the user-entered path (e.g., '.'), displays the fully-qualified path resolved by the file system

Closes IFL-2706

## Testing Plan
before:
<img width="657" alt="image" src="https://github.com/user-attachments/assets/d00c70fc-aa59-410c-9bc3-9e2e3303f3d3">

after:
<img width="745" alt="image" src="https://github.com/user-attachments/assets/8df73654-e1c0-4aae-9fcf-dbc45a3255a3">


## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
