### PR TITLE
Switch from ubuntu-latest to ubuntu-22.04

### DIFF
--- a/.github/workflows/build-ironfish-rust-nodejs.yml
+++ b/.github/workflows/build-ironfish-rust-nodejs.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         settings:
-          - host: ubuntu-latest
+          - host: ubuntu-22.04
             target: x86_64-apple-darwin
 
           - host: windows-latest
@@ -24,16 +24,16 @@ jobs:
           - host: macos-latest
             target: x86_64-unknown-linux-gnu
 
-          - host: ubuntu-latest
+          - host: ubuntu-22.04
             target: x86_64-unknown-linux-musl
 
-          - host: ubuntu-latest
+          - host: ubuntu-22.04
             target: aarch64-apple-darwin
 
-          - host: ubuntu-latest
+          - host: ubuntu-22.04
             target: aarch64-unknown-linux-gnu
 
-          - host: ubuntu-latest
+          - host: ubuntu-22.04
             target: aarch64-unknown-linux-musl
 
     name: Build ${{ matrix.settings.target }}
@@ -94,19 +94,19 @@ jobs:
           - host: windows-latest
             target: x86_64-pc-windows-msvc
 
-          - host: ubuntu-latest
+          - host: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             docker: node:18-slim
 
-          - host: ubuntu-latest
+          - host: ubuntu-22.04
             target: x86_64-unknown-linux-musl
             docker: node:18-alpine
 
-          - host: ubuntu-latest
+          - host: ubuntu-22.04
             target: aarch64-unknown-linux-gnu
             docker: ghcr.io/napi-rs/napi-rs/nodejs:aarch64-16
 
-          - host: ubuntu-latest
+          - host: ubuntu-22.04
             target: aarch64-unknown-linux-musl
             docker: arm64v8/node:18-alpine
             platform: linux/arm64/v8

--- a/.github/workflows/check-pr-branch.yml
+++ b/.github/workflows/check-pr-branch.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - if: ${{ contains(github.event.pull_request.base.ref, 'master') && !contains(github.event.pull_request.title, 'master') }}
         run: |

--- a/.github/workflows/ci-regenerate-fixtures.yml
+++ b/.github/workflows/ci-regenerate-fixtures.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Check out Git repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
   lint:
     name: Lint
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Check out Git repository
@@ -51,7 +51,7 @@ jobs:
 
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         shard: [1/3, 2/3, 3/3]
@@ -96,7 +96,7 @@ jobs:
 
   testslow:
     name: Slow Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         shard: [1/2, 2/2]

--- a/.github/workflows/deploy-node-docker-image.yml
+++ b/.github/workflows/deploy-node-docker-image.yml
@@ -37,7 +37,7 @@ permissions:
 jobs:
   Deploy:
     name: Deploy
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Check out Git repository

--- a/.github/workflows/deploy-npm-ironfish-cli.yml
+++ b/.github/workflows/deploy-npm-ironfish-cli.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v4

--- a/.github/workflows/deploy-npm-ironfish-rust-nodejs.yml
+++ b/.github/workflows/deploy-npm-ironfish-rust-nodejs.yml
@@ -13,7 +13,7 @@ jobs:
 
   publish:
     name: Publish
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs:
       - build-and-test
     defaults:

--- a/.github/workflows/deploy-npm-ironfish.yml
+++ b/.github/workflows/deploy-npm-ironfish.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v4

--- a/.github/workflows/push-version-to-api.yml
+++ b/.github/workflows/push-version-to-api.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   Push:
     name: Push Version to API
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Check out Git repository

--- a/.github/workflows/rust_ci.yml
+++ b/.github/workflows/rust_ci.yml
@@ -33,7 +33,7 @@ name: Rust CI
 jobs:
   rust_lint:
     name: Lint Rust
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -63,7 +63,7 @@ jobs:
 
   cargo_check:
     name: Check Rust
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -83,7 +83,7 @@ jobs:
 
   cargo_vet:
     name: Vet Dependencies
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -103,7 +103,7 @@ jobs:
 
   ironfish_rust:
     name: Test ironfish-rust
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         shard: [1/2, 2/2]
@@ -142,7 +142,7 @@ jobs:
 
   ironfish_rust_no_default_features:
     name: Test ironfish-rust (no default features)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         shard: [1/2, 2/2]
@@ -168,7 +168,7 @@ jobs:
 
   ironfish_rust_all_features:
     name: Test ironfish-rust (all features)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         shard: [1/2, 2/2]
@@ -194,7 +194,7 @@ jobs:
 
   ironfish_zkp:
     name: Test ironfish-zkp
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -228,7 +228,7 @@ jobs:
 
   ironfish_wasm:
     name: Test ironfish-rust-wasm
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/rust_ci_cache.yml
+++ b/.github/workflows/rust_ci_cache.yml
@@ -19,7 +19,7 @@ name: Cache Rust build
 jobs:
   build-rust-cache:
     name: Build and cache rust code
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary

ubuntu-latest is switching to default to Ubuntu 24 soon: https://github.blog/changelog/2024-11-05-notice-of-breaking-changes-for-github-actions/ I think it's not likely to cause any problems, but for now we can opt out of the update by fixing the version.

I created an issue for upgrading versions later: https://linear.app/if-labs/issue/IFL-3158/upgrade-github-actions-from-ubuntu-2204-to-ubuntu-2404

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
