### PR TITLE
Mark a doc comment block as `text` instead of `ignore`

### DIFF
--- a/ironfish-rust/src/frost_utils/account_keys.rs
+++ b/ironfish-rust/src/frost_utils/account_keys.rs
@@ -26,7 +26,7 @@ pub struct MultisigAccountKeys {
 
 /// Derives the account keys for a multisig account, realizing the following key hierarchy:
 ///
-/// ```ignore
+/// ```text
 ///                 ak ─┐
 ///                     ├─ ivk ── pk
 ///   gsk ── nsk ── nk ─┘


### PR DESCRIPTION
## Summary

A text block has been incorrectly marked with `ignore`. This means that `cargo test` considers the block as a doc test that shouldn't be compiled/run and is reported in its output.

## Testing Plan

Run `cargo test -p ironfish` and verify that this line is gone:

```
test ironfish-rust/src/frost_utils/account_keys.rs - frost_utils::account_keys::derive_account_keys (line 29) ... ignored
```

## Documentation

N/A

## Breaking Change

N/A