### PR TITLE
getBalances: removed assetVerification, assetName, assetCreator, assetOwner 

### DIFF
--- a/ironfish/src/rpc/routes/wallet/getBalances.test.ts
+++ b/ironfish/src/rpc/routes/wallet/getBalances.test.ts
@@ -27,9 +27,6 @@ describe('Route wallet/getBalances', () => {
       const mockBalances = [
         {
           assetId,
-          assetName: asset.name(),
-          assetCreator: asset.creator(),
-          assetOwner: asset.creator(),
           confirmed: BigInt(8),
           unconfirmed: BigInt(8),
           pending: BigInt(8),
@@ -42,9 +39,6 @@ describe('Route wallet/getBalances', () => {
         },
         {
           assetId: Asset.nativeId(),
-          assetName: Buffer.from('$IRON', 'utf8'),
-          assetCreator: Buffer.from('Iron Fish', 'utf8'),
-          assetOwner: Buffer.from('Iron Fish', 'utf8'),
           confirmed: BigInt(2000000000),
           unconfirmed: BigInt(2000000000),
           pending: BigInt(2000000000),
@@ -91,104 +85,12 @@ describe('Route wallet/getBalances', () => {
         mockBalances.map((mockBalance) => ({
           ...mockBalance,
           assetId: mockBalance.assetId.toString('hex'),
-          assetName: mockBalance.assetName.toString('hex'),
-          assetCreator: mockBalance.assetCreator.toString('hex'),
-          assetOwner: mockBalance.assetOwner.toString('hex'),
           confirmed: mockBalance.confirmed.toString(),
           unconfirmed: mockBalance.unconfirmed.toString(),
           pending: mockBalance.pending.toString(),
           available: mockBalance.available.toString(),
         })),
       )
-    })
-
-    it('returns asset verification information', async () => {
-      const node = routeTest.node
-      const wallet = node.wallet
-      const account = await useAccountFixture(wallet, 'accountB')
-      const asset = new Asset(account.publicAddress, 'mint-asset', 'metadata')
-      const assetId = asset.id()
-
-      const mockBalances = [
-        {
-          assetId,
-          assetName: asset.name(),
-          assetCreator: asset.creator(),
-          assetOwner: asset.creator(),
-          confirmed: BigInt(8),
-          unconfirmed: BigInt(8),
-          pending: BigInt(8),
-          available: BigInt(8),
-          availableNoteCount: 1,
-          unconfirmedCount: 0,
-          pendingCount: 0,
-          blockHash: null,
-          sequence: null,
-        },
-        {
-          assetId: Asset.nativeId(),
-          assetName: Buffer.from('$IRON', 'utf8'),
-          assetCreator: Buffer.from('Iron Fish', 'utf8'),
-          assetOwner: Buffer.from('Copper Clam', 'utf8'),
-          confirmed: BigInt(2000000000),
-          unconfirmed: BigInt(2000000000),
-          pending: BigInt(2000000000),
-          available: BigInt(2000000000),
-          availableNoteCount: 1,
-          unconfirmedCount: 0,
-          pendingCount: 0,
-          blockHash: null,
-          sequence: null,
-        },
-      ]
-
-      const getBalances = jest
-        .spyOn(account, 'getBalances')
-        // eslint-disable-next-line @typescript-eslint/require-await
-        .mockImplementationOnce(async function* (_confirmations) {
-          for (const balance of mockBalances) {
-            yield balance
-          }
-        })
-
-      jest.spyOn(account, 'getAsset').mockReturnValueOnce(
-        Promise.resolve({
-          id: asset.id(),
-          metadata: asset.metadata(),
-          name: asset.name(),
-          nonce: asset.nonce(),
-          creator: asset.creator(),
-          owner: asset.creator(),
-          createdTransactionHash: Buffer.alloc(32),
-          blockHash: Buffer.alloc(32),
-          sequence: null,
-          supply: null,
-        }),
-      )
-
-      const verifyAsset = jest
-        .spyOn(node.assetsVerifier, 'verify')
-        .mockReturnValueOnce({ status: 'unverified' })
-        .mockReturnValueOnce({ status: 'verified', symbol: 'FOO' })
-
-      const response = await routeTest.client.wallet.getAccountBalances({
-        account: account.name,
-      })
-
-      expect(getBalances).toHaveBeenCalledTimes(1)
-      expect(verifyAsset).toHaveBeenCalledWith(asset.id())
-      expect(verifyAsset).toHaveBeenCalledWith(Asset.nativeId())
-
-      expect(response.content.balances).toMatchObject([
-        {
-          assetId: assetId.toString('hex'),
-          assetVerification: { status: 'unverified' },
-        },
-        {
-          assetId: Asset.nativeId().toString('hex'),
-          assetVerification: { status: 'verified' },
-        },
-      ])
     })
   })
 })

--- a/ironfish/src/rpc/routes/wallet/getBalances.ts
+++ b/ironfish/src/rpc/routes/wallet/getBalances.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
-import { AssetVerification } from '../../../assets'
 import { CurrencyUtils } from '../../../utils'
 import { ApiNamespace } from '../namespaces'
 import { routes } from '../router'
@@ -27,22 +26,6 @@ export interface GetBalancesResponse {
     availableNoteCount: number
     blockHash: string | null
     sequence: number | null
-    /**
-     * @deprecated Please use getAsset endpoint to get this information
-     */
-    assetName: string
-    /**
-     * @deprecated Please use getAsset endpoint to get this information
-     */
-    assetCreator: string
-    /**
-     * @deprecated Please use getAsset endpoint to get this information
-     * */
-    assetOwner: string
-    /**
-     * @deprecated Please use getAsset endpoint to get this information
-     * */
-    assetVerification: { status: AssetVerification['status'] }
   }[]
 }
 
@@ -63,14 +46,6 @@ export const GetBalancesResponseSchema: yup.ObjectSchema<GetBalancesResponse> = 
           .object()
           .shape({
             assetId: yup.string().defined(),
-            assetName: yup.string().defined(),
-            assetCreator: yup.string().defined(),
-            assetOwner: yup.string().defined(),
-            assetVerification: yup
-              .object({
-                status: yup.string().oneOf(['verified', 'unverified', 'unknown']).defined(),
-              })
-              .defined(),
             unconfirmed: yup.string().defined(),
             unconfirmedCount: yup.number().defined(),
             pending: yup.string().defined(),
@@ -104,14 +79,8 @@ routes.register<typeof GetBalancesRequestSchema, GetBalancesResponse>(
         return
       }
 
-      const asset = await account.getAsset(balance.assetId)
-
       balances.push({
         assetId: balance.assetId.toString('hex'),
-        assetName: asset?.name.toString('hex') ?? '',
-        assetCreator: asset?.creator.toString('hex') ?? '',
-        assetOwner: asset?.owner.toString('hex') ?? '',
-        assetVerification: { status: context.assetsVerifier.verify(balance.assetId).status },
         blockHash: balance.blockHash?.toString('hex') ?? null,
         confirmed: CurrencyUtils.encode(balance.confirmed),
         sequence: balance.sequence,


### PR DESCRIPTION
## Summary
removed assetVerification, assetName, assetCreator, assetOwner from getBalances, schema, tests since we are now using getAsset endpoint for that info.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[X] Yes - https://github.com/iron-fish/website/pull/781
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[X] Yes - breaking-change-rpc
```
