### PR TITLE
reads identity from Ledger in DKG round3

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/dkg/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/create.ts
@@ -447,14 +447,18 @@ export class DkgCreateCommand extends IronfishCommand {
     ledger: LedgerMultiSigner,
     client: RpcClient,
     accountName: string,
-    participantName: string,
     round1PublicPackagesStr: string[],
     round2PublicPackagesStr: string[],
     round2SecretPackage: string,
     accountCreatedAt?: number,
   ): Promise<void> {
-    const identityResponse = await client.wallet.multisig.getIdentity({ name: participantName })
-    const identity = identityResponse.content.identity
+    const identity = (
+      await ui.ledger({
+        ledger,
+        message: 'Getting Ledger Identity',
+        action: () => ledger.dkgGetIdentity(0),
+      })
+    ).toString('hex')
 
     // Sort packages by identity
     const round1PublicPackages = round1PublicPackagesStr
@@ -563,7 +567,6 @@ export class DkgCreateCommand extends IronfishCommand {
         ledger,
         client,
         accountName,
-        participantName,
         round1PublicPackages,
         round2PublicPackages,
         round2Result.secretPackage,

--- a/ironfish-cli/src/commands/wallet/multisig/dkg/round3.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/round3.ts
@@ -163,8 +163,13 @@ export class DkgRound3Command extends IronfishCommand {
   ): Promise<void> {
     const ledger = new LedgerMultiSigner()
 
-    const identityResponse = await client.wallet.multisig.getIdentity({ name: participantName })
-    const identity = identityResponse.content.identity
+    const identity = (
+      await ui.ledger({
+        ledger,
+        message: 'Getting Ledger Identity',
+        action: () => ledger.dkgGetIdentity(0),
+      })
+    ).toString('hex')
 
     // Sort packages by identity
     const round1PublicPackages = round1PublicPackagesStr


### PR DESCRIPTION
## Summary

when running DKG using a Ledger device we must use the identity from the Ledger

reads the identity from the Ledger device during DKG round3 instead of from the walletDB when using the '--ledger' flag in 'wallet:multisig:dkg:create' and 'wallet:multisig:dkg:round3'

Closes IFL-3170
Closes IFL-3171

## Testing Plan

- create multisig account using `wallet:multisig:dkg:create`
- create multisig account using separate dkg commands:
  - `wallet:multisig:participant:create`
  - `wallet:multisig:dkg:round1`
  - `wallet:multisig:dkg:round2`
  - `wallet:multisig:dkg:round3`


## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
