### PR TITLE
WASM: expose authorizing keys from `SaplingKey`

### DIFF
--- a/ironfish-rust-wasm/src/keys/sapling_key.rs
+++ b/ironfish-rust-wasm/src/keys/sapling_key.rs
@@ -7,6 +7,7 @@ use crate::{
     keys::{
         IncomingViewKey, Language, OutgoingViewKey, ProofGenerationKey, PublicAddress, ViewKey,
     },
+    primitives::Fr,
     wasm_bindgen_wrapper,
 };
 use wasm_bindgen::prelude::*;
@@ -71,6 +72,16 @@ impl SaplingKey {
     #[wasm_bindgen(getter, js_name = spendingKey)]
     pub fn spending_key(&self) -> Vec<u8> {
         self.0.spending_key().to_vec()
+    }
+
+    #[wasm_bindgen(getter, js_name = spendAuthorizingKey)]
+    pub fn spend_authorizing_key(&self) -> Fr {
+        self.0.spend_authorizing_key().to_owned().into()
+    }
+
+    #[wasm_bindgen(getter, js_name = proofAuthorizingKey)]
+    pub fn proof_authorizing_key(&self) -> Fr {
+        self.0.proof_authorizing_key().to_owned().into()
     }
 
     #[wasm_bindgen(getter, js_name = incomingViewKey)]

--- a/ironfish-rust/src/keys/mod.rs
+++ b/ironfish-rust/src/keys/mod.rs
@@ -191,6 +191,14 @@ impl SaplingKey {
         Self::new(byte_arr)
     }
 
+    pub fn spend_authorizing_key(&self) -> &ironfish_jubjub::Fr {
+        &self.spend_authorizing_key
+    }
+
+    pub fn proof_authorizing_key(&self) -> &ironfish_jubjub::Fr {
+        &self.proof_authorizing_key
+    }
+
     /// Retrieve the publicly visible outgoing viewing key
     pub fn outgoing_view_key(&self) -> &OutgoingViewKey {
         &self.outgoing_viewing_key


### PR DESCRIPTION
## Summary

These are needed to create proofs, like Oreowallet does.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
