### PR TITLE
mintAsset: removed hash

### DIFF
--- a/ironfish/src/rpc/routes/chain/followChainStream.ts
+++ b/ironfish/src/rpc/routes/chain/followChainStream.ts
@@ -28,12 +28,7 @@ export type FollowChainStreamResponse = {
   head: {
     sequence: number
   }
-  block: RpcBlock & {
-    /**
-     * @deprecated this can be derived from the type
-     */
-    main: boolean
-  }
+  block: RpcBlock
 }
 
 export const FollowChainStreamRequestSchema: yup.ObjectSchema<FollowChainStreamRequest> = yup
@@ -53,13 +48,7 @@ export const FollowChainStreamResponseSchema: yup.ObjectSchema<FollowChainStream
         sequence: yup.number().defined(),
       })
       .defined(),
-    block: RpcBlockSchema.concat(
-      yup
-        .object({
-          main: yup.boolean().defined(),
-        })
-        .defined(),
-    ),
+    block: RpcBlockSchema.defined(),
   })
   .defined()
 
@@ -127,7 +116,6 @@ routes.register<typeof FollowChainStreamRequestSchema, FollowChainStreamResponse
         block: {
           ...blockHeaderResponse,
           size: getBlockSize(block),
-          main: type === 'connected',
           transactions,
         },
       })

--- a/ironfish/src/rpc/routes/wallet/getBalance.test.ts
+++ b/ironfish/src/rpc/routes/wallet/getBalance.test.ts
@@ -112,58 +112,5 @@ describe('Route wallet/getBalance', () => {
         sequence: null,
       })
     })
-
-    it('returns asset verification information', async () => {
-      const node = routeTest.node
-      const wallet = node.wallet
-      const account = await useAccountFixture(wallet, 'accountC')
-
-      const getBalances = jest
-        .spyOn(wallet, 'getBalance')
-        // eslint-disable-next-line @typescript-eslint/require-await
-        .mockImplementationOnce(async (_account, _assetId, _options?) => {
-          return {
-            assetId: Asset.nativeId(),
-            assetName: Buffer.from('$IRON', 'utf8'),
-            assetCreator: Buffer.from('Iron Fish', 'utf8'),
-            assetOwner: Buffer.from('Copper Clam', 'utf8'),
-            confirmed: BigInt(2000000000),
-            unconfirmed: BigInt(2000000000),
-            pending: BigInt(2000000000),
-            available: BigInt(2000000000),
-            availableNoteCount: 1,
-            unconfirmedCount: 0,
-            pendingCount: 0,
-            blockHash: null,
-            sequence: null,
-          }
-        })
-
-      const verifyAsset = jest
-        .spyOn(node.assetsVerifier, 'verify')
-        .mockReturnValueOnce({ status: 'verified', symbol: 'FOO' })
-
-      const response = await routeTest.client.wallet.getAccountBalance({
-        account: account.name,
-      })
-
-      expect(getBalances).toHaveBeenCalledWith(account, Asset.nativeId(), { confirmations: 0 })
-      expect(verifyAsset).toHaveBeenCalledWith(Asset.nativeId())
-
-      expect(response.content).toEqual({
-        account: account.name,
-        assetId: Asset.nativeId().toString('hex'),
-        confirmed: '2000000000',
-        unconfirmed: '2000000000',
-        pending: '2000000000',
-        available: '2000000000',
-        availableNoteCount: 1,
-        unconfirmedCount: 0,
-        pendingCount: 0,
-        blockHash: null,
-        confirmations: 0,
-        sequence: null,
-      })
-    })
   })
 })

