### PR TITLE
Enable lints for unused code/dependencies in our Rust crates

### DIFF
--- a/ironfish-rust-nodejs/src/lib.rs
+++ b/ironfish-rust-nodejs/src/lib.rs
@@ -2,7 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#![warn(clippy::dbg_macro)]
+#![warn(clippy::print_stderr)]
+#![warn(clippy::print_stdout)]
 #![warn(unreachable_pub)]
+#![warn(unused_crate_dependencies)]
+#![warn(unused_macro_rules)]
 #![warn(unused_qualifications)]
 
 use std::fmt::Display;

--- a/ironfish-rust/src/lib.rs
+++ b/ironfish-rust/src/lib.rs
@@ -2,7 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#![warn(clippy::dbg_macro)]
+#![warn(clippy::print_stderr)]
+#![warn(clippy::print_stdout)]
 #![warn(unreachable_pub)]
+#![warn(unused_crate_dependencies)]
+#![warn(unused_macro_rules)]
 #![warn(unused_qualifications)]
 
 #[cfg(feature = "transaction-proofs")]

--- a/ironfish-rust/src/mining/thread.rs
+++ b/ironfish-rust/src/mining/thread.rs
@@ -192,8 +192,7 @@ fn process_commands(
                     }
 
                     if remaining_search_space < default_batch_size {
-                        // miner has exhausted it's search space, stop mining
-                        println!("Search space exhausted, no longer mining this block.");
+                        // miner has exhausted its search space, stop mining
                         break;
                     }
                     batch_start += batch_size + step_size as u64 - (batch_size % step_size as u64);

--- a/ironfish-zkp/src/lib.rs
+++ b/ironfish-zkp/src/lib.rs
@@ -1,4 +1,9 @@
+#![warn(clippy::dbg_macro)]
+#![warn(clippy::print_stderr)]
+#![warn(clippy::print_stdout)]
 #![warn(unreachable_pub)]
+#![warn(unused_crate_dependencies)]
+#![warn(unused_macro_rules)]
 #![warn(unused_qualifications)]
 
 mod circuits;


### PR DESCRIPTION
## Summary

Also forbid the use of `println!`, `eprintln!`, `dbg!` and similar invocations, which should not be allowed in a library.

## Testing Plan

* Unit tests
* `cargo clippy`

## Documentation

N/A

## Breaking Change

N/A