### PR TITLE
Remove unnecessary qualifications from Rust code

### DIFF
--- a/ironfish-rust/src/mining/thread.rs
+++ b/ironfish-rust/src/mining/thread.rs
@@ -48,10 +48,7 @@ impl Thread {
             .name(id.to_string())
             .spawn(move || {
                 let mut fish_hash_context = if fish_hash_options.enabled {
-                    Some(fish_hash::Context::new(
-                        fish_hash_options.full_context,
-                        None,
-                    ))
+                    Some(Context::new(fish_hash_options.full_context, None))
                 } else {
                     None
                 };

--- a/ironfish-rust/src/transaction/mints.rs
+++ b/ironfish-rust/src/transaction/mints.rs
@@ -336,7 +336,7 @@ impl MintDescription {
             transfer_ownership_to = None;
         }
 
-        let authorizing_signature = redjubjub::Signature::read(&mut reader)?;
+        let authorizing_signature = Signature::read(&mut reader)?;
 
         Ok(MintDescription {
             proof,

--- a/ironfish-rust/src/transaction/spends.rs
+++ b/ironfish-rust/src/transaction/spends.rs
@@ -268,7 +268,7 @@ impl SpendDescription {
         let tree_size = reader.read_u32::<LittleEndian>()?;
         let mut nullifier = Nullifier([0; 32]);
         reader.read_exact(&mut nullifier.0)?;
-        let authorizing_signature = redjubjub::Signature::read(&mut reader)?;
+        let authorizing_signature = Signature::read(&mut reader)?;
 
         Ok(SpendDescription {
             proof,

--- a/ironfish-zkp/src/circuits/util.rs
+++ b/ironfish-zkp/src/circuits/util.rs
@@ -135,7 +135,7 @@ pub(crate) fn assert_valid_asset_generator<CS: ConstraintSystem<blstrs::Scalar>>
     // Compare the generator bits to the computed generator bits, proving that
     // this is the asset id that derived the generator
     for i in 0..256 {
-        boolean::Boolean::enforce_equal(
+        Boolean::enforce_equal(
             cs.namespace(|| format!("asset generator bit {} equality", i)),
             &asset_generator_bits[i],
             &asset_generator_repr[i],


### PR DESCRIPTION
## Summary

These are qualifications that rust 1.76 (specified in `rust-toolchain.toml` does not detect, but the latest version of Rust detects and warns about.

## Testing Plan

* Unit tests
* Run `cargo build` with the latest version of the Rust toolchain and verify that no warnings are produced

## Documentation

N/A

## Breaking Change

N/A