### PR TITLE
WASM: use a macro to simplify the definition of binding types

### DIFF
--- a/ironfish-rust-wasm/src/assets.rs
+++ b/ironfish-rust-wasm/src/assets.rs
@@ -6,13 +6,15 @@ use crate::{
     errors::IronfishError,
     keys::PublicAddress,
     primitives::{ExtendedPoint, SubgroupPoint},
+    wasm_bindgen_wrapper,
 };
 use ironfish::errors::IronfishErrorKind;
 use wasm_bindgen::prelude::*;
 
-#[wasm_bindgen]
-#[derive(Clone, PartialEq, Eq, Debug)]
-pub struct Asset(ironfish::assets::asset::Asset);
+wasm_bindgen_wrapper! {
+    #[derive(Clone, PartialEq, Eq, Debug)]
+    pub struct Asset(ironfish::assets::asset::Asset);
+}
 
 #[wasm_bindgen]
 impl Asset {
@@ -99,21 +101,10 @@ impl Asset {
     }
 }
 
-impl From<ironfish::assets::asset::Asset> for Asset {
-    fn from(d: ironfish::assets::asset::Asset) -> Self {
-        Self(d)
-    }
+wasm_bindgen_wrapper! {
+    #[derive(Clone, PartialEq, Eq, Debug)]
+    pub struct AssetIdentifier(ironfish::assets::asset_identifier::AssetIdentifier);
 }
-
-impl AsRef<ironfish::assets::asset::Asset> for Asset {
-    fn as_ref(&self) -> &ironfish::assets::asset::Asset {
-        &self.0
-    }
-}
-
-#[wasm_bindgen]
-#[derive(Clone, PartialEq, Eq, Debug)]
-pub struct AssetIdentifier(ironfish::assets::asset_identifier::AssetIdentifier);
 
 #[wasm_bindgen]
 impl AssetIdentifier {
@@ -137,18 +128,6 @@ impl AssetIdentifier {
     #[wasm_bindgen(getter, js_name = valueCommitmentGenerator)]
     pub fn value_commitment_generator(&self) -> SubgroupPoint {
         self.0.value_commitment_generator().into()
-    }
-}
-
-impl From<ironfish::assets::asset_identifier::AssetIdentifier> for AssetIdentifier {
-    fn from(d: ironfish::assets::asset_identifier::AssetIdentifier) -> Self {
-        Self(d)
-    }
-}
-
-impl AsRef<ironfish::assets::asset_identifier::AssetIdentifier> for AssetIdentifier {
-    fn as_ref(&self) -> &ironfish::assets::asset_identifier::AssetIdentifier {
-        &self.0
     }
 }
 

--- a/ironfish-rust-wasm/src/keys/public_address.rs
+++ b/ironfish-rust-wasm/src/keys/public_address.rs
@@ -2,12 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use crate::errors::IronfishError;
+use crate::{errors::IronfishError, wasm_bindgen_wrapper};
 use wasm_bindgen::prelude::*;
 
-#[wasm_bindgen]
-#[derive(Clone, PartialEq, Eq, Debug)]
-pub struct PublicAddress(ironfish::PublicAddress);
+wasm_bindgen_wrapper! {
+    #[derive(Clone, PartialEq, Eq, Debug)]
+    pub struct PublicAddress(ironfish::PublicAddress);
+}
 
 #[wasm_bindgen]
 impl PublicAddress {
@@ -29,18 +30,6 @@ impl PublicAddress {
     #[wasm_bindgen(getter)]
     pub fn hex(&self) -> String {
         self.0.hex_public_address()
-    }
-}
-
-impl From<ironfish::PublicAddress> for PublicAddress {
-    fn from(d: ironfish::PublicAddress) -> Self {
-        Self(d)
-    }
-}
-
-impl AsRef<ironfish::PublicAddress> for PublicAddress {
-    fn as_ref(&self) -> &ironfish::PublicAddress {
-        &self.0
     }
 }
 

--- a/ironfish-rust-wasm/src/lib.rs
+++ b/ironfish-rust-wasm/src/lib.rs
@@ -22,6 +22,66 @@ pub mod merkle_note;
 pub mod primitives;
 pub mod transaction;
 
+/// Creates a [`wasm_bindgen`] wrapper for an existing type.
+///
+/// This macro can be invoked as follows:
+///
+/// ```
+/// wasm_bindgen_wrapper! {
+///     #[derive(Clone, Debug)]
+///     pub struct FooBinding(Foo);
+/// }
+/// ```
+///
+/// and expands to the following:
+///
+/// ```
+/// #[wasm_bindgen]
+/// #[derive(Clone, Debug)]
+/// pub struct FooBinding(Foo);
+///
+/// impl From<Foo> for FooBinding { ... }
+/// impl From<FooBinding> for Foo { ... }
+/// impl AsRef<Foo> for FooBinding { ... }
+/// impl Borrow<Foo> for FooBinding { ... }
+/// ```
+macro_rules! wasm_bindgen_wrapper {
+    ($(
+        $( #[ $meta:meta ] )*
+        $vis:vis struct $name:ident ( $inner:ty ) ;
+    )*) => {$(
+        $(#[$meta])*
+        #[::wasm_bindgen::prelude::wasm_bindgen]
+        $vis struct $name($inner);
+
+        impl ::std::convert::From<$inner> for $name {
+            fn from(x: $inner) -> Self {
+                Self(x)
+            }
+        }
+
+        impl ::std::convert::From<$name> for $inner {
+            fn from(x: $name) -> Self {
+                x.0
+            }
+        }
+
+        impl ::std::convert::AsRef<$inner> for $name {
+            fn as_ref(&self) -> &$inner {
+                &self.0
+            }
+        }
+
+        impl ::std::borrow::Borrow<$inner> for $name {
+            fn borrow(&self) -> &$inner {
+                &self.0
+            }
+        }
+    )*}
+}
+
+use wasm_bindgen_wrapper;
+
 #[cfg(test)]
 mod tests {
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);

--- a/ironfish-rust-wasm/src/merkle_note.rs
+++ b/ironfish-rust-wasm/src/merkle_note.rs
@@ -2,12 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use crate::{errors::IronfishError, primitives::Scalar};
+use crate::{errors::IronfishError, primitives::Scalar, wasm_bindgen_wrapper};
 use wasm_bindgen::prelude::*;
 
-#[wasm_bindgen]
-#[derive(Clone, PartialEq, Eq, Debug)]
-pub struct MerkleNote(ironfish::MerkleNote);
+wasm_bindgen_wrapper! {
+    #[derive(Clone, PartialEq, Eq, Debug)]
+    pub struct MerkleNote(ironfish::MerkleNote);
+}
 
 #[wasm_bindgen]
 impl MerkleNote {
@@ -31,21 +32,10 @@ impl MerkleNote {
     }
 }
 
-impl From<ironfish::MerkleNote> for MerkleNote {
-    fn from(d: ironfish::MerkleNote) -> Self {
-        Self(d)
-    }
+wasm_bindgen_wrapper! {
+    #[derive(Clone, PartialEq, Eq, Debug)]
+    pub struct MerkleNoteHash(ironfish::MerkleNoteHash);
 }
-
-impl AsRef<ironfish::MerkleNote> for MerkleNote {
-    fn as_ref(&self) -> &ironfish::MerkleNote {
-        &self.0
-    }
-}
-
-#[wasm_bindgen]
-#[derive(Clone, PartialEq, Eq, Debug)]
-pub struct MerkleNoteHash(ironfish::MerkleNoteHash);
 
 #[wasm_bindgen]
 impl MerkleNoteHash {
@@ -77,18 +67,6 @@ impl MerkleNoteHash {
     pub fn combine_hash(depth: usize, left: &Self, right: &Self) -> Self {
         let hash = ironfish::MerkleNoteHash::combine_hash(depth, &left.0 .0, &right.0 .0);
         ironfish::MerkleNoteHash(hash).into()
-    }
-}
-
-impl From<ironfish::MerkleNoteHash> for MerkleNoteHash {
-    fn from(d: ironfish::MerkleNoteHash) -> Self {
-        Self(d)
-    }
-}
-
-impl AsRef<ironfish::MerkleNoteHash> for MerkleNoteHash {
-    fn as_ref(&self) -> &ironfish::MerkleNoteHash {
-        &self.0
     }
 }
 

--- a/ironfish-rust-wasm/src/primitives.rs
+++ b/ironfish-rust-wasm/src/primitives.rs
@@ -2,16 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use crate::errors::IronfishError;
+use crate::{errors::IronfishError, wasm_bindgen_wrapper};
 use group::GroupEncoding;
 use ironfish::errors::IronfishErrorKind;
 use ironfish_zkp::redjubjub;
 use rand::thread_rng;
 use wasm_bindgen::prelude::*;
 
-#[wasm_bindgen]
-#[derive(Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
-pub struct Scalar(blstrs::Scalar);
+wasm_bindgen_wrapper! {
+    #[derive(Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
+    pub struct Scalar(blstrs::Scalar);
+}
 
 #[wasm_bindgen]
 impl Scalar {
@@ -26,21 +27,10 @@ impl Scalar {
     }
 }
 
-impl From<blstrs::Scalar> for Scalar {
-    fn from(s: blstrs::Scalar) -> Self {
-        Self(s)
-    }
+wasm_bindgen_wrapper! {
+    #[derive(Default, Copy, Clone, PartialEq, Eq, Debug)]
+    pub struct Fr(ironfish_jubjub::Fr);
 }
-
-impl AsRef<blstrs::Scalar> for Scalar {
-    fn as_ref(&self) -> &blstrs::Scalar {
-        &self.0
-    }
-}
-
-#[wasm_bindgen]
-#[derive(Default, Copy, Clone, PartialEq, Eq, Debug)]
-pub struct Fr(ironfish_jubjub::Fr);
 
 #[wasm_bindgen]
 impl Fr {
@@ -50,21 +40,10 @@ impl Fr {
     }
 }
 
-impl From<ironfish_jubjub::Fr> for Fr {
-    fn from(s: ironfish_jubjub::Fr) -> Self {
-        Self(s)
-    }
+wasm_bindgen_wrapper! {
+    #[derive(Default, Copy, Clone, PartialEq, Eq, Debug)]
+    pub struct ExtendedPoint(ironfish_jubjub::ExtendedPoint);
 }
-
-impl AsRef<ironfish_jubjub::Fr> for Fr {
-    fn as_ref(&self) -> &ironfish_jubjub::Fr {
-        &self.0
-    }
-}
-
-#[wasm_bindgen]
-#[derive(Default, Copy, Clone, PartialEq, Eq, Debug)]
-pub struct ExtendedPoint(ironfish_jubjub::ExtendedPoint);
 
 #[wasm_bindgen]
 impl ExtendedPoint {
@@ -74,21 +53,10 @@ impl ExtendedPoint {
     }
 }
 
-impl From<ironfish_jubjub::ExtendedPoint> for ExtendedPoint {
-    fn from(s: ironfish_jubjub::ExtendedPoint) -> Self {
-        Self(s)
-    }
+wasm_bindgen_wrapper! {
+    #[derive(Default, Copy, Clone, PartialEq, Eq, Debug)]
+    pub struct SubgroupPoint(ironfish_jubjub::SubgroupPoint);
 }
-
-impl AsRef<ironfish_jubjub::ExtendedPoint> for ExtendedPoint {
-    fn as_ref(&self) -> &ironfish_jubjub::ExtendedPoint {
-        &self.0
-    }
-}
-
-#[wasm_bindgen]
-#[derive(Default, Copy, Clone, PartialEq, Eq, Debug)]
-pub struct SubgroupPoint(ironfish_jubjub::SubgroupPoint);
 
 #[wasm_bindgen]
 impl SubgroupPoint {
@@ -98,21 +66,10 @@ impl SubgroupPoint {
     }
 }
 
-impl From<ironfish_jubjub::SubgroupPoint> for SubgroupPoint {
-    fn from(s: ironfish_jubjub::SubgroupPoint) -> Self {
-        Self(s)
-    }
+wasm_bindgen_wrapper! {
+    #[derive(Copy, Clone, PartialEq, Eq, Debug)]
+    pub struct Nullifier(ironfish_zkp::Nullifier);
 }
-
-impl AsRef<ironfish_jubjub::SubgroupPoint> for SubgroupPoint {
-    fn as_ref(&self) -> &ironfish_jubjub::SubgroupPoint {
-        &self.0
-    }
-}
-
-#[wasm_bindgen]
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
-pub struct Nullifier(ironfish_zkp::Nullifier);
 
 #[wasm_bindgen]
 impl Nullifier {
@@ -122,20 +79,9 @@ impl Nullifier {
     }
 }
 
-impl From<ironfish_zkp::Nullifier> for Nullifier {
-    fn from(s: ironfish_zkp::Nullifier) -> Self {
-        Self(s)
-    }
+wasm_bindgen_wrapper! {
+    pub struct PrivateKey(redjubjub::PrivateKey);
 }
-
-impl AsRef<ironfish_zkp::Nullifier> for Nullifier {
-    fn as_ref(&self) -> &ironfish_zkp::Nullifier {
-        &self.0
-    }
-}
-
-#[wasm_bindgen]
-pub struct PrivateKey(redjubjub::PrivateKey);
 
 #[wasm_bindgen]
 impl PrivateKey {
@@ -168,21 +114,10 @@ impl PrivateKey {
     }
 }
 
-impl From<redjubjub::PrivateKey> for PrivateKey {
-    fn from(p: redjubjub::PrivateKey) -> Self {
-        Self(p)
-    }
+wasm_bindgen_wrapper! {
+    #[derive(Clone, Debug)]
+    pub struct PublicKey(redjubjub::PublicKey);
 }
-
-impl AsRef<redjubjub::PrivateKey> for PrivateKey {
-    fn as_ref(&self) -> &redjubjub::PrivateKey {
-        &self.0
-    }
-}
-
-#[wasm_bindgen]
-#[derive(Clone, Debug)]
-pub struct PublicKey(redjubjub::PublicKey);
 
 #[wasm_bindgen]
 impl PublicKey {
@@ -218,21 +153,10 @@ impl PublicKey {
     }
 }
 
-impl From<redjubjub::PublicKey> for PublicKey {
-    fn from(p: redjubjub::PublicKey) -> Self {
-        Self(p)
-    }
+wasm_bindgen_wrapper! {
+    #[derive(Clone, Debug)]
+    pub struct Signature(redjubjub::Signature);
 }
-
-impl AsRef<redjubjub::PublicKey> for PublicKey {
-    fn as_ref(&self) -> &redjubjub::PublicKey {
-        &self.0
-    }
-}
-
-#[wasm_bindgen]
-#[derive(Clone, Debug)]
-pub struct Signature(redjubjub::Signature);
 
 #[wasm_bindgen]
 impl Signature {
@@ -247,17 +171,5 @@ impl Signature {
         let mut buf = Vec::new();
         self.0.write(&mut buf).expect("serialization failed");
         buf
-    }
-}
-
-impl From<redjubjub::Signature> for Signature {
-    fn from(s: redjubjub::Signature) -> Self {
-        Self(s)
-    }
-}
-
-impl AsRef<redjubjub::Signature> for Signature {
-    fn as_ref(&self) -> &redjubjub::Signature {
-        &self.0
     }
 }

--- a/ironfish-rust-wasm/src/transaction/burns.rs
+++ b/ironfish-rust-wasm/src/transaction/burns.rs
@@ -2,12 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use crate::{assets::AssetIdentifier, errors::IronfishError};
+use crate::{assets::AssetIdentifier, errors::IronfishError, wasm_bindgen_wrapper};
 use wasm_bindgen::prelude::*;
 
-#[wasm_bindgen]
-#[derive(Clone, PartialEq, Eq, Debug)]
-pub struct BurnDescription(ironfish::transaction::burns::BurnDescription);
+wasm_bindgen_wrapper! {
+    #[derive(Clone, PartialEq, Eq, Debug)]
+    pub struct BurnDescription(ironfish::transaction::burns::BurnDescription);
+}
 
 #[wasm_bindgen]
 impl BurnDescription {
@@ -35,17 +36,5 @@ impl BurnDescription {
     #[wasm_bindgen(getter)]
     pub fn value(&self) -> u64 {
         self.0.value
-    }
-}
-
-impl From<ironfish::transaction::burns::BurnDescription> for BurnDescription {
-    fn from(d: ironfish::transaction::burns::BurnDescription) -> Self {
-        Self(d)
-    }
-}
-
-impl AsRef<ironfish::transaction::burns::BurnDescription> for BurnDescription {
-    fn as_ref(&self) -> &ironfish::transaction::burns::BurnDescription {
-        &self.0
     }
 }

--- a/ironfish-rust-wasm/src/transaction/mints.rs
+++ b/ironfish-rust-wasm/src/transaction/mints.rs
@@ -7,13 +7,15 @@ use crate::{
     errors::IronfishError,
     keys::PublicAddress,
     primitives::{PublicKey, Scalar},
+    wasm_bindgen_wrapper,
 };
 use ironfish::{errors::IronfishErrorKind, transaction::TransactionVersion};
 use wasm_bindgen::prelude::*;
 
-#[wasm_bindgen]
-#[derive(Clone, Debug)]
-pub struct MintDescription(ironfish::transaction::mints::MintDescription);
+wasm_bindgen_wrapper! {
+    #[derive(Clone, Debug)]
+    pub struct MintDescription(ironfish::transaction::mints::MintDescription);
+}
 
 #[wasm_bindgen]
 impl MintDescription {
@@ -75,17 +77,5 @@ impl MintDescription {
             .into_iter()
             .map(Scalar::from)
             .collect()
-    }
-}
-
-impl From<ironfish::transaction::mints::MintDescription> for MintDescription {
-    fn from(d: ironfish::transaction::mints::MintDescription) -> Self {
-        Self(d)
-    }
-}
-
-impl AsRef<ironfish::transaction::mints::MintDescription> for MintDescription {
-    fn as_ref(&self) -> &ironfish::transaction::mints::MintDescription {
-        &self.0
     }
 }

--- a/ironfish-rust-wasm/src/transaction/mod.rs
+++ b/ironfish-rust-wasm/src/transaction/mod.rs
@@ -7,7 +7,7 @@ mod mints;
 mod outputs;
 mod spends;
 
-use crate::{errors::IronfishError, primitives::PublicKey};
+use crate::{errors::IronfishError, primitives::PublicKey, wasm_bindgen_wrapper};
 use wasm_bindgen::prelude::*;
 
 pub use burns::BurnDescription;
@@ -15,9 +15,10 @@ pub use mints::MintDescription;
 pub use outputs::OutputDescription;
 pub use spends::SpendDescription;
 
-#[wasm_bindgen]
-#[derive(Clone, Debug)]
-pub struct Transaction(ironfish::Transaction);
+wasm_bindgen_wrapper! {
+    #[derive(Clone, Debug)]
+    pub struct Transaction(ironfish::Transaction);
+}
 
 #[wasm_bindgen]
 impl Transaction {
@@ -96,18 +97,6 @@ impl Transaction {
             .transaction_signature_hash()
             .map(|hash| hash.to_vec())
             .map_err(|err| err.into())
-    }
-}
-
-impl From<ironfish::Transaction> for Transaction {
-    fn from(t: ironfish::Transaction) -> Self {
-        Self(t)
-    }
-}
-
-impl AsRef<ironfish::Transaction> for Transaction {
-    fn as_ref(&self) -> &ironfish::Transaction {
-        &self.0
     }
 }
 

--- a/ironfish-rust-wasm/src/transaction/outputs.rs
+++ b/ironfish-rust-wasm/src/transaction/outputs.rs
@@ -6,12 +6,14 @@ use crate::{
     errors::IronfishError,
     merkle_note::MerkleNote,
     primitives::{PublicKey, Scalar},
+    wasm_bindgen_wrapper,
 };
 use wasm_bindgen::prelude::*;
 
-#[wasm_bindgen]
-#[derive(Clone, PartialEq, Debug)]
-pub struct OutputDescription(ironfish::OutputDescription);
+wasm_bindgen_wrapper! {
+    #[derive(Clone, PartialEq, Debug)]
+    pub struct OutputDescription(ironfish::OutputDescription);
+}
 
 #[wasm_bindgen]
 impl OutputDescription {
@@ -46,17 +48,5 @@ impl OutputDescription {
     #[wasm_bindgen(getter, js_name = merkleNote)]
     pub fn merkle_note(&self) -> MerkleNote {
         self.0.merkle_note().into()
-    }
-}
-
-impl From<ironfish::OutputDescription> for OutputDescription {
-    fn from(d: ironfish::OutputDescription) -> Self {
-        Self(d)
-    }
-}
-
-impl AsRef<ironfish::OutputDescription> for OutputDescription {
-    fn as_ref(&self) -> &ironfish::OutputDescription {
-        &self.0
     }
 }

--- a/ironfish-rust-wasm/src/transaction/spends.rs
+++ b/ironfish-rust-wasm/src/transaction/spends.rs
@@ -5,13 +5,15 @@
 use crate::{
     errors::IronfishError,
     primitives::{Nullifier, PublicKey, Scalar},
+    wasm_bindgen_wrapper,
 };
 use ironfish::errors::IronfishErrorKind;
 use wasm_bindgen::prelude::*;
 
-#[wasm_bindgen]
-#[derive(Clone, Debug)]
-pub struct SpendDescription(ironfish::SpendDescription);
+wasm_bindgen_wrapper! {
+    #[derive(Clone, Debug)]
+    pub struct SpendDescription(ironfish::SpendDescription);
+}
 
 #[wasm_bindgen]
 impl SpendDescription {
@@ -70,17 +72,5 @@ impl SpendDescription {
             .into_iter()
             .map(Scalar::from)
             .collect()
-    }
-}
-
-impl From<ironfish::SpendDescription> for SpendDescription {
-    fn from(d: ironfish::SpendDescription) -> Self {
-        Self(d)
-    }
-}
-
-impl AsRef<ironfish::SpendDescription> for SpendDescription {
-    fn as_ref(&self) -> &ironfish::SpendDescription {
-        &self.0
     }
 }


### PR DESCRIPTION
## Summary

This reduces the amount of repeated code. Also, it adds some conversions that were previously not implemented.

## Testing Plan

Unit tests

## Documentation

N/A

## Breaking Change

N/A