### PR TITLE
uses multisigAccountPrompt in signing commands

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/commitment/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/commitment/create.ts
@@ -53,9 +53,9 @@ export class CreateSigningCommitmentCommand extends IronfishCommand {
     const client = await this.connectRpc()
     await ui.checkWalletUnlocked(client)
 
-    let participantName = flags.account
-    if (!participantName) {
-      participantName = await ui.multisigSecretPrompt(client)
+    let accountName = flags.account
+    if (!accountName) {
+      accountName = await ui.multisigAccountPrompt(client)
     }
 
     let identities = options.identity
@@ -88,7 +88,7 @@ export class CreateSigningCommitmentCommand extends IronfishCommand {
     await renderUnsignedTransactionDetails(
       client,
       unsignedTransaction,
-      participantName,
+      accountName,
       this.logger,
     )
 
@@ -100,7 +100,7 @@ export class CreateSigningCommitmentCommand extends IronfishCommand {
     }
 
     const response = await client.wallet.multisig.createSigningCommitment({
-      account: participantName,
+      account: accountName,
       unsignedTransaction: unsignedTransactionInput,
       signers: identities.map((identity) => ({ identity })),
     })

--- a/ironfish-cli/src/commands/wallet/multisig/signature/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/signature/create.ts
@@ -46,9 +46,9 @@ export class CreateSignatureShareCommand extends IronfishCommand {
     const client = await this.connectRpc()
     await ui.checkWalletUnlocked(client)
 
-    let participantName = flags.account
-    if (!participantName) {
-      participantName = await ui.multisigSecretPrompt(client)
+    let accountName = flags.account
+    if (!accountName) {
+      accountName = await ui.multisigAccountPrompt(client)
     }
 
     let signingPackageString = options.signingPackage
@@ -66,7 +66,7 @@ export class CreateSignatureShareCommand extends IronfishCommand {
     await renderUnsignedTransactionDetails(
       client,
       unsignedTransaction,
-      participantName,
+      accountName,
       this.logger,
     )
 
@@ -83,7 +83,7 @@ export class CreateSignatureShareCommand extends IronfishCommand {
     }
 
     const signatureShareResponse = await client.wallet.multisig.createSignatureShare({
-      account: participantName,
+      account: accountName,
       signingPackage: signingPackageString,
     })
 


### PR DESCRIPTION
## Summary

replaces 'multisigSecretPrompt' with 'multisigAccountPrompt' in 'wallet:multisig:commitment:create' and 'wallet:multisig:signature:create'.

renames 'participantName' variable to 'accountName' since this refers to the name of an imported account

Closes IFL-3174
Closes IFL-3175

## Testing Plan
run both commands using a node that has both multisig and single-signer accounts and observe that the prompt only shows the multisig accounts

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
