### PR TITLE
Fix `cargo clippy` errors generated when `transaction-proofs` is off

### DIFF
--- a/ironfish-rust-wasm/src/transaction/mod.rs
+++ b/ironfish-rust-wasm/src/transaction/mod.rs
@@ -5,7 +5,6 @@
 mod burns;
 mod mints;
 mod outputs;
-mod proposed;
 mod spends;
 mod unsigned;
 
@@ -17,6 +16,9 @@ pub use mints::{MintDescription, UnsignedMintDescription};
 pub use outputs::OutputDescription;
 pub use spends::{SpendDescription, UnsignedSpendDescription};
 pub use unsigned::UnsignedTransaction;
+
+#[cfg(feature = "transaction-proofs")]
+mod proposed;
 
 #[cfg(feature = "transaction-builders")]
 pub use self::{mints::MintBuilder, spends::SpendBuilder};

--- a/ironfish-rust/Cargo.toml
+++ b/ironfish-rust/Cargo.toml
@@ -29,7 +29,7 @@ default = ["transaction-proofs"]
 benchmark = []
 download-params = ["dep:reqwest"]
 note-encryption-stats = []
-transaction-proofs = []
+transaction-proofs = ["dep:lazy_static"]
 
 [lib]
 name = "ironfish"
@@ -50,7 +50,7 @@ ironfish-frost = { version = "0.1.0" }
 fish_hash = "0.3.0"
 ironfish_zkp = { version = "0.2.0", path = "../ironfish-zkp" }
 ironfish-jubjub = { version = "0.1.0", features = ["multiply-many"] }
-lazy_static = "1.4.0"
+lazy_static = { version = "1.4.0", optional = true }
 rand = "0.8.5"
 tiny-bip39 = "1.0"
 xxhash-rust = { version = "0.8.5", features = ["xxh3"] }


### PR DESCRIPTION
## Summary

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
