### PR TITLE
creates ui prompt to select multisig account

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/sign.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/sign.ts
@@ -86,7 +86,7 @@ export class SignMultisigTransactionCommand extends IronfishCommand {
 
     let multisigAccountName: string
     if (!flags.account) {
-      multisigAccountName = await ui.accountPrompt(client)
+      multisigAccountName = await ui.multisigAccountPrompt(client)
     } else {
       multisigAccountName = flags.account
       const account = (await client.wallet.getAccounts()).content.accounts.find(

--- a/ironfish-cli/src/ui/prompts.ts
+++ b/ironfish-cli/src/ui/prompts.ts
@@ -16,6 +16,25 @@ export async function accountPrompt(
   return listPrompt(message, accountsResponse.content.accounts, (a) => a)
 }
 
+export async function multisigAccountPrompt(
+  client: Pick<RpcClient, 'wallet'>,
+  message: string = 'Select multisig account',
+): Promise<string> {
+  const accountsResponse = await client.wallet.getAccounts()
+
+  const accountIdentityPromises = accountsResponse.content.accounts.map((accountName) =>
+    client.wallet.multisig
+      .getAccountIdentity({ account: accountName })
+      .then(() => accountName)
+      .catch(() => undefined),
+  )
+
+  const multisigAccounts = (await Promise.all(accountIdentityPromises)).filter(
+    (accountName): accountName is string => accountName !== undefined,
+  )
+  return listPrompt(message, multisigAccounts, (a) => a)
+}
+
 export async function multisigSecretPrompt(client: Pick<RpcClient, 'wallet'>): Promise<string> {
   const identitiesResponse = await client.wallet.multisig.getIdentities()
 


### PR DESCRIPTION
## Summary

uses 'wallet/getAccounts' RPC to fetch the list of all account names

next uses 'wallet/multisig/getAccountIdentity' to filter accounts that are not multisig accounts (if an account is not a multisig account then it will not have an identity)

replaces 'accountPrompt' prompt with 'multisigAccountPrompt' in 'wallet:multisig:sign' command

## Testing Plan

- run `wallet:multisig:sign` on a node that has a mix of multisig and single-signer accounts and observe that the prompt only includes the multisig accounts

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
