### PR TITLE
ci: Publish Rust WASM package to npm

### DIFF
--- a/.github/workflows/deploy-npm-ironfish-rust-wasm.yml
+++ b/.github/workflows/deploy-npm-ironfish-rust-wasm.yml
@@ -1,0 +1,55 @@
+name: Deploy NPM Ironfish Rust Wasm
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: 'Run the publish command in dry-run mode'
+        required: false
+        default: 'false'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: 'https://registry.npmjs.org'
+          cache: yarn
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: wasm
+
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - name: Generate package
+        working-directory: ./ironfish-rust-wasm
+        run: wasm-pack build --release --target=web
+
+      - name: Test in Firefox
+        working-directory: ./ironfish-rust-wasm
+        run: wasm-pack test --headless --firefox
+
+      - name: Test in Chrome
+        working-directory: ./ironfish-rust-wasm
+        run: wasm-pack test --headless --chrome
+
+      - name: Publish
+        working-directory: ./ironfish-rust-wasm/pkg
+        run: |
+          if [ ${{ github.event.inputs.dry-run }} = "true" ]; then
+            npm publish --access public --dry-run
+          else
+            npm publish --access public
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

Adds GitHub Actions workflow to build, test and publish the ironfish-rust-wasm package to npm. Includes Firefox and Chrome headless testing and supports dry-run mode for validation before actual publishing.

Successful run: https://github.com/iron-fish/ironfish/actions/runs/13186387340/job/36809353086

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
