### PR TITLE
wallet:ledger:address CLI command

### DIFF
--- a/ironfish-cli/src/commands/wallet/ledger/address.ts
+++ b/ironfish-cli/src/commands/wallet/ledger/address.ts
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { IronfishCommand } from '../../../command'
+import { JsonFlags, RemoteFlags } from '../../../flags'
+import { LedgerSingleSigner } from '../../../ledger'
+import * as ui from '../../../ui'
+
+export class AddressCommand extends IronfishCommand {
+  static description = `verify the ledger device's public address`
+
+  static flags = {
+    ...RemoteFlags,
+    ...JsonFlags,
+  }
+
+  async start(): Promise<void> {
+    const ledger = new LedgerSingleSigner()
+
+    const address = await ui.ledger({
+      ledger,
+      message: 'Retrieve Wallet Address',
+      approval: true,
+      action: () => ledger.getPublicAddress(true),
+    })
+
+    this.log(ui.card({ Address: address }))
+  }
+}

--- a/ironfish-cli/src/ledger/ledgerSingleSigner.ts
+++ b/ironfish-cli/src/ledger/ledgerSingleSigner.ts
@@ -10,9 +10,9 @@ export class LedgerSingleSigner extends Ledger {
     super(false)
   }
 
-  getPublicAddress = async () => {
+  getPublicAddress = async (showInDevice: boolean = false) => {
     const response: KeyResponse = await this.tryInstruction((app) =>
-      app.retrieveKeys(this.PATH, IronfishKeys.PublicAddress, false),
+      app.retrieveKeys(this.PATH, IronfishKeys.PublicAddress, showInDevice),
     )
 
     if (!isResponseAddress(response)) {


### PR DESCRIPTION
## Summary

CLI command that displays the wallet address of the connected Ledger device.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
