### PR TITLE
chore(IFL-2555): Prompt currency cleanup

### DIFF
--- a/ironfish-cli/src/commands/wallet/burn.ts
+++ b/ironfish-cli/src/commands/wallet/burn.ts
@@ -151,11 +151,10 @@ This will destroy tokens and decrease supply for a given asset.`
       amount = await promptCurrency({
         client: client,
         required: true,
-        text: 'Enter the amount of the custom asset to burn',
+        text: 'Enter the amount to burn',
         minimum: 1n,
         logger: this.logger,
-        assetId: assetId,
-        assetVerification: assetData.verification,
+        assetData,
         balance: {
           account,
           confirmations: flags.confirmations,

--- a/ironfish-cli/src/commands/wallet/chainport/send.ts
+++ b/ironfish-cli/src/commands/wallet/chainport/send.ts
@@ -296,11 +296,10 @@ export class BridgeCommand extends IronfishCommand {
       amount = await promptCurrency({
         client: client,
         required: true,
-        text: 'Enter the amount in the major denomination',
+        text: 'Enter the amount',
         minimum: 1n,
         logger: this.logger,
-        assetId: assetId,
-        assetVerification: assetData.verification,
+        assetData,
         balance: {
           account: from,
         },

--- a/ironfish-cli/src/commands/wallet/mint.ts
+++ b/ironfish-cli/src/commands/wallet/mint.ts
@@ -209,11 +209,10 @@ This will create tokens and increase supply for a given asset.`
       amount = await promptCurrency({
         client: client,
         required: true,
-        text: 'Enter the amount',
+        text: 'Enter the amount to mint',
         minimum: 0n,
         logger: this.logger,
-        assetId: assetId,
-        assetVerification: assetData?.verification,
+        assetData,
       })
     }
 

--- a/ironfish-cli/src/commands/wallet/send.ts
+++ b/ironfish-cli/src/commands/wallet/send.ts
@@ -172,11 +172,10 @@ export class Send extends IronfishCommand {
       amount = await promptCurrency({
         client: client,
         required: true,
-        text: 'Enter the amount in the major denomination',
+        text: 'Enter the amount',
         minimum: 1n,
         logger: this.logger,
-        assetId: assetId,
-        assetVerification: assetData.verification,
+        assetData,
         balance: {
           account: from,
           confirmations: flags.confirmations,

--- a/ironfish-cli/src/utils/fees.ts
+++ b/ironfish-cli/src/utils/fees.ts
@@ -75,7 +75,7 @@ export async function selectFee(options: {
     const fee = await promptCurrency({
       client: options.client,
       required: true,
-      text: 'Enter the fee amount in $IRON',
+      text: 'Enter the fee in $IRON',
       logger: options.logger,
       balance: {
         account: options.account,


### PR DESCRIPTION
## Summary
For verified assets, show `asset.name ✓`
for unverified show `asset.name`

Open to suggestions on what to show after unverified name

## Testing Plan
```
51f33a2f14f92735e562dc658a5639279ddca3d5079a6d1242b2a588a9cbf44c ($IRON✓) (984.90098975) 
f3b28d5a7a1d6674cff47b5518e81c729b8330118ab0a42582fa7c345e3416fd (NORI) (9999999999999999) 
```

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
