### PR TITLE
Implement the `Debug` trait for `Transaction`

### DIFF
--- a/ironfish-rust/src/transaction/burns.rs
+++ b/ironfish-rust/src/transaction/burns.rs
@@ -32,7 +32,7 @@ impl BurnBuilder {
 
 /// This description represents an action to decrease the supply of an existing
 /// asset on Iron Fish
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct BurnDescription {
     /// Identifier for the Asset which is being burned
     pub asset_id: AssetIdentifier,

--- a/ironfish-rust/src/transaction/mints.rs
+++ b/ironfish-rust/src/transaction/mints.rs
@@ -185,7 +185,7 @@ impl UnsignedMintDescription {
 
 /// This description represents an action to increase the supply of an existing
 /// asset on Iron Fish
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct MintDescription {
     /// Proof that the mint was valid for the provided creator and asset
     pub proof: groth16::Proof<Bls12>,

--- a/ironfish-rust/src/transaction/mod.rs
+++ b/ironfish-rust/src/transaction/mod.rs
@@ -63,7 +63,7 @@ pub const TRANSACTION_FEE_SIZE: usize = 8;
 /// any of the working data or private keys used in creating the proofs.
 ///
 /// This is the serializable form of a transaction.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Transaction {
     /// The transaction serialization version. This can be incremented when
     /// changes need to be made to the transaction format

--- a/ironfish-rust/src/transaction/outputs.rs
+++ b/ironfish-rust/src/transaction/outputs.rs
@@ -131,7 +131,7 @@ impl OutputBuilder {
 ///
 /// This is the variation of an Output that gets serialized to bytes and can
 /// be loaded from bytes.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct OutputDescription {
     /// Proof that the output circuit was valid and successful
     pub(crate) proof: groth16::Proof<Bls12>,

--- a/ironfish-rust/src/transaction/spends.rs
+++ b/ironfish-rust/src/transaction/spends.rs
@@ -225,7 +225,7 @@ impl UnsignedSpendDescription {
 /// The publicly visible value of a spent note. These get serialized to prove
 /// that the owner once had access to these values. It also publishes the
 /// nullifier so that they can't pretend they still have access to them.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct SpendDescription {
     /// Proof that the spend was valid and successful for the provided owner
     /// and note.


### PR DESCRIPTION
## Summary

This way writing tests is easier, because a lot of methods commonly used in tests expects the arguments to implement `Debug`.

Note that `Transaction` and all the related descriptions do not hold any private/secret data, hence implementing `Debug` is safe.

## Testing Plan

N/A

## Documentation

N/A

## Breaking Change

N/A