### PR TITLE
RPC Deprecated Routes

### DIFF
--- a/ironfish/src/rpc/routes/chain/exportChainStream.test.ts
+++ b/ironfish/src/rpc/routes/chain/exportChainStream.test.ts
@@ -37,8 +37,8 @@ describe('Route chain/exportChainStream', () => {
         block: {
           head: true,
           hash: blockA1.header.hash.toString('hex'),
-          prev: chain.genesis.hash.toString('hex'),
-          seq: 2,
+          previousBlockHash: chain.genesis.hash.toString('hex'),
+          sequence: 2,
         },
       },
     })

--- a/ironfish/src/rpc/routes/chain/exportChainStream.ts
+++ b/ironfish/src/rpc/routes/chain/exportChainStream.ts
@@ -24,14 +24,6 @@ export type ExportChainStreamResponse = {
     main: boolean
     head: boolean
     latest: boolean
-    /**
-     * @deprecated Please use sequence instead
-     */
-    seq: number
-    /**
-     * @deprecated Please use previousBlockHash instead
-     */
-    prev: string
   }
 }
 
@@ -49,9 +41,7 @@ export const ExportChainStreamResponseSchema: yup.ObjectSchema<ExportChainStream
     block: RpcBlockHeaderSchema.concat(
       yup
         .object({
-          seq: yup.number().defined(),
           main: yup.boolean().defined(),
-          prev: yup.string().defined(),
           head: yup.boolean().defined(),
           latest: yup.boolean().defined(),
         })
@@ -84,8 +74,6 @@ routes.register<typeof ExportChainStreamRequestSchema, ExportChainStreamResponse
         const blockResult = {
           ...serializeRpcBlockHeader(block),
           main: isMain,
-          seq: block.sequence,
-          prev: block.previousBlockHash.toString('hex'),
           head: block.hash.equals(node.chain.head.hash),
           latest: block.hash.equals(node.chain.latest.hash),
         }

--- a/ironfish/src/rpc/routes/chain/followChainStream.ts
+++ b/ironfish/src/rpc/routes/chain/followChainStream.ts
@@ -28,12 +28,7 @@ export type FollowChainStreamResponse = {
   head: {
     sequence: number
   }
-  block: RpcBlock & {
-    /**
-     * @deprecated this can be derived from the type
-     */
-    main: boolean
-  }
+  block: RpcBlock
 }
 
 export const FollowChainStreamRequestSchema: yup.ObjectSchema<FollowChainStreamRequest> = yup
@@ -53,13 +48,7 @@ export const FollowChainStreamResponseSchema: yup.ObjectSchema<FollowChainStream
         sequence: yup.number().defined(),
       })
       .defined(),
-    block: RpcBlockSchema.concat(
-      yup
-        .object({
-          main: yup.boolean().defined(),
-        })
-        .defined(),
-    ),
+    block: RpcBlockSchema.defined(),
   })
   .defined()
 
@@ -127,7 +116,6 @@ routes.register<typeof FollowChainStreamRequestSchema, FollowChainStreamResponse
         block: {
           ...blockHeaderResponse,
           size: getBlockSize(block),
-          main: type === 'connected',
           transactions,
         },
       })

