### PR TITLE
logs warning if bootstrap node on different network

### DIFF
--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -17,6 +17,7 @@ import {
 import { PeerStore } from '../fileStores/peerStore'
 import { createRootLogger, Logger } from '../logger'
 import { MetricsMonitor } from '../metrics'
+import { renderNetworkName } from '../networks'
 import { FullNode } from '../node'
 import { IronfishPKG } from '../package'
 import { Platform } from '../platform'
@@ -379,7 +380,9 @@ export class PeerNetwork {
         if (message instanceof IdentifyMessage) {
           if (message.networkId !== this.networkId) {
             this.logger.warn(
-              `Bootstrap node ${node} is on network ${message.networkId} while we are on network ${this.networkId}`,
+              `Bootstrap node ${node} is on ${renderNetworkName(
+                message.networkId,
+              )} while we are on ${renderNetworkName(this.networkId)}`,
             )
           }
 

--- a/ironfish/src/network/peers/peer.ts
+++ b/ironfish/src/network/peers/peer.ts
@@ -662,7 +662,7 @@ export class Peer {
    */
   dispose(): void {
     this.onStateChanged.clearAfter()
-    this.onMessage.clear()
+    this.onMessage.clearAfter()
     this.onBanned.clear()
     this.disposeMessageMeter()
   }


### PR DESCRIPTION
## Summary

adds onMessage event handler to log a warning message if a bootstrap node is on a different network than the user's node

outputs the warning without requiring verbose output and specifies that the peer with the network mismatch is a bootstrap node

updates 'Peer.dispose' to use 'clearAfter' on 'onMessage' so that this second handler will still fire to log the warning even after disconnecting from the bootstrap node

Closes IFL-1217

## Testing Plan
run a testnet node and use the `--bootstrap` or `-b` flag to specify a mainnet bootstrap node, observe warning message
<img width="720" alt="image" src="https://github.com/user-attachments/assets/93fd99f2-5218-4db1-aafb-8c4ce79f3327">


## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
