### PR TITLE
Rust CI: run `cargo check-all-features` instead of `cargo check`

### DIFF
--- a/.github/workflows/rust_ci.yml
+++ b/.github/workflows/rust_ci.yml
@@ -41,14 +41,6 @@ jobs:
           save-if: false
           shared-key: base
 
-      - name: Install Cargo tools
-        run: |
-          rustup component add rustfmt clippy
-
-      - name: Check that cargo lockfile is up to date
-        run: |
-          cargo check --locked --all-targets
-
       # Note: ironfish-zkp is does not need this due to different licensing
       - name: Check for license headers for ironfish-rust
         run: ./ci/lintHeaders.sh ./ironfish-rust/src *.rs
@@ -63,6 +55,26 @@ jobs:
       - name: "Clippy check on ironfish-rust"
         run: |
           cargo clippy --all-targets --all-features -- -D warnings
+
+  cargo_check:
+    name: Check Rust
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: false
+          shared-key: base
+
+      - name: Install cargo-all-features
+        run: |
+          cargo install --locked cargo-all-features
+
+      - name: Check that cargo lockfile is up to date
+        run: |
+          cargo check-all-features --locked --all-targets
 
   cargo_vet:
     name: Vet Dependencies


### PR DESCRIPTION
## Summary

This changes the Rust CI to run `cargo check` for every possible feature combination.

What `cargo check` does is compiling the Rust packages without performing the last step of code generation (see the [documentation](https://doc.rust-lang.org/cargo/commands/cargo-check.html)), which basically mean it will catch almost all build errors. Running `cargo check` for every feature combination helps ensuring that every combination can be built.

## Testing Plan

Example run: https://github.com/iron-fish/ironfish/actions/runs/11620444213/job/32362234716?pr=5609

## Documentation

N/A

## Breaking Change

N/A