--- a/ironfish/src/rpc/routes/chain/serializers.ts
+++ b/ironfish/src/rpc/routes/chain/serializers.ts
@@ -11,7 +11,6 @@ import { RpcBlock, RpcBlockHeader, RpcEncryptedNote, RpcTransaction } from './ty
 export function serializeRpcBlockHeader(header: BlockHeader): RpcBlockHeader {
   return {
     hash: header.hash.toString('hex'),
-    previous: header.previousBlockHash.toString('hex'),
     sequence: Number(header.sequence),
     previousBlockHash: header.previousBlockHash.toString('hex'),
     timestamp: header.timestamp.valueOf(),

--- a/ironfish/src/rpc/routes/chain/types.ts
+++ b/ironfish/src/rpc/routes/chain/types.ts
@@ -143,16 +143,11 @@ export type RpcBlockHeader = {
   graffiti: string
   work: string
   noteSize: number | null
-  /**
-   * @deprecated Please use previousBlockHash instead
-   */
-  previous: string
 }
 
 export const RpcBlockHeaderSchema: yup.ObjectSchema<RpcBlockHeader> = yup
   .object({
     hash: yup.string().defined(),
-    previous: yup.string().defined(),
     sequence: yup.number().defined(),
     previousBlockHash: yup.string().defined(),
     timestamp: yup.number().defined(),

--- a/ironfish/src/rpc/routes/wallet/getBalance.test.ts
+++ b/ironfish/src/rpc/routes/wallet/getBalance.test.ts
@@ -112,58 +112,5 @@ describe('Route wallet/getBalance', () => {
         sequence: null,
       })
     })
-
-    it('returns asset verification information', async () => {
-      const node = routeTest.node
-      const wallet = node.wallet
-      const account = await useAccountFixture(wallet, 'accountC')
-
-      const getBalances = jest
-        .spyOn(wallet, 'getBalance')
-        // eslint-disable-next-line @typescript-eslint/require-await
-        .mockImplementationOnce(async (_account, _assetId, _options?) => {
-          return {
-            assetId: Asset.nativeId(),
-            assetName: Buffer.from('$IRON', 'utf8'),
-            assetCreator: Buffer.from('Iron Fish', 'utf8'),
-            assetOwner: Buffer.from('Copper Clam', 'utf8'),
-            confirmed: BigInt(2000000000),
-            unconfirmed: BigInt(2000000000),
-            pending: BigInt(2000000000),
-            available: BigInt(2000000000),
-            availableNoteCount: 1,
-            unconfirmedCount: 0,
-            pendingCount: 0,
-            blockHash: null,
-            sequence: null,
-          }
-        })
-
-      const verifyAsset = jest
-        .spyOn(node.assetsVerifier, 'verify')
-        .mockReturnValueOnce({ status: 'verified', symbol: 'FOO' })
-
-      const response = await routeTest.client.wallet.getAccountBalance({
-        account: account.name,
-      })
-
-      expect(getBalances).toHaveBeenCalledWith(account, Asset.nativeId(), { confirmations: 0 })
-      expect(verifyAsset).toHaveBeenCalledWith(Asset.nativeId())
-
-      expect(response.content).toEqual({
-        account: account.name,
-        assetId: Asset.nativeId().toString('hex'),
-        confirmed: '2000000000',
-        unconfirmed: '2000000000',
-        pending: '2000000000',
-        available: '2000000000',
-        availableNoteCount: 1,
-        unconfirmedCount: 0,
-        pendingCount: 0,
-        blockHash: null,
-        confirmations: 0,
-        sequence: null,
-      })
-    })
   })
 })

