### PR TITLE
adds command to display status for single account

### DIFF
--- a/ironfish-cli/src/commands/wallet/account.ts
+++ b/ironfish-cli/src/commands/wallet/account.ts
@@ -1,0 +1,70 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { RpcRequestError } from '@ironfish/sdk'
+import { Args } from '@oclif/core'
+import chalk from 'chalk'
+import { IronfishCommand } from '../../command'
+import { JsonFlags, RemoteFlags } from '../../flags'
+import * as ui from '../../ui'
+
+export class AccountsCommand extends IronfishCommand {
+  static description = `display status for a wallet account`
+  static enableJsonFlag = true
+
+  static flags = {
+    ...RemoteFlags,
+    ...JsonFlags,
+  }
+
+  static args = {
+    account: Args.string({
+      description: 'name of the account to display status for',
+    }),
+  }
+
+  async start(): Promise<unknown> {
+    const { args } = await this.parse(AccountsCommand)
+
+    const client = await this.connectRpc()
+    await ui.checkWalletUnlocked(client)
+
+    const account =
+      args.account ?? (await client.wallet.getDefaultAccount()).content.account?.name
+
+    if (!account) {
+      this.log(
+        'There is currently no account being used.\n' +
+          ' * Create an account: "ironfish wallet:create"\n' +
+          ' * List all accounts: "ironfish wallet:accounts"\n' +
+          ' * Use an existing account: "ironfish wallet:use <name>"',
+      )
+      return {}
+    }
+
+    try {
+      const response = await client.wallet.getAccountStatus({ account })
+
+      const status: Record<string, unknown> = {
+        Account: response.content.account.name,
+        Default: response.content.account.default ? chalk.green('✓') : '',
+        'View Only': response.content.account.viewOnly ? chalk.green('✓') : '',
+        'In Chain': response.content.account.head?.inChain ? chalk.green('✓') : '',
+        Scanning: response.content.account.scanningEnabled ? chalk.green('✓') : '',
+        Sequence: response.content.account.head?.sequence,
+        Head: response.content.account.head?.hash,
+      }
+
+      this.log(ui.card(status))
+
+      return status
+    } catch (e) {
+      if (e instanceof RpcRequestError && e.codeMessage.includes('No account with name')) {
+        this.log(e.codeMessage)
+        return {}
+      } else {
+        throw e
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

'wallet:account' displays the status information available in 'wallet:accounts --extended' for a single account accepted as an arg

defaults to the wallet's default account

Closes IFL-2651

## Testing Plan
default account:
<img width="594" alt="image" src="https://github.com/user-attachments/assets/cb46cb4a-c7f5-4546-a06e-06dc90dff153">

no account with name:
<img width="536" alt="image" src="https://github.com/user-attachments/assets/24e3ad9b-f789-47c5-b2da-2de1a8c483cc">

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[X] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
