### PR TITLE
Add filter start and end support

### DIFF
--- a/ironfish-cli/src/commands/wallet/transactions/index.ts
+++ b/ironfish-cli/src/commands/wallet/transactions/index.ts
@@ -63,11 +63,11 @@ export class TransactionsCommand extends IronfishCommand {
       helpGroup: 'OUTPUT',
     }),
     'filter.start': Flags.string({
-      description: 'include transactions after this date (inclusive). Example: 04/20/2023',
+      description: 'include transactions after this date (inclusive). Example: 2023-04-01',
       parse: (input) => Promise.resolve(new Date(input).toISOString()),
     }),
     'filter.end': Flags.string({
-      description: 'include transactions before this date (exclusive). Example: 05/20/2023',
+      description: 'include transactions before this date (exclusive). Example: 2023-05-01',
       parse: (input) => Promise.resolve(new Date(input).toISOString()),
     }),
   }

--- a/ironfish-cli/src/commands/wallet/transactions/index.ts
+++ b/ironfish-cli/src/commands/wallet/transactions/index.ts
@@ -25,6 +25,19 @@ const { sort: _, ...tableFlags } = ui.TableFlags
 export class TransactionsCommand extends IronfishCommand {
   static description = `list the account's transactions`
 
+  static examples = [
+    {
+      description: 'List all transactions in the current wallet:',
+      command: '$ <%= config.bin %> <%= command.id %>',
+    },
+    {
+      description:
+        'Export transactions in all wallets for the month of october in an accounting friendly format:',
+      command:
+        '$ <%= config.bin %> <%= command.id %> --no-account --filter.start 2024-10-01 --filter.end 2024-11-01 --output csv --format transfers',
+    },
+  ]
+
   static flags = {
     ...RemoteFlags,
     ...tableFlags,


### PR DESCRIPTION
## Summary

This lets you filter dates based on a date input such as 04/20/2023

## Testing Plan

```
ironfish wallet:transactions --no-account --filter.start 09/1/2024 --filter.end 10/01/2024
```

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
