### PR TITLE
handles expert mode required error in ledger ui

### DIFF
--- a/ironfish-cli/src/ledger/ledger.ts
+++ b/ironfish-cli/src/ledger/ledger.ts
@@ -24,6 +24,7 @@ export const IronfishLedgerStatusCodes = {
   UNKNOWN_TRANSPORT_ERROR: 0xffff,
   INVALID_TX_HASH: 0xb025,
   PANIC: 0xe000,
+  EXPERT_MODE_REQUIRED: 0x6984,
 }
 
 export class Ledger {
@@ -71,6 +72,8 @@ export class Ledger {
           throw new LedgerPanicError()
         } else if (error.returnCode === IronfishLedgerStatusCodes.GP_AUTH_FAILED) {
           throw new LedgerGPAuthFailed()
+        } else if (error.returnCode === IronfishLedgerStatusCodes.EXPERT_MODE_REQUIRED) {
+          throw new LedgerExpertModeError()
         } else if (
           [
             IronfishLedgerStatusCodes.COMMAND_NOT_ALLOWED,
@@ -183,3 +186,4 @@ export class LedgerAppNotOpen extends LedgerError {}
 export class LedgerActionRejected extends LedgerError {}
 export class LedgerInvalidTxHash extends LedgerError {}
 export class LedgerPanicError extends LedgerError {}
+export class LedgerExpertModeError extends LedgerError {}

--- a/ironfish-cli/src/ui/ledger.ts
+++ b/ironfish-cli/src/ui/ledger.ts
@@ -19,6 +19,7 @@ import {
   LedgerClaNotSupportedError,
   LedgerConnectError,
   LedgerDeviceLockedError,
+  LedgerExpertModeError,
   LedgerGPAuthFailed,
   LedgerPanicError,
   LedgerPortIsBusyError,
@@ -73,6 +74,24 @@ export async function ledger<TResult>({
 
           const confirmed = await ui.confirmList(
             'Ledger Locked. Unlock and press enter to retry:',
+            'Retry',
+          )
+
+          if (!confirmed) {
+            ux.stdout('Operation aborted.')
+            ux.exit(0)
+          }
+
+          if (!wasRunning) {
+            ux.action.start(message)
+          }
+        } else if (e instanceof LedgerExpertModeError) {
+          // Polling the device may prevent the user from navigating to the
+          // expert mode screen in the app and enabling expert mode.
+          ux.action.stop('Expert mode required to send custom assets')
+
+          const confirmed = await ui.confirmList(
+            'Enable expert mode and press enter to retry:',
             'Retry',
           )
 


### PR DESCRIPTION
## Summary

as of v1.1.0 of the Ironfish Ledger app expert mode must be required to review a transaction that sends custom assets

defines the error code for the new export mode error

stops polling the Ledger app when an expert mode error is thrown so that the user can navigate to the expert mode screen and enable expert mode before continuing

Closes IFL-3148

## Testing Plan
manual testing:
with expert mode set to `disabled`, run `wallet:mint --ledger --transferTo <other_address>` to send a transaction with a custom asset as an output note

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
