### PR TITLE
getAccountsTransactions.test: Removed sort from streams back transactions for a given block sequence range

### DIFF
--- a/ironfish/src/rpc/routes/wallet/getAccountTransactions.test.ts
+++ b/ironfish/src/rpc/routes/wallet/getAccountTransactions.test.ts
@@ -114,9 +114,9 @@ describe('Route wallet/getAccountTransactions', () => {
       block3.transactions[0].hash(),
     ]
     const accountTransactions = await AsyncUtils.materialize(response.contentStream())
-    const accountTransactionHashes = accountTransactions
-      .map(({ hash }) => Buffer.from(hash, 'hex'))
-      .sort()
+    const accountTransactionHashes = accountTransactions.map(({ hash }) =>
+      Buffer.from(hash, 'hex'),
+    )
 
     expect(accountTransactionHashes).toEqual(blockTransactionHashes)
   })


### PR DESCRIPTION
## Summary
Removed the sort for the accountTransactions since it is already received in order. I regenerated the fixtures and the random hash lexographically sorted ended up swapping the order of the transactions.

## Testing Plan
I regenerated fixtures without sort and test passed

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.
N/A

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.
N/A

