### PR TITLE
removes unused methods from walletDb

### DIFF
--- a/ironfish/src/wallet/account/account.ts
+++ b/ironfish/src/wallet/account/account.ts
@@ -845,16 +845,6 @@ export class Account {
     }
   }
 
-  async *getTransactionsOrderedBySequence(
-    tx?: IDatabaseTransaction,
-  ): AsyncGenerator<Readonly<TransactionValue>> {
-    for await (const { hash } of this.walletDb.getTransactionHashesBySequence(this, tx)) {
-      const transaction = await this.getTransaction(hash, tx)
-      Assert.isNotUndefined(transaction)
-      yield transaction
-    }
-  }
-
   getPendingTransactions(
     headSequence: number,
     tx?: IDatabaseTransaction,

--- a/ironfish/src/wallet/walletdb/walletdb.ts
+++ b/ironfish/src/wallet/walletdb/walletdb.ts
@@ -482,6 +482,14 @@ export class WalletDB {
     await this.heads.del(account.id, tx)
   }
 
+  async *loadHeads(
+    tx?: IDatabaseTransaction,
+  ): AsyncGenerator<{ accountId: string; head: HeadValue | null }, void, unknown> {
+    for await (const [accountId, head] of this.heads.getAllIter(tx)) {
+      yield { accountId, head }
+    }
+  }
+
   async saveTransaction(
     account: Account,
     transactionHash: Buffer,

--- a/ironfish/src/wallet/walletdb/walletdb.ts
+++ b/ironfish/src/wallet/walletdb/walletdb.ts
@@ -482,14 +482,6 @@ export class WalletDB {
     await this.heads.del(account.id, tx)
   }
 
-  async *loadHeads(
-    tx?: IDatabaseTransaction,
-  ): AsyncGenerator<{ accountId: string; head: HeadValue | null }, void, unknown> {
-    for await (const [accountId, head] of this.heads.getAllIter(tx)) {
-      yield { accountId, head }
-    }
-  }
-
   async saveTransaction(
     account: Account,
     transactionHash: Buffer,
@@ -540,19 +532,6 @@ export class WalletDB {
       tx,
     )
     await this.transactions.del([account.prefix, transactionHash], tx)
-  }
-
-  async *getTransactionHashesBySequence(
-    account: Account,
-    tx?: IDatabaseTransaction,
-  ): AsyncGenerator<{ sequence: number; hash: Buffer }> {
-    for await (const [, [sequence, hash]] of this.sequenceToTransactionHash.getAllKeysIter(
-      tx,
-      account.prefixRange,
-      { ordered: true },
-    )) {
-      yield { sequence, hash }
-    }
   }
 
   async *loadTransactions(
@@ -828,24 +807,6 @@ export class WalletDB {
     await this.nullifierToNoteHash.put([account.prefix, nullifier], noteHash, tx)
     if (this.nullifierBloomFilter) {
       this.nullifierBloomFilter.put(nullifier)
-    }
-  }
-
-  async *loadNullifierToNoteHash(
-    account: Account,
-    tx?: IDatabaseTransaction,
-  ): AsyncGenerator<{
-    nullifier: Buffer
-    noteHash: Buffer
-  }> {
-    for await (const [[_, nullifier], noteHash] of this.nullifierToNoteHash.getAllIter(
-      tx,
-      account.prefixRange,
-    )) {
-      yield {
-        nullifier,
-        noteHash,
-      }
     }
   }
 
@@ -1142,19 +1103,6 @@ export class WalletDB {
     }
   }
 
-  async saveSequenceToTransactionHash(
-    account: Account,
-    sequence: number,
-    transactionHash: Buffer,
-    tx?: IDatabaseTransaction,
-  ): Promise<void> {
-    await this.sequenceToTransactionHash.put(
-      [account.prefix, [sequence, transactionHash]],
-      null,
-      tx,
-    )
-  }
-
   async deleteSequenceToTransactionHash(
     account: Account,
     sequence: number,
@@ -1404,10 +1352,6 @@ export class WalletDB {
     tx?: IDatabaseTransaction,
   ): Promise<MultisigIdentityValue | undefined> {
     return this.multisigIdentities.get(identity, tx)
-  }
-
-  async hasMultisigIdentity(identity: Buffer, tx?: IDatabaseTransaction): Promise<boolean> {
-    return (await this.getMultisigIdentity(identity, tx)) !== undefined
   }
 
   async deleteMultisigIdentity(identity: Buffer, tx?: IDatabaseTransaction): Promise<void> {


### PR DESCRIPTION
## Summary

cleans up the walletDb by removing unused methods

removes one unused wallet method that was the only usage of a walletDb method

## Testing Plan
N/A

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
