### PR TITLE
Run tests on the WASM package as part of the GitHub workflow

### DIFF
--- a/.github/workflows/rust_ci.yml
+++ b/.github/workflows/rust_ci.yml
@@ -6,6 +6,7 @@ on:
       - "ironfish-phase2/**"
       - "ironfish-rust/**"
       - "ironfish-rust-nodejs/**"
+      - "ironfish-rust-wasm/**"
       - "ironfish-zkp/**"
       - "rust-toolchain"
       - ".github/workflows/rust*"
@@ -20,6 +21,7 @@ on:
       - "ironfish-phase2/**"
       - "ironfish-rust/**"
       - "ironfish-rust-nodejs/**"
+      - "ironfish-rust-wasm/**"
       - "ironfish-zkp/**"
       - "rust-toolchain"
       - ".github/workflows/rust*"
@@ -48,11 +50,14 @@ jobs:
       - name: Check for license headers for ironfish-rust-nodejs
         run: ./ci/lintHeaders.sh ./ironfish-rust-nodejs/src *.rs
 
-      - name: "`cargo fmt` check on ironfish-rust"
+      - name: Check for license headers for ironfish-rust-wasm
+        run: ./ci/lintHeaders.sh ./ironfish-rust-wasm/src *.rs
+
+      - name: cargo fmt
         run: |
           cargo fmt --all -- --check
 
-      - name: "Clippy check on ironfish-rust"
+      - name: cargo clippy
         run: |
           cargo clippy --all-targets --all-features -- -D warnings
 
@@ -220,3 +225,29 @@ jobs:
         with:
           token: ${{secrets.CODECOV_TOKEN}}
           flags: ironfish-zkp
+
+  ironfish_wasm:
+    name: Test ironfish-rust-wasm
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: wasm
+
+      - name: Install wasm-pack
+        # use the installation method reccommended on
+        # https://rustwasm.github.io/docs/wasm-bindgen/wasm-bindgen-test/continuous-integration.html#github-actions
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - name: Run tests in Firefox
+        run: |
+          cd ironfish-rust-wasm
+          wasm-pack test --headless --firefox
+
+      - name: Run tests in Chrome
+        run: |
+          cd ironfish-rust-wasm
+          wasm-pack test --headless --chrome

--- a/ironfish-rust-wasm/src/errors.rs
+++ b/ironfish-rust-wasm/src/errors.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]

--- a/ironfish-rust-wasm/src/primitives.rs
+++ b/ironfish-rust-wasm/src/primitives.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 use crate::errors::IronfishError;
 use group::GroupEncoding;
 use ironfish::errors::IronfishErrorKind;


### PR DESCRIPTION
## Summary

* Expanded the license header check to include the wasm crate (and fixed the files that did not have the header)
* Added a workflow to run the wasm tests in Chrome and Firefox

## Testing Plan

Example run: https://github.com/iron-fish/ironfish/actions/runs/11809229845/job/32899173267?pr=5647

## Documentation

N/A

## Breaking Change

N/A
