### PR TITLE
makes participantName and ledger flags exclusive in dkg

### DIFF
--- a/ironfish-cli/src/commands/wallet/multisig/dkg/round1.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/round1.ts
@@ -30,6 +30,7 @@ export class DkgRound1Command extends IronfishCommand {
     ledger: Flags.boolean({
       default: false,
       description: 'Perform operation with a ledger device',
+      exclusive: ['participantName'],
     }),
   }
 
@@ -38,11 +39,6 @@ export class DkgRound1Command extends IronfishCommand {
 
     const client = await this.connectRpc()
     await ui.checkWalletUnlocked(client)
-
-    let participantName = flags.participantName
-    if (!participantName) {
-      participantName = await ui.multisigSecretPrompt(client)
-    }
 
     let identities = flags.identity
     if (!identities || identities.length < 2) {
@@ -72,6 +68,11 @@ export class DkgRound1Command extends IronfishCommand {
     if (flags.ledger) {
       await this.performRound1WithLedger(identities, minSigners)
       return
+    }
+
+    let participantName = flags.participantName
+    if (!participantName) {
+      participantName = await ui.multisigSecretPrompt(client)
     }
 
     const response = await client.wallet.multisig.dkg.round1({

--- a/ironfish-cli/src/commands/wallet/multisig/dkg/round2.ts
+++ b/ironfish-cli/src/commands/wallet/multisig/dkg/round2.ts
@@ -30,6 +30,7 @@ export class DkgRound2Command extends IronfishCommand {
     ledger: Flags.boolean({
       default: false,
       description: 'Perform operation with a ledger device',
+      exclusive: ['participantName'],
     }),
   }
 
@@ -39,17 +40,9 @@ export class DkgRound2Command extends IronfishCommand {
     const client = await this.connectRpc()
     await ui.checkWalletUnlocked(client)
 
-    let participantName = flags.participantName
-    if (!participantName) {
-      participantName = await ui.multisigSecretPrompt(client)
-    }
-
     let round1SecretPackage = flags.round1SecretPackage
     if (!round1SecretPackage) {
-      round1SecretPackage = await ui.inputPrompt(
-        `Enter the round 1 secret package for participant ${participantName}`,
-        true,
-      )
+      round1SecretPackage = await ui.inputPrompt('Enter your round 1 secret package', true)
     }
 
     let round1PublicPackages = flags.round1PublicPackages
@@ -71,6 +64,11 @@ export class DkgRound2Command extends IronfishCommand {
     if (flags.ledger) {
       await this.performRound2WithLedger(round1PublicPackages, round1SecretPackage)
       return
+    }
+
+    let participantName = flags.participantName
+    if (!participantName) {
+      participantName = await ui.multisigSecretPrompt(client)
     }
 
     const response = await client.wallet.multisig.dkg.round2({


### PR DESCRIPTION
## Summary

when using a ledger device the user should not need to enter a participant name or select the participant from those in the walletDB since the identity should be read from the ledger device

prompts the user for an account name in round3 if using a ledger

Closes IFL-3176

## Testing Plan

used dkg rounds 1,2, and 3 to create a multisig account. used two participants on one node, one with a ledger

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
