### PR TITLE
WASM: rename `randomized_public_key` to `randomized_public_key_pair`

### DIFF
--- a/ironfish-rust-wasm/src/keys/view_keys.rs
+++ b/ironfish-rust-wasm/src/keys/view_keys.rs
@@ -150,7 +150,7 @@ impl ViewKey {
         self.0.nullifier_deriving_key.into()
     }
 
-    #[wasm_bindgen(js_name = randomizedPublicKey)]
+    #[wasm_bindgen(js_name = randomizedPublicKeyPair)]
     pub fn randomized_public_key_pair(&self) -> RandomizedPublicKeyPair {
         let (r, s) = self.0.randomized_public_key(thread_rng());
         RandomizedPublicKeyPair::new(r.into(), s.into())


### PR DESCRIPTION
## Summary

This method returns a struct which also has a `randomized_public_key` method, which results in code like this:

```rs
let r = x.randomized_public_key();
let p = r.randomized_public_key();
```

... which is very ambiguous/confusing. With this PR, the above code becomes:

```rs
let r = x.randomized_public_key_pair();
let p = r.randomized_public_key();
```

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
