### PR TITLE
upgrades multisig signing commands to use ui.ledger

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/commitment/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/commitment/create.ts
@@ -125,20 +125,16 @@ export class CreateSigningCommitmentCommand extends IronfishCommand {
     signers: string[],
   ): Promise<void> {
     const ledger = new LedgerMultiSigner()
-    try {
-      await ledger.connect()
-    } catch (e) {
-      if (e instanceof Error) {
-        this.error(e.message)
-      } else {
-        throw e
-      }
-    }
 
     const identityResponse = await client.wallet.multisig.getIdentity({ name: participantName })
     const identity = identityResponse.content.identity
 
-    const rawCommitments = await ledger.dkgGetCommitments(unsignedTransaction)
+    const rawCommitments = await ui.ledger({
+      ledger,
+      message: 'Get Commitments',
+      approval: true,
+      action: () => ledger.dkgGetCommitments(unsignedTransaction),
+    })
 
     const signingCommitment = multisig.SigningCommitment.fromRaw(
       identity,

--- a/ironfish-cli/src/commands/wallet/multisig/signature/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/signature/create.ts
@@ -121,20 +121,16 @@ export class CreateSignatureShareCommand extends IronfishCommand {
     frostSigningPackage: string,
   ): Promise<void> {
     const ledger = new LedgerMultiSigner()
-    try {
-      await ledger.connect()
-    } catch (e) {
-      if (e instanceof Error) {
-        this.error(e.message)
-      } else {
-        throw e
-      }
-    }
 
     const identityResponse = await client.wallet.multisig.getIdentity({ name: participantName })
     const identity = identityResponse.content.identity
 
-    const frostSignatureShare = await ledger.dkgSign(unsignedTransaction, frostSigningPackage)
+    const frostSignatureShare = await ui.ledger({
+      ledger,
+      message: 'Sign Transaction',
+      approval: true,
+      action: () => ledger.dkgSign(unsignedTransaction, frostSigningPackage),
+    })
 
     const signatureShare = multisig.SignatureShare.fromFrost(
       frostSignatureShare,


### PR DESCRIPTION
the ui.ledger function includes error handling and retry logic that will be helpful when signing multisig transactions using the dkg ledger app

Closes IFL-3153

## Testing Plan
manual testing signing transaction with ledger dkg app

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
