### PR TITLE
Fix tests + schema for wallet/create endpoint

### DIFF
--- a/ironfish/src/rpc/routes/wallet/create.ts
+++ b/ironfish/src/rpc/routes/wallet/create.ts
@@ -8,11 +8,31 @@
  * is the verbObject naming convention. For example, `POST /wallet/burnAsset` burns an asset.
  */
 
+import * as yup from 'yup'
 import { RPC_ERROR_CODES, RpcValidationError } from '../../adapters'
 import { ApiNamespace } from '../namespaces'
 import { routes } from '../router'
 import { AssertHasRpcContext } from '../rpcContext'
-import { CreateAccountRequestSchema, CreateAccountResponse } from '../wallet'
+
+type CreateAccountRequest = {
+  name: string
+  default?: boolean
+  createdAt?: number | null
+}
+
+type CreateAccountResponse = {
+  name: string
+  publicAddress: string
+  isDefaultAccount: boolean
+}
+
+const CreateAccountRequestSchema: yup.ObjectSchema<CreateAccountRequest> = yup
+  .object({
+    name: yup.string().defined(),
+    default: yup.boolean().optional(),
+    createdAt: yup.number().optional().nullable(),
+  })
+  .defined()
 
 routes.register<typeof CreateAccountRequestSchema, CreateAccountResponse>(
   `${ApiNamespace.wallet}/create`,

--- a/ironfish/src/rpc/routes/wallet/createAccount.test.slow.ts
+++ b/ironfish/src/rpc/routes/wallet/createAccount.test.slow.ts
@@ -9,9 +9,8 @@ import { v4 as uuid } from 'uuid'
 import { createRouteTest } from '../../../testUtilities/routeTest'
 import { RPC_ERROR_CODES } from '../../adapters'
 import { RpcRequestError } from '../../clients/errors'
-import { CreateAccountResponse } from './createAccount'
 
-describe('Route wallet/create', () => {
+describe('Route wallet/createAccount', () => {
   jest.setTimeout(15000)
   const routeTest = createRouteTest()
 
@@ -28,8 +27,7 @@ describe('Route wallet/create', () => {
 
     const name = uuid()
 
-    const response = await routeTest.client.request(`wallet/create`, { name }).waitForEnd()
-
+    const response = await routeTest.client.wallet.createAccount({ name })
     expect(response.status).toBe(200)
     expect(response.content).toMatchObject({
       name: name,
@@ -40,7 +38,7 @@ describe('Route wallet/create', () => {
     const account = routeTest.node.wallet.getAccountByName(name)
     expect(account).toMatchObject({
       name: name,
-      publicAddress: (response.content as CreateAccountResponse).publicAddress,
+      publicAddress: response.content.publicAddress,
       createdAt: createdAtHead,
     })
   })
@@ -50,8 +48,7 @@ describe('Route wallet/create', () => {
 
     const name = uuid()
 
-    const response = await routeTest.client.request(`wallet/create`, { name }).waitForEnd()
-
+    const response = await routeTest.client.wallet.createAccount({ name })
     expect(response.content).toMatchObject({
       name: name,
       publicAddress: expect.any(String),
@@ -67,13 +64,13 @@ describe('Route wallet/create', () => {
 
     try {
       expect.assertions(2)
-      await routeTest.client.request(`wallet/create`, { name }).waitForEnd()
+      await routeTest.client.wallet.createAccount({ name: name })
     } catch (e: unknown) {
       if (!(e instanceof RpcRequestError)) {
         throw e
       }
       expect(e.status).toBe(400)
-      expect(e.code).toBe(RPC_ERROR_CODES.ACCOUNT_EXISTS)
+      expect(e.code).toBe(RPC_ERROR_CODES.DUPLICATE_ACCOUNT_NAME)
     }
   })
 
@@ -86,8 +83,7 @@ describe('Route wallet/create', () => {
 
     const name = uuid()
 
-    const response = await routeTest.client.request(`wallet/create`, { name }).waitForEnd()
-
+    const response = await routeTest.client.wallet.createAccount({ name })
     expect(response.status).toBe(200)
     expect(response.content).toMatchObject({
       name: name,
@@ -96,5 +92,55 @@ describe('Route wallet/create', () => {
     })
 
     expect(scanSpy).toHaveBeenCalled()
+  })
+
+  it('should set account createdAt if passed', async () => {
+    const name = uuid()
+    const createdAt = 10
+
+    const response = await routeTest.client.wallet.createAccount({
+      name,
+      createdAt,
+    })
+
+    expect(response.status).toBe(200)
+    expect(response.content).toMatchObject({
+      name: name,
+      publicAddress: expect.any(String),
+      isDefaultAccount: true,
+    })
+
+    const account = routeTest.node.wallet.getAccountByName(name)
+    expect(account).toMatchObject({
+      name: name,
+      publicAddress: response.content.publicAddress,
+      createdAt: {
+        hash: Buffer.alloc(32, 0),
+        sequence: 10,
+      },
+    })
+  })
+
+  it('should set account createdAt to null', async () => {
+    const name = uuid()
+
+    const response = await routeTest.client.wallet.createAccount({
+      name,
+      createdAt: null,
+    })
+
+    expect(response.status).toBe(200)
+    expect(response.content).toMatchObject({
+      name: name,
+      publicAddress: expect.any(String),
+      isDefaultAccount: true,
+    })
+
+    const account = routeTest.node.wallet.getAccountByName(name)
+    expect(account).toMatchObject({
+      name: name,
+      publicAddress: response.content.publicAddress,
+      createdAt: null,
+    })
   })
 })


### PR DESCRIPTION
## Summary
The wallet/create endpoint is being deprecated but it is not yet. We removed the tests so adding them back in. The endpoint also was not working as expected so fixing passing in the schema on register of the endpoint 

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
