### PR TITLE
getBalance: removed assetVerification

### DIFF
--- a/ironfish/src/rpc/routes/wallet/getBalance.test.ts
+++ b/ironfish/src/rpc/routes/wallet/getBalance.test.ts
@@ -112,58 +112,5 @@ describe('Route wallet/getBalance', () => {
         sequence: null,
       })
     })
-
-    it('returns asset verification information', async () => {
-      const node = routeTest.node
-      const wallet = node.wallet
-      const account = await useAccountFixture(wallet, 'accountC')
-
-      const getBalances = jest
-        .spyOn(wallet, 'getBalance')
-        // eslint-disable-next-line @typescript-eslint/require-await
-        .mockImplementationOnce(async (_account, _assetId, _options?) => {
-          return {
-            assetId: Asset.nativeId(),
-            assetName: Buffer.from('$IRON', 'utf8'),
-            assetCreator: Buffer.from('Iron Fish', 'utf8'),
-            assetOwner: Buffer.from('Copper Clam', 'utf8'),
-            confirmed: BigInt(2000000000),
-            unconfirmed: BigInt(2000000000),
-            pending: BigInt(2000000000),
-            available: BigInt(2000000000),
-            availableNoteCount: 1,
-            unconfirmedCount: 0,
-            pendingCount: 0,
-            blockHash: null,
-            sequence: null,
-          }
-        })
-
-      const verifyAsset = jest
-        .spyOn(node.assetsVerifier, 'verify')
-        .mockReturnValueOnce({ status: 'verified', symbol: 'FOO' })
-
-      const response = await routeTest.client.wallet.getAccountBalance({
-        account: account.name,
-      })
-
-      expect(getBalances).toHaveBeenCalledWith(account, Asset.nativeId(), { confirmations: 0 })
-      expect(verifyAsset).toHaveBeenCalledWith(Asset.nativeId())
-
-      expect(response.content).toEqual({
-        account: account.name,
-        assetId: Asset.nativeId().toString('hex'),
-        confirmed: '2000000000',
-        unconfirmed: '2000000000',
-        pending: '2000000000',
-        available: '2000000000',
-        availableNoteCount: 1,
-        unconfirmedCount: 0,
-        pendingCount: 0,
-        blockHash: null,
-        confirmations: 0,
-        sequence: null,
-      })
-    })
   })
 })

--- a/ironfish/src/rpc/routes/wallet/getBalance.test.ts
+++ b/ironfish/src/rpc/routes/wallet/getBalance.test.ts
@@ -31,7 +31,6 @@ describe('Route wallet/getBalance', () => {
             assetName: Buffer.from('$IRON', 'utf8'),
             assetCreator: Buffer.from('Iron Fish', 'utf8'),
             assetOwner: Buffer.from('Copper Clam', 'utf8'),
-            assetVerification: { status: 'unknown' },
             confirmed: BigInt(2000000000),
             unconfirmed: BigInt(2000000000),
             pending: BigInt(2000000000),
@@ -52,7 +51,6 @@ describe('Route wallet/getBalance', () => {
       expect(response.content).toEqual({
         account: account.name,
         assetId: Asset.nativeId().toString('hex'),
-        assetVerification: { status: 'unknown' },
         confirmed: '2000000000',
         unconfirmed: '2000000000',
         pending: '2000000000',
@@ -81,7 +79,6 @@ describe('Route wallet/getBalance', () => {
             assetName: asset.name(),
             assetCreator: asset.creator(),
             assetOwner: asset.creator(),
-            assetVerification: { status: 'unknown' },
             confirmed: BigInt(8),
             unconfirmed: BigInt(8),
             pending: BigInt(8),
@@ -103,7 +100,6 @@ describe('Route wallet/getBalance', () => {
       expect(response.content).toEqual({
         account: account.name,
         assetId: asset.id().toString('hex'),
-        assetVerification: { status: 'unknown' },
         confirmed: '8',
         unconfirmed: '8',
         pending: '8',
@@ -131,7 +127,6 @@ describe('Route wallet/getBalance', () => {
             assetName: Buffer.from('$IRON', 'utf8'),
             assetCreator: Buffer.from('Iron Fish', 'utf8'),
             assetOwner: Buffer.from('Copper Clam', 'utf8'),
-            assetVerification: { status: 'unknown' },
             confirmed: BigInt(2000000000),
             unconfirmed: BigInt(2000000000),
             pending: BigInt(2000000000),
@@ -158,7 +153,6 @@ describe('Route wallet/getBalance', () => {
       expect(response.content).toEqual({
         account: account.name,
         assetId: Asset.nativeId().toString('hex'),
-        assetVerification: { status: 'verified' },
         confirmed: '2000000000',
         unconfirmed: '2000000000',
         pending: '2000000000',

--- a/ironfish/src/rpc/routes/wallet/getBalance.ts
+++ b/ironfish/src/rpc/routes/wallet/getBalance.ts
@@ -30,10 +30,6 @@ export type GetBalanceResponse = {
   confirmations: number
   blockHash: string | null
   sequence: number | null
-  /**
-   * @deprecated Please use getAsset endpoint to get this information
-   * */
-  assetVerification: { status: AssetVerification['status'] }
 }
 
 export const GetBalanceRequestSchema: yup.ObjectSchema<GetBalanceRequest> = yup
@@ -48,9 +44,6 @@ export const GetBalanceResponseSchema: yup.ObjectSchema<GetBalanceResponse> = yu
   .object({
     account: yup.string().defined(),
     assetId: yup.string().defined(),
-    assetVerification: yup
-      .object({ status: yup.string().oneOf(['verified', 'unverified', 'unknown']).defined() })
-      .defined(),
     unconfirmed: yup.string().defined(),
     unconfirmedCount: yup.number().defined(),
     pending: yup.string().defined(),
@@ -86,7 +79,6 @@ routes.register<typeof GetBalanceRequestSchema, GetBalanceResponse>(
     request.end({
       account: account.name,
       assetId: assetId.toString('hex'),
-      assetVerification: { status: node.assetsVerifier.verify(assetId).status },
       confirmed: balance.confirmed.toString(),
       unconfirmed: balance.unconfirmed.toString(),
       unconfirmedCount: balance.unconfirmedCount,

--- a/ironfish/src/rpc/routes/wallet/getBalance.ts
+++ b/ironfish/src/rpc/routes/wallet/getBalance.ts
@@ -3,7 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Asset } from '@ironfish/rust-nodejs'
 import * as yup from 'yup'
-import { AssetVerification } from '../../../assets'
 import { ApiNamespace } from '../namespaces'
 import { routes } from '../router'
 import { AssertHasRpcContext } from '../rpcContext'


### PR DESCRIPTION
## Summary
Removed assetVerification reference from getBalance route and tests

we're using getAsset endpoint instead now.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[X] Yes - https://github.com/iron-fish/website/pull/780
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[X] Yes - breaking-change-rpc
```
