### PR TITLE
Expose the ironfish crate features in the wasm crate

### DIFF
--- a/ironfish-rust-wasm/Cargo.toml
+++ b/ironfish-rust-wasm/Cargo.toml
@@ -13,11 +13,18 @@ publish = false
 [lib]
 crate-type = ["cdylib"]
 
+[features]
+default = ["transaction-proofs"]
+
+download-params = ["ironfish/download-params"]
+note-encryption-stats = ["ironfish/note-encryption-stats"]
+transaction-proofs = ["ironfish/transaction-proofs"]
+
 [dependencies]
 blstrs = "0.6.0"
 getrandom = { version = "0.2.8", features = ["js"] } # need to explicitly enable the `js` feature in order to run in a browser
 group = "0.12.0"
-ironfish = { version = "0.3.0", path = "../ironfish-rust" }
+ironfish = { version = "0.3.0", path = "../ironfish-rust", default-features = false }
 ironfish-jubjub = "0.1.0"
 ironfish_zkp = { version = "0.2.0", path = "../ironfish-zkp" }
 rand = "0.8.5"


### PR DESCRIPTION
## Summary

Make it so that `ironfish-wasm` and `ironfish` have the same set of toggleable features, and the same defaults.

## Testing Plan

Unit tests

In the future, I might add a GitHub Actions test that builds all feature combinations, based on https://github.com/frewsxcv/cargo-all-features

## Documentation

N/A

## Breaking Change

N/A