### PR TITLE
Enable the `unused_qualifications` lint for our Rust crates

### DIFF
--- a/ironfish-rust-nodejs/src/lib.rs
+++ b/ironfish-rust-nodejs/src/lib.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#![warn(unused_qualifications)]
+
 use std::fmt::Display;
 use std::num::NonZeroUsize;
 
@@ -31,7 +33,7 @@ pub mod xchacha20poly1305;
 #[cfg(feature = "stats")]
 pub mod stats;
 
-fn to_napi_err(err: impl Display) -> napi::Error {
+fn to_napi_err(err: impl Display) -> Error {
     Error::from_reason(err.to_string())
 }
 

--- a/ironfish-rust-nodejs/src/nacl.rs
+++ b/ironfish-rust-nodejs/src/nacl.rs
@@ -37,7 +37,7 @@ impl BoxKeyPair {
     }
 
     #[napi(factory)]
-    pub fn from_hex(secret_hex: String) -> napi::Result<BoxKeyPair> {
+    pub fn from_hex(secret_hex: String) -> Result<BoxKeyPair> {
         let bytes: [u8; nacl::KEY_LENGTH] =
             hex_to_bytes(&secret_hex).map_err(|_| to_napi_err("Unable to decode secret key"))?;
 

--- a/ironfish-rust/src/keys/public_address.rs
+++ b/ironfish-rust/src/keys/public_address.rs
@@ -94,7 +94,7 @@ impl std::fmt::Debug for PublicAddress {
     }
 }
 
-impl std::cmp::PartialEq for PublicAddress {
+impl PartialEq for PublicAddress {
     fn eq(&self, other: &Self) -> bool {
         self.hex_public_address() == other.hex_public_address()
     }

--- a/ironfish-rust/src/keys/view_keys.rs
+++ b/ironfish-rust/src/keys/view_keys.rs
@@ -110,11 +110,11 @@ pub struct ViewKey {
     /// Part of the full viewing key. Generally referred to as
     /// `ak` in the literature. Derived from spend_authorizing_key using scalar
     /// multiplication in Sapling. Used to construct incoming viewing key.
-    pub authorizing_key: ironfish_jubjub::SubgroupPoint,
+    pub authorizing_key: SubgroupPoint,
     /// Part of the full viewing key. Generally referred to as
     /// `nk` in the literature. Derived from proof_authorizing_key using scalar
     /// multiplication. Used to construct incoming viewing key.
-    pub nullifier_deriving_key: ironfish_jubjub::SubgroupPoint,
+    pub nullifier_deriving_key: SubgroupPoint,
 }
 
 impl ViewKey {

--- a/ironfish-rust/src/lib.rs
+++ b/ironfish-rust/src/lib.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#![warn(unused_qualifications)]
+
 #[cfg(feature = "transaction-proofs")]
 mod sapling;
 

--- a/ironfish-rust/src/note.rs
+++ b/ironfish-rust/src/note.rs
@@ -27,6 +27,7 @@ use ironfish_zkp::{
 };
 use rand::thread_rng;
 use std::{fmt, io, io::Read};
+
 pub const ENCRYPTED_NOTE_SIZE: usize =
     SCALAR_SIZE + MEMO_SIZE + AMOUNT_VALUE_SIZE + ASSET_ID_LENGTH + PUBLIC_ADDRESS_SIZE;
 //   8  value
@@ -136,7 +137,7 @@ impl Note {
     ///
     /// You probably don't want to use this unless you are transmitting
     /// across nodejs threads in memory.
-    pub fn read<R: io::Read>(mut reader: R) -> Result<Self, IronfishError> {
+    pub fn read<R: Read>(mut reader: R) -> Result<Self, IronfishError> {
         let owner = PublicAddress::read(&mut reader)?;
 
         let asset_id = AssetIdentifier::read(&mut reader)?;
@@ -286,7 +287,7 @@ impl Note {
     }
 
     /// Computes the note commitment, returning the full point.
-    fn commitment_full_point(&self) -> ironfish_jubjub::SubgroupPoint {
+    fn commitment_full_point(&self) -> SubgroupPoint {
         commitment_full_point(
             self.asset_generator(),
             self.value,

--- a/ironfish-rust/src/transaction/mints.rs
+++ b/ironfish-rust/src/transaction/mints.rs
@@ -207,7 +207,7 @@ pub struct MintDescription {
     /// Signature of the creator authorizing the mint action. This value is
     /// calculated after the transaction is signed since the value is dependent
     /// on the binding signature key
-    pub authorizing_signature: redjubjub::Signature,
+    pub authorizing_signature: Signature,
 }
 
 impl MintDescription {

--- a/ironfish-rust/src/transaction/mod.rs
+++ b/ironfish-rust/src/transaction/mod.rs
@@ -153,7 +153,7 @@ impl Transaction {
 
     /// Store the bytes of this transaction in the given writer. This is used
     /// to serialize transactions to file or network
-    pub fn write<W: io::Write>(&self, mut writer: W) -> Result<(), IronfishError> {
+    pub fn write<W: Write>(&self, mut writer: W) -> Result<(), IronfishError> {
         self.version.write(&mut writer)?;
         writer.write_u64::<LittleEndian>(self.spends.len() as u64)?;
         writer.write_u64::<LittleEndian>(self.outputs.len() as u64)?;

--- a/ironfish-rust/src/transaction/unsigned.rs
+++ b/ironfish-rust/src/transaction/unsigned.rs
@@ -127,7 +127,7 @@ impl UnsignedTransaction {
 
     /// Store the bytes of this transaction in the given writer. This is used
     /// to serialize transactions to file or network
-    pub fn write<W: io::Write>(&self, mut writer: W) -> Result<(), IronfishError> {
+    pub fn write<W: Write>(&self, mut writer: W) -> Result<(), IronfishError> {
         self.version.write(&mut writer)?;
         writer.write_u64::<LittleEndian>(self.spends.len() as u64)?;
         writer.write_u64::<LittleEndian>(self.outputs.len() as u64)?;

--- a/ironfish-rust/src/witness.rs
+++ b/ironfish-rust/src/witness.rs
@@ -5,14 +5,14 @@
 use blstrs::Scalar;
 
 use super::MerkleNoteHash;
-use std::fmt::{self, Debug};
+use std::fmt;
 
 /// Witness to a specific node in an authentication path.
 ///
 /// The Left/Right is the Hash of THIS node, but the MerkleHash at node.0 is
 /// the hash of the SIBLING node.
 #[derive(PartialEq, Eq, Debug, Clone)]
-pub enum WitnessNode<H: Clone + PartialEq + Debug> {
+pub enum WitnessNode<H: Clone + PartialEq + fmt::Debug> {
     Left(H),
     Right(H),
 }

--- a/ironfish-zkp/src/circuits/util.rs
+++ b/ironfish-zkp/src/circuits/util.rs
@@ -56,7 +56,7 @@ pub fn expose_value_commitment<CS>(
     mut cs: CS,
     asset_generator: EdwardsPoint,
     value_commitment: Option<ValueCommitment>,
-) -> Result<Vec<boolean::Boolean>, SynthesisError>
+) -> Result<Vec<Boolean>, SynthesisError>
 where
     CS: ConstraintSystem<blstrs::Scalar>,
 {
@@ -110,7 +110,7 @@ where
     Ok(value_bits)
 }
 
-pub fn assert_valid_asset_generator<CS: ironfish_bellperson::ConstraintSystem<blstrs::Scalar>>(
+pub fn assert_valid_asset_generator<CS: ConstraintSystem<blstrs::Scalar>>(
     mut cs: CS,
     asset_id: &[u8; ASSET_ID_LENGTH],
     asset_generator_repr: &[Boolean],

--- a/ironfish-zkp/src/lib.rs
+++ b/ironfish-zkp/src/lib.rs
@@ -1,3 +1,5 @@
+#![warn(unused_qualifications)]
+
 mod circuits;
 pub mod constants;
 pub mod hex;

--- a/ironfish-zkp/src/primitives/value_commitment.rs
+++ b/ironfish-zkp/src/primitives/value_commitment.rs
@@ -2,7 +2,7 @@ use byteorder::{LittleEndian, ReadBytesExt};
 use ff::Field;
 use group::{cofactor::CofactorGroup, GroupEncoding};
 
-use ironfish_jubjub::ExtendedPoint;
+use ironfish_jubjub::{ExtendedPoint, Fr};
 use rand::thread_rng;
 
 use crate::constants::VALUE_COMMITMENT_RANDOMNESS_GENERATOR;
@@ -12,21 +12,21 @@ use crate::constants::VALUE_COMMITMENT_RANDOMNESS_GENERATOR;
 #[derive(Clone)]
 pub struct ValueCommitment {
     pub value: u64,
-    pub randomness: ironfish_jubjub::Fr,
-    pub asset_generator: ironfish_jubjub::ExtendedPoint,
+    pub randomness: Fr,
+    pub asset_generator: ExtendedPoint,
 }
 
 impl ValueCommitment {
-    pub fn new(value: u64, asset_generator: ironfish_jubjub::ExtendedPoint) -> Self {
+    pub fn new(value: u64, asset_generator: ExtendedPoint) -> Self {
         Self {
             value,
-            randomness: ironfish_jubjub::Fr::random(thread_rng()),
+            randomness: Fr::random(thread_rng()),
             asset_generator,
         }
     }
 
     pub fn commitment(&self) -> ironfish_jubjub::SubgroupPoint {
-        (self.asset_generator.clear_cofactor() * ironfish_jubjub::Fr::from(self.value))
+        (self.asset_generator.clear_cofactor() * Fr::from(self.value))
             + (*VALUE_COMMITMENT_RANDOMNESS_GENERATOR * self.randomness)
     }
 
@@ -47,7 +47,7 @@ impl ValueCommitment {
         let value = reader.read_u64::<LittleEndian>()?;
         let mut randomness_bytes = [0u8; 32];
         reader.read_exact(&mut randomness_bytes)?;
-        let randomness = ironfish_jubjub::Fr::from_bytes(&randomness_bytes).unwrap();
+        let randomness = Fr::from_bytes(&randomness_bytes).unwrap();
         let mut asset_generator = [0u8; 32];
         reader.read_exact(&mut asset_generator)?;
         let asset_generator = ExtendedPoint::from_bytes(&asset_generator).unwrap();
@@ -61,11 +61,11 @@ impl ValueCommitment {
 
 #[cfg(test)]
 mod test {
+    use crate::primitives::ValueCommitment;
     use ff::Field;
     use group::{Group, GroupEncoding};
+    use ironfish_jubjub::{ExtendedPoint, Fr};
     use rand::{rngs::StdRng, thread_rng, SeedableRng};
-
-    use crate::primitives::ValueCommitment;
 
     #[test]
     fn test_value_commitment() {
@@ -74,8 +74,8 @@ mod test {
 
         let value_commitment = ValueCommitment {
             value: 5,
-            randomness: ironfish_jubjub::Fr::random(&mut rng),
-            asset_generator: ironfish_jubjub::ExtendedPoint::random(&mut rng),
+            randomness: Fr::random(&mut rng),
+            asset_generator: ExtendedPoint::random(&mut rng),
         };
 
         let commitment = value_commitment.commitment();
@@ -91,7 +91,7 @@ mod test {
 
     #[test]
     fn test_value_commitment_new() {
-        let generator = ironfish_jubjub::ExtendedPoint::random(thread_rng());
+        let generator = ExtendedPoint::random(thread_rng());
         let value = 5;
 
         let value_commitment = ValueCommitment::new(value, generator);
@@ -105,9 +105,9 @@ mod test {
         // Seed a fixed rng for determinism in the test
         let mut rng = StdRng::seed_from_u64(0);
 
-        let randomness = ironfish_jubjub::Fr::random(&mut rng);
+        let randomness = Fr::random(&mut rng);
 
-        let asset_generator_one = ironfish_jubjub::ExtendedPoint::random(&mut rng);
+        let asset_generator_one = ExtendedPoint::random(&mut rng);
 
         let value_commitment_one = ValueCommitment {
             value: 5,
@@ -117,7 +117,7 @@ mod test {
 
         let commitment_one = value_commitment_one.commitment();
 
-        let asset_generator_two = ironfish_jubjub::ExtendedPoint::random(&mut rng);
+        let asset_generator_two = ExtendedPoint::random(&mut rng);
 
         let value_commitment_two = ValueCommitment {
             value: 5,
@@ -145,9 +145,9 @@ mod test {
         // Seed a fixed rng for determinism in the test
         let mut rng = StdRng::seed_from_u64(0);
 
-        let randomness_one = ironfish_jubjub::Fr::random(&mut rng);
+        let randomness_one = Fr::random(&mut rng);
 
-        let asset_generator = ironfish_jubjub::ExtendedPoint::random(&mut rng);
+        let asset_generator = ExtendedPoint::random(&mut rng);
 
         let value_commitment_one = ValueCommitment {
             value: 5,
@@ -157,7 +157,7 @@ mod test {
 
         let commitment_one = value_commitment_one.commitment();
 
-        let randomness_two = ironfish_jubjub::Fr::random(&mut rng);
+        let randomness_two = Fr::random(&mut rng);
 
         let value_commitment_two = ValueCommitment {
             value: 5,
@@ -184,8 +184,8 @@ mod test {
 
         let value_one = 5;
 
-        let randomness = ironfish_jubjub::Fr::random(&mut rng);
-        let asset_generator = ironfish_jubjub::ExtendedPoint::random(&mut rng);
+        let randomness = Fr::random(&mut rng);
+        let asset_generator = ExtendedPoint::random(&mut rng);
 
         let value_commitment_one = ValueCommitment {
             value: value_one,
@@ -226,8 +226,8 @@ mod test {
 
         let value_commitment = ValueCommitment {
             value: 5,
-            randomness: ironfish_jubjub::Fr::random(&mut rng),
-            asset_generator: ironfish_jubjub::ExtendedPoint::random(&mut rng),
+            randomness: Fr::random(&mut rng),
+            asset_generator: ExtendedPoint::random(&mut rng),
         };
 
         // Serialize to bytes


### PR DESCRIPTION
## Summary

## Testing Plan

* Unit tests
* `cargo clippy`

## Documentation

N/A

## Breaking Change

N/A