### PR TITLE
does not import ledger identity in 'wallet:multisig:dkg:create'

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/dkg/create.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/create.ts
@@ -235,37 +235,19 @@ export class DkgCreateCommand extends IronfishCommand {
     identity: string
     name: string
   }> {
-    const identities = await client.wallet.multisig.getIdentities()
-
     if (ledger) {
-      const ledgerIdentity = await ui.ledger({
-        ledger,
-        message: 'Getting Ledger Identity',
-        action: () => ledger.dkgGetIdentity(0),
-      })
+      const ledgerIdentity = (
+        await ui.ledger({
+          ledger,
+          message: 'Getting Ledger Identity',
+          action: () => ledger.dkgGetIdentity(0),
+        })
+      ).toString('hex')
 
-      const foundIdentity = identities.content.identities.find(
-        (i) => i.identity === ledgerIdentity.toString('hex'),
-      )
-
-      if (foundIdentity) {
-        this.debug('Identity from ledger already exists')
-        return foundIdentity
-      }
-
-      // We must use the ledger's identity
-      while (identities.content.identities.find((i) => i.name === name)) {
-        this.log('An identity with the same name already exists')
-        name = await ui.inputPrompt('Enter a new name for the identity', true)
-      }
-
-      const created = await client.wallet.multisig.importParticipant({
-        name,
-        identity: ledgerIdentity.toString('hex'),
-      })
-
-      return { name, identity: created.content.identity }
+      return { name, identity: ledgerIdentity }
     }
+
+    const identities = await client.wallet.multisig.getIdentities()
 
     const foundIdentity = identities.content.identities.find((i) => i.name === name)
 


### PR DESCRIPTION
## Summary

we don't need to import the identity from the Ledger device into the walletDB unless and until we finish creating the account.

removes the call to 'wallet/multisig/importParticipant' in 'wallet:multisig:dkg:create' command

Closes IFL-3164

## Testing Plan

- run `wallet:multisig:dkg:create` with and without the `--ledger` flag

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
