### PR TITLE
getTransaction: removed notesCount, spendscount, notesEncrypted 

### DIFF
--- a/ironfish/src/rpc/routes/chain/getTransaction.test.ts
+++ b/ironfish/src/rpc/routes/chain/getTransaction.test.ts
@@ -18,11 +18,9 @@ describe('Route chain/getTransaction', () => {
 
     const transaction = block2.transactions[0]
 
-    const notesEncrypted: string[] = []
     const notes: { hash: string; serialized: string }[] = []
 
     for (const note of transaction.notes) {
-      notesEncrypted.push(note.serialize().toString('hex'))
       notes.push({
         hash: note.hash().toString('hex'),
         serialized: note.serialize().toString('hex'),
@@ -44,10 +42,7 @@ describe('Route chain/getTransaction', () => {
     expect(response.content).toMatchObject({
       fee: Number(transaction.fee()),
       expiration: transaction.expiration(),
-      notesCount: 1,
-      spendsCount: 0,
       signature: transaction.transactionSignature().toString('hex'),
-      notesEncrypted,
       spends,
       mints: [],
       burns: [],
@@ -63,11 +58,9 @@ describe('Route chain/getTransaction', () => {
 
     const transaction = block2.transactions[0]
 
-    const notesEncrypted: string[] = []
     const notes: { hash: string; serialized: string }[] = []
 
     for (const note of transaction.notes) {
-      notesEncrypted.push(note.serialize().toString('hex'))
       notes.push({
         hash: note.hash().toString('hex'),
         serialized: note.serialize().toString('hex'),
@@ -90,10 +83,7 @@ describe('Route chain/getTransaction', () => {
     expect(response.content).toMatchObject({
       fee: Number(transaction.fee()),
       expiration: transaction.expiration(),
-      notesCount: 1,
-      spendsCount: 0,
       signature: transaction.transactionSignature().toString('hex'),
-      notesEncrypted,
       spends,
       mints: [],
       burns: [],

--- a/ironfish/src/rpc/routes/chain/getTransaction.ts
+++ b/ironfish/src/rpc/routes/chain/getTransaction.ts
@@ -16,18 +16,6 @@ export type GetTransactionRequest = { transactionHash: string; blockHash?: strin
 export type GetTransactionResponse = RpcTransaction & {
   noteSize: number
   blockHash: string
-  /**
-   * @deprecated Please use `notes.length` instead
-   */
-  notesCount: number
-  /**
-   * @deprecated Please use `spends.length` instead
-   */
-  spendsCount: number
-  /**
-   * @deprecated Please use `notes` instead
-   */
-  notesEncrypted: string[]
 }
 
 export const GetTransactionRequestSchema: yup.ObjectSchema<GetTransactionRequest> = yup
@@ -41,9 +29,6 @@ export const GetTransactionResponseSchema: yup.ObjectSchema<GetTransactionRespon
   RpcTransactionSchema.concat(
     yup
       .object({
-        notesCount: yup.number().defined(),
-        spendsCount: yup.number().defined(),
-        notesEncrypted: yup.array(yup.string().defined()).defined(),
         noteSize: yup.number().defined(),
         blockHash: yup.string().defined(),
       })
@@ -95,11 +80,6 @@ routes.register<typeof GetTransactionRequestSchema, GetTransactionResponse>(
       ...serializeRpcTransaction(chainTransaction.transaction, true),
       blockHash: blockHashBuffer.toString('hex'),
       noteSize: chainTransaction.initialNoteIndex + chainTransaction.transaction.notes.length,
-      notesCount: chainTransaction.transaction.notes.length,
-      spendsCount: chainTransaction.transaction.spends.length,
-      notesEncrypted: chainTransaction.transaction.notes.map((note) =>
-        note.serialize().toString('hex'),
-      ),
     })
   },
 )


### PR DESCRIPTION
## Summary
removed notesCount, spendscount, notesEncrypted 
using notes.length, spends.length, and notes now

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[X] Yes - https://github.com/iron-fish/website/pull/784
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[X] Yes - breaking-change-rpc
```
