### PR TITLE
exportChainStream: removed seq and prev from block and tests

### DIFF
--- a/ironfish/src/rpc/routes/chain/exportChainStream.test.ts
+++ b/ironfish/src/rpc/routes/chain/exportChainStream.test.ts
@@ -37,8 +37,8 @@ describe('Route chain/exportChainStream', () => {
         block: {
           head: true,
           hash: blockA1.header.hash.toString('hex'),
-          prev: chain.genesis.hash.toString('hex'),
-          seq: 2,
+          previousBlockHash: chain.genesis.hash.toString('hex'),
+          sequence: 2,
         },
       },
     })

--- a/ironfish/src/rpc/routes/chain/exportChainStream.ts
+++ b/ironfish/src/rpc/routes/chain/exportChainStream.ts
@@ -24,14 +24,6 @@ export type ExportChainStreamResponse = {
     main: boolean
     head: boolean
     latest: boolean
-    /**
-     * @deprecated Please use sequence instead
-     */
-    seq: number
-    /**
-     * @deprecated Please use previousBlockHash instead
-     */
-    prev: string
   }
 }
 
@@ -49,9 +41,7 @@ export const ExportChainStreamResponseSchema: yup.ObjectSchema<ExportChainStream
     block: RpcBlockHeaderSchema.concat(
       yup
         .object({
-          seq: yup.number().defined(),
           main: yup.boolean().defined(),
-          prev: yup.string().defined(),
           head: yup.boolean().defined(),
           latest: yup.boolean().defined(),
         })
@@ -84,8 +74,6 @@ routes.register<typeof ExportChainStreamRequestSchema, ExportChainStreamResponse
         const blockResult = {
           ...serializeRpcBlockHeader(block),
           main: isMain,
-          seq: block.sequence,
-          prev: block.previousBlockHash.toString('hex'),
           head: block.hash.equals(node.chain.head.hash),
           latest: block.hash.equals(node.chain.latest.hash),
         }

--- a/ironfish/src/rpc/routes/chain/serializers.ts
+++ b/ironfish/src/rpc/routes/chain/serializers.ts
@@ -11,7 +11,6 @@ import { RpcBlock, RpcBlockHeader, RpcEncryptedNote, RpcTransaction } from './ty
 export function serializeRpcBlockHeader(header: BlockHeader): RpcBlockHeader {
   return {
     hash: header.hash.toString('hex'),
-    previous: header.previousBlockHash.toString('hex'),
     sequence: Number(header.sequence),
     previousBlockHash: header.previousBlockHash.toString('hex'),
     timestamp: header.timestamp.valueOf(),

--- a/ironfish/src/rpc/routes/chain/types.ts
+++ b/ironfish/src/rpc/routes/chain/types.ts
@@ -143,16 +143,11 @@ export type RpcBlockHeader = {
   graffiti: string
   work: string
   noteSize: number | null
-  /**
-   * @deprecated Please use previousBlockHash instead
-   */
-  previous: string
 }
 
 export const RpcBlockHeaderSchema: yup.ObjectSchema<RpcBlockHeader> = yup
   .object({
     hash: yup.string().defined(),
-    previous: yup.string().defined(),
     sequence: yup.number().defined(),
     previousBlockHash: yup.string().defined(),
     timestamp: yup.number().defined(),


### PR DESCRIPTION
## Summary
Removed deprecated seq and prev properties from exportChainStream.
Updated to sequence and previousBlockHash

## Testing Plan
Successfully exportedChainStream after change

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[X] Yes - https://github.com/iron-fish/website/pull/774/files
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[X] Yes, this removes backward compatibility for seq and previous
```