--- a/ironfish/src/rpc/routes/wallet/getBalance.test.ts
+++ b/ironfish/src/rpc/routes/wallet/getBalance.test.ts
@@ -31,7 +31,6 @@ describe('Route wallet/getBalance', () => {
             assetName: Buffer.from('$IRON', 'utf8'),
             assetCreator: Buffer.from('Iron Fish', 'utf8'),
             assetOwner: Buffer.from('Copper Clam', 'utf8'),
-            assetVerification: { status: 'unknown' },
             confirmed: BigInt(2000000000),
             unconfirmed: BigInt(2000000000),
             pending: BigInt(2000000000),
@@ -52,7 +51,6 @@ describe('Route wallet/getBalance', () => {
       expect(response.content).toEqual({
         account: account.name,
         assetId: Asset.nativeId().toString('hex'),
-        assetVerification: { status: 'unknown' },
         confirmed: '2000000000',
         unconfirmed: '2000000000',
         pending: '2000000000',
@@ -81,7 +79,6 @@ describe('Route wallet/getBalance', () => {
             assetName: asset.name(),
             assetCreator: asset.creator(),
             assetOwner: asset.creator(),
-            assetVerification: { status: 'unknown' },
             confirmed: BigInt(8),
             unconfirmed: BigInt(8),
             pending: BigInt(8),
@@ -103,7 +100,6 @@ describe('Route wallet/getBalance', () => {
       expect(response.content).toEqual({
         account: account.name,
         assetId: asset.id().toString('hex'),
-        assetVerification: { status: 'unknown' },
         confirmed: '8',
         unconfirmed: '8',
         pending: '8',
@@ -131,7 +127,6 @@ describe('Route wallet/getBalance', () => {
             assetName: Buffer.from('$IRON', 'utf8'),
             assetCreator: Buffer.from('Iron Fish', 'utf8'),
             assetOwner: Buffer.from('Copper Clam', 'utf8'),
-            assetVerification: { status: 'unknown' },
             confirmed: BigInt(2000000000),
             unconfirmed: BigInt(2000000000),
             pending: BigInt(2000000000),
@@ -158,7 +153,6 @@ describe('Route wallet/getBalance', () => {
       expect(response.content).toEqual({
         account: account.name,
         assetId: Asset.nativeId().toString('hex'),
-        assetVerification: { status: 'verified' },
         confirmed: '2000000000',
         unconfirmed: '2000000000',
         pending: '2000000000',

--- a/ironfish/src/rpc/routes/wallet/getBalance.ts
+++ b/ironfish/src/rpc/routes/wallet/getBalance.ts
@@ -30,10 +30,6 @@ export type GetBalanceResponse = {
   confirmations: number
   blockHash: string | null
   sequence: number | null
-  /**
-   * @deprecated Please use getAsset endpoint to get this information
-   * */
-  assetVerification: { status: AssetVerification['status'] }
 }
 
 export const GetBalanceRequestSchema: yup.ObjectSchema<GetBalanceRequest> = yup
@@ -48,9 +44,6 @@ export const GetBalanceResponseSchema: yup.ObjectSchema<GetBalanceResponse> = yu
   .object({
     account: yup.string().defined(),
     assetId: yup.string().defined(),
-    assetVerification: yup
-      .object({ status: yup.string().oneOf(['verified', 'unverified', 'unknown']).defined() })
-      .defined(),
     unconfirmed: yup.string().defined(),
     unconfirmedCount: yup.number().defined(),
     pending: yup.string().defined(),
@@ -86,7 +79,6 @@ routes.register<typeof GetBalanceRequestSchema, GetBalanceResponse>(
     request.end({
       account: account.name,
       assetId: assetId.toString('hex'),
-      assetVerification: { status: node.assetsVerifier.verify(assetId).status },
       confirmed: balance.confirmed.toString(),
       unconfirmed: balance.unconfirmed.toString(),
       unconfirmedCount: balance.unconfirmedCount,

--- a/ironfish/src/rpc/routes/wallet/getBalance.ts
+++ b/ironfish/src/rpc/routes/wallet/getBalance.ts
@@ -3,7 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Asset } from '@ironfish/rust-nodejs'
 import * as yup from 'yup'
-import { AssetVerification } from '../../../assets'
 import { ApiNamespace } from '../namespaces'
 import { routes } from '../router'
 import { AssertHasRpcContext } from '../rpcContext'

--- a/ironfish/src/rpc/routes/wallet/getBalances.test.ts
+++ b/ironfish/src/rpc/routes/wallet/getBalances.test.ts
@@ -27,9 +27,6 @@ describe('Route wallet/getBalances', () => {
       const mockBalances = [
         {
           assetId,
-          assetName: asset.name(),
-          assetCreator: asset.creator(),
-          assetOwner: asset.creator(),
           confirmed: BigInt(8),
           unconfirmed: BigInt(8),
           pending: BigInt(8),
@@ -42,9 +39,6 @@ describe('Route wallet/getBalances', () => {
         },
         {
           assetId: Asset.nativeId(),
-          assetName: Buffer.from('$IRON', 'utf8'),
-          assetCreator: Buffer.from('Iron Fish', 'utf8'),
-          assetOwner: Buffer.from('Iron Fish', 'utf8'),
           confirmed: BigInt(2000000000),
           unconfirmed: BigInt(2000000000),
           pending: BigInt(2000000000),
@@ -91,104 +85,12 @@ describe('Route wallet/getBalances', () => {
         mockBalances.map((mockBalance) => ({
           ...mockBalance,
           assetId: mockBalance.assetId.toString('hex'),
-          assetName: mockBalance.assetName.toString('hex'),
-          assetCreator: mockBalance.assetCreator.toString('hex'),
-          assetOwner: mockBalance.assetOwner.toString('hex'),
           confirmed: mockBalance.confirmed.toString(),
           unconfirmed: mockBalance.unconfirmed.toString(),
           pending: mockBalance.pending.toString(),
           available: mockBalance.available.toString(),
         })),
       )
-    })
-
-    it('returns asset verification information', async () => {
-      const node = routeTest.node
-      const wallet = node.wallet
-      const account = await useAccountFixture(wallet, 'accountB')
-      const asset = new Asset(account.publicAddress, 'mint-asset', 'metadata')
-      const assetId = asset.id()
-
-      const mockBalances = [
-        {
-          assetId,
-          assetName: asset.name(),
-          assetCreator: asset.creator(),
-          assetOwner: asset.creator(),
-          confirmed: BigInt(8),
-          unconfirmed: BigInt(8),
-          pending: BigInt(8),
-          available: BigInt(8),
-          availableNoteCount: 1,
-          unconfirmedCount: 0,
-          pendingCount: 0,
-          blockHash: null,
-          sequence: null,
-        },
-        {
-          assetId: Asset.nativeId(),
-          assetName: Buffer.from('$IRON', 'utf8'),
-          assetCreator: Buffer.from('Iron Fish', 'utf8'),
-          assetOwner: Buffer.from('Copper Clam', 'utf8'),
-          confirmed: BigInt(2000000000),
-          unconfirmed: BigInt(2000000000),
-          pending: BigInt(2000000000),
-          available: BigInt(2000000000),
-          availableNoteCount: 1,
-          unconfirmedCount: 0,
-          pendingCount: 0,
-          blockHash: null,
-          sequence: null,
-        },
-      ]
-
-      const getBalances = jest
-        .spyOn(account, 'getBalances')
-        // eslint-disable-next-line @typescript-eslint/require-await
-        .mockImplementationOnce(async function* (_confirmations) {
-          for (const balance of mockBalances) {
-            yield balance
-          }
-        })
-
-      jest.spyOn(account, 'getAsset').mockReturnValueOnce(
-        Promise.resolve({
-          id: asset.id(),
-          metadata: asset.metadata(),
-          name: asset.name(),
-          nonce: asset.nonce(),
-          creator: asset.creator(),
-          owner: asset.creator(),
-          createdTransactionHash: Buffer.alloc(32),
-          blockHash: Buffer.alloc(32),
-          sequence: null,
-          supply: null,
-        }),
-      )
-
-      const verifyAsset = jest
-        .spyOn(node.assetsVerifier, 'verify')
-        .mockReturnValueOnce({ status: 'unverified' })
-        .mockReturnValueOnce({ status: 'verified', symbol: 'FOO' })
-
-      const response = await routeTest.client.wallet.getAccountBalances({
-        account: account.name,
-      })
-
-      expect(getBalances).toHaveBeenCalledTimes(1)
-      expect(verifyAsset).toHaveBeenCalledWith(asset.id())
-      expect(verifyAsset).toHaveBeenCalledWith(Asset.nativeId())
-
-      expect(response.content.balances).toMatchObject([
-        {
-          assetId: assetId.toString('hex'),
-          assetVerification: { status: 'unverified' },
-        },
-        {
-          assetId: Asset.nativeId().toString('hex'),
-          assetVerification: { status: 'verified' },
-        },
-      ])
     })
   })
 })

--- a/ironfish/src/rpc/routes/wallet/getBalances.ts
+++ b/ironfish/src/rpc/routes/wallet/getBalances.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
-import { AssetVerification } from '../../../assets'
 import { CurrencyUtils } from '../../../utils'
 import { ApiNamespace } from '../namespaces'
 import { routes } from '../router'
@@ -27,22 +26,6 @@ export interface GetBalancesResponse {
     availableNoteCount: number
     blockHash: string | null
     sequence: number | null
-    /**
-     * @deprecated Please use getAsset endpoint to get this information
-     */
-    assetName: string
-    /**
-     * @deprecated Please use getAsset endpoint to get this information
-     */
-    assetCreator: string
-    /**
-     * @deprecated Please use getAsset endpoint to get this information
-     * */
-    assetOwner: string
-    /**
-     * @deprecated Please use getAsset endpoint to get this information
-     * */
-    assetVerification: { status: AssetVerification['status'] }
   }[]
 }
 
@@ -63,14 +46,6 @@ export const GetBalancesResponseSchema: yup.ObjectSchema<GetBalancesResponse> = 
           .object()
           .shape({
             assetId: yup.string().defined(),
-            assetName: yup.string().defined(),
-            assetCreator: yup.string().defined(),
-            assetOwner: yup.string().defined(),
-            assetVerification: yup
-              .object({
-                status: yup.string().oneOf(['verified', 'unverified', 'unknown']).defined(),
-              })
-              .defined(),
             unconfirmed: yup.string().defined(),
             unconfirmedCount: yup.number().defined(),
             pending: yup.string().defined(),
@@ -104,14 +79,8 @@ routes.register<typeof GetBalancesRequestSchema, GetBalancesResponse>(
         return
       }
 
-      const asset = await account.getAsset(balance.assetId)
-
       balances.push({
         assetId: balance.assetId.toString('hex'),
-        assetName: asset?.name.toString('hex') ?? '',
-        assetCreator: asset?.creator.toString('hex') ?? '',
-        assetOwner: asset?.owner.toString('hex') ?? '',
-        assetVerification: { status: context.assetsVerifier.verify(balance.assetId).status },
         blockHash: balance.blockHash?.toString('hex') ?? null,
         confirmed: CurrencyUtils.encode(balance.confirmed),
         sequence: balance.sequence,


### PR DESCRIPTION
## Summary
This is a collection of PRs from deprecated routes that were previously reviewed:

exportChainStream: https://github.com/iron-fish/ironfish/pull/5704
getBalance: https://github.com/iron-fish/ironfish/pull/5744
getBalances: https://github.com/iron-fish/ironfish/pull/5745

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[X] Yes
```
exportChainStream: https://github.com/iron-fish/website/pull/774
getBalance: https://github.com/iron-fish/website/pull/780
getBalances: https://github.com/iron-fish/website/pull/781

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[X] Yes - breaking-change-rpc
```
