### PR TITLE
adds multisigAccount boolean to account status

### DIFF
--- a/ironfish/src/rpc/routes/wallet/serializers.ts
+++ b/ironfish/src/rpc/routes/wallet/serializers.ts
@@ -12,6 +12,7 @@ import {
 } from '../../../wallet/exporter/multisig'
 import { AssetValue } from '../../../wallet/walletdb/assetValue'
 import { DecryptedNoteValue } from '../../../wallet/walletdb/decryptedNoteValue'
+import { isSignerMultisig } from '../../../wallet/walletdb/multisigKeys'
 import { TransactionValue } from '../../../wallet/walletdb/transactionValue'
 import {
   RpcAccountAssetBalanceDelta,
@@ -157,6 +158,9 @@ export async function serializeRpcAccountStatus(
   account: Account,
 ): Promise<RpcAccountStatus> {
   const head = await account.getHead()
+  const isMultisigAccount = account.multisigKeys
+    ? isSignerMultisig(account.multisigKeys)
+    : false
 
   return {
     name: account.name,
@@ -171,5 +175,6 @@ export async function serializeRpcAccountStatus(
     scanningEnabled: account.scanningEnabled,
     viewOnly: !account.isSpendingAccount(),
     default: wallet.getDefaultAccount()?.id === account.id,
+    multisigAccount: isMultisigAccount,
   }
 }

--- a/ironfish/src/rpc/routes/wallet/types.ts
+++ b/ironfish/src/rpc/routes/wallet/types.ts
@@ -173,6 +173,7 @@ export type RpcAccountStatus = {
   scanningEnabled: boolean
   viewOnly: boolean
   default: boolean
+  multisigAccount: boolean
 }
 
 export const RpcAccountStatusSchema: yup.ObjectSchema<RpcAccountStatus> = yup
@@ -190,5 +191,6 @@ export const RpcAccountStatusSchema: yup.ObjectSchema<RpcAccountStatus> = yup
     scanningEnabled: yup.boolean().defined(),
     viewOnly: yup.boolean().defined(),
     default: yup.boolean().defined(),
+    multisigAccount: yup.boolean().defined(),
   })
   .defined()


### PR DESCRIPTION
## Summary

signifies to the user that the account is a multisig account. This will be helpful in many usecases in the CLI and Node App.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
