### PR TITLE
handles Ledger 'invalid dkg status' errors

### DIFF
--- a/ironfish-cli/src/ledger/ledger.ts
+++ b/ironfish-cli/src/ledger/ledger.ts
@@ -26,6 +26,7 @@ export const IronfishLedgerStatusCodes = {
   PANIC: 0xe000,
   EXPERT_MODE_REQUIRED: 0x6984,
   DKG_EXPERT_MODE_REQUIRED: 0xb027,
+  INVALID_DKG_STATUS: 0xb022,
 }
 
 export class Ledger {
@@ -73,6 +74,8 @@ export class Ledger {
           throw new LedgerPanicError()
         } else if (error.returnCode === IronfishLedgerStatusCodes.GP_AUTH_FAILED) {
           throw new LedgerGPAuthFailed()
+        } else if (error.returnCode === IronfishLedgerStatusCodes.INVALID_DKG_STATUS) {
+          throw new LedgerInvalidDkgStatusError()
         } else if (
           error.returnCode === IronfishLedgerStatusCodes.EXPERT_MODE_REQUIRED ||
           error.returnCode === IronfishLedgerStatusCodes.DKG_EXPERT_MODE_REQUIRED
@@ -191,3 +194,4 @@ export class LedgerActionRejected extends LedgerError {}
 export class LedgerInvalidTxHash extends LedgerError {}
 export class LedgerPanicError extends LedgerError {}
 export class LedgerExpertModeError extends LedgerError {}
+export class LedgerInvalidDkgStatusError extends LedgerError {}

--- a/ironfish-cli/src/ui/ledger.ts
+++ b/ironfish-cli/src/ui/ledger.ts
@@ -21,6 +21,7 @@ import {
   LedgerDeviceLockedError,
   LedgerExpertModeError,
   LedgerGPAuthFailed,
+  LedgerInvalidDkgStatusError,
   LedgerPanicError,
   LedgerPortIsBusyError,
   LedgerSingleSigner,
@@ -103,6 +104,12 @@ export async function ledger<TResult>({
           if (!wasRunning) {
             ux.action.start(message)
           }
+        } else if (e instanceof LedgerInvalidDkgStatusError) {
+          ux.action.stop('Ironfish DKG Ledger App does not have any multisig keys!')
+          ux.stdout(
+            'Use `wallet:multisig:ledger:restore` to restore an encrypted backup to your Ledger',
+          )
+          ux.exit(1)
         } else if (e instanceof LedgerActionRejected) {
           ux.action.status = 'User Rejected Ledger Request!'
           ux.stdout('User Rejected Ledger Request!')


### PR DESCRIPTION
## Summary

if a user attempts to sign a transaction, but their ledger app doesn't have any multisig keys persisted, then the signing operation will fail with an 'invalid dkg status' error. this can happen if the user reinstalls the app or if the user starts creating a new account on the device using bkg, but doesn't finish

the only ways to recover from this error are to restore an encrypted backup to the device, or to create a new multisig account using the device. since the error shows up during signing, we can infer that the user expects to have an account on the device and should be instructed to restore the backup

Closes IFL-3151

## Testing Plan
manual testing:
1. create multisig ledger account
2. create a transaction to sign using the multisig account(s)
3. reinstall the ironfish dkg app to clear the account keys from the device's storage
4. attempt to sign the transaction to produce the error

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
