### PR TITLE
Enable the `unreachable_pub` lint for our Rust crates

### DIFF
--- a/ironfish-rust-nodejs/src/lib.rs
+++ b/ironfish-rust-nodejs/src/lib.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#![warn(unreachable_pub)]
 #![warn(unused_qualifications)]
 
 use std::fmt::Display;

--- a/ironfish-rust/src/lib.rs
+++ b/ironfish-rust/src/lib.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#![warn(unreachable_pub)]
 #![warn(unused_qualifications)]
 
 #[cfg(feature = "transaction-proofs")]

--- a/ironfish-rust/src/mining/thread.rs
+++ b/ironfish-rust/src/mining/thread.rs
@@ -11,7 +11,7 @@ use super::mine;
 use fish_hash::Context;
 
 #[derive(Debug)]
-pub(crate) enum Command {
+pub(super) enum Command {
     NewWork(
         Vec<u8>, // header bytes
         Vec<u8>, // target
@@ -23,17 +23,17 @@ pub(crate) enum Command {
     Pause,
 }
 
-pub struct FishHashOptions {
-    pub enabled: bool,
-    pub full_context: bool,
+pub(super) struct FishHashOptions {
+    pub(super) enabled: bool,
+    pub(super) full_context: bool,
 }
 
-pub(crate) struct Thread {
+pub(super) struct Thread {
     command_channel: Sender<Command>,
 }
 
 impl Thread {
-    pub(crate) fn new(
+    pub(super) fn new(
         id: u64,
         block_found_channel: Sender<(u64, u32)>,
         hash_rate_channel: Sender<u32>,
@@ -76,7 +76,7 @@ impl Thread {
         }
     }
 
-    pub(crate) fn new_work(
+    pub(super) fn new_work(
         &self,
         header_bytes: Vec<u8>,
         target: Vec<u8>,
@@ -93,11 +93,11 @@ impl Thread {
         ))
     }
 
-    pub(crate) fn pause(&self) -> Result<(), SendError<Command>> {
+    pub(super) fn pause(&self) -> Result<(), SendError<Command>> {
         self.command_channel.send(Command::Pause)
     }
 
-    pub(crate) fn stop(&self) -> Result<(), SendError<Command>> {
+    pub(super) fn stop(&self) -> Result<(), SendError<Command>> {
         self.command_channel.send(Command::Stop)
     }
 }

--- a/ironfish-rust/src/transaction/value_balances.rs
+++ b/ironfish-rust/src/transaction/value_balances.rs
@@ -8,12 +8,12 @@ use crate::{
     errors::{IronfishError, IronfishErrorKind},
 };
 
-pub struct ValueBalances {
+pub(super) struct ValueBalances {
     values: HashMap<AssetIdentifier, i64>,
 }
 
 impl ValueBalances {
-    pub fn new() -> Self {
+    pub(super) fn new() -> Self {
         let mut hash_map = HashMap::default();
 
         hash_map.insert(NATIVE_ASSET, 0);
@@ -21,7 +21,11 @@ impl ValueBalances {
         ValueBalances { values: hash_map }
     }
 
-    pub fn add(&mut self, asset_id: &AssetIdentifier, value: i64) -> Result<(), IronfishError> {
+    pub(super) fn add(
+        &mut self,
+        asset_id: &AssetIdentifier,
+        value: i64,
+    ) -> Result<(), IronfishError> {
         let current_value = self.values.entry(*asset_id).or_insert(0);
         let new_value = current_value
             .checked_add(value)
@@ -32,7 +36,7 @@ impl ValueBalances {
         Ok(())
     }
 
-    pub fn subtract(
+    pub(super) fn subtract(
         &mut self,
         asset_id: &AssetIdentifier,
         value: i64,
@@ -47,11 +51,11 @@ impl ValueBalances {
         Ok(())
     }
 
-    pub fn iter(&self) -> hash_map::Iter<AssetIdentifier, i64> {
+    pub(super) fn iter(&self) -> hash_map::Iter<AssetIdentifier, i64> {
         self.values.iter()
     }
 
-    pub fn fee(&self) -> &i64 {
+    pub(super) fn fee(&self) -> &i64 {
         self.values.get(&NATIVE_ASSET).unwrap()
     }
 }

--- a/ironfish-zkp/src/circuits/mod.rs
+++ b/ironfish-zkp/src/circuits/mod.rs
@@ -1,4 +1,4 @@
-pub mod mint_asset;
-pub mod output;
-pub mod spend;
-pub mod util;
+pub(crate) mod mint_asset;
+pub(crate) mod output;
+pub(crate) mod spend;
+pub(crate) mod util;

--- a/ironfish-zkp/src/circuits/util.rs
+++ b/ironfish-zkp/src/circuits/util.rs
@@ -17,7 +17,7 @@ use crate::{
     primitives::ValueCommitment,
 };
 
-pub fn slice_into_boolean_vec_le<Scalar: PrimeField, CS: ConstraintSystem<Scalar>>(
+fn slice_into_boolean_vec_le<Scalar: PrimeField, CS: ConstraintSystem<Scalar>>(
     mut cs: CS,
     value: Option<&[u8]>,
     byte_length: u32,
@@ -52,7 +52,7 @@ pub fn slice_into_boolean_vec_le<Scalar: PrimeField, CS: ConstraintSystem<Scalar
 
 /// Exposes a Pedersen commitment to the value as an
 /// input to the circuit
-pub fn expose_value_commitment<CS>(
+pub(crate) fn expose_value_commitment<CS>(
     mut cs: CS,
     asset_generator: EdwardsPoint,
     value_commitment: Option<ValueCommitment>,
@@ -110,7 +110,7 @@ where
     Ok(value_bits)
 }
 
-pub fn assert_valid_asset_generator<CS: ConstraintSystem<blstrs::Scalar>>(
+pub(crate) fn assert_valid_asset_generator<CS: ConstraintSystem<blstrs::Scalar>>(
     mut cs: CS,
     asset_id: &[u8; ASSET_ID_LENGTH],
     asset_generator_repr: &[Boolean],

--- a/ironfish-zkp/src/lib.rs
+++ b/ironfish-zkp/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(unreachable_pub)]
 #![warn(unused_qualifications)]
 
 mod circuits;


### PR DESCRIPTION
## Summary

## Testing Plan

* Unit tests
* `cargo clippy`

## Documentation

N/A

## Breaking Change

N/A