### PR TITLE
Encoder tests now look for specific errors

### DIFF
--- a/ironfish/src/wallet/exporter/encoders/base64json.test.ts
+++ b/ironfish/src/wallet/exporter/encoders/base64json.test.ts
@@ -184,12 +184,12 @@ describe('Base64JsonEncoder', () => {
   it('throws an error when decoding strings without the prefix', () => {
     const encoded = 'not base64'
 
-    expect(() => encoder.decode(encoded)).toThrow()
+    expect(() => encoder.decode(encoded)).toThrow('Invalid prefix for base64 encoded account')
   })
 
   it('throws an error when decoding non-base64 strings', () => {
     const encoded = 'ifaccountnot base64'
 
-    expect(() => encoder.decode(encoded)).toThrow()
+    expect(() => encoder.decode(encoded)).toThrow('Invalid JSON')
   })
 })

--- a/ironfish/src/wallet/exporter/encoders/bech32.test.ts
+++ b/ironfish/src/wallet/exporter/encoders/bech32.test.ts
@@ -165,13 +165,15 @@ describe('Bech32AccountEncoder', () => {
   it('throws an error if it cannot decode the bech32 string', () => {
     const encoded = Bech32m.encode('incorrect serialization', BECH32_ACCOUNT_PREFIX)
 
-    expect(() => encoder.decode(encoded)).toThrow()
+    expect(() => encoder.decode(encoded)).toThrow(
+      'Bufio decoding failed while using bech32 encoder',
+    )
   })
 
   it('throws an error when decoding non-bech32 strings', () => {
     const encoded = 'not bech32'
 
-    expect(() => encoder.decode(encoded)).toThrow()
+    expect(() => encoder.decode(encoded)).toThrow('Could not decode account')
   })
 
   it('throws an error when decoding if the version is not supported', () => {
@@ -192,6 +194,6 @@ describe('Bech32AccountEncoder', () => {
     const encoded = encoder.encode(accountImport)
     expect(encoded.startsWith(BECH32_ACCOUNT_PREFIX)).toBe(true)
 
-    expect(() => encoder.decode(encoded)).toThrow()
+    expect(() => encoder.decode(encoded)).toThrow('Encoded account version 0 not supported')
   })
 })

--- a/ironfish/src/wallet/exporter/encoders/bech32json.test.ts
+++ b/ironfish/src/wallet/exporter/encoders/bech32json.test.ts
@@ -38,7 +38,7 @@ describe('Bech32JsonEncoder', () => {
     it('throws when bech32 decoded string is not json account', () => {
       const invalidJson = 'ironfishaccount1qqqqqqqqc5n9p2'
       const encoder = new Bech32JsonEncoder()
-      expect(() => encoder.decode(invalidJson)).toThrow()
+      expect(() => encoder.decode(invalidJson)).toThrow('Invalid JSON')
     })
 
     it('derives missing viewKeys from the spendingKey', () => {

--- a/ironfish/src/wallet/exporter/encoders/json.test.ts
+++ b/ironfish/src/wallet/exporter/encoders/json.test.ts
@@ -51,7 +51,7 @@ describe('JsonEncoder', () => {
     it('throws when json is not a valid account', () => {
       const invalidJson = '{}'
       const encoder = new JsonEncoder()
-      expect(() => encoder.decode(invalidJson)).toThrow()
+      expect(() => encoder.decode(invalidJson)).toThrow('Invalid Schema')
     })
 
     it('derives missing viewKeys from the spendingKey', () => {

--- a/ironfish/src/wallet/exporter/encoders/mnemonic.test.ts
+++ b/ironfish/src/wallet/exporter/encoders/mnemonic.test.ts
@@ -16,10 +16,11 @@ describe('MnemonicEncoder', () => {
       const encoded = encoder.encode(decoded, { language: 'English' })
       expect(encoded).toEqual(mnemonic)
     })
+
     it('should throw with invalid mnemonic', () => {
       const mnemonic = 'invalid mnemonic'
       const encoder = new MnemonicEncoder()
-      expect(() => encoder.decode(mnemonic, { name: 'foo' })).toThrow()
+      expect(() => encoder.decode(mnemonic, { name: 'foo' })).toThrow('Invalid mnemonic')
     })
   })
 })

--- a/ironfish/src/wallet/exporter/encoders/spendingKey.test.ts
+++ b/ironfish/src/wallet/exporter/encoders/spendingKey.test.ts
@@ -15,10 +15,13 @@ describe('SpendingKeyEncoder', () => {
       const encoded = encoder.encode(decoded)
       expect(encoded).toEqual(spendingKey)
     })
+
     it('should throw with invalid spending key', () => {
       const invalidSpendingKey = 'foo'
       const encoder = new SpendingKeyEncoder()
-      expect(() => encoder.decode(invalidSpendingKey, { name: 'key' })).toThrow()
+      expect(() => encoder.decode(invalidSpendingKey, { name: 'key' })).toThrow(
+        'Invalid spending key',
+      )
     })
   })
 })


### PR DESCRIPTION
## Summary

This improves the reliability of these tests by ensuring they are receiving the errors they are actually looking for. Without these checks, the code could begin throwing an unrelated error and the unit tests would not catch it.

## Testing Plan

These changes are specifically to unit tests, so they should still pass.

## Documentation

N/A

## Breaking Change

N/A