### PR TITLE
Fix warning that table is being truncated

### DIFF
--- a/ironfish-cli/src/ui/table.ts
+++ b/ironfish-cli/src/ui/table.ts
@@ -220,8 +220,10 @@ class Table<T extends Record<string, unknown>> {
       }
       this.options.printLine(` ${rowValues.join(' ')}`)
     }
-    if (this.options.limit && this.options.limit <= 0 && rows.length >= this.options.limit) {
-      this.options.printLine(`...\n[see more rows by using --limit flag]`)
+    if (this.options.limit && this.options.limit >= 0 && rows.length >= this.options.limit) {
+      this.options.printLine(
+        `...\nsee ${rows.length - slicedRows.length} rows using --limit flag`,
+      )
     }
   }
 }


### PR DESCRIPTION
## Summary

This output would not print because of the inversed sign introduced in https://github.com/iron-fish/ironfish/pull/5611/files#diff-03f7c44b5cd857fe07731018037071afdb7710680236763c818fda56e8340825R219

## Testing Plan

1. Create 3 accounts
2. Use `ironfish wallet --limit 1`
3. See that message does not print before, but does after

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
