### PR TITLE
adds ledger flag to burn command

### DIFF
--- a/ironfish-cli/src/commands/wallet/burn.ts
+++ b/ironfish-cli/src/commands/wallet/burn.ts
@@ -87,6 +87,10 @@ This will destroy tokens and decrease supply for a given asset.`
       default: false,
       description: 'Wait for the transaction to be confirmed',
     }),
+    ledger: Flags.boolean({
+      default: false,
+      description: 'Burn a transaction using a Ledger device',
+    }),
   }
 
   async start(): Promise<void> {
@@ -220,6 +224,18 @@ This will destroy tokens and decrease supply for a given asset.`
     }
 
     await this.confirm(assetData, amount, raw.fee, account, flags.confirm)
+
+    if (flags.ledger) {
+      await ui.sendTransactionWithLedger(
+        client,
+        raw,
+        account,
+        flags.watch,
+        flags.confirm,
+        this.logger,
+      )
+      this.exit(0)
+    }
 
     ux.action.start('Sending the transaction')
 


### PR DESCRIPTION
## Summary

Allows the user to use a ledger device to sign the burn transaction.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
