### PR TITLE
Prevent reorg checks on `setAccountHead` if start is genesis

### DIFF
--- a/ironfish/src/rpc/routes/wallet/setAccountHead.ts
+++ b/ironfish/src/rpc/routes/wallet/setAccountHead.ts
@@ -101,8 +101,7 @@ routes.register<typeof SetAccountHeadRequestSchema, SetAccountHeadResponse>(
 
     // Validate account head is compatible with start and end blocks
     let accountHead = await account.getHead()
-
-    if (accountHead !== null) {
+    if (accountHead !== null && !startHeader.equals(context.chain.genesis)) {
       const accountHeader = await context.chain.getHeader(accountHead.hash)
       if (!accountHeader) {
         throw new Error(`accountHead ${accountHead.hash.toString('hex')} not found in chain`)


### PR DESCRIPTION
## Summary
If blocks sent are started from genesis, no reorg checks are necessary.

I found this because this process slows down the API request significantly when oreowallet was resending blocks on account updates.
## Testing Plan
tests pass
## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
