### PR TITLE
Make it easier to construct an `IronfishError` from an `IronfishError…

### DIFF
--- a/ironfish-rust/src/errors.rs
+++ b/ironfish-rust/src/errors.rs
@@ -111,6 +111,12 @@ impl fmt::Display for IronfishError {
     }
 }
 
+impl From<IronfishErrorKind> for IronfishError {
+    fn from(kind: IronfishErrorKind) -> Self {
+        Self::new(kind)
+    }
+}
+
 impl From<io::Error> for IronfishError {
     fn from(e: io::Error) -> IronfishError {
         IronfishError::new_with_source(IronfishErrorKind::Io, e)


### PR DESCRIPTION
## Summary

This way we can write `IronfishErrorKind::InvalidData.into()` instead of `IronfishError::new(IronfishErrorKind::InvalidData)`.

## Testing Plan

N/A

## Documentation

N/A

## Breaking Change

N/A