### PR TITLE
Add a barebone WASM crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1150,8 +1150,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1626,6 +1628,15 @@ dependencies = [
  "num_cpus",
  "rand",
  "signal-hook",
+]
+
+[[package]]
+name = "ironfish-wasm"
+version = "0.1.0"
+dependencies = [
+ "getrandom",
+ "ironfish",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3053,26 +3064,27 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.84"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
+checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
 dependencies = [
  "cfg-if",
+ "once_cell",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.84"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
+checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn 2.0.77",
  "wasm-bindgen-shared",
 ]
 
@@ -3090,9 +3102,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.84"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
+checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3100,22 +3112,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.84"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
+checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn 2.0.77",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.84"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
 
 [[package]]
 name = "web-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "benchmarks",
     "ironfish-rust",
     "ironfish-rust-nodejs",
+    "ironfish-rust-wasm",
     "ironfish-zkp",
 ]
 

--- a/ironfish-rust-wasm/Cargo.toml
+++ b/ironfish-rust-wasm/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "ironfish-wasm"
+version = "0.1.0"
+license = "MPL-2.0"
+
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+getrandom = { version = "0.2.8", features = ["js"] } # need to explicitly enable the `js` feature in order to run in a browser
+ironfish = { version = "0.3.0", path = "../ironfish-rust" }
+wasm-bindgen = "0.2.95"

--- a/ironfish-rust-wasm/src/errors.rs
+++ b/ironfish-rust-wasm/src/errors.rs
@@ -1,0 +1,26 @@
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+#[derive(Debug)]
+pub struct IronfishError(ironfish::errors::IronfishError);
+
+impl<T> From<T> for IronfishError
+where
+    ironfish::errors::IronfishError: From<T>,
+{
+    fn from(e: T) -> Self {
+        Self(ironfish::errors::IronfishError::from(e))
+    }
+}
+
+impl AsRef<ironfish::errors::IronfishError> for IronfishError {
+    fn as_ref(&self) -> &ironfish::errors::IronfishError {
+        &self.0
+    }
+}
+
+impl AsRef<ironfish::errors::IronfishErrorKind> for IronfishError {
+    fn as_ref(&self) -> &ironfish::errors::IronfishErrorKind {
+        &self.0.kind
+    }
+}

--- a/ironfish-rust-wasm/src/lib.rs
+++ b/ironfish-rust-wasm/src/lib.rs
@@ -1,0 +1,12 @@
+#![warn(clippy::dbg_macro)]
+#![warn(clippy::print_stderr)]
+#![warn(clippy::print_stdout)]
+#![warn(unreachable_pub)]
+#![warn(unused_crate_dependencies)]
+#![warn(unused_macro_rules)]
+#![warn(unused_qualifications)]
+
+// The getrandom dependency exists only to ensure that the `js` feature is enabled
+use getrandom as _;
+
+pub mod errors;

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -108,6 +108,36 @@ who = "Andrea <andrea@iflabs.network>"
 criteria = "safe-to-deploy"
 version = "1.0.0"
 
+[[audits.wasm-bindgen]]
+who = "andrea <andrea@iflabs.network>"
+criteria = "safe-to-deploy"
+delta = "0.2.84 -> 0.2.95"
+notes = "New features and removed code; some new unsafe blocks and they all look benign"
+
+[[audits.wasm-bindgen-backend]]
+who = "andrea <andrea@iflabs.network>"
+criteria = "safe-to-deploy"
+delta = "0.2.84 -> 0.2.95"
+notes = "New features and bug fixes; there's are new/changed unsafe blocks and they all look benign"
+
+[[audits.wasm-bindgen-macro]]
+who = "andrea <andrea@iflabs.network>"
+criteria = "safe-to-deploy"
+delta = "0.2.84 -> 0.2.95"
+notes = "Minor changes and a lot of removed code"
+
+[[audits.wasm-bindgen-macro-support]]
+who = "andrea <andrea@iflabs.network>"
+criteria = "safe-to-deploy"
+delta = "0.2.92 -> 0.2.95"
+notes = "New features and bug fixes; no new unsafe code or system calls introduced"
+
+[[audits.wasm-bindgen-shared]]
+who = "andrea <andrea@iflabs.network>"
+criteria = "safe-to-deploy"
+delta = "0.2.92 -> 0.2.95"
+notes = "Only minor changes; no new unsafe code or system calls introduced"
+
 [[trusted.reddsa]]
 criteria = "safe-to-deploy"
 user-id = 6289 # Jack Grigg (str4d)

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -776,10 +776,6 @@ criteria = "safe-to-deploy"
 version = "0.2.84"
 criteria = "safe-to-deploy"
 
-[[exemptions.wasm-bindgen-macro-support]]
-version = "0.2.84"
-criteria = "safe-to-deploy"
-
 [[exemptions.web-sys]]
 version = "0.3.61"
 criteria = "safe-to-deploy"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1297,9 +1297,33 @@ delta = "0.4.1 -> 0.5.0"
 notes = "I checked correctness of to_blocks which uses unsafe code in a safe function."
 aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
 
+[[audits.zcash.audits.wasm-bindgen-macro-support]]
+who = "Daira-Emma Hopwood <daira@jacaranda.org>"
+criteria = "safe-to-deploy"
+version = "0.2.92"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
 [[audits.zcash.audits.wasm-bindgen-shared]]
 who = "Jack Grigg <jack@z.cash>"
 criteria = "safe-to-deploy"
 delta = "0.2.83 -> 0.2.84"
 notes = "Bumps the schema version to add `linked_modules`."
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.wasm-bindgen-shared]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "0.2.84 -> 0.2.87"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.wasm-bindgen-shared]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "0.2.87 -> 0.2.89"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.wasm-bindgen-shared]]
+who = "Daira-Emma Hopwood <daira@jacaranda.org>"
+criteria = "safe-to-deploy"
+delta = "0.2.89 -> 0.2.92"
 aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"


### PR DESCRIPTION
## Summary

This adds a new `ironfish-rust-wasm` crate whose goal is to expose the `ironfish-rust` functionality to WASM for web browsers, just like `ironfish-rust-nodejs` exposes the functionality to NodeJS.

For now, the new crate only exposes the `IronfishError` struct.

## Testing Plan

* `cd ironfish-rust-wasm && cargo build --target=wasm32-unknown-unknown`
* `cd ironfish-rust-wasm && cargo test`

Support for proper testing through a web browser will be added in a future PR.

## Documentation

N/A

## Breaking Change

N/A