### PR TITLE
Adds scope flag to wasm github action

### DIFF
--- a/.github/workflows/deploy-npm-ironfish-rust-wasm.yml
+++ b/.github/workflows/deploy-npm-ironfish-rust-wasm.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Generate package
         working-directory: ./ironfish-rust-wasm
-        run: wasm-pack build --release --target=web
+        run: wasm-pack build --release --target=web --scope=ironfish
 
       - name: Test in Firefox
         working-directory: ./ironfish-rust-wasm


### PR DESCRIPTION
## Summary

This has the effect of creating the package.json with a different package name.

Without the flag: "name": "ironfish-wasm",
With the flag:    "name": "@ironfish/ironfish-wasm",

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
