### PR TITLE
reads identity from ledger in dkg round1

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/dkg/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/create.ts
@@ -306,7 +306,13 @@ export class DkgCreateCommand extends IronfishCommand {
   ): Promise<{
     round1: { secretPackage: string; publicPackage: string }
   }> {
-    const identity = (await ledger.dkgGetIdentity(0, false)).toString('hex')
+    const identity = (
+      await ui.ledger({
+        ledger,
+        message: 'Getting Ledger Identity',
+        action: () => ledger.dkgGetIdentity(0),
+      })
+    ).toString('hex')
 
     if (!identities.includes(identity)) {
       identities.push(identity)

--- a/ironfish-cli/src/commands/wallet/multisig/dkg/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/create.ts
@@ -301,15 +301,12 @@ export class DkgCreateCommand extends IronfishCommand {
 
   async performRound1WithLedger(
     ledger: LedgerMultiSigner,
-    client: RpcClient,
-    participantName: string,
     identities: string[],
     minSigners: number,
   ): Promise<{
     round1: { secretPackage: string; publicPackage: string }
   }> {
-    const identityResponse = await client.wallet.multisig.getIdentity({ name: participantName })
-    const identity = identityResponse.content.identity
+    const identity = (await ledger.dkgGetIdentity(0, false)).toString('hex')
 
     if (!identities.includes(identity)) {
       identities.push(identity)
@@ -351,13 +348,7 @@ export class DkgCreateCommand extends IronfishCommand {
     })
 
     if (ledger) {
-      return await this.performRound1WithLedger(
-        ledger,
-        client,
-        participantName,
-        identities,
-        minSigners,
-      )
+      return await this.performRound1WithLedger(ledger, identities, minSigners)
     }
 
     this.log('\nPerforming DKG Round 1...')

--- a/ironfish-cli/src/commands/wallet/multisig/dkg/round1.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/round1.ts
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { RpcClient } from '@ironfish/sdk'
 import { Flags } from '@oclif/core'
 import { IronfishCommand } from '../../../../command'
 import { RemoteFlags } from '../../../../flags'
@@ -72,7 +71,7 @@ export class DkgRound1Command extends IronfishCommand {
     }
 
     if (flags.ledger) {
-      await this.performRound1WithLedger(client, participantName, identities, minSigners)
+      await this.performRound1WithLedger(identities, minSigners)
       return
     }
 
@@ -94,16 +93,10 @@ export class DkgRound1Command extends IronfishCommand {
     this.log('Send the round 1 public package to each participant')
   }
 
-  async performRound1WithLedger(
-    client: RpcClient,
-    participantName: string,
-    identities: string[],
-    minSigners: number,
-  ): Promise<void> {
+  async performRound1WithLedger(identities: string[], minSigners: number): Promise<void> {
     const ledger = new LedgerMultiSigner()
 
-    const identityResponse = await client.wallet.multisig.getIdentity({ name: participantName })
-    const identity = identityResponse.content.identity
+    const identity = (await ledger.dkgGetIdentity(0, false)).toString('hex')
 
     if (!identities.includes(identity)) {
       identities.push(identity)

--- a/ironfish-cli/src/commands/wallet/multisig/dkg/round1.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/round1.ts
@@ -96,7 +96,13 @@ export class DkgRound1Command extends IronfishCommand {
   async performRound1WithLedger(identities: string[], minSigners: number): Promise<void> {
     const ledger = new LedgerMultiSigner()
 
-    const identity = (await ledger.dkgGetIdentity(0, false)).toString('hex')
+    const identity = (
+      await ui.ledger({
+        ledger,
+        message: 'Getting Ledger Identity',
+        action: () => ledger.dkgGetIdentity(0),
+      })
+    ).toString('hex')
 
     if (!identities.includes(identity)) {
       identities.push(identity)


### PR DESCRIPTION
## Summary

when running DKG using a Ledger device, the user's identity must match the identity from the Ledger device.

rather than reading an identity from the node based on a name we can read the identity directly from the Ledger.

reads identity from Ledger in 'wallet:multisig:dkg:round1' and 'wallet:multisig:dkg:create' instead of reading the identity from the node

## Testing Plan
- created multisig account using ledger

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
