### PR TITLE
chore(IFL-2545): adds default limit for table output to 50

### DIFF
--- a/ironfish-cli/src/commands/peers/banned.ts
+++ b/ironfish-cli/src/commands/peers/banned.ts
@@ -33,7 +33,7 @@ export class BannedCommand extends IronfishCommand {
     if (!flags.follow) {
       await this.sdk.client.connect()
       const response = await this.sdk.client.peer.getBannedPeers()
-      this.log(renderTable(response.content))
+      this.log(renderTable(response.content, flags.limit))
       this.exit(0)
     }
 
@@ -59,14 +59,14 @@ export class BannedCommand extends IronfishCommand {
 
       for await (const value of response.contentStream()) {
         text.clearBaseLine(0)
-        text.setContent(renderTable(value))
+        text.setContent(renderTable(value, flags.limit))
         screen.render()
       }
     }
   }
 }
 
-function renderTable(content: GetBannedPeersResponse): string {
+function renderTable(content: GetBannedPeersResponse, limit: number): string {
   const columns: TableColumns<BannedPeerResponse> = {
     identity: {
       minWidth: 45,
@@ -87,6 +87,7 @@ function renderTable(content: GetBannedPeersResponse): string {
   let result = ''
 
   table(content.peers, columns, {
+    limit,
     printLine: (line) => (result += `${String(line)}\n`),
   })
 

--- a/ironfish-cli/src/commands/wallet/assets.ts
+++ b/ironfish-cli/src/commands/wallet/assets.ts
@@ -52,68 +52,68 @@ export class AssetsCommand extends IronfishCommand {
     const assetNameWidth = flags.extended
       ? MAX_ASSET_NAME_COLUMN_WIDTH
       : MIN_ASSET_NAME_COLUMN_WIDTH
-    let showHeader = !flags['no-header']
-
+    const assets = []
     for await (const asset of response.contentStream()) {
-      table(
-        [asset],
-        {
-          name: TableCols.fixedWidth({
-            header: 'Name',
-            width: assetNameWidth,
-            get: (row) =>
-              renderAssetWithVerificationStatus(
-                BufferUtils.toHuman(Buffer.from(row.name, 'hex')),
-                {
-                  verification: row.verification,
-                  outputType: flags.output,
-                },
-              ),
-          }),
-          id: {
-            header: 'ID',
-            minWidth: ASSET_ID_LENGTH + 1,
-            get: (row) => row.id,
-          },
-          metadata: TableCols.fixedWidth({
-            header: 'Metadata',
-            width: assetMetadataWidth,
-            get: (row) => BufferUtils.toHuman(Buffer.from(row.metadata, 'hex')),
-          }),
-          createdTransactionHash: {
-            header: 'Created Transaction Hash',
-            get: (row) => row.createdTransactionHash,
-          },
-          supply: {
-            header: 'Supply',
-            minWidth: 16,
-            get: (row) => row.supply ?? 'NULL',
-          },
-          creator: {
-            header: 'Creator',
-            minWidth: PUBLIC_ADDRESS_LENGTH + 1,
-            get: (row) =>
-              row.id === Asset.nativeId().toString('hex')
-                ? BufferUtils.toHuman(Buffer.from(row.creator, 'hex'))
-                : row.creator,
-          },
-          owner: {
-            header: 'Owner',
-            minWidth: PUBLIC_ADDRESS_LENGTH + 1,
-            get: (row) =>
-              row.id === Asset.nativeId().toString('hex')
-                ? BufferUtils.toHuman(Buffer.from(row.owner, 'hex'))
-                : row.owner,
-          },
-        },
-        {
-          printLine: this.log.bind(this),
-          ...flags,
-          'no-header': !showHeader,
-        },
-      )
-
-      showHeader = false
+      assets.push(asset)
+      if (assets.length >= flags.limit) {
+        break
+      }
     }
+    table(
+      assets,
+      {
+        name: TableCols.fixedWidth({
+          header: 'Name',
+          width: assetNameWidth,
+          get: (row) =>
+            renderAssetWithVerificationStatus(
+              BufferUtils.toHuman(Buffer.from(row.name, 'hex')),
+              {
+                verification: row.verification,
+                outputType: flags.output,
+              },
+            ),
+        }),
+        id: {
+          header: 'ID',
+          minWidth: ASSET_ID_LENGTH + 1,
+          get: (row) => row.id,
+        },
+        metadata: TableCols.fixedWidth({
+          header: 'Metadata',
+          width: assetMetadataWidth,
+          get: (row) => BufferUtils.toHuman(Buffer.from(row.metadata, 'hex')),
+        }),
+        createdTransactionHash: {
+          header: 'Created Transaction Hash',
+          get: (row) => row.createdTransactionHash,
+        },
+        supply: {
+          header: 'Supply',
+          minWidth: 16,
+          get: (row) => row.supply ?? 'NULL',
+        },
+        creator: {
+          header: 'Creator',
+          minWidth: PUBLIC_ADDRESS_LENGTH + 1,
+          get: (row) =>
+            row.id === Asset.nativeId().toString('hex')
+              ? BufferUtils.toHuman(Buffer.from(row.creator, 'hex'))
+              : row.creator,
+        },
+        owner: {
+          header: 'Owner',
+          minWidth: PUBLIC_ADDRESS_LENGTH + 1,
+          get: (row) =>
+            row.id === Asset.nativeId().toString('hex')
+              ? BufferUtils.toHuman(Buffer.from(row.owner, 'hex'))
+              : row.owner,
+        },
+      },
+      {
+        printLine: this.log.bind(this),
+        ...flags,
+      },
+    )
   }
 }

--- a/ironfish-cli/src/ui/table.ts
+++ b/ironfish-cli/src/ui/table.ts
@@ -30,6 +30,7 @@ export interface TableOptions {
   output?: string
   printLine?(this: void, s: unknown): unknown
   sort?: string
+  limit?: number
 }
 
 export const TableFlags = {
@@ -50,6 +51,10 @@ export const TableFlags = {
   }),
   sort: Flags.string({
     description: "property to sort by (prepend '-' for descending)",
+  }),
+  limit: Flags.integer({
+    description: 'the number of rows to display, 0 will show all rows',
+    default: 50,
   }),
 }
 
@@ -82,6 +87,7 @@ class Table<T extends Record<string, unknown>> {
       output: options.csv ? 'csv' : options.output,
       printLine: options.printLine ?? ux.stdout.bind(ux),
       sort: options.sort,
+      limit: options.limit ?? 50,
     }
   }
 
@@ -168,7 +174,6 @@ class Table<T extends Record<string, unknown>> {
     for (const column of this.columns) {
       column.width = maxColumnLength(column, rows)
     }
-
     if (!this.options['no-header']) {
       // Print headers
       const columnHeaders = []
@@ -199,7 +204,8 @@ class Table<T extends Record<string, unknown>> {
     }
 
     // Print rows
-    for (const row of rows) {
+    const slicedRows = this.options.limit ? rows.slice(0, this.options.limit) : rows
+    for (const row of slicedRows) {
       const rowValues = []
       for (const [key, value] of Object.entries(row)) {
         const column = this.columns.find((c) => c.key === key)
@@ -209,6 +215,9 @@ class Table<T extends Record<string, unknown>> {
         rowValues.push(`${value}${' '.repeat(spacerLength)}`)
       }
       this.options.printLine(` ${rowValues.join(' ')}`)
+    }
+    if (this.options.limit && this.options.limit <= 0 && rows.length >= this.options.limit) {
+      this.options.printLine(`...\n[see more rows by using --limit flag]`)
     }
   }
 }


### PR DESCRIPTION
## Summary
- adds default limit for table output to 50
- prints message at end of table if limit is reached
- updates commands to handle limit
- Intentionally excluded table command updates for: multisig, genesis, and combine notes
- Did not update print to occur on csv/json

## Testing Plan
Tested all updated commands with `--limit 1`
```
     Timestamp                  Status       Type     Hash                                                             Expiration Submitted Sequence Fee Paid ($IRON) Asset                     Amount          
 ─── ────────────────────────── ──────────── ──────── ──────────────────────────────────────────────────────────────── ────────── ────────────────── ──────────────── ───────────────────────── ────────────────
     10/28/2024 2:45:48 PM PDT  confirmed    send     dc6116865d0e4e92df1e75c94afd951d6d2ca40eddd71b0900bcd270fa149bce 738792     738778             0.00000010       NORI              (f3b28) -1              
...
[see more rows by using --limit flag]
```
## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
