### PR TITLE
fix transaction list output

### DIFF
--- a/ironfish-cli/src/commands/wallet/transactions/index.ts
+++ b/ironfish-cli/src/commands/wallet/transactions/index.ts
@@ -102,7 +102,9 @@ export class TransactionsCommand extends IronfishCommand {
               : ('Bridge (incoming)' as TransactionType)
         }
 
-        transactionRows = this.getTransactionRowsByNote(assetLookup, transaction, format)
+        transactionRows = transactionRows.concat(
+          this.getTransactionRowsByNote(assetLookup, transaction, format),
+        )
       } else {
         const assetLookup = await getAssetsByIDs(
           client,
@@ -110,7 +112,9 @@ export class TransactionsCommand extends IronfishCommand {
           account,
           flags.confirmations,
         )
-        transactionRows = this.getTransactionRows(assetLookup, transaction, format)
+        transactionRows = transactionRows.concat(
+          this.getTransactionRows(assetLookup, transaction, format),
+        )
       }
       hasTransactions = true
     }


### PR DESCRIPTION
## Summary
Was previously only printing out last row, bug was introduced here: https://github.com/iron-fish/ironfish/pull/5611/files

## Testing Plan
```
❯ fish wallet:transactions -d ~/.ironfish-testnet
yarn run v1.22.19
$ yarn build && yarn start:js wallet:transactions -d /Users/joe/.ironfish-testnet
$ tsc -b tsconfig.build.json
$ cross-env OCLIF_TS_NODE=0 IRONFISH_DEBUG=1 node --expose-gc --inspect=:0 --inspect-publish-uid=http --enable-source-maps bin/run wallet:transactions -d /Users/joe/.ironfish-testnet
     Timestamp                  Status       Type     Hash                                                             Expiration Submitted Sequence Fee Paid ($IRON) Asset                     Amount           
 ─── ────────────────────────── ──────────── ──────── ──────────────────────────────────────────────────────────────── ────────── ────────────────── ──────────────── ───────────────────────── ─────────────────
     11/12/2024 11:00:55 AM PST confirmed    send     8e1dc92675d52cb26f5dbce90aea65a9ebfdb939d056a53dc689f3e540d4d960 0          760239             0.00000001       $IRON             (51f33) 0.00000000       
     11/12/2024 10:57:18 AM PST confirmed    send     41d45a7e34ef5fb347e48b7bcd42a7ba1601cf9bf1513a7a7d446b752eacf44a 0          760237             0.00000001       $IRON             (51f33) 0.00000000       
     10/28/2024 2:47:48 PM PDT  confirmed    send     dc6116865d0e4e92df1e75c94afd951d6d2ca40eddd71b0900bcd270fa149bce 738792     738780             0.00000010       NORI              (f3b28) -1               
     10/28/2024 2:43:08 PM PDT  confirmed    send     7b10541dd5cd9ee5084ce50048a4c8bb779cdbf7bb0399bb23c430dac24a201b 738788     738775             0.00000001       NORI              (f3b28) 10000000000000000
     8/14/2024 11:23:38 AM PDT  confirmed    receive  9635afaa3135c5b68d33979016e9fa6a4a24a47067e99ba7ac6d984b60504e92 635624     635612                              $IRON             (51f33) 0.00100000       
     5/30/2024 10:52:19 AM PDT  confirmed    send     2d752a4b146d2a91654fd85c23d793683c33f3f0a8285fe22544332526b0b789 526123     526110             0.00000001       $IRON             (51f33) -5.00000000      
     5/21/2024 1:35:12 PM PDT   confirmed    send     9a2cbd87b2bbfed0f41ee7ea4bced666fc67fa73a136dd87d55f81aa062127ed 513656     513647             0.00000002       $IRON             (51f33) -0.00001003      
     5/9/2024 2:08:24 PM PDT    confirmed    send     29bb52f7306ed363b70b3108288bc05253a7e404308883c3fa6d6ac91ed562ac 496460     496447             0.00000001       $IRON             (51f33) -10.00000000     
     4/26/2024 12:06:35 PM PDT  confirmed    send     daa605a6c0050338b9598fdc9f3fcbc88504eab10cdb67707a3b5832c08ffdcf 0          482251             0.00000002       $IRON             (51f33) -0.10000003      
     9/26/2023 9:41:09 AM PDT   confirmed    send     03943923e8f7c47f72fbdec6a47b155e2b98e6b9e346ec02833c43e621dfcb29 0          214571             0.00000001       $IRON             (51f33) 0.00000000       
     9/25/2023 1:47:14 PM PDT   confirmed    send     d35a03dbff7c100c6544efa608939705e151ebf1cdc13d03fd553d743783fc82 0          213396             0.00000001       $IRON             (51f33) 0.00000000       
     9/25/2023 12:40:25 PM PDT  confirmed    receive  100709a57130b88469544b90afffd3ed57ff1902f8d6f585057bc4c4d015d8d5 213350     213337                              $IRON             (51f33) 1000.00000000    
✨  Done in 5.08s.
```
## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
