### PR TITLE
Rust CI: run tests with `--no-default-features` and `--all-features`

### DIFF
--- a/.github/workflows/rust_ci.yml
+++ b/.github/workflows/rust_ci.yml
@@ -123,6 +123,58 @@ jobs:
           token: ${{secrets.CODECOV_TOKEN}}
           flags: ironfish-rust
 
+  ironfish_rust_no_default_features:
+    name: Test ironfish-rust (no default features)
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        shard: [1/2, 2/2]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: base
+
+      - name: Run tests
+        run: |
+          cargo nextest run \
+            --package ironfish \
+            --release \
+            --no-default-features \
+            --partition count:${{ matrix.shard }}
+
+  ironfish_rust_all_features:
+    name: Test ironfish-rust (all features)
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        shard: [1/2, 2/2]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: base
+
+      - name: Run tests (all features)
+        run: |
+          cargo nextest run \
+            --package ironfish \
+            --release \
+            --all-features \
+            --partition count:${{ matrix.shard }}
+
   ironfish_zkp:
     name: Test ironfish-zkp
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

This is to ensure that our code works with different Rust feature combinations.

This does not exercise *all* feature combinations, but a subset. The reason why we're using a subset are multiple:
* tests are slow and expensive
* exercising all combinations would be done with tools like [cargo-all-features](https://github.com/frewsxcv/cargo-all-features) that however do not support parallelization of tests
* even if the tools supported parallelization, integrating them with the GitHub CI wouldn't be straighforward

To make sure that all feature combinations at least *build* successfully, the clippy checks will be expanded in a future PR.

## Testing Plan

Example run for this PR: https://github.com/iron-fish/ironfish/actions/runs/11620113212?pr=5608

## Documentation

N/A

## Breaking Change

N/A