### PR TITLE
fixes wallet:lock early exit

### DIFF
--- a/ironfish-cli/src/commands/wallet/lock.ts
+++ b/ironfish-cli/src/commands/wallet/lock.ts
@@ -16,8 +16,8 @@ export class LockCommand extends IronfishCommand {
     const client = await this.connectRpc()
 
     const response = await client.wallet.getAccountsStatus()
-    if (!response.content.encrypted) {
-      this.log('Wallet is decrypted')
+    if (response.content.encrypted) {
+      this.log('Wallet is already encrypted')
       this.exit(1)
     }
 


### PR DESCRIPTION
## Summary
fixes incorrect conditional when locking wallet

exits early from wallet:lock if the wallet is already encrypted instead of exiting early if the wallet is decrypted

## Testing Plan
before:
<img width="573" alt="image" src="https://github.com/user-attachments/assets/1a57feb0-a86b-4b5f-8f11-4875c19ddc98">

after:
<img width="572" alt="image" src="https://github.com/user-attachments/assets/1d401690-f754-4d9b-b521-c03cbff9c2dd">

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
