### PR TITLE
Pass through Chainport error messages from API

### DIFF
--- a/ironfish-cli/src/utils/chainport/requests.ts
+++ b/ironfish-cli/src/utils/chainport/requests.ts
@@ -76,11 +76,11 @@ const makeChainportRequest = async <T extends object>(url: string): Promise<T> =
     })
     .catch((error) => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      const chainportError = error.response?.data?.error?.description as string
-      if (chainportError) {
-        throw new Error(chainportError)
+      const apiError = error.response?.data?.message as string
+      if (apiError) {
+        throw new Error('Chainport error: ' + apiError)
       } else {
-        throw new Error('Chainport error - ' + error)
+        throw new Error('Chainport error: ' + error)
       }
     })
 


### PR DESCRIPTION
## Summary

Previously the API wasn't passing through Chainport error messages on the response. Now that it does, we update the response parsing to pull out the error messages if they exist.

## Testing Plan

Tested by manually modifying the command to send known bad parameters:

```
? Enter the public address of the recipient: <omitted>
Fetching bridgeable assets... done
? Select the asset you wish to send 51f33a2f14f92735e562dc658a5639279ddca3d5079a6d1242b2a588a9cbf44c ($IRON✓) (<omitted>)
Fetching available networks... done
? Select the network you would like to bridge IRON to Base
? Enter the amount in $IRON✓ (balance <omitted>): 1
Error: Chainport error: Amount too big
    at <anonymous> (/Users/derek/repos/ironfish/ironfish-cli/src/utils/chainport/requests.ts:81:15)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async makeChainportRequest (/Users/derek/repos/ironfish/ironfish-cli/src/utils/chainport/requests.ts:72:20)
    at async fetchChainportBridgeTransaction (/Users/derek/repos/ironfish/ironfish-cli/src/utils/chainport/requests.ts:68:10)
    at async BridgeCommand.constructBridgeTransaction (/Users/derek/repos/ironfish/ironfish-cli/src/commands/wallet/chainport/send.ts:325:17)
    at async BridgeCommand.start (/Users/derek/repos/ironfish/ironfish-cli/src/commands/wallet/chainport/send.ts:113:28)
    at async BridgeCommand.run (/Users/derek/repos/ironfish/ironfish-cli/src/command.ts:92:14)
    at async BridgeCommand._run (/Users/derek/repos/ironfish/node_modules/@oclif/core/lib/command.js:301:22)
    at async Config.runCommand (/Users/derek/repos/ironfish/node_modules/@oclif/core/lib/config/config.js:424:25)
    at async run (/Users/derek/repos/ironfish/node_modules/@oclif/core/lib/main.js:95:16)
Fetching bridge transaction details... !
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
