### PR TITLE
WASM: enable in-browser tests through `wasm-bindgen-test`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -493,6 +493,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
 
 [[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "const-crc32-nostd"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1643,6 +1653,7 @@ dependencies = [
  "ironfish_zkp",
  "rand",
  "wasm-bindgen",
+ "wasm-bindgen-test",
 ]
 
 [[package]]
@@ -1688,9 +1699,9 @@ checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "js-sys"
-version = "0.3.61"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
+checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1820,6 +1831,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minicov"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27fe9f1cc3c22e1687f9446c2083c4c5fc7f0bcf1c7a86bdbded14985895b4b"
+dependencies = [
+ "cc",
+ "walkdir",
+]
 
 [[package]]
 name = "mio"
@@ -2494,6 +2515,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3096,9 +3123,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.34"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f219e0d211ba40266969f6dbdd90636da12f75bee4fc9d6c23d1260dadb51454"
+checksum = "cc7ec4f8827a71586374db3e87abdb5a2bb3a15afed140221307c3ec06b1f63b"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -3134,6 +3161,32 @@ name = "wasm-bindgen-shared"
 version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d381749acb0943d357dcbd8f0b100640679883fcdeeef04def49daf8d33a5426"
+dependencies = [
+ "console_error_panic_hook",
+ "js-sys",
+ "minicov",
+ "scoped-tls",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c97b2ef2c8d627381e51c071c2ab328eac606d3f69dd82bcbca20a9e389d95f0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
 
 [[package]]
 name = "web-sys"

--- a/ironfish-rust-wasm/Cargo.toml
+++ b/ironfish-rust-wasm/Cargo.toml
@@ -25,3 +25,4 @@ wasm-bindgen = "0.2.95"
 
 [dev-dependencies]
 hex-literal = "0.4.1"
+wasm-bindgen-test = "0.3.45"

--- a/ironfish-rust-wasm/src/keys/public_address.rs
+++ b/ironfish-rust-wasm/src/keys/public_address.rs
@@ -48,8 +48,10 @@ impl AsRef<ironfish::PublicAddress> for PublicAddress {
 mod tests {
     use crate::keys::public_address::PublicAddress;
     use hex_literal::hex;
+    use wasm_bindgen_test::wasm_bindgen_test;
 
     #[test]
+    #[wasm_bindgen_test]
     fn valid_address() {
         let bytes = hex!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0");
         let addr = PublicAddress::deserialize(&bytes[..])
@@ -63,6 +65,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn invalid_address() {
         let bytes = hex!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1");
         PublicAddress::deserialize(&bytes[..])

--- a/ironfish-rust-wasm/src/lib.rs
+++ b/ironfish-rust-wasm/src/lib.rs
@@ -16,3 +16,8 @@ use getrandom as _;
 pub mod errors;
 pub mod keys;
 pub mod primitives;
+
+#[cfg(test)]
+mod tests {
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+}

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -12,6 +12,11 @@ criteria = "safe-to-deploy"
 delta = "0.10.1 -> 0.11.0"
 notes = "Main change is how langauges are handled (previous version: through an enum, new version: through a marker type)"
 
+[[audits.console_error_panic_hook]]
+who = "andrea <andrea@iflabs.network>"
+criteria = "safe-to-run"
+version = "0.1.7"
+
 [[audits.crypto_box]]
 who = "Andrea <andrea@iflabs.network>"
 criteria = "safe-to-deploy"
@@ -78,6 +83,16 @@ criteria = "safe-to-deploy"
 version = "0.1.0"
 notes = "Crate owned by the Iron Fish organization"
 
+[[audits.js-sys]]
+who = "andrea <andrea@iflabs.network>"
+criteria = "safe-to-deploy"
+delta = "0.3.69 -> 0.3.72"
+
+[[audits.minicov]]
+who = "andrea <andrea@iflabs.network>"
+criteria = "safe-to-run"
+version = "0.3.7"
+
 [[audits.mio]]
 who = "Andrea <andrea@iflabs.network>"
 criteria = "safe-to-deploy"
@@ -120,6 +135,11 @@ criteria = "safe-to-deploy"
 delta = "0.2.84 -> 0.2.95"
 notes = "New features and bug fixes; there's are new/changed unsafe blocks and they all look benign"
 
+[[audits.wasm-bindgen-futures]]
+who = "andrea <andrea@iflabs.network>"
+criteria = "safe-to-deploy"
+delta = "0.4.34 -> 0.4.45"
+
 [[audits.wasm-bindgen-macro]]
 who = "andrea <andrea@iflabs.network>"
 criteria = "safe-to-deploy"
@@ -137,6 +157,16 @@ who = "andrea <andrea@iflabs.network>"
 criteria = "safe-to-deploy"
 delta = "0.2.92 -> 0.2.95"
 notes = "Only minor changes; no new unsafe code or system calls introduced"
+
+[[audits.wasm-bindgen-test]]
+who = "andrea <andrea@iflabs.network>"
+criteria = "safe-to-run"
+version = "0.3.45"
+
+[[audits.wasm-bindgen-test-macro]]
+who = "andrea <andrea@iflabs.network>"
+criteria = "safe-to-run"
+version = "0.3.45"
 
 [[trusted.reddsa]]
 criteria = "safe-to-deploy"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -612,6 +612,12 @@ The delta just 1) inlines/expands `impl ToTokens` that used to be handled via
 """
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
+[[audits.google.audits.scoped-tls]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+version = "1.0.0"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
 [[audits.google.audits.unicode-xid]]
 who = "George Burgess IV <gbiv@google.com>"
 criteria = "safe-to-deploy"
@@ -1029,6 +1035,12 @@ version = "1.1.0"
 notes = "Straightforward crate with no unsafe code, does what it says on the tin."
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.scoped-tls]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-run"
+delta = "1.0.0 -> 1.0.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.sha2]]
 who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
@@ -1226,6 +1238,30 @@ who = "Daira Hopwood <daira@jacaranda.org>"
 criteria = "safe-to-deploy"
 version = "0.1.3"
 notes = "Reviewed in full."
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.js-sys]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "0.3.61 -> 0.3.64"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.js-sys]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "0.3.64 -> 0.3.66"
+notes = """
+- Fixes the `BigInt64Array` variants of the existing `Atomics.wait` method.
+- Adds `Atomics.waitAsync`, the `DataView` constructor variant that takes
+  `SharedArrayBuffer`, and `WebAssembly.Exception`; I checked these against their
+  MDN documentation.
+"""
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.js-sys]]
+who = "Daira-Emma Hopwood <daira@jacaranda.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.66 -> 0.3.69"
 aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
 
 [[audits.zcash.audits.jubjub]]


### PR DESCRIPTION
## Summary

The unit tests currently are marked with both `#[test]` and `#[wasm_bindgen_test]`. This allows tests to run with both `cargo test` and `wasm-pack test`.

In theory, we could drop `#[test]`, but given that `cargo test` is faster than `wasm-pack test`, this makes developing easier, so I'm keeping it for now.

## Testing Plan

One or more of the following:
* `cd ironfish-rust-wasm && wasm-pack test --firefox --headless`
* `cd ironfish-rust-wasm && wasm-pack test --chrome --headless`
* `cd ironfish-rust-wasm && wasm-pack test --safari --headless`

`--headless` is not required (it makes the output appear on the terminal instead of in the browser)

## Documentation

N/A

## Breaking Change

N/A