### PR TITLE
Implement spend and mint description builders

### DIFF
--- a/ironfish-rust-wasm/Cargo.toml
+++ b/ironfish-rust-wasm/Cargo.toml
@@ -19,6 +19,7 @@ default = ["transaction-proofs"]
 
 download-params = ["ironfish/download-params"]
 note-encryption-stats = ["ironfish/note-encryption-stats"]
+transaction-builders = ["transaction-proofs"]
 transaction-proofs = ["ironfish/transaction-proofs"]
 
 [dependencies]

--- a/ironfish-rust-wasm/src/transaction/mod.rs
+++ b/ironfish-rust-wasm/src/transaction/mod.rs
@@ -17,6 +17,9 @@ pub use outputs::OutputDescription;
 pub use spends::{SpendDescription, UnsignedSpendDescription};
 pub use unsigned::UnsignedTransaction;
 
+#[cfg(feature = "transaction-builders")]
+pub use self::{mints::MintBuilder, spends::SpendBuilder};
+
 wasm_bindgen_wrapper! {
     #[derive(Clone, Debug)]
     pub struct Transaction(ironfish::Transaction);

--- a/ironfish-rust-wasm/src/transaction/spends.rs
+++ b/ironfish-rust-wasm/src/transaction/spends.rs
@@ -11,6 +11,14 @@ use crate::{
 use ironfish::errors::IronfishErrorKind;
 use wasm_bindgen::prelude::*;
 
+#[cfg(feature = "transaction-builders")]
+use crate::{
+    keys::{ProofGenerationKey, ViewKey},
+    note::Note,
+    primitives::Fr,
+    witness::Witness,
+};
+
 wasm_bindgen_wrapper! {
     #[derive(Clone, Debug)]
     pub struct SpendDescription(ironfish::SpendDescription);
@@ -117,5 +125,112 @@ impl UnsignedSpendDescription {
     #[wasm_bindgen(js_name = addSignature)]
     pub fn add_signature(self, signature: Signature) -> SpendDescription {
         self.0.add_signature(signature.into()).into()
+    }
+}
+
+#[cfg(feature = "transaction-builders")]
+wasm_bindgen_wrapper! {
+    #[derive(Clone, Debug)]
+    pub struct SpendBuilder(ironfish::transaction::spends::SpendBuilder);
+}
+
+#[wasm_bindgen]
+#[cfg(feature = "transaction-builders")]
+impl SpendBuilder {
+    #[wasm_bindgen(constructor)]
+    pub fn new(note: Note, witness: &Witness) -> Self {
+        Self(ironfish::transaction::spends::SpendBuilder::new(
+            note.into(),
+            witness.as_ref(),
+        ))
+    }
+
+    #[wasm_bindgen]
+    pub fn build(
+        self,
+        proof_generation_key: &ProofGenerationKey,
+        view_key: &ViewKey,
+        public_key_randomness: &Fr,
+        randomized_public_key: &PublicKey,
+    ) -> Result<UnsignedSpendDescription, IronfishError> {
+        self.0
+            .build(
+                proof_generation_key.as_ref(),
+                view_key.as_ref(),
+                public_key_randomness.as_ref(),
+                randomized_public_key.as_ref(),
+            )
+            .map(|d| d.into())
+            .map_err(|e| e.into())
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "transaction-builders")]
+mod tests {
+    mod builder {
+        use crate::{
+            assets::AssetIdentifier,
+            keys::SaplingKey,
+            merkle_note::MerkleNoteHash,
+            note::Note,
+            primitives::Scalar,
+            transaction::SpendBuilder,
+            witness::{Witness, WitnessNode},
+        };
+        use rand::{thread_rng, Rng};
+        use wasm_bindgen_test::wasm_bindgen_test;
+
+        fn random_witness(note: &Note) -> Witness {
+            let depth = 32;
+            let zero = Scalar::zero();
+            let auth_path = vec![WitnessNode::left(zero); depth];
+            let root_hash = {
+                let mut cur_hash = MerkleNoteHash::from_value(note.commitment_point());
+                for (i, node) in auth_path.iter().enumerate() {
+                    cur_hash = MerkleNoteHash::combine_hash(i, &cur_hash, &node.hash())
+                }
+                cur_hash
+            };
+
+            Witness::new(depth, root_hash, auth_path)
+        }
+
+        #[test]
+        #[wasm_bindgen_test]
+        fn build() {
+            let owner_key = SaplingKey::random();
+            let sender_key = SaplingKey::random();
+            let note = Note::from_parts(
+                owner_key.public_address(),
+                123,
+                "some memo",
+                AssetIdentifier::native(),
+                sender_key.public_address(),
+            );
+            let witness = random_witness(&note);
+            let randomized_public_key_pair = owner_key.view_key().randomized_public_key_pair();
+
+            let unsigned = SpendBuilder::new(note, &witness)
+                .build(
+                    &owner_key.proof_generation_key(),
+                    &owner_key.view_key(),
+                    &randomized_public_key_pair.public_key_randomness(),
+                    &randomized_public_key_pair.randomized_public_key(),
+                )
+                .expect("failed to build spend description");
+
+            let sign_hash: [u8; 32] = thread_rng().gen();
+            let signed = unsigned
+                .sign(&owner_key, &sign_hash)
+                .expect("failed to sign mint description");
+
+            signed
+                .verify_signature(
+                    &sign_hash,
+                    &randomized_public_key_pair.randomized_public_key(),
+                )
+                .expect("signature verification failed");
+        }
     }
 }


### PR DESCRIPTION
## Summary

These are feature-gated and disabled by default because they do not work in a web environment. In order to work, users need to patch `yastl` so that it runs tasks serially rather than in parallel (because there's no support for threads in a web environment). Also, even after patching, generating a zero-knowledge proof currently takes an absurd amount of time in a web browser.

## Testing Plan

```
cargo test --all-features
```

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
