### PR TITLE
Move transactions list command to index

### DIFF
--- a/ironfish-cli/src/commands/wallet/transactions/index.ts
+++ b/ironfish-cli/src/commands/wallet/transactions/index.ts
@@ -11,12 +11,12 @@ import {
   TransactionType,
 } from '@ironfish/sdk'
 import { Flags } from '@oclif/core'
-import { IronfishCommand } from '../../command'
-import { RemoteFlags } from '../../flags'
-import * as ui from '../../ui'
-import { getAssetsByIDs, useAccount } from '../../utils'
-import { extractChainportDataFromTransaction } from '../../utils/chainport'
-import { Format, TableCols } from '../../utils/table'
+import { IronfishCommand } from '../../../command'
+import { RemoteFlags } from '../../../flags'
+import * as ui from '../../../ui'
+import { getAssetsByIDs, useAccount } from '../../../utils'
+import { extractChainportDataFromTransaction } from '../../../utils/chainport'
+import { Format, TableCols } from '../../../utils/table'
 
 const { sort: _, ...tableFlags } = ui.TableFlags
 export class TransactionsCommand extends IronfishCommand {


### PR DESCRIPTION
## Summary

All other list commands are index.ts instead of a duplicated name file. Making this consistent.

## Testing Plan

1. `yarn clean`
1. `yarn build`
1. `yarn start wallet:transactions`

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
