### PR TITLE
remove duplicate isSignerMultisig calls

### DIFF
--- a/ironfish/src/migrations/data/031-add-pak-to-account/new/MultisigKeys.ts
+++ b/ironfish/src/migrations/data/031-add-pak-to-account/new/MultisigKeys.ts
@@ -12,12 +12,13 @@ export class MultisigKeysEncoding implements IDatabaseEncoding<MultisigKeys> {
   serialize(value: MultisigKeys): Buffer {
     const bw = bufio.write(this.getSize(value))
 
-    let flags = 0
-    flags |= Number(!!isSignerMultisig(value)) << 0
-    bw.writeU8(flags)
+    const isMultisigSigner = isSignerMultisig(value)
+    const flags = Number(!!isMultisigSigner) << 0
 
+    bw.writeU8(flags)
     bw.writeVarBytes(Buffer.from(value.publicKeyPackage, 'hex'))
-    if (isSignerMultisig(value)) {
+
+    if (isMultisigSigner) {
       bw.writeVarBytes(Buffer.from(value.secret, 'hex'))
       bw.writeVarBytes(Buffer.from(value.keyPackage, 'hex'))
     }

--- a/ironfish/src/migrations/data/032-add-account-syncing/old/MultisigKeys.ts
+++ b/ironfish/src/migrations/data/032-add-account-syncing/old/MultisigKeys.ts
@@ -12,12 +12,13 @@ export class MultisigKeysEncoding implements IDatabaseEncoding<MultisigKeys> {
   serialize(value: MultisigKeys): Buffer {
     const bw = bufio.write(this.getSize(value))
 
-    let flags = 0
-    flags |= Number(!!isSignerMultisig(value)) << 0
-    bw.writeU8(flags)
+    const isMultisigSigner = isSignerMultisig(value)
+    const flags = Number(!!isMultisigSigner) << 0
 
+    bw.writeU8(flags)
     bw.writeVarBytes(Buffer.from(value.publicKeyPackage, 'hex'))
-    if (isSignerMultisig(value)) {
+
+    if (isMultisigSigner) {
       bw.writeVarBytes(Buffer.from(value.secret, 'hex'))
       bw.writeVarBytes(Buffer.from(value.keyPackage, 'hex'))
     }

--- a/ironfish/src/wallet/exporter/encoders/multisigKeys.ts
+++ b/ironfish/src/wallet/exporter/encoders/multisigKeys.ts
@@ -21,12 +21,13 @@ export class MultisigKeysEncoding {
   serialize(value: MultisigKeys): Buffer {
     const bw = bufio.write(this.getSize(value))
 
-    let flags = 0
-    flags |= Number(!!isSignerMultisig(value)) << 0
-    bw.writeU8(flags)
+    const isMultisigSigner = isSignerMultisig(value)
+    const flags = Number(!!isMultisigSigner) << 0
 
+    bw.writeU8(flags)
     bw.writeVarBytes(Buffer.from(value.publicKeyPackage, 'hex'))
-    if (isSignerMultisig(value)) {
+
+    if (isMultisigSigner) {
       bw.writeVarBytes(Buffer.from(value.secret, 'hex'))
       bw.writeVarBytes(Buffer.from(value.keyPackage, 'hex'))
     }

--- a/ironfish/src/wallet/walletdb/multisigKeys.ts
+++ b/ironfish/src/wallet/walletdb/multisigKeys.ts
@@ -14,16 +14,20 @@ export class MultisigKeysEncoding implements IDatabaseEncoding<MultisigKeys> {
   serialize(value: MultisigKeys): Buffer {
     const bw = bufio.write(this.getSize(value))
 
-    let flags = 0
-    flags |= Number(!!isSignerMultisig(value)) << 0
-    flags |= Number(!!isHardwareSignerMultisig(value)) << 1
-    bw.writeU8(flags)
+    const isMultisigSigner = isSignerMultisig(value)
+    const isMultisigHardwareSigner = isHardwareSignerMultisig(value)
 
+    let flags = 0
+    flags |= Number(!!isMultisigSigner) << 0
+    flags |= Number(!!isMultisigHardwareSigner) << 1
+
+    bw.writeU8(flags)
     bw.writeVarBytes(Buffer.from(value.publicKeyPackage, 'hex'))
-    if (isSignerMultisig(value)) {
+
+    if (isMultisigSigner) {
       bw.writeVarBytes(Buffer.from(value.secret, 'hex'))
       bw.writeVarBytes(Buffer.from(value.keyPackage, 'hex'))
-    } else if (isHardwareSignerMultisig(value)) {
+    } else if (isMultisigHardwareSigner) {
       bw.writeVarBytes(Buffer.from(value.identity, 'hex'))
     }
 


### PR DESCRIPTION
## Summary

Small refactor that removes duplicate calls to isSignerMultisig in various files.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
