### PR TITLE
Move table flags into OUTPUT group

### DIFF
--- a/ironfish-cli/src/ui/table.ts
+++ b/ironfish-cli/src/ui/table.ts
@@ -36,18 +36,22 @@ export interface TableOptions {
 export const TableFlags = {
   csv: Flags.boolean({
     description: 'output is csv format [alias: --output=csv]',
+    helpGroup: 'OUTPUT',
   }),
   extended: Flags.boolean({
     description: 'show extra columns',
+    helpGroup: 'OUTPUT',
   }),
   'no-header': Flags.boolean({
     description: 'hide table header from output',
     exclusive: ['csv'],
+    helpGroup: 'OUTPUT',
   }),
   output: Flags.string({
     description: 'output in a more machine friendly format',
     exclusive: ['csv'],
     options: ['csv', 'json'],
+    helpGroup: 'OUTPUT',
   }),
   sort: Flags.string({
     description: "property to sort by (prepend '-' for descending)",


### PR DESCRIPTION
## Summary

This puts all these flags in the output group along with other flags like COLOR and VERBOSE.

```
OUTPUT FLAGS
  --csv              output is csv format [alias: --output=csv]
  --extended         show extra columns
  --no-header        hide table header from output
  --output=<option>  output in a more machine friendly format
                     <options: csv|json>
```

## Testing Plan

Run `ironfish wallet:transactions --help`

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
