### PR TITLE
Rust: remove unnecessary uses of dynamic dispatch

### DIFF
--- a/ironfish-rust/src/merkle_note.rs
+++ b/ironfish-rust/src/merkle_note.rs
@@ -285,7 +285,9 @@ impl MerkleNote {
 }
 
 #[cfg(feature = "transaction-proofs")]
-pub(crate) fn sapling_auth_path(witness: &dyn WitnessTrait) -> Vec<Option<(Scalar, bool)>> {
+pub(crate) fn sapling_auth_path<W: WitnessTrait + ?Sized>(
+    witness: &W,
+) -> Vec<Option<(Scalar, bool)>> {
     let mut auth_path = vec![];
     for element in &witness.get_auth_path() {
         let sapling_element = match element {
@@ -305,7 +307,7 @@ pub(crate) fn sapling_auth_path(witness: &dyn WitnessTrait) -> Vec<Option<(Scala
 /// like making Witness a trait since it's otherwise very simple.
 /// So this hacky function gets to live here.
 #[cfg(feature = "transaction-proofs")]
-pub(crate) fn position(witness: &dyn WitnessTrait) -> u64 {
+pub(crate) fn position<W: WitnessTrait + ?Sized>(witness: &W) -> u64 {
     let mut pos = 0;
     for (i, element) in witness.get_auth_path().iter().enumerate() {
         if let WitnessNode::Right(_) = element {

--- a/ironfish-rust/src/transaction/proposed.rs
+++ b/ironfish-rust/src/transaction/proposed.rs
@@ -102,10 +102,10 @@ impl ProposedTransaction {
     }
 
     /// Spend the note owned by spender_key at the given witness location.
-    pub fn add_spend(
+    pub fn add_spend<W: WitnessTrait + ?Sized>(
         &mut self,
         note: Note,
-        witness: &dyn WitnessTrait,
+        witness: &W,
     ) -> Result<(), IronfishError> {
         self.value_balances
             .add(note.asset_id(), note.value().try_into()?)?;

--- a/ironfish-rust/src/transaction/spends.rs
+++ b/ironfish-rust/src/transaction/spends.rs
@@ -68,7 +68,7 @@ impl SpendBuilder {
     /// This is the only time this API thinks about the merkle tree. The witness
     /// contains the root-hash at the time the witness was created and the path
     /// to verify the location of that note in the tree.
-    pub(crate) fn new(note: Note, witness: &dyn WitnessTrait) -> Self {
+    pub(crate) fn new<W: WitnessTrait + ?Sized>(note: Note, witness: &W) -> Self {
         let value_commitment = ValueCommitment::new(note.value, note.asset_generator());
 
         SpendBuilder {


### PR DESCRIPTION
## Summary

Dynamic dispatch has a small runtime overhead, hence removing it.

## Testing Plan

Unit tests

## Documentation

N/A

## Breaking Change

This change should be 100% backward-compatible as it makes the inputs to some functions more generic.