### PR TITLE
Pass hash into createdAt for new account

### DIFF
--- a/ironfish/src/rpc/routes/wallet/createAccount.test.ts
+++ b/ironfish/src/rpc/routes/wallet/createAccount.test.ts
@@ -95,7 +95,10 @@ describe('Route wallet/createAccount', () => {
 
   it('should set account createdAt if passed', async () => {
     const name = uuid()
-    const createdAt = 10
+    const createdAt = {
+      sequence: 10,
+      hash: '000000000001743343a9e9514bfeed210af3576f4b867d17c95c23007c282930',
+    }
 
     const response = await routeTest.client.wallet.createAccount({
       name,
@@ -109,37 +112,22 @@ describe('Route wallet/createAccount', () => {
       isDefaultAccount: true,
     })
 
+    const expectedHeadValue = {
+      hash: Buffer.from(
+        '000000000001743343a9e9514bfeed210af3576f4b867d17c95c23007c282930',
+        'hex',
+      ),
+      sequence: 10,
+    }
     const account = routeTest.node.wallet.getAccountByName(name)
+
     expect(account).toMatchObject({
       name: name,
       publicAddress: response.content.publicAddress,
-      createdAt: {
-        hash: Buffer.alloc(32, 0),
-        sequence: 10,
-      },
-    })
-  })
-
-  it('should set account createdAt to null', async () => {
-    const name = uuid()
-
-    const response = await routeTest.client.wallet.createAccount({
-      name,
-      createdAt: null,
+      createdAt: expectedHeadValue,
     })
 
-    expect(response.status).toBe(200)
-    expect(response.content).toMatchObject({
-      name: name,
-      publicAddress: expect.any(String),
-      isDefaultAccount: true,
-    })
-
-    const account = routeTest.node.wallet.getAccountByName(name)
-    expect(account).toMatchObject({
-      name: name,
-      publicAddress: response.content.publicAddress,
-      createdAt: null,
-    })
+    const head = await account?.getHead()
+    expect(head).toMatchObject(expectedHeadValue)
   })
 })


### PR DESCRIPTION
## Summary
Simple passing in the `sequence` for an account birthday does not have the intended behavior when the chain is not yet synced. This is the case that needs to be solved when creating a fresh account in the node app before syncing or snapshotting. If we don't want to refactor the wallet syncer the only way to skip syncing alltogether is to pass in a hash along with the sequence for the account birthday

## Testing Plan
Unit tests + tested with the node app syncing from snapshot and from peers

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
