### PR TITLE
account.test - getTransactionsByTime: added buffer comparison to sort

### DIFF
--- a/ironfish/src/wallet/account/account.test.ts
+++ b/ironfish/src/wallet/account/account.test.ts
@@ -2598,7 +2598,8 @@ describe('Accounts', () => {
       expect(accountBTx).toHaveLength(2)
 
       // tx1 and tx2 will have the same timestamp for accountB, so ordering should be reverse by hash
-      const sortedHashes = [tx1.hash(), tx2.hash()].sort().reverse()
+
+      const sortedHashes = [tx1.hash(), tx2.hash()].sort((a, b) => b.compare(a))
 
       expect(accountBTx[0].transaction.hash()).toEqualHash(sortedHashes[0])
       expect(accountBTx[1].transaction.hash()).toEqualHash(sortedHashes[1])
@@ -2616,7 +2617,7 @@ describe('Accounts', () => {
       expect(accountATxChronological).toHaveLength(5)
 
       // tx1 and tx2 will have the same timestamp for accountB, so ordering should be reverse by hash
-      const sortedHashesChron = [tx1.hash(), tx2.hash()].sort()
+      const sortedHashesChron = [tx1.hash(), tx2.hash()].sort((a, b) => a.compare(b))
 
       expect(accountBTxChronological[0].transaction.hash()).toEqualHash(sortedHashesChron[0])
       expect(accountBTxChronological[1].transaction.hash()).toEqualHash(sortedHashesChron[1])


### PR DESCRIPTION
## Summary
Original test was lexicographically sorting the hashed transactions, which could misorder the transactions based on their string representations. Added in sorting based on the buffer compare method to compare the bytes

## Testing Plan
Deleted and regenerated account.test.fixture and reran test 10 times.
Staging - failed
account.test - 10/10 passed

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.
No

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.
No
