### PR TITLE
converts dkg commands to use ui.ledger

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/dkg/round1.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/round1.ts
@@ -101,15 +101,6 @@ export class DkgRound1Command extends IronfishCommand {
     minSigners: number,
   ): Promise<void> {
     const ledger = new LedgerMultiSigner()
-    try {
-      await ledger.connect()
-    } catch (e) {
-      if (e instanceof Error) {
-        this.error(e.message)
-      } else {
-        throw e
-      }
-    }
 
     const identityResponse = await client.wallet.multisig.getIdentity({ name: participantName })
     const identity = identityResponse.content.identity
@@ -118,8 +109,12 @@ export class DkgRound1Command extends IronfishCommand {
       identities.push(identity)
     }
 
-    // TODO(hughy): determine how to handle multiple identities using index
-    const { publicPackage, secretPackage } = await ledger.dkgRound1(0, identities, minSigners)
+    const { publicPackage, secretPackage } = await ui.ledger({
+      ledger,
+      message: 'Round1 on Ledger',
+      approval: true,
+      action: () => ledger.dkgRound1(0, identities, minSigners),
+    })
 
     this.log('\nRound 1 Encrypted Secret Package:\n')
     this.log(secretPackage.toString('hex'))

--- a/ironfish-cli/src/commands/wallet/multisig/dkg/round2.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/round2.ts
@@ -98,22 +98,13 @@ export class DkgRound2Command extends IronfishCommand {
     round1SecretPackage: string,
   ): Promise<void> {
     const ledger = new LedgerMultiSigner()
-    try {
-      await ledger.connect()
-    } catch (e) {
-      if (e instanceof Error) {
-        this.error(e.message)
-      } else {
-        throw e
-      }
-    }
 
-    // TODO(hughy): determine how to handle multiple identities using index
-    const { publicPackage, secretPackage } = await ledger.dkgRound2(
-      0,
-      round1PublicPackages,
-      round1SecretPackage,
-    )
+    const { publicPackage, secretPackage } = await ui.ledger({
+      ledger,
+      message: 'Round2 on Ledger',
+      approval: true,
+      action: () => ledger.dkgRound2(0, round1PublicPackages, round1SecretPackage),
+    })
 
     this.log('\nRound 2 Encrypted Secret Package:\n')
     this.log(secretPackage.toString('hex'))

--- a/ironfish-cli/src/commands/wallet/multisig/participant/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/participant/create.ts
@@ -72,17 +72,11 @@ export class MultisigIdentityCreate extends IronfishCommand {
 
   async getIdentityFromLedger(): Promise<Buffer> {
     const ledger = new LedgerMultiSigner()
-    try {
-      await ledger.connect()
-    } catch (e) {
-      if (e instanceof Error) {
-        this.error(e.message)
-      } else {
-        throw e
-      }
-    }
 
-    // TODO(hughy): support multiple identities using index
-    return ledger.dkgGetIdentity(0)
+    return ui.ledger({
+      ledger,
+      message: 'Getting Ledger Identity',
+      action: () => ledger.dkgGetIdentity(0),
+    })
   }
 }


### PR DESCRIPTION
## Summary

the ui.ledger function includes error handling and retry logic that could be useful in each of the standalone dkg commands ('participant:create', 'dkg:round1', 'dkg:round2', and 'dkg:round3')

Closes IFL-3152

## Testing Plan
manual testing:
created ledger multisig account using separate cli command flow

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
