### PR TITLE
WASM: add bindings for `Proof`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1649,6 +1649,7 @@ dependencies = [
  "group 0.12.1",
  "hex-literal",
  "ironfish",
+ "ironfish-bellperson",
  "ironfish-jubjub",
  "ironfish_zkp",
  "rand",

--- a/ironfish-rust-wasm/Cargo.toml
+++ b/ironfish-rust-wasm/Cargo.toml
@@ -25,6 +25,7 @@ blstrs = "0.6.0"
 getrandom = { version = "0.2.8", features = ["js"] } # need to explicitly enable the `js` feature in order to run in a browser
 group = "0.12.0"
 ironfish = { version = "0.3.0", path = "../ironfish-rust", default-features = false }
+ironfish-bellperson = { version = "0.1.0", features = ["groth16"] }
 ironfish-jubjub = "0.1.0"
 ironfish_zkp = { version = "0.2.0", path = "../ironfish-zkp" }
 rand = "0.8.5"

--- a/ironfish-rust-wasm/src/primitives.rs
+++ b/ironfish-rust-wasm/src/primitives.rs
@@ -196,3 +196,24 @@ impl Signature {
         buf
     }
 }
+
+wasm_bindgen_wrapper! {
+    #[derive(Clone, PartialEq, Debug)]
+    pub struct Proof(ironfish_bellperson::groth16::Proof<blstrs::Bls12>);
+}
+
+#[wasm_bindgen]
+impl Proof {
+    #[wasm_bindgen(constructor)]
+    pub fn deserialize(bytes: &[u8]) -> Result<Self, IronfishError> {
+        let s = ironfish_bellperson::groth16::Proof::read(bytes)?;
+        Ok(Self::from(s))
+    }
+
+    #[wasm_bindgen]
+    pub fn serialize(&self) -> Vec<u8> {
+        let mut buf = Vec::new();
+        self.0.write(&mut buf).expect("serialization failed");
+        buf
+    }
+}


### PR DESCRIPTION
## Summary

This is the last bit remaining to support Oreowallet

## Testing Plan

* Unit tests

## Documentation

N/A

## Breaking Change

N/A