### PR TITLE
updates sign command to use ui.ledger for ledger signing

### DIFF
--- a/ironfish-cli/src/commands/wallet/transactions/sign.ts
+++ b/ironfish-cli/src/commands/wallet/transactions/sign.ts
@@ -110,17 +110,15 @@ export class TransactionsSignCommand extends IronfishCommand {
 
   private async signWithLedger(client: RpcClient, unsignedTransaction: string) {
     const ledger = new LedgerSingleSigner()
-    try {
-      await ledger.connect()
-    } catch (e) {
-      if (e instanceof Error) {
-        this.error(e.message)
-      } else {
-        throw e
-      }
-    }
 
-    const signature = (await ledger.sign(unsignedTransaction)).toString('hex')
+    const signature = (
+      await ui.ledger({
+        ledger,
+        message: 'Sign Transaction',
+        approval: true,
+        action: () => ledger.sign(unsignedTransaction),
+      })
+    ).toString('hex')
 
     this.log(`\nSignature: ${signature}`)
 


### PR DESCRIPTION
## Summary

the 'ledger' function from the ui module handles a variety of errors from the ledger app. using the ui function to wrap the app interactions improves user experience over calling the ledger sign method directly

Closes IFL-3149

## Testing Plan
1. create an unsigned transaction from a ledger account using `wallet:send --unsignedTransaction`
2. checkout the staging branch
3. without connecting your ledger, use `wallet:transactions:sign` to attempt to sign the transaction and observer that the command crashes with an error
<img width="907" alt="image" src="https://github.com/user-attachments/assets/4bf3dece-42e5-4b0b-bf14-e34eb35b2bf3">

4. checkout this branch
5. repeat step 3 but observe that the command catches the error and instructs you to connect and unlock your ledger
<img width="408" alt="image" src="https://github.com/user-attachments/assets/f8a4def8-3f0f-47e5-9816-5f2f389cf3d9">


## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
