### PR TITLE
optionally retries in cli commands if user rejects Ledger request

### DIFF
--- a/ironfish-cli/src/ui/ledger.ts
+++ b/ironfish-cli/src/ui/ledger.ts
@@ -111,8 +111,8 @@ export async function ledger<TResult>({
           )
           ux.exit(1)
         } else if (e instanceof LedgerActionRejected) {
-          ux.action.status = 'User Rejected Ledger Request!'
-          ux.stdout('User Rejected Ledger Request!')
+          ux.action.stop('User Rejected Ledger Request!')
+          ux.exit(0)
         } else if (e instanceof LedgerConnectError) {
           ux.action.status = 'Connect and unlock your Ledger'
         } else if (e instanceof LedgerAppNotOpen) {


### PR DESCRIPTION
## Summary

if a user rejects an action on their Ledger, the command will now ~exit~ ask the user to retry instead of automatically retrying and prompting the user again to approve the action

## Testing Plan

before:
<img width="346" alt="image" src="https://github.com/user-attachments/assets/1d75329d-35c7-4f09-b883-8465921d402c">

after:
<img width="403" alt="image" src="https://github.com/user-attachments/assets/19f11a89-d251-4db1-85c0-ac17949ce9f6">


## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
