### PR TITLE
Account name for balance command is arg

### DIFF
--- a/ironfish-cli/src/commands/wallet/balance.ts
+++ b/ironfish-cli/src/commands/wallet/balance.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { CurrencyUtils, GetBalanceResponse, isNativeIdentifier, RpcAsset } from '@ironfish/sdk'
-import { Flags } from '@oclif/core'
+import { Args, Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 import * as ui from '../../ui'
@@ -27,12 +27,15 @@ Balance is your coins from all of your transactions, even if they are on forks o
     },
   ]
 
-  static flags = {
-    ...RemoteFlags,
-    account: Flags.string({
-      char: 'a',
+  static args = {
+    account: Args.string({
+      required: false,
       description: 'Name of the account to get balance for',
     }),
+  }
+
+  static flags = {
+    ...RemoteFlags,
     explain: Flags.boolean({
       default: false,
       description: 'Explain your balance',
@@ -50,12 +53,12 @@ Balance is your coins from all of your transactions, even if they are on forks o
   }
 
   async start(): Promise<void> {
-    const { flags } = await this.parse(BalanceCommand)
+    const { flags, args } = await this.parse(BalanceCommand)
 
     const client = await this.connectRpc()
     await ui.checkWalletUnlocked(client)
 
-    const account = await useAccount(client, flags.account)
+    const account = await useAccount(client, args.account)
 
     const response = await client.wallet.getAccountBalance({
       account,


### PR DESCRIPTION
## Summary

Previously, it was a flag. This didn't conform to the standard we have for other commands like address.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
