### PR TITLE
reads identity from ledger in 'wallet:multisig:signature:create'

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/signature/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/signature/create.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { multisig } from '@ironfish/rust-nodejs'
-import { RpcClient, UnsignedTransaction } from '@ironfish/sdk'
+import { UnsignedTransaction } from '@ironfish/sdk'
 import { Flags } from '@oclif/core'
 import { IronfishCommand } from '../../../../command'
 import { RemoteFlags } from '../../../../flags'
@@ -76,8 +76,6 @@ export class CreateSignatureShareCommand extends IronfishCommand {
 
     if (flags.ledger) {
       await this.createSignatureShareWithLedger(
-        client,
-        participantName,
         unsignedTransaction,
         signingPackage.frostSigningPackage().toString('hex'),
       )
@@ -115,15 +113,18 @@ export class CreateSignatureShareCommand extends IronfishCommand {
   }
 
   async createSignatureShareWithLedger(
-    client: RpcClient,
-    participantName: string,
     unsignedTransaction: UnsignedTransaction,
     frostSigningPackage: string,
   ): Promise<void> {
     const ledger = new LedgerMultiSigner()
 
-    const identityResponse = await client.wallet.multisig.getIdentity({ name: participantName })
-    const identity = identityResponse.content.identity
+    const identity = (
+      await ui.ledger({
+        ledger,
+        message: 'Getting Ledger Identity',
+        action: () => ledger.dkgGetIdentity(0),
+      })
+    ).toString('hex')
 
     const frostSignatureShare = await ui.ledger({
       ledger,


### PR DESCRIPTION
## Summary

when a user passes the '--ledger' flag to the
'wallet:multisig:signature:create' command they intend to use a Ledger device to create a signature share. the identity used _must_ be the identity from the Ledger device, so read the identity from the device instead of from the walletDB

Closes IFL-3172

## Testing Plan

1. start devnet node
2. mine devnet blocks
3. create multisig account using ledger
4. fund multisig account with transaction from default account
5. create unsigned transaction from multisig account
6. create signing commitment with multisig account and ledger
7. create signature share with multisig account and ledger


## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
