### PR TITLE
Pass in account head to wallet/createAccount

### DIFF
--- a/ironfish/src/rpc/routes/wallet/create.test.ts
+++ b/ironfish/src/rpc/routes/wallet/create.test.ts
@@ -21,7 +21,7 @@ describe('Route wallet/create', () => {
   it('should create an account', async () => {
     await routeTest.node.wallet.createAccount('existingAccount', { setDefault: true })
     const createdAtHead = {
-      hash: routeTest.node.chain.head.hash,
+      hash: Buffer.alloc(32, 0),
       sequence: routeTest.node.chain.head.sequence,
     }
 

--- a/ironfish/src/testUtilities/fixtures/account.ts
+++ b/ironfish/src/testUtilities/fixtures/account.ts
@@ -11,7 +11,7 @@ import { FixtureGenerate, useFixture } from './fixture'
 export function useAccountFixture(
   wallet: Wallet,
   generate: FixtureGenerate<SpendingAccount> | string = 'test',
-  options?: { createdAt?: HeadValue | null; setDefault?: boolean },
+  options?: Parameters<Wallet['createAccount']>[1],
 ): Promise<SpendingAccount> {
   if (typeof generate === 'string') {
     const name = generate
@@ -61,7 +61,7 @@ export async function useAccountAndAddFundsFixture(
   wallet: Wallet,
   chain: Blockchain,
   generate: FixtureGenerate<SpendingAccount> | string = 'test',
-  options?: { createdAt?: HeadValue | null; setDefault?: boolean },
+  options?: Parameters<Wallet['createAccount']>[1],
 ): Promise<SpendingAccount> {
   const account = await useAccountFixture(wallet, generate, options)
   const block = await useMinerBlockFixture(chain, undefined, account)

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -1355,7 +1355,7 @@ export class Wallet {
 
   async createAccount(
     name: string,
-    options: { createdAt?: HeadValue | null; setDefault?: boolean } = {
+    options: { setDefault?: boolean; createdAt?: number | null; head?: HeadValue | null } = {
       setDefault: false,
     },
   ): Promise<Account> {
@@ -1369,16 +1369,11 @@ export class Wallet {
 
     const key = generateKey()
 
-    let createdAt: HeadValue | null = null
-    if (options.createdAt !== undefined) {
-      createdAt = options.createdAt
-    } else if (this.nodeClient) {
-      try {
-        createdAt = await this.getChainHead()
-      } catch {
-        this.logger.warn('Failed to fetch chain head from node client')
-      }
-    }
+    const createdAt = await this.createdAtWithDefault(options.createdAt)
+    const accountHead =
+      options.head === undefined
+        ? await this.getAccountHeadFromCreatedAt(createdAt && createdAt.sequence)
+        : options.head
 
     const account = new Account({
       accountValue: {
@@ -1413,7 +1408,7 @@ export class Wallet {
         await this.walletDb.setAccount(account, tx)
       }
 
-      await account.updateHead(createdAt, tx)
+      await account.updateHead(accountHead, tx)
     })
 
     this.accountById.set(account.id, account)
@@ -1423,6 +1418,58 @@ export class Wallet {
     }
 
     return account
+  }
+
+  /*
+   * Use createdAt if provided, otherwise use the current chain head
+   */
+  private async createdAtWithDefault(createdAt?: number | null): Promise<HeadValue | null> {
+    if (createdAt === null) {
+      return null
+    }
+
+    if (createdAt === undefined) {
+      try {
+        const sequence = (await this.getChainHead()).sequence
+        return {
+          sequence,
+          hash: Buffer.alloc(32, 0),
+        }
+      } catch {
+        this.logger.warn('Failed to fetch chain head from node client')
+        return null
+      }
+    }
+
+    return {
+      sequence: createdAt,
+      hash: Buffer.alloc(32, 0),
+    }
+  }
+
+  /*
+   * Try to get the block hash from the chain with createdAt sequence
+   * Otherwise, return null
+   */
+  private async getAccountHeadFromCreatedAt(
+    createdAt: number | null,
+  ): Promise<HeadValue | null> {
+    if (createdAt === null) {
+      return null
+    }
+
+    try {
+      const previousBlock = await this.chainGetBlock({ sequence: createdAt - 1 })
+      return previousBlock
+        ? {
+            hash: Buffer.from(previousBlock.block.hash, 'hex'),
+            sequence: previousBlock.block.sequence,
+          }
+        : null
+    } catch {
+      this.logger.warn(`Failed to fetch block ${createdAt - 1} from node client`)
+      return null
+    }
   }
 
   async skipRescan(account: Account, tx?: IDatabaseTransaction): Promise<void> {
@@ -1544,20 +1591,11 @@ export class Wallet {
         }
       }
 
-      if (createdAt !== null) {
-        const previousBlock = await this.chainGetBlock({ sequence: createdAt.sequence - 1 })
+      const accountHead = await this.getAccountHeadFromCreatedAt(
+        createdAt && createdAt.sequence,
+      )
 
-        const head = previousBlock
-          ? {
-              hash: Buffer.from(previousBlock.block.hash, 'hex'),
-              sequence: previousBlock.block.sequence,
-            }
-          : null
-
-        await account.updateHead(head, tx)
-      } else {
-        await account.updateHead(null, tx)
-      }
+      await account.updateHead(accountHead, tx)
     })
 
     this.accountById.set(account.id, account)

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -1372,8 +1372,7 @@ export class Wallet {
     const createdAt = await this.createdAtWithDefault(options.createdAt)
     let accountHead: HeadValue | null
     if (options.head === undefined) {
-      accountHead =
-        createdAt == null ? null : await this.accountHeadAtSequence(createdAt.sequence)
+      accountHead = createdAt && (await this.accountHeadAtSequence(createdAt.sequence))
     } else {
       accountHead = options.head
     }
@@ -1589,7 +1588,7 @@ export class Wallet {
       }
 
       const accountHead =
-        createdAt == null ? null : await this.accountHeadAtSequence(createdAt.sequence - 1)
+        createdAt && (await this.accountHeadAtSequence(createdAt.sequence - 1))
 
       await account.updateHead(accountHead, tx)
     })


### PR DESCRIPTION
## Summary
This allows syncing to completely skip over an account until it reaches the passed in head value

## Testing Plan
Unit tests + testing with node app creating a fresh account

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