--- a/ironfish/src/rpc/routes/wallet/getBalance.test.ts
+++ b/ironfish/src/rpc/routes/wallet/getBalance.test.ts
@@ -31,7 +31,6 @@ describe('Route wallet/getBalance', () => {
             assetName: Buffer.from('$IRON', 'utf8'),
             assetCreator: Buffer.from('Iron Fish', 'utf8'),
             assetOwner: Buffer.from('Copper Clam', 'utf8'),
-            assetVerification: { status: 'unknown' },
             confirmed: BigInt(2000000000),
             unconfirmed: BigInt(2000000000),
             pending: BigInt(2000000000),
@@ -52,7 +51,6 @@ describe('Route wallet/getBalance', () => {
       expect(response.content).toEqual({
         account: account.name,
         assetId: Asset.nativeId().toString('hex'),
-        assetVerification: { status: 'unknown' },
         confirmed: '2000000000',
         unconfirmed: '2000000000',
         pending: '2000000000',
@@ -81,7 +79,6 @@ describe('Route wallet/getBalance', () => {
             assetName: asset.name(),
             assetCreator: asset.creator(),
             assetOwner: asset.creator(),
-            assetVerification: { status: 'unknown' },
             confirmed: BigInt(8),
             unconfirmed: BigInt(8),
             pending: BigInt(8),
@@ -103,7 +100,6 @@ describe('Route wallet/getBalance', () => {
       expect(response.content).toEqual({
         account: account.name,
         assetId: asset.id().toString('hex'),
-        assetVerification: { status: 'unknown' },
         confirmed: '8',
         unconfirmed: '8',
         pending: '8',
@@ -131,7 +127,6 @@ describe('Route wallet/getBalance', () => {
             assetName: Buffer.from('$IRON', 'utf8'),
             assetCreator: Buffer.from('Iron Fish', 'utf8'),
             assetOwner: Buffer.from('Copper Clam', 'utf8'),
-            assetVerification: { status: 'unknown' },
             confirmed: BigInt(2000000000),
             unconfirmed: BigInt(2000000000),
             pending: BigInt(2000000000),
@@ -158,7 +153,6 @@ describe('Route wallet/getBalance', () => {
       expect(response.content).toEqual({
         account: account.name,
         assetId: Asset.nativeId().toString('hex'),
-        assetVerification: { status: 'verified' },
         confirmed: '2000000000',
         unconfirmed: '2000000000',
         pending: '2000000000',

--- a/ironfish/src/rpc/routes/wallet/getBalance.ts
+++ b/ironfish/src/rpc/routes/wallet/getBalance.ts
@@ -30,10 +30,6 @@ export type GetBalanceResponse = {
   confirmations: number
   blockHash: string | null
   sequence: number | null
-  /**
-   * @deprecated Please use getAsset endpoint to get this information
-   * */
-  assetVerification: { status: AssetVerification['status'] }
 }
 
 export const GetBalanceRequestSchema: yup.ObjectSchema<GetBalanceRequest> = yup
@@ -48,9 +44,6 @@ export const GetBalanceResponseSchema: yup.ObjectSchema<GetBalanceResponse> = yu
   .object({
     account: yup.string().defined(),
     assetId: yup.string().defined(),
-    assetVerification: yup
-      .object({ status: yup.string().oneOf(['verified', 'unverified', 'unknown']).defined() })
-      .defined(),
     unconfirmed: yup.string().defined(),
     unconfirmedCount: yup.number().defined(),
     pending: yup.string().defined(),
@@ -86,7 +79,6 @@ routes.register<typeof GetBalanceRequestSchema, GetBalanceResponse>(
     request.end({
       account: account.name,
       assetId: assetId.toString('hex'),
-      assetVerification: { status: node.assetsVerifier.verify(assetId).status },
       confirmed: balance.confirmed.toString(),
       unconfirmed: balance.unconfirmed.toString(),
       unconfirmedCount: balance.unconfirmedCount,

--- a/ironfish/src/rpc/routes/wallet/getBalance.ts
+++ b/ironfish/src/rpc/routes/wallet/getBalance.ts
@@ -3,7 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Asset } from '@ironfish/rust-nodejs'
 import * as yup from 'yup'
-import { AssetVerification } from '../../../assets'
 import { ApiNamespace } from '../namespaces'
 import { routes } from '../router'
 import { AssertHasRpcContext } from '../rpcContext'

--- a/ironfish/src/rpc/routes/wallet/getBalances.test.ts
+++ b/ironfish/src/rpc/routes/wallet/getBalances.test.ts
@@ -27,9 +27,6 @@ describe('Route wallet/getBalances', () => {
       const mockBalances = [
         {
           assetId,
-          assetName: asset.name(),
-          assetCreator: asset.creator(),
-          assetOwner: asset.creator(),
           confirmed: BigInt(8),
           unconfirmed: BigInt(8),
           pending: BigInt(8),
@@ -42,9 +39,6 @@ describe('Route wallet/getBalances', () => {
         },
         {
           assetId: Asset.nativeId(),
-          assetName: Buffer.from('$IRON', 'utf8'),
-          assetCreator: Buffer.from('Iron Fish', 'utf8'),
-          assetOwner: Buffer.from('Iron Fish', 'utf8'),
           confirmed: BigInt(2000000000),
           unconfirmed: BigInt(2000000000),
           pending: BigInt(2000000000),
@@ -91,104 +85,12 @@ describe('Route wallet/getBalances', () => {
         mockBalances.map((mockBalance) => ({
           ...mockBalance,
           assetId: mockBalance.assetId.toString('hex'),
-          assetName: mockBalance.assetName.toString('hex'),
-          assetCreator: mockBalance.assetCreator.toString('hex'),
-          assetOwner: mockBalance.assetOwner.toString('hex'),
           confirmed: mockBalance.confirmed.toString(),
           unconfirmed: mockBalance.unconfirmed.toString(),
           pending: mockBalance.pending.toString(),
           available: mockBalance.available.toString(),
         })),
       )
-    })
-
-    it('returns asset verification information', async () => {
-      const node = routeTest.node
-      const wallet = node.wallet
-      const account = await useAccountFixture(wallet, 'accountB')
-      const asset = new Asset(account.publicAddress, 'mint-asset', 'metadata')
-      const assetId = asset.id()
-
-      const mockBalances = [
-        {
-          assetId,
-          assetName: asset.name(),
-          assetCreator: asset.creator(),
-          assetOwner: asset.creator(),
-          confirmed: BigInt(8),
-          unconfirmed: BigInt(8),
-          pending: BigInt(8),
-          available: BigInt(8),
-          availableNoteCount: 1,
-          unconfirmedCount: 0,
-          pendingCount: 0,
-          blockHash: null,
-          sequence: null,
-        },
-        {
-          assetId: Asset.nativeId(),
-          assetName: Buffer.from('$IRON', 'utf8'),
-          assetCreator: Buffer.from('Iron Fish', 'utf8'),
-          assetOwner: Buffer.from('Copper Clam', 'utf8'),
-          confirmed: BigInt(2000000000),
-          unconfirmed: BigInt(2000000000),
-          pending: BigInt(2000000000),
-          available: BigInt(2000000000),
-          availableNoteCount: 1,
-          unconfirmedCount: 0,
-          pendingCount: 0,
-          blockHash: null,
-          sequence: null,
-        },
-      ]
-
-      const getBalances = jest
-        .spyOn(account, 'getBalances')
-        // eslint-disable-next-line @typescript-eslint/require-await
-        .mockImplementationOnce(async function* (_confirmations) {
-          for (const balance of mockBalances) {
-            yield balance
-          }
-        })
-
-      jest.spyOn(account, 'getAsset').mockReturnValueOnce(
-        Promise.resolve({
-          id: asset.id(),
-          metadata: asset.metadata(),
-          name: asset.name(),
-          nonce: asset.nonce(),
-          creator: asset.creator(),
-          owner: asset.creator(),
-          createdTransactionHash: Buffer.alloc(32),
-          blockHash: Buffer.alloc(32),
-          sequence: null,
-          supply: null,
-        }),
-      )
-
-      const verifyAsset = jest
-        .spyOn(node.assetsVerifier, 'verify')
-        .mockReturnValueOnce({ status: 'unverified' })
-        .mockReturnValueOnce({ status: 'verified', symbol: 'FOO' })
-
-      const response = await routeTest.client.wallet.getAccountBalances({
-        account: account.name,
-      })
-
-      expect(getBalances).toHaveBeenCalledTimes(1)
-      expect(verifyAsset).toHaveBeenCalledWith(asset.id())
-      expect(verifyAsset).toHaveBeenCalledWith(Asset.nativeId())
-
-      expect(response.content.balances).toMatchObject([
-        {
-          assetId: assetId.toString('hex'),
-          assetVerification: { status: 'unverified' },
-        },
-        {
-          assetId: Asset.nativeId().toString('hex'),
-          assetVerification: { status: 'verified' },
-        },
-      ])
     })
   })
 })

--- a/ironfish/src/rpc/routes/wallet/getBalances.ts
+++ b/ironfish/src/rpc/routes/wallet/getBalances.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
-import { AssetVerification } from '../../../assets'
 import { CurrencyUtils } from '../../../utils'
 import { ApiNamespace } from '../namespaces'
 import { routes } from '../router'
@@ -27,22 +26,6 @@ export interface GetBalancesResponse {
     availableNoteCount: number
     blockHash: string | null
     sequence: number | null
-    /**
-     * @deprecated Please use getAsset endpoint to get this information
-     */
-    assetName: string
-    /**
-     * @deprecated Please use getAsset endpoint to get this information
-     */
-    assetCreator: string
-    /**
-     * @deprecated Please use getAsset endpoint to get this information
-     * */
-    assetOwner: string
-    /**
-     * @deprecated Please use getAsset endpoint to get this information
-     * */
-    assetVerification: { status: AssetVerification['status'] }
   }[]
 }
 
@@ -63,14 +46,6 @@ export const GetBalancesResponseSchema: yup.ObjectSchema<GetBalancesResponse> = 
           .object()
           .shape({
             assetId: yup.string().defined(),
-            assetName: yup.string().defined(),
-            assetCreator: yup.string().defined(),
-            assetOwner: yup.string().defined(),
-            assetVerification: yup
-              .object({
-                status: yup.string().oneOf(['verified', 'unverified', 'unknown']).defined(),
-              })
-              .defined(),
             unconfirmed: yup.string().defined(),
             unconfirmedCount: yup.number().defined(),
             pending: yup.string().defined(),
@@ -104,14 +79,8 @@ routes.register<typeof GetBalancesRequestSchema, GetBalancesResponse>(
         return
       }
 
-      const asset = await account.getAsset(balance.assetId)
-
       balances.push({
         assetId: balance.assetId.toString('hex'),
-        assetName: asset?.name.toString('hex') ?? '',
-        assetCreator: asset?.creator.toString('hex') ?? '',
-        assetOwner: asset?.owner.toString('hex') ?? '',
-        assetVerification: { status: context.assetsVerifier.verify(balance.assetId).status },
         blockHash: balance.blockHash?.toString('hex') ?? null,
         confirmed: CurrencyUtils.encode(balance.confirmed),
         sequence: balance.sequence,

--- a/ironfish/src/rpc/routes/wallet/mintAsset.test.ts
+++ b/ironfish/src/rpc/routes/wallet/mintAsset.test.ts
@@ -145,7 +145,6 @@ describe('Route wallet/mintAsset', () => {
         owner: asset.creator().toString('hex'),
         assetId: asset.id().toString('hex'),
         metadata: asset.metadata().toString('hex'),
-        hash: mintTransaction.hash().toString('hex'),
         name: asset.name().toString('hex'),
         assetName: asset.name().toString('hex'),
         value: mintTransaction.mints[0].value.toString(),

--- a/ironfish/src/rpc/routes/wallet/mintAsset.ts
+++ b/ironfish/src/rpc/routes/wallet/mintAsset.ts
@@ -51,10 +51,6 @@ export const MintAssetRequestSchema: yup.ObjectSchema<MintAssetRequest> = yup
 export type MintAssetResponse = RpcMint & {
   asset: RpcAsset
   transaction: RpcWalletTransaction
-  /**
-   * @deprecated Please use `transaction.hash` instead
-   */
-  hash: string
 }
 
 export const MintAssetResponseSchema: yup.ObjectSchema<MintAssetResponse> =
@@ -63,7 +59,6 @@ export const MintAssetResponseSchema: yup.ObjectSchema<MintAssetResponse> =
       .object({
         asset: RpcAssetSchema.defined(),
         transaction: RpcWalletTransactionSchema.defined(),
-        hash: yup.string().defined(),
       })
       .defined(),
   ).defined()
@@ -157,7 +152,6 @@ routes.register<typeof MintAssetRequestSchema, MintAssetResponse>(
         transactionValue,
       ),
       assetId: asset.id.toString('hex'),
-      hash: transaction.hash().toString('hex'),
       name: asset.name.toString('hex'),
       value: mint.value.toString(),
       id: mint.asset.id().toString('hex'),


### PR DESCRIPTION
## Summary
removed hash ref from mintAsset and tests
now being ref from transaction.hash

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[X] Yes - https://github.com/iron-fish/website/pull/786
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[X] Yes - breaking-change-rpc
```
