### PR TITLE
Fix docker builds by pinning rust toolchain

### DIFF
--- a/ironfish-cli/Dockerfile
+++ b/ironfish-cli/Dockerfile
@@ -6,7 +6,7 @@ RUN \
     apt-get update && \
     apt-get install jq rsync -y
 
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain=1.76.0
 
 COPY ./ /usr/src/ironfish
 


### PR DESCRIPTION
## Summary

This pins the rust version to our current toolchain of 1.76.0 because the sh.rustup.rs script automatically installs stable. This means if stable drifts from our toolchain version it will automatically start failing new builds.

## Testing Plan

Just run `RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain=1.76.0` with different versions, or excluded.

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and label it with `breaking-change-rpc` or `breaking-change-sdk`.

```
[ ] Yes
```
