### PR TITLE
removes unused argument from RawTransaction.postedSize

### DIFF
--- a/ironfish/src/primitives/rawTransaction.test.slow.ts
+++ b/ironfish/src/primitives/rawTransaction.test.slow.ts
@@ -219,7 +219,7 @@ describe('RawTransaction', () => {
             )
           ).serialize()
 
-          expect(raw.postedSize(account.publicAddress)).toEqual(serialized.byteLength)
+          expect(raw.postedSize()).toEqual(serialized.byteLength)
         })
       })
     })
@@ -254,7 +254,7 @@ describe('RawTransaction', () => {
             )
           ).serialize()
 
-          expect(raw.postedSize(account.publicAddress)).toEqual(serialized.byteLength)
+          expect(raw.postedSize()).toEqual(serialized.byteLength)
         })
       })
     })

--- a/ironfish/src/primitives/rawTransaction.test.ts
+++ b/ironfish/src/primitives/rawTransaction.test.ts
@@ -87,7 +87,7 @@ describe('RawTransaction', () => {
 
     // should have same size for posted transaction and estimated size from raw transaction
     const serializedPost = posted.serialize()
-    expect(raw.postedSize(account.publicAddress)).toEqual(serializedPost.byteLength)
+    expect(raw.postedSize()).toEqual(serializedPost.byteLength)
   })
 
   it('should throw an error if the max mint value is exceeded', async () => {

--- a/ironfish/src/primitives/rawTransaction.ts
+++ b/ironfish/src/primitives/rawTransaction.ts
@@ -63,7 +63,7 @@ export class RawTransaction {
     this.version = version
   }
 
-  postedSize(_publicAddress: string): number {
+  postedSize(): number {
     let size = 0
     size += 1 // version
     size += 8 // spends length

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -914,7 +914,7 @@ export class Wallet {
       }
 
       if (options.feeRate) {
-        raw.fee = getFee(options.feeRate, raw.postedSize(options.account.publicAddress))
+        raw.fee = getFee(options.feeRate, raw.postedSize())
       }
 
       await this.fund(raw, {
@@ -924,7 +924,7 @@ export class Wallet {
       })
 
       if (options.feeRate) {
-        raw.fee = getFee(options.feeRate, raw.postedSize(options.account.publicAddress))
+        raw.fee = getFee(options.feeRate, raw.postedSize())
         raw.spends = []
 
         await this.fund(raw, {


### PR DESCRIPTION
## Summary

the publicAddress passed to postedSize is not used

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
