### PR TITLE
Support viewing transaction data for all accounts

### DIFF
--- a/ironfish-cli/src/commands/wallet/transactions/index.ts
+++ b/ironfish-cli/src/commands/wallet/transactions/index.ts
@@ -91,6 +91,7 @@ export class TransactionsCommand extends IronfishCommand {
       flags.limit,
       flags.offset,
       flags.confirmations,
+      flags.notes,
     )
 
     const columns = this.getColumns(flags.extended, flags.notes, format)


### PR DESCRIPTION
## Summary

This allows you to use --no-account to now see all the transactions data for all accounts.

### Examples
**View transactions for the default account**
- `ironfish wallet:transactions`

**View transactions for myaccount**
- `ironfish wallet:transactions --account myaccount`
- `ironfish wallet:transactions --a myaccount`

**View transactions for all accounts**
- `ironfish wallet:transactions --no-account`
- `ironfish wallet:transactions --no-a`

## Testing Plan
Execute the commands listed above in the examples

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
