### PR TITLE
adds 'format' option to account import

### DIFF
--- a/ironfish/src/rpc/routes/wallet/importAccount.test.ts
+++ b/ironfish/src/rpc/routes/wallet/importAccount.test.ts
@@ -665,22 +665,19 @@ describe('Route wallet/importAccount', () => {
       const name = 'mnemonic-format'
       const mnemonic = spendingKeyToWords(generateKey().spendingKey, LanguageCode.English)
 
-      try {
-        await routeTest.client.wallet.importAccount({
+      await expect(
+        routeTest.client.wallet.importAccount({
           account: mnemonic,
           name,
           rescan: false,
           format: AccountFormat.JSON,
-        })
-      } catch (e: unknown) {
-        if (!(e instanceof RpcRequestError)) {
-          throw e
-        }
-
-        expect(e.status).toBe(400)
-        expect(e.message).not.toContain('decoder errors:')
-        expect(e.message).toContain('Invalid JSON')
-      }
+        }),
+      ).rejects.toMatchObject({
+        status: 400,
+        message:
+          expect.not.stringContaining('decoder errors:') &&
+          expect.stringContaining('Invalid JSON'),
+      })
     })
   })
 })

--- a/ironfish/src/rpc/routes/wallet/importAccount.test.ts
+++ b/ironfish/src/rpc/routes/wallet/importAccount.test.ts
@@ -642,4 +642,45 @@ describe('Route wallet/importAccount', () => {
     Assert.isNotUndefined(existingIdentity)
     expect(existingIdentity.name).toEqual('existingIdentity')
   })
+
+  describe('account format', () => {
+    it('should decode an account import with the requested format', async () => {
+      const name = 'mnemonic-format'
+      const mnemonic = spendingKeyToWords(generateKey().spendingKey, LanguageCode.English)
+
+      const response = await routeTest.client.wallet.importAccount({
+        account: mnemonic,
+        name: name,
+        rescan: false,
+        format: AccountFormat.Mnemonic,
+      })
+
+      expect(response.status).toBe(200)
+      expect(response.content).toMatchObject({
+        name: name,
+      })
+    })
+
+    it('should fail to decode an account import with the incorrect format', async () => {
+      const name = 'mnemonic-format'
+      const mnemonic = spendingKeyToWords(generateKey().spendingKey, LanguageCode.English)
+
+      try {
+        await routeTest.client.wallet.importAccount({
+          account: mnemonic,
+          name,
+          rescan: false,
+          format: AccountFormat.JSON,
+        })
+      } catch (e: unknown) {
+        if (!(e instanceof RpcRequestError)) {
+          throw e
+        }
+
+        expect(e.status).toBe(400)
+        expect(e.message).not.toContain('decoder errors:')
+        expect(e.message).toContain('Invalid JSON')
+      }
+    })
+  })
 })

--- a/ironfish/src/wallet/exporter/encoder.ts
+++ b/ironfish/src/wallet/exporter/encoder.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { LanguageKey } from '../../utils'
+import { AccountFormat } from './account'
 import { AccountImport } from './accountImport'
 
 export class DecodeInvalid extends Error {}
@@ -25,6 +26,7 @@ export type AccountEncodingOptions = {
 
 export type AccountDecodingOptions = {
   name?: string
+  format?: AccountFormat
 }
 
 export type AccountEncoder = {


### PR DESCRIPTION
## Summary

adds a field to the wallet/importAccount RPC that allows clients to specify the format of the account (Base64Json, JSON, Mnemonic, or SpendingKey)

if format is specified in the request then the decoding is only attempted for the specified format

results in more specific error messages instead of an error message containing the errors for each encoder

## Testing Plan
- adds unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[X] Yes
```

https://github.com/iron-fish/website/pull/755

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